### PR TITLE
chore: self-linting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,10 @@ jobs:
         shell: bash
         run: just test
 
+      - name: Dogfood
+        shell: bash
+        run: just dogfood
+
       - name: Clean workspace artifacts before cache
         if: always()
         continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,9 +63,9 @@ jobs:
         shell: bash
         run: just test
 
-      - name: Dogfood
+      - name: Self-lint
         shell: bash
-        run: just dogfood
+        run: just self-lint
 
       - name: Clean workspace artifacts before cache
         if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           path: |
             ~/.cargo
+            ~/.dylint_drivers
             target
           key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,3 @@ dylint_testing = "5.0.0"
 
 [package.metadata.rust-analyzer]
 rustc_private = true
-
-[workspace.metadata.dylint]
-libraries = [
-  { path = "." },
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ dylint_testing = "5.0.0"
 [package.metadata.rust-analyzer]
 rustc_private = true
 
-[package.metadata.dylint]
+[workspace.metadata.dylint]
 libraries = [
   { path = "." },
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,8 @@ dylint_testing = "5.0.0"
 
 [package.metadata.rust-analyzer]
 rustc_private = true
+
+[package.metadata.dylint]
+libraries = [
+  { path = "." },
+]

--- a/dylint.toml
+++ b/dylint.toml
@@ -1,3 +1,4 @@
+[workspace.metadata.dylint]
 libraries = [
   { path = "." },
 ]

--- a/dylint.toml
+++ b/dylint.toml
@@ -1,0 +1,3 @@
+libraries = [
+  { path = "." },
+]

--- a/justfile
+++ b/justfile
@@ -32,4 +32,4 @@ test:
 
 # Run perfectionist's own lints on its source
 self-lint:
-  cargo dylint --all -- --all-targets
+  DYLINT_RUSTFLAGS='-D warnings' cargo dylint --all -- --all-targets

--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@ all:
   just doc
   just lint
   just test
+  just dogfood
 
 # Check format
 fmt:
@@ -28,3 +29,7 @@ lint:
 # Run all the tests
 test:
   cargo test
+
+# Run perfectionist's own lints on its source (dogfood)
+dogfood:
+  cargo dylint --all -- --all-targets

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ all:
   just doc
   just lint
   just test
-  just dogfood
+  just self-lint
 
 # Check format
 fmt:
@@ -30,6 +30,6 @@ lint:
 test:
   cargo test
 
-# Run perfectionist's own lints on its source (dogfood)
-dogfood:
+# Run perfectionist's own lints on its source
+self-lint:
   cargo dylint --all -- --all-targets


### PR DESCRIPTION
Run `perfectionist`'s own lints against its own source.

## Changes

- `dylint.toml` registers the local crate as a lint library under `[workspace.metadata.dylint]`.
- `justfile`: new `self-lint` recipe runs `cargo dylint --all -- --all-targets` with `DYLINT_RUSTFLAGS='-D warnings'`; folded into `all`.
- `.github/workflows/test.yaml`:
  - new `Self-lint` step;
  - `~/.dylint_drivers` added to the cache (the dylint rustc-wrapper lives there, outside `target/` and `~/.cargo`).

## Notes

- The only implemented lint, `unicode_ellipsis_in_comments`, ignores `///` and `//!`, so existing `…` characters in src/ aren't flagged.
- Verified locally: a non-doc `…` injected into `src/lib.rs` makes `just self-lint` exit 1 with the expected diagnostic; reverting the probe makes it exit 0.
- Two false starts along the way (left in commit history as fixes for traceability):
  - First put the metadata under `[package.metadata.dylint]`; `cargo dylint` only reads `[workspace.metadata.dylint]`.
  - Then put `libraries` at the root of `dylint.toml` instead of under `[workspace.metadata.dylint]`; same "No libraries were found" symptom.
  - And `cargo dylint` exits 0 on lint warnings — without `-D warnings`, the lint fired but CI passed anyway.