### PR TITLE
feat!: remove `extra_known_names` from `unknown_perfectionist_lints`

### DIFF
--- a/src/unknown_perfectionist_lints.rs
+++ b/src/unknown_perfectionist_lints.rs
@@ -57,11 +57,11 @@ pub struct UnknownPerfectionistLints {
 }
 
 impl UnknownPerfectionistLints {
-    fn new(registered_names: Vec<String>) -> Self {
+    fn new(known: Vec<String>) -> Self {
         let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
         Self {
             suggestion_distance: config.suggestion_distance,
-            known: registered_names,
+            known,
         }
     }
 }

--- a/src/unknown_perfectionist_lints.rs
+++ b/src/unknown_perfectionist_lints.rs
@@ -41,14 +41,12 @@ const TOOL_NAME: &str = "perfectionist";
 #[serde(default, rename_all = "snake_case")]
 struct Config {
     suggestion_distance: usize,
-    extra_known_names: Vec<String>,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             suggestion_distance: 2,
-            extra_known_names: Vec::new(),
         }
     }
 }
@@ -61,15 +59,9 @@ pub struct UnknownPerfectionistLints {
 impl UnknownPerfectionistLints {
     fn new(registered_names: Vec<String>) -> Self {
         let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-        let mut known = registered_names;
-        for extra in config.extra_known_names {
-            if !known.iter().any(|n| n == &extra) {
-                known.push(extra);
-            }
-        }
         Self {
             suggestion_distance: config.suggestion_distance,
-            known,
+            known: registered_names,
         }
     }
 }


### PR DESCRIPTION
## Why

`extra_known_names` was specced as a migration buffer for renamed lints, but it works against the rule it belongs to: marking a name "known" doesn't make a stale `#[allow(perfectionist::renamed)]` actually suppress anything — it just hides the warning that exists to surface that exact dead-suppression case.

The genuine deferred-migration use case is already covered better by `#[allow(perfectionist::unknown_perfectionist_lints)]`, which is per-site rather than a global string allowlist that silently swallows future typos of the same name. And a maintainer-driven rename should register the old name as a deprecated alias in `LintStore` once, not push the allowlist out to every consumer's `dylint.toml`.

The knob also has no tests, no in-tree docs referencing it, and no `dylint.toml` example. `suggestion_distance` stays — orthogonal and useful.

## Compat

Consumers with `extra_known_names = [...]` in `dylint.toml` will have those entries silently ignored after this change (the `Config` struct uses `#[serde(default)]` without `deny_unknown_fields`). The names will revert to being flagged as unknown; the fix is to delete the config line and either remove the stale `#[allow(...)]` sites or wrap them in `#[allow(perfectionist::unknown_perfectionist_lints)]`.

## Test plan

- [ ] `just all` (fmt, build, doc, lint, test, self-lint) on a machine with `dylint-link` installed — couldn't run locally in this sandbox.