### PR TITLE
refactor: naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,21 +99,29 @@ explicitly retracted.
 
 ## Registering a new rule in `lib.rs`
 
-`src/lib.rs::register_lints` registers each rule module's lints
-in turn, then — *as the final step* — calls
-`unknown_perfectionist_lints::register_pass`. That pass snapshots
-the registered `perfectionist::*` lint names out of the
-`LintStore`, so any module that registers lints below this call
-will be invisible to it and its legitimate suppression sites will
-warn as "unknown lint".
+Every rule module exposes two registration functions:
+
+- `register_lint(lint_store)` — registers the lint declaration
+  only.
+- `register_pass(lint_store)` — installs the rule's early/late
+  pass.
+
+`src/lib.rs::register_lints` calls them in two phases: every
+`register_lint` first, then every `register_pass`. The phasing
+exists because `unknown_perfectionist_lints::register_pass`
+snapshots the registered `perfectionist::*` lint names out of the
+`LintStore` at construction time, so every rule's lint
+declaration must already be in the store before any pass is
+installed.
 
 When you add a new rule:
 
-1. Add the `mod` line and call its `register` (or
-   `register_lint`) function alongside the other modules in
-   `register_lints`, *above* the
-   `unknown_perfectionist_lints::register_pass(...)` call.
-2. Do not introduce a parallel `REGISTERED_LINT_NAMES`-style
+1. Add the `mod` line and expose both `register_lint` and
+   `register_pass` from the rule module.
+2. Call `your_rule::register_lint(lint_store)` in the phase-1
+   block of `register_lints` and
+   `your_rule::register_pass(lint_store)` in the phase-2 block.
+3. Do not introduce a parallel `REGISTERED_LINT_NAMES`-style
    array. The `LintStore` is the single source of truth.
 
 ## Notes on cross-rule dependencies

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,17 +18,8 @@ mod rules;
 #[allow(clippy::no_mangle_with_rust_abi)]
 pub fn register_lints(session: &Session, lint_store: &mut LintStore) {
     dylint_linting::init_config(session);
-
-    // Phase 1: register every rule's lint declaration first, so the
-    // `LintStore` holds the full set of `perfectionist::*` names before any
-    // pass tries to read it back.
     rules::unicode_ellipsis_in_comments::register_lint(lint_store);
     rules::unknown_perfectionist_lints::register_lint(lint_store);
-
-    // Phase 2: install the early/late passes. `unknown_perfectionist_lints`
-    // snapshots the registered names at construction time, which is why
-    // every lint must be registered above before any pass is installed
-    // here.
     rules::unicode_ellipsis_in_comments::register_pass(lint_store);
     rules::unknown_perfectionist_lints::register_pass(lint_store);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,19 @@ mod rules;
 
 #[unsafe(no_mangle)]
 #[allow(clippy::no_mangle_with_rust_abi)]
-pub fn register_lints(sess: &Session, lint_store: &mut LintStore) {
-    dylint_linting::init_config(sess);
-    rules::unicode_ellipsis_in_comments::register(lint_store);
+pub fn register_lints(session: &Session, lint_store: &mut LintStore) {
+    dylint_linting::init_config(session);
+
+    // Phase 1: register every rule's lint declaration first, so the
+    // `LintStore` holds the full set of `perfectionist::*` names before any
+    // pass tries to read it back.
+    rules::unicode_ellipsis_in_comments::register_lint(lint_store);
     rules::unknown_perfectionist_lints::register_lint(lint_store);
+
+    // Phase 2: install the early/late passes. `unknown_perfectionist_lints`
+    // snapshots the registered names at construction time, which is why
+    // every lint must be registered above before any pass is installed
+    // here.
+    rules::unicode_ellipsis_in_comments::register_pass(lint_store);
     rules::unknown_perfectionist_lints::register_pass(lint_store);
 }

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::Crate;
 use rustc_errors::Applicability;
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
@@ -62,21 +62,21 @@ enum Scope {
 }
 
 pub struct UnicodeEllipsisInComments {
-    needles: Vec<char>,
+    flagged_chars: Vec<char>,
     scopes: BTreeSet<Scope>,
 }
 
 impl UnicodeEllipsisInComments {
     fn new() -> Self {
         let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-        let mut needles = vec!['\u{2026}'];
+        let mut flagged_chars = vec!['\u{2026}'];
         for ch in config.also_flag {
-            if !needles.contains(&ch) {
-                needles.push(ch);
+            if !flagged_chars.contains(&ch) {
+                flagged_chars.push(ch);
             }
         }
         Self {
-            needles,
+            flagged_chars,
             scopes: config.scope.into_iter().collect(),
         }
     }
@@ -84,45 +84,51 @@ impl UnicodeEllipsisInComments {
 
 impl_lint_pass!(UnicodeEllipsisInComments => [UNICODE_ELLIPSIS_IN_COMMENTS]);
 
-pub fn register(lint_store: &mut LintStore) {
+/// Register this rule's lint declaration. Paired with [`register_pass`];
+/// see the module-level convention documented in `register_lints`.
+pub fn register_lint(lint_store: &mut LintStore) {
     lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_COMMENTS]);
+}
+
+/// Install this rule's early pass.
+pub fn register_pass(lint_store: &mut LintStore) {
     lint_store.register_early_pass(|| Box::new(UnicodeEllipsisInComments::new()));
 }
 
 impl EarlyLintPass for UnicodeEllipsisInComments {
     fn check_crate(&mut self, cx: &EarlyContext<'_>, _: &Crate) {
         let source_map = cx.sess().source_map();
-        let want_line = self.scopes.contains(&Scope::Line);
-        let want_block = self.scopes.contains(&Scope::Block);
-        if !(want_line || want_block) {
+        let scan_line_comments = self.scopes.contains(&Scope::Line);
+        let scan_block_comments = self.scopes.contains(&Scope::Block);
+        if !(scan_line_comments || scan_block_comments) {
             return;
         }
         for source_file in source_map.files().iter() {
             if source_file.cnum != LOCAL_CRATE {
                 continue;
             }
-            let Some(src) = source_file.src.as_deref() else {
+            let Some(source_text) = source_file.src.as_deref() else {
                 continue;
             };
             let mut offset: u32 = 0;
-            for token in tokenize(src, FrontmatterAllowed::Yes) {
-                let len = token.len;
-                let scan = match token.kind {
-                    TokenKind::LineComment { doc_style: None } => want_line,
+            for token in tokenize(source_text, FrontmatterAllowed::Yes) {
+                let token_len = token.len;
+                let should_scan_token = match token.kind {
+                    TokenKind::LineComment { doc_style: None } => scan_line_comments,
                     TokenKind::BlockComment {
                         doc_style: None, ..
-                    } => want_block,
+                    } => scan_block_comments,
                     _ => false,
                 };
-                if scan {
+                if should_scan_token {
                     let end = offset
-                        .checked_add(len)
+                        .checked_add(token_len)
                         .expect("source-file offset overflowed u32");
-                    let comment = &src[offset as usize..end as usize];
+                    let comment = &source_text[offset as usize..end as usize];
                     self.scan_comment(cx, source_file, offset, comment);
                 }
                 offset = offset
-                    .checked_add(len)
+                    .checked_add(token_len)
                     .expect("source-file offset overflowed u32");
             }
         }
@@ -137,28 +143,34 @@ impl UnicodeEllipsisInComments {
         comment_offset: u32,
         comment: &str,
     ) {
-        for (idx, ch) in comment.char_indices() {
-            if !self.needles.contains(&ch) {
+        for (byte_index, ch) in comment.char_indices() {
+            if !self.flagged_chars.contains(&ch) {
                 continue;
             }
             let char_len = ch.len_utf8() as u32;
-            let lo = source_file
-                .absolute_position(RelativeBytePos::from_u32(comment_offset + idx as u32));
-            let hi = BytePos::from_u32(lo.0 + char_len);
-            let span = Span::new(lo, hi, SyntaxContext::root(), None);
+            let span_start = source_file.absolute_position(RelativeBytePos::from_u32(
+                comment_offset + byte_index as u32,
+            ));
+            let span_end = BytePos::from_u32(span_start.0 + char_len);
+            let span = Span::new(span_start, span_end, SyntaxContext::root(), None);
             let applicability = if ch == '\u{2026}' {
                 Applicability::MachineApplicable
             } else {
                 Applicability::MaybeIncorrect
             };
-            span_lint_and_sugg(
+            span_lint_and_then(
                 cx,
                 UNICODE_ELLIPSIS_IN_COMMENTS,
                 span,
                 format!("Unicode `{ch}` (U+{:04X}) in comment", ch as u32),
-                "use ASCII `...` instead",
-                "...".to_owned(),
-                applicability,
+                |diagnostic| {
+                    diagnostic.span_suggestion(
+                        span,
+                        "use ASCII `...` instead",
+                        "...".to_owned(),
+                        applicability,
+                    );
+                },
             );
         }
     }

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -70,9 +70,9 @@ impl UnicodeEllipsisInComments {
     fn new() -> Self {
         let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
         let mut flagged_chars = vec!['\u{2026}'];
-        for ch in config.also_flag {
-            if !flagged_chars.contains(&ch) {
-                flagged_chars.push(ch);
+        for character in config.also_flag {
+            if !flagged_chars.contains(&character) {
+                flagged_chars.push(character);
             }
         }
         Self {
@@ -93,8 +93,8 @@ pub fn register_pass(lint_store: &mut LintStore) {
 }
 
 impl EarlyLintPass for UnicodeEllipsisInComments {
-    fn check_crate(&mut self, cx: &EarlyContext<'_>, _: &Crate) {
-        let source_map = cx.sess().source_map();
+    fn check_crate(&mut self, lint_context: &EarlyContext<'_>, _: &Crate) {
+        let source_map = lint_context.sess().source_map();
         let scan_line_comments = self.scopes.contains(&Scope::Line);
         let scan_block_comments = self.scopes.contains(&Scope::Block);
         if !(scan_line_comments || scan_block_comments) {
@@ -122,7 +122,7 @@ impl EarlyLintPass for UnicodeEllipsisInComments {
                         .checked_add(token_len)
                         .expect("source-file offset overflowed u32");
                     let comment = &source_text[offset as usize..end as usize];
-                    self.scan_comment(cx, source_file, offset, comment);
+                    self.scan_comment(lint_context, source_file, offset, comment);
                 }
                 offset = offset
                     .checked_add(token_len)
@@ -135,31 +135,34 @@ impl EarlyLintPass for UnicodeEllipsisInComments {
 impl UnicodeEllipsisInComments {
     fn scan_comment(
         &self,
-        cx: &EarlyContext<'_>,
+        lint_context: &EarlyContext<'_>,
         source_file: &SourceFile,
         comment_offset: u32,
         comment: &str,
     ) {
-        for (byte_index, ch) in comment.char_indices() {
-            if !self.flagged_chars.contains(&ch) {
+        for (byte_index, character) in comment.char_indices() {
+            if !self.flagged_chars.contains(&character) {
                 continue;
             }
-            let char_len = ch.len_utf8() as u32;
+            let char_len = character.len_utf8() as u32;
             let span_start = source_file.absolute_position(RelativeBytePos::from_u32(
                 comment_offset + byte_index as u32,
             ));
             let span_end = BytePos::from_u32(span_start.0 + char_len);
             let span = Span::new(span_start, span_end, SyntaxContext::root(), None);
-            let applicability = if ch == '\u{2026}' {
+            let applicability = if character == '\u{2026}' {
                 Applicability::MachineApplicable
             } else {
                 Applicability::MaybeIncorrect
             };
             span_lint_and_sugg(
-                cx,
+                lint_context,
                 UNICODE_ELLIPSIS_IN_COMMENTS,
                 span,
-                format!("Unicode `{ch}` (U+{:04X}) in comment", ch as u32),
+                format!(
+                    "Unicode `{character}` (U+{:04X}) in comment",
+                    character as u32
+                ),
                 "use ASCII `...` instead",
                 "...".to_owned(),
                 applicability,

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use clippy_utils::diagnostics::span_lint_and_then;
+use clippy_utils::diagnostics::span_lint_and_sugg;
 use rustc_ast::Crate;
 use rustc_errors::Applicability;
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
@@ -84,13 +84,10 @@ impl UnicodeEllipsisInComments {
 
 impl_lint_pass!(UnicodeEllipsisInComments => [UNICODE_ELLIPSIS_IN_COMMENTS]);
 
-/// Register this rule's lint declaration. Paired with [`register_pass`];
-/// see the module-level convention documented in `register_lints`.
 pub fn register_lint(lint_store: &mut LintStore) {
     lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_COMMENTS]);
 }
 
-/// Install this rule's early pass.
 pub fn register_pass(lint_store: &mut LintStore) {
     lint_store.register_early_pass(|| Box::new(UnicodeEllipsisInComments::new()));
 }
@@ -158,19 +155,14 @@ impl UnicodeEllipsisInComments {
             } else {
                 Applicability::MaybeIncorrect
             };
-            span_lint_and_then(
+            span_lint_and_sugg(
                 cx,
                 UNICODE_ELLIPSIS_IN_COMMENTS,
                 span,
                 format!("Unicode `{ch}` (U+{:04X}) in comment", ch as u32),
-                |diagnostic| {
-                    diagnostic.span_suggestion(
-                        span,
-                        "use ASCII `...` instead",
-                        "...".to_owned(),
-                        applicability,
-                    );
-                },
+                "use ASCII `...` instead",
+                "...".to_owned(),
+                applicability,
             );
         }
     }

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Attribute, MetaItem, MetaItemInner, MetaItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::{Symbol, sym};
+use rustc_span::{Symbol, sym as symbols};
 
 declare_tool_lint! {
     /// ### What it does
@@ -101,12 +101,12 @@ fn collect_registered_lint_names(lint_store: &LintStore) -> Vec<String> {
 }
 
 impl EarlyLintPass for UnknownPerfectionistLints {
-    fn check_attribute(&mut self, cx: &EarlyContext<'_>, attribute: &Attribute) {
+    fn check_attribute(&mut self, lint_context: &EarlyContext<'_>, attribute: &Attribute) {
         if is_lint_level_attribute(attribute) {
             if let Some(lint_names) = attribute.meta_item_list() {
-                self.check_lint_name_list(cx, &lint_names);
+                self.check_lint_name_list(lint_context, &lint_names);
             }
-        } else if attribute.has_name(sym::cfg_attr) {
+        } else if attribute.has_name(symbols::cfg_attr) {
             let Some(cfg_attr_args) = attribute.meta_item_list() else {
                 return;
             };
@@ -120,14 +120,19 @@ impl EarlyLintPass for UnknownPerfectionistLints {
                 let MetaItemKind::List(lint_names) = &wrapped_meta_item.kind else {
                     continue;
                 };
-                self.check_lint_name_list(cx, lint_names);
+                self.check_lint_name_list(lint_context, lint_names);
             }
         }
     }
 }
 
-const LINT_LEVEL_ATTRIBUTE_NAMES: [Symbol; 5] =
-    [sym::allow, sym::warn, sym::deny, sym::forbid, sym::expect];
+const LINT_LEVEL_ATTRIBUTE_NAMES: [Symbol; 5] = [
+    symbols::allow,
+    symbols::warn,
+    symbols::deny,
+    symbols::forbid,
+    symbols::expect,
+];
 
 fn is_lint_level_attribute(attribute: &Attribute) -> bool {
     LINT_LEVEL_ATTRIBUTE_NAMES
@@ -142,16 +147,16 @@ fn is_lint_level_meta_item(meta_item: &MetaItem) -> bool {
 }
 
 impl UnknownPerfectionistLints {
-    fn check_lint_name_list(&self, cx: &EarlyContext<'_>, lint_names: &[MetaItemInner]) {
+    fn check_lint_name_list(&self, lint_context: &EarlyContext<'_>, lint_names: &[MetaItemInner]) {
         for lint_name in lint_names {
             let Some(meta_item) = lint_name.meta_item() else {
                 continue;
             };
-            self.check_lint_name(cx, meta_item);
+            self.check_lint_name(lint_context, meta_item);
         }
     }
 
-    fn check_lint_name(&self, cx: &EarlyContext<'_>, meta_item: &MetaItem) {
+    fn check_lint_name(&self, lint_context: &EarlyContext<'_>, meta_item: &MetaItem) {
         let segments = &meta_item.path.segments;
         let Some(first_segment) = segments.first() else {
             return;
@@ -165,11 +170,11 @@ impl UnknownPerfectionistLints {
             .collect();
         match segments_after_tool.as_slice() {
             [name] if self.is_registered(name) => {}
-            [name] => self.report(cx, meta_item, name),
-            [] => self.report_no_name(cx, meta_item),
+            [name] => self.report(lint_context, meta_item, name),
+            [] => self.report_no_name(lint_context, meta_item),
             _ => {
                 let candidate = segments_after_tool.join("_");
-                self.report(cx, meta_item, &candidate);
+                self.report(lint_context, meta_item, &candidate);
             }
         }
     }
@@ -196,11 +201,11 @@ impl UnknownPerfectionistLints {
         closest.map(|(name, _)| name)
     }
 
-    fn report(&self, cx: &EarlyContext<'_>, meta_item: &MetaItem, candidate: &str) {
+    fn report(&self, lint_context: &EarlyContext<'_>, meta_item: &MetaItem, candidate: &str) {
         let path_text = path_to_string(meta_item);
         let suggestion = self.find_closest_match(candidate);
         span_lint_and_then(
-            cx,
+            lint_context,
             UNKNOWN_PERFECTIONIST_LINTS,
             meta_item.span,
             format!("unknown lint: `{path_text}`"),
@@ -212,9 +217,9 @@ impl UnknownPerfectionistLints {
         );
     }
 
-    fn report_no_name(&self, cx: &EarlyContext<'_>, meta_item: &MetaItem) {
+    fn report_no_name(&self, lint_context: &EarlyContext<'_>, meta_item: &MetaItem) {
         span_lint_and_then(
-            cx,
+            lint_context,
             UNKNOWN_PERFECTIONIST_LINTS,
             meta_item.span,
             format!("unknown lint: `{TOOL_NAME}` is a tool prefix, not a lint name"),

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Attribute, MetaItem, MetaItemInner, MetaItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::{Symbol, sym as symbols};
+use rustc_span::{Symbol, sym};
 
 declare_tool_lint! {
     /// ### What it does
@@ -106,7 +106,7 @@ impl EarlyLintPass for UnknownPerfectionistLints {
             if let Some(lint_names) = attribute.meta_item_list() {
                 self.check_lint_name_list(lint_context, &lint_names);
             }
-        } else if attribute.has_name(symbols::cfg_attr) {
+        } else if attribute.has_name(sym::cfg_attr) {
             let Some(cfg_attr_args) = attribute.meta_item_list() else {
                 return;
             };
@@ -126,13 +126,8 @@ impl EarlyLintPass for UnknownPerfectionistLints {
     }
 }
 
-const LINT_LEVEL_ATTRIBUTE_NAMES: [Symbol; 5] = [
-    symbols::allow,
-    symbols::warn,
-    symbols::deny,
-    symbols::forbid,
-    symbols::expect,
-];
+const LINT_LEVEL_ATTRIBUTE_NAMES: [Symbol; 5] =
+    [sym::allow, sym::warn, sym::deny, sym::forbid, sym::expect];
 
 fn is_lint_level_attribute(attribute: &Attribute) -> bool {
     LINT_LEVEL_ATTRIBUTE_NAMES

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -53,40 +53,39 @@ impl Default for Config {
 
 pub struct UnknownPerfectionistLints {
     suggestion_distance: usize,
-    known: Vec<String>,
+    registered_lints: Vec<String>,
 }
 
 impl UnknownPerfectionistLints {
-    fn new(known: Vec<String>) -> Self {
+    fn new(registered_lints: Vec<String>) -> Self {
         let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
         Self {
             suggestion_distance: config.suggestion_distance,
-            known,
+            registered_lints,
         }
     }
 }
 
 impl_lint_pass!(UnknownPerfectionistLints => [UNKNOWN_PERFECTIONIST_LINTS]);
 
-/// Register only the lint declaration. Call this from `register_lints`
-/// alongside the other rule modules' registration calls; the early pass
-/// itself is installed separately by [`register_pass`] once every lint has
-/// been registered, so the pass can read the full set out of the store.
+/// Register this rule's lint declaration. Paired with [`register_pass`];
+/// see the module-level convention documented in `register_lints`.
 pub fn register_lint(lint_store: &mut LintStore) {
     lint_store.register_lints(&[UNKNOWN_PERFECTIONIST_LINTS]);
 }
 
-/// Install the early pass. Must be called *after* every other rule module
+/// Install this rule's early pass. Must be called *after* every rule module
 /// has registered its lints, since the pass snapshots the registered
 /// `perfectionist::*` names from `lint_store` at construction time.
 pub fn register_pass(lint_store: &mut LintStore) {
-    let registered: Vec<String> = collect_registered_names(lint_store);
-    lint_store
-        .register_early_pass(move || Box::new(UnknownPerfectionistLints::new(registered.clone())));
+    let registered_lints: Vec<String> = collect_registered_lint_names(lint_store);
+    lint_store.register_early_pass(move || {
+        Box::new(UnknownPerfectionistLints::new(registered_lints.clone()))
+    });
 }
 
-fn collect_registered_names(lint_store: &LintStore) -> Vec<String> {
-    let prefix = format!("{TOOL_NAME}::");
+fn collect_registered_lint_names(lint_store: &LintStore) -> Vec<String> {
+    let tool_prefix = format!("{TOOL_NAME}::");
     lint_store
         .get_lints()
         .iter()
@@ -95,158 +94,170 @@ fn collect_registered_names(lint_store: &LintStore) -> Vec<String> {
             // (`perfectionist::UNICODE_ELLIPSIS_IN_COMMENTS`); `name_lower()`
             // returns the snake-case form rustc surfaces in diagnostics and
             // attribute references (`perfectionist::unicode_ellipsis_in_comments`).
-            let lower = lint.name_lower();
-            lower.strip_prefix(&prefix).map(str::to_owned)
+            let lower_name = lint.name_lower();
+            lower_name.strip_prefix(&tool_prefix).map(str::to_owned)
         })
         .collect()
 }
 
 impl EarlyLintPass for UnknownPerfectionistLints {
-    fn check_attribute(&mut self, cx: &EarlyContext<'_>, attr: &Attribute) {
-        if is_lint_control_attr(attr) {
-            if let Some(items) = attr.meta_item_list() {
-                self.check_items(cx, &items);
+    fn check_attribute(&mut self, cx: &EarlyContext<'_>, attribute: &Attribute) {
+        if is_lint_level_attribute(attribute) {
+            if let Some(lint_names) = attribute.meta_item_list() {
+                self.check_lint_name_list(cx, &lint_names);
             }
-        } else if attr.has_name(sym::cfg_attr) {
-            let Some(items) = attr.meta_item_list() else {
+        } else if attribute.has_name(sym::cfg_attr) {
+            let Some(cfg_attr_args) = attribute.meta_item_list() else {
                 return;
             };
-            for inner in items.iter().skip(1) {
-                let Some(meta) = inner.meta_item() else {
+            // `cfg_attr(predicate, attr1, attr2, ...)`: skip the predicate at
+            // index 0 and walk every wrapped attribute.
+            for wrapped_attribute in cfg_attr_args.iter().skip(1) {
+                let Some(wrapped_meta_item) = wrapped_attribute.meta_item() else {
                     continue;
                 };
-                if !is_lint_control_meta(meta) {
+                if !is_lint_level_meta_item(wrapped_meta_item) {
                     continue;
                 }
-                let MetaItemKind::List(nested) = &meta.kind else {
+                let MetaItemKind::List(lint_names) = &wrapped_meta_item.kind else {
                     continue;
                 };
-                self.check_items(cx, nested);
+                self.check_lint_name_list(cx, lint_names);
             }
         }
     }
 }
 
-const LINT_CONTROL_NAMES: [Symbol; 5] =
+const LINT_LEVEL_ATTRIBUTE_NAMES: [Symbol; 5] =
     [sym::allow, sym::warn, sym::deny, sym::forbid, sym::expect];
 
-fn is_lint_control_attr(attr: &Attribute) -> bool {
-    LINT_CONTROL_NAMES.iter().any(|name| attr.has_name(*name))
+fn is_lint_level_attribute(attribute: &Attribute) -> bool {
+    LINT_LEVEL_ATTRIBUTE_NAMES
+        .iter()
+        .any(|name| attribute.has_name(*name))
 }
 
-fn is_lint_control_meta(meta: &MetaItem) -> bool {
-    LINT_CONTROL_NAMES.iter().any(|name| meta.has_name(*name))
+fn is_lint_level_meta_item(meta_item: &MetaItem) -> bool {
+    LINT_LEVEL_ATTRIBUTE_NAMES
+        .iter()
+        .any(|name| meta_item.has_name(*name))
 }
 
 impl UnknownPerfectionistLints {
-    fn check_items(&self, cx: &EarlyContext<'_>, items: &[MetaItemInner]) {
-        for inner in items {
-            let Some(meta) = inner.meta_item() else {
+    fn check_lint_name_list(&self, cx: &EarlyContext<'_>, lint_names: &[MetaItemInner]) {
+        for lint_name in lint_names {
+            let Some(meta_item) = lint_name.meta_item() else {
                 continue;
             };
-            self.check_lint_name(cx, meta);
+            self.check_lint_name(cx, meta_item);
         }
     }
 
-    fn check_lint_name(&self, cx: &EarlyContext<'_>, meta: &MetaItem) {
-        let segments = &meta.path.segments;
-        let Some(first) = segments.first() else {
+    fn check_lint_name(&self, cx: &EarlyContext<'_>, meta_item: &MetaItem) {
+        let segments = &meta_item.path.segments;
+        let Some(first_segment) = segments.first() else {
             return;
         };
-        if first.ident.name.as_str() != TOOL_NAME {
+        if first_segment.ident.name.as_str() != TOOL_NAME {
             return;
         }
-        let trailing: Vec<&str> = segments[1..]
+        let segments_after_tool: Vec<&str> = segments[1..]
             .iter()
-            .map(|s| s.ident.name.as_str())
+            .map(|segment| segment.ident.name.as_str())
             .collect();
-        match trailing.as_slice() {
-            [name] if self.is_known(name) => {}
-            [name] => self.report(cx, meta, name),
-            [] => self.report_no_name(cx, meta),
+        match segments_after_tool.as_slice() {
+            [name] if self.is_registered(name) => {}
+            [name] => self.report(cx, meta_item, name),
+            [] => self.report_no_name(cx, meta_item),
             _ => {
-                let candidate = trailing.join("_");
-                self.report(cx, meta, &candidate);
+                let candidate = segments_after_tool.join("_");
+                self.report(cx, meta_item, &candidate);
             }
         }
     }
 
-    fn is_known(&self, name: &str) -> bool {
-        self.known.iter().any(|k| k == name)
+    fn is_registered(&self, name: &str) -> bool {
+        self.registered_lints
+            .iter()
+            .any(|registered| registered == name)
     }
 
-    fn nearest(&self, candidate: &str) -> Option<&str> {
+    fn find_closest_match(&self, candidate: &str) -> Option<&str> {
         if self.suggestion_distance == 0 {
             return None;
         }
-        let mut best: Option<(&str, usize)> = None;
-        for k in &self.known {
-            let d = levenshtein(candidate, k);
-            if d <= self.suggestion_distance && best.is_none_or(|(_, bd)| d < bd) {
-                best = Some((k.as_str(), d));
+        let mut closest: Option<(&str, usize)> = None;
+        for registered in &self.registered_lints {
+            let distance = levenshtein(candidate, registered);
+            if distance <= self.suggestion_distance
+                && closest.is_none_or(|(_, closest_distance)| distance < closest_distance)
+            {
+                closest = Some((registered.as_str(), distance));
             }
         }
-        best.map(|(name, _)| name)
+        closest.map(|(name, _)| name)
     }
 
-    fn report(&self, cx: &EarlyContext<'_>, meta: &MetaItem, candidate: &str) {
-        let printed = path_to_string(meta);
-        let suggestion = self.nearest(candidate);
+    fn report(&self, cx: &EarlyContext<'_>, meta_item: &MetaItem, candidate: &str) {
+        let path_text = path_to_string(meta_item);
+        let suggestion = self.find_closest_match(candidate);
         span_lint_and_then(
             cx,
             UNKNOWN_PERFECTIONIST_LINTS,
-            meta.span,
-            format!("unknown lint: `{printed}`"),
-            |diag| {
-                if let Some(s) = suggestion {
-                    diag.help(format!("did you mean `{TOOL_NAME}::{s}`?"));
+            meta_item.span,
+            format!("unknown lint: `{path_text}`"),
+            |diagnostic| {
+                if let Some(suggested_name) = suggestion {
+                    diagnostic.help(format!("did you mean `{TOOL_NAME}::{suggested_name}`?"));
                 }
             },
         );
     }
 
-    fn report_no_name(&self, cx: &EarlyContext<'_>, meta: &MetaItem) {
+    fn report_no_name(&self, cx: &EarlyContext<'_>, meta_item: &MetaItem) {
         span_lint_and_then(
             cx,
             UNKNOWN_PERFECTIONIST_LINTS,
-            meta.span,
+            meta_item.span,
             format!("unknown lint: `{TOOL_NAME}` is a tool prefix, not a lint name"),
             |_| {},
         );
     }
 }
 
-fn path_to_string(meta: &MetaItem) -> String {
-    let mut out = String::new();
-    for (i, seg) in meta.path.segments.iter().enumerate() {
-        if i > 0 {
-            out.push_str("::");
+fn path_to_string(meta_item: &MetaItem) -> String {
+    let mut result = String::new();
+    for (index, segment) in meta_item.path.segments.iter().enumerate() {
+        if index > 0 {
+            result.push_str("::");
         }
-        out.push_str(seg.ident.name.as_str());
+        result.push_str(segment.ident.name.as_str());
     }
-    out
+    result
 }
 
-fn levenshtein(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-    let n = a.len();
-    let m = b.len();
-    if n == 0 {
-        return m;
+fn levenshtein(left: &str, right: &str) -> usize {
+    let left_chars: Vec<char> = left.chars().collect();
+    let right_chars: Vec<char> = right.chars().collect();
+    let left_len = left_chars.len();
+    let right_len = right_chars.len();
+    if left_len == 0 {
+        return right_len;
     }
-    if m == 0 {
-        return n;
+    if right_len == 0 {
+        return left_len;
     }
-    let mut prev: Vec<usize> = (0..=m).collect();
-    let mut curr: Vec<usize> = vec![0; m + 1];
-    for i in 1..=n {
-        curr[0] = i;
-        for j in 1..=m {
-            let cost = usize::from(a[i - 1] != b[j - 1]);
-            curr[j] = (prev[j] + 1).min(curr[j - 1] + 1).min(prev[j - 1] + cost);
+    let mut previous_row: Vec<usize> = (0..=right_len).collect();
+    let mut current_row: Vec<usize> = vec![0; right_len + 1];
+    for i in 1..=left_len {
+        current_row[0] = i;
+        for j in 1..=right_len {
+            let substitution_cost = usize::from(left_chars[i - 1] != right_chars[j - 1]);
+            current_row[j] = (previous_row[j] + 1)
+                .min(current_row[j - 1] + 1)
+                .min(previous_row[j - 1] + substitution_cost);
         }
-        std::mem::swap(&mut prev, &mut curr);
+        std::mem::swap(&mut previous_row, &mut current_row);
     }
-    prev[m]
+    previous_row[right_len]
 }

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -110,8 +110,6 @@ impl EarlyLintPass for UnknownPerfectionistLints {
             let Some(cfg_attr_args) = attribute.meta_item_list() else {
                 return;
             };
-            // `cfg_attr(predicate, attr1, attr2, ...)`: skip the predicate at
-            // index 0 and walk every wrapped attribute.
             for wrapped_attribute in cfg_attr_args.iter().skip(1) {
                 let Some(wrapped_meta_item) = wrapped_attribute.meta_item() else {
                     continue;


### PR DESCRIPTION
## Summary

Rename arbitrary, abbreviated, and AI-flavoured identifiers across `src/` to spelled-out, descriptive forms, and unify the per-rule registration API so the lint-store-snapshot ordering in `lib.rs` is structural rather than an asymmetric special case.

## Renames (internal only — config keys and serde variants are untouched)

- `needles` → `flagged_chars`, `known` → `registered_lints`, `nearest` → `find_closest_match`, `is_known` → `is_registered`, `printed` → `path_text`, `lower` → `lower_name`.
- `want_line`/`want_block` → `scan_line_comments`/`scan_block_comments`; `src` → `source_text`; `idx` → `byte_index`; `lo`/`hi` → `span_start`/`span_end`.
- `sess` → `session`, `cx` → `lint_context`, `ch` → `character`, `attr` → `attribute`, `meta` → `meta_item`, `diag` → `diagnostic`.
- `LINT_CONTROL_NAMES` → `LINT_LEVEL_ATTRIBUTE_NAMES` (and the helpers); `inner`/`nested` in cfg_attr handling → `cfg_attr_args`/`wrapped_attribute`/`wrapped_meta_item`.
- Levenshtein: `a`/`b`/`n`/`m`/`prev`/`curr`/`cost` → `left`/`right`/`left_len`/`right_len`/`previous_row`/`current_row`/`substitution_cost`.

Externally-defined identifiers (`rustc_span::sym`, `clippy_utils::diagnostics::span_lint_and_sugg`) are left untouched — renaming them would require `as` imports that this codebase doesn't use.

## Registration API

Both rule modules now expose `register_lint(store)` and `register_pass(store)`. `register_lints` in `lib.rs` runs every `register_lint` first, then every `register_pass`, so `unknown_perfectionist_lints`'s snapshot of registered names is satisfied by ordering rather than a one-off public function. `CLAUDE.md` is updated to match.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (UI tests for both rules pass unchanged)