### PR TITLE
docs(dev/guide): markdown parsing

### DIFF
--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -103,8 +103,10 @@ Six rules in this catalogue scan a slice of markdown:
 - [`em-dash-prose`](./em-dash-prose.md) — strips code regions, then
   byte-scans for `—` / `–`.
 
-They share one crate-internal scanner, `src/markdown.rs`, built
-from `take_*` combinators per the "Parser style" section above.
+They share one crate-internal scanner, to be added at
+`src/markdown.rs`, built from `take_*` combinators per the
+"Parser style" section above. The helper does not exist yet — the
+first rule to need it implements it; subsequent rules consume it.
 The helper is hand-written. **Do not pull in `pulldown_cmark`,
 `comrak`, `markdown-rs`, or `markdown-it`** for any of these rules
 without first revisiting the rationale below.
@@ -129,8 +131,8 @@ Two needs sit on top of the same primitives.
 One `take_*` per CommonMark construct the catalogue recognises:
 
 - `take_code_span` — between matching `` ` `` runs of equal length.
-- `take_code_block` — fenced (``` ``` ```, `~~~`) or four-space
-  indented.
+- `take_code_block` — fenced (triple-backtick or `~~~`) or
+  four-space indented.
 - `take_link` — `[text](dest)`, `[text][id]`, `[text]`, `` [`Type`] ``.
 - `take_autolink` — `<https://...>`, `<mailto:...>`.
 - `take_reference_definition` — `[id]: dest` at block start.
@@ -154,7 +156,7 @@ without overshooting:
 
 - **`pulldown_cmark`** — the de facto Rust choice. Event-based,
   carries source offsets via `OffsetIter`, MIT, fast, used by
-  `mdbook` and historically by rustdoc. For a five-construct
+  `mdbook` and historically by rustdoc. For a seven-construct
   predicate it is still ~2-3k LoC of dependency loaded into
   rustc, and consumers must map its event taxonomy onto the
   lints' construct taxonomy. The closest fit, still not free.

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -81,6 +81,133 @@ The rules that explicitly call this convention out in their
 implementation notes are the candidates; rules that just walk a
 fixed-size byte sequence do not.
 
+## Markdown parsing
+
+Six rules in this catalogue scan a slice of markdown:
+
+- [`intra-doc-links`](./intra-doc-links.md) — distinguishes
+  `` `Foo` `` (candidate) from `` [`Foo`] ``, `[Foo]`,
+  `[Foo](path)`, `[Foo][id]` (already linked).
+- [`clap-help-no-markdown`](./clap-help-no-markdown.md) — classifies
+  every banned construct (links, code spans, code blocks, HTML
+  tags, headings, reference definitions) and emits a per-construct
+  diagnostic.
+- [`bare-issue-reference`](./bare-issue-reference.md) — skips code
+  regions, existing links, and reference-link definitions before
+  flagging bare `#123` tokens.
+- [`bare-url`](./bare-url.md) — skips code regions, autolinks
+  (`<...>`), labelled links, and reference-link definitions before
+  flagging bare `http(s)://` URLs.
+- [`unicode-ellipsis-in-docs`](./unicode-ellipsis-in-docs.md) —
+  strips code regions, then byte-scans for U+2026.
+- [`em-dash-prose`](./em-dash-prose.md) — strips code regions, then
+  byte-scans for `—` / `–`.
+
+They share one crate-internal scanner, `src/markdown.rs`, built
+from `take_*` combinators per the "Parser style" section above.
+The helper is hand-written. **Do not pull in `pulldown_cmark`,
+`comrak`, `markdown-rs`, or `markdown-it`** for any of these rules
+without first revisiting the rationale below.
+
+### Two tiers of consumer
+
+Two needs sit on top of the same primitives.
+
+- **Tier A — structural classification.** Distinguishes a code
+  span from an inline link from a reference definition from an
+  autolink from an HTML tag from a heading. Consumers:
+  `intra_doc_links`, `clap_help_no_markdown`, `bare_issue_reference`,
+  `bare_url`.
+- **Tier B — code-region mask.** Only needs the predicate "is this
+  byte inside a code span or code block?". Consumers:
+  `unicode_ellipsis_in_docs`, `em_dash_prose`. The mask is
+  `take_code_span` plus `take_code_block` in a loop over the input;
+  no separate scanner.
+
+### Combinator surface
+
+One `take_*` per CommonMark construct the catalogue recognises:
+
+- `take_code_span` — between matching `` ` `` runs of equal length.
+- `take_code_block` — fenced (``` ``` ```, `~~~`) or four-space
+  indented.
+- `take_link` — `[text](dest)`, `[text][id]`, `[text]`, `` [`Type`] ``.
+- `take_autolink` — `<https://...>`, `<mailto:...>`.
+- `take_reference_definition` — `[id]: dest` at block start.
+- `take_html_tag` — `<tag ...>` and `</tag>`.
+- `take_heading` — ATX (`# h`) and Setext (`h\n===`).
+
+Each combinator returns the matched substring and the remainder
+per the canonical shapes in "Parser style". Rust-specific
+extraction layered on top — `intra_doc_links` pulling an
+identifier out of a `take_code_span` result, `bare_url` pulling a
+scheme out of `take_autolink` failure-fallback prose — lives in
+each rule's own module, not in `src/markdown.rs`.
+
+### Why hand-rolled rather than a library
+
+A Dylint plugin loads into rustc's process; every transitive crate
+is paid for at lint time. The grammar these six rules need is
+seven constructs, no inline-emphasis precedence, no link-reference
+resolution across the whole comment. No library hits that target
+without overshooting:
+
+- **`pulldown_cmark`** — the de facto Rust choice. Event-based,
+  carries source offsets via `OffsetIter`, MIT, fast, used by
+  `mdbook` and historically by rustdoc. For a five-construct
+  predicate it is still ~2-3k LoC of dependency loaded into
+  rustc, and consumers must map its event taxonomy onto the
+  lints' construct taxonomy. The closest fit, still not free.
+- **`comrak`** — CommonMark + GFM, AST-based. Brings
+  `typed-arena`, `unicode-categories`, `entities`, `slug`, `xdg`.
+  Heavier than `pulldown_cmark` and aimed at GFM rendering, not
+  at "give me byte spans of code regions".
+- **`markdown-rs`** (`wooorm/markdown-rs`) — CommonMark + GFM +
+  MDX + frontmatter. Most spec-faithful, largest dep tree, worst
+  weight-vs-need ratio for this use case.
+- **`markdown-it`** — JS port. Pluggable. Less battle-tested in
+  Rust than `pulldown_cmark`.
+
+The combinator approach also keeps span construction precise
+without a mapping layer: each `take_*` knows exactly how many
+bytes it consumed, which is how the lints' diagnostics anchor
+into the source map.
+
+### Rustdoc flavour
+
+Rustdoc intra-doc links — `` [`Foo`] ``, `[Foo]`,
+`[Foo](crate::foo::Foo)` — are *plain CommonMark* at the parser
+level. What makes them intra-doc links is rustdoc's *post-parse*
+resolution step, which tries each link's destination text as a
+Rust path through the documented item's scope. No general-purpose
+markdown library models that resolution; rustdoc's own pipeline
+lives in `rustc_resolve` and `rustdoc::html::markdown` and is not
+published as a library.
+
+The practical consequence: the scanner's job is to say "this is a
+link, here is its destination text". Whether the destination
+resolves as a Rust path is `intra_doc_links`'s job, performed
+against `TyCtxt` in a `LateLintPass`, not the scanner's.
+Consumers that need only "is this any kind of link?" (e.g.,
+`clap_help_no_markdown`, which rejects all link forms) stop at the
+scanner's answer.
+
+This also means library choice is downstream of the intra-doc-link
+question, not upstream of it: even if a hypothetical library
+parsed rustdoc-flavoured markdown, the resolution layer would
+still be custom code in this repo.
+
+### Where to revisit this decision
+
+The decision is per-helper, not per-codebase. If, during
+implementation of `clap_help_no_markdown`, the HTML-tag and
+reference-definition combinators turn out to dominate the helper's
+complexity — they cover constructs none of the other five rules
+need — that single rule may switch to a vendored `pulldown_cmark`
+walk while the other five continue on the hand-rolled helper.
+Open a follow-up PR; do not silently expand `src/markdown.rs`'s
+dependency surface for the other consumers.
+
 ## Lint name namespacing
 
 Every lint registered by this plugin lives in the `perfectionist`

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -85,12 +85,13 @@ form = "inline"
 
 ## Implementation notes
 
-- `LateLintPass::check_attribute` to read `#[doc = "..."]` attribute
-  values. Walk the rendered text once per item, applying the markdown
-  exclusion logic from
-  [`intra-doc-links`](./intra-doc-links.md) and
-  [`unicode-ellipsis-in-docs`](./unicode-ellipsis-in-docs.md). Share
-  the helper.
+- `LateLintPass::check_attribute` to read `#[doc = "..."]`
+  attribute values. Walk the rendered text once per item, using
+  the shared markdown scanner (Tier A — structural classification)
+  per
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md#markdown-parsing)
+  to skip code regions, existing links, and reference-link
+  definitions.
 - The autofix substitutes the bare span with the rendered link.
   Suggestion applicability:
   - `suggestion_mode = "issue_url"` → `MachineApplicable`. The

--- a/planned-rules/bare-url.md
+++ b/planned-rules/bare-url.md
@@ -119,11 +119,14 @@ skip_hosts = ["example.com", "example.org", "localhost"]
 
 ## Implementation notes
 
-- `LateLintPass`. Reuse the doc-comment scanner from
-  [`intra-doc-links`](./intra-doc-links.md) for the doc target and
-  the regular-comment retokenizer from the implemented
+- `LateLintPass`. For the doc target, use the shared markdown
+  scanner (Tier A — structural classification) per
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md#markdown-parsing)
+  to skip code regions, autolinks, labelled links, and
+  reference-link definitions. For the comment target, reuse the
+  regular-comment retokenizer from the implemented
   `perfectionist::unicode_ellipsis_in_comments` lint
-  (see `src/lib.rs`) for the comment target.
+  (see `src/lib.rs`).
 - The autofix span includes only the matched URL bytes; the
   replacement is `<{matched}>`. For the `MaybeIncorrect` cases,
   emit two suggestions — one keeping the trailing character inside

--- a/planned-rules/clap-help-no-markdown.md
+++ b/planned-rules/clap-help-no-markdown.md
@@ -110,29 +110,21 @@ struct Cli {
   2. **For each documented item, check membership.** A field's
      container is its struct; an enum variant's container is its enum.
      The lint fires only when the container is in the cached set.
-- Re-use the doc-comment scanner from
+- Share the "stitch `#[doc = ...]` attributes, walk, emit
+  per-construct sub-spans" pipeline with
   [`intra-doc-links`](./intra-doc-links.md) and
-  [`unicode-ellipsis-in-docs`](./unicode-ellipsis-in-docs.md) — the
-  three lints all need the same "stitch `#[doc = ...]` attributes,
-  walk markdown structure, emit per-construct sub-spans" pipeline.
-  Factor it into a shared helper crate-internally.
-- Markdown parsing: use a small hand-written scanner for the four
-  high-value constructs (links, code spans, code blocks, HTML tags).
-  `pulldown_cmark` is overkill for one Dylint pass and would balloon
-  the binary; the four constructs are individually trivial to detect
-  by character.
-- **Parser style.** Implement the markdown scanner as parser-
-  combinator-style `take_*` functions per
-  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md):
-  `take_code_span`, `take_code_block`, `take_link`,
-  `take_reference_definition`, `take_html_tag`, and `take_heading`,
-  one per banned construct. Each combinator returns the matched
-  substring and remaining input, so the dispatcher can branch on
-  whether the construct is in `forbid` and emit the right
-  per-construct diagnostic. Share the markdown helpers with
-  [`intra-doc-links`](./intra-doc-links.md),
-  [`unicode-ellipsis-in-docs`](./unicode-ellipsis-in-docs.md), and
-  [`em-dash-prose`](./em-dash-prose.md).
+  [`unicode-ellipsis-in-docs`](./unicode-ellipsis-in-docs.md).
+  Factor it into a crate-internal helper.
+- Use the shared markdown scanner (Tier A — structural
+  classification) per
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md#markdown-parsing).
+  Each banned construct in `forbid` maps to one `take_*` result;
+  the dispatcher branches on the match and emits the right
+  per-construct diagnostic. This rule is the most demanding
+  consumer of the scanner — if its HTML-tag and
+  reference-definition needs come to dominate, the convention's
+  escape hatch (vendor `pulldown_cmark` for this rule alone)
+  applies here.
 - Override detection: walk attribute lists for `clap`, `arg`,
   `command` paths. Recognise `MetaNameValue` shape with the override
   key. `clippy_utils::attrs::find_by_name` is a starting point but

--- a/planned-rules/em-dash-prose.md
+++ b/planned-rules/em-dash-prose.md
@@ -106,14 +106,9 @@ action.
   `ExprKind::Macro` (post-expansion, look for `Span::from_expansion`
   and the macro `DefId`'s diagnostic name).
 - For doc comments, strip code spans and code blocks before scanning.
-- **Parser style.** When the markdown exclusion (code spans and
-  code blocks) is non-trivial, implement it as parser-combinator-
-  style `take_*` functions per
-  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md).
-  Share the helper with
-  [`intra-doc-links`](./intra-doc-links.md) and
-  [`unicode-ellipsis-in-docs`](./unicode-ellipsis-in-docs.md) so
-  the three rules agree on what counts as a code region.
+- Use the shared markdown scanner (Tier B — code-region mask) per
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md#markdown-parsing)
+  for the code-span / code-block exclusion.
 - **No autofix is offered, ever.** The lint is deliberately
   fix-resistant: a tool-generated `—` → `,` substitution would mask
   the symptom while leaving the underlying loose phrasing in place,

--- a/planned-rules/intra-doc-links.md
+++ b/planned-rules/intra-doc-links.md
@@ -51,16 +51,15 @@ pub fn install(manifest: &PackageManifest, store: &Store) { /* ... */ }
   rustc's resolver in late-pass for the symbol in the current
   `ParentScope`.
 - The autofix wraps the existing backticked span with `[` / `]`.
-- **Parser style.** Implement the markdown scanner as parser-
-  combinator-style `take_*` functions per
-  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md):
-  `take_code_span` (between matching `` ` `` runs),
-  `take_code_block` (between matching ``` ``` ``` ``` fences or a
-  four-space-indent block), `take_link_target`
-  (`` [`Foo`] ``, `[Foo]`, `[Foo](path)`, `[Foo][id]`), and
-  `take_backticked_ident` for the candidate-extraction step. The
-  combinators stitch into one walk that classifies each span as
-  excluded, already-linked, or candidate.
+- Use the shared markdown scanner (Tier A — structural
+  classification) per
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md#markdown-parsing).
+  `take_code_span` excludes code regions; `take_link` excludes
+  already-linked spans. On top of those, add a rule-local
+  `take_backticked_ident` that pulls a Rust identifier out of a
+  code-span body — this is the Rust-aware extraction the convention
+  explicitly leaves to each consumer. The walk classifies each
+  span as excluded, already-linked, or candidate.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
   for cross-cutting conventions that apply to every rule in this

--- a/planned-rules/unicode-ellipsis-in-docs.md
+++ b/planned-rules/unicode-ellipsis-in-docs.md
@@ -57,22 +57,10 @@ Skip:
   `clippy_utils::source::position_before_rarrow`-style helpers, or
   more directly with `attr.value_str().unwrap()`'s span and an offset
   computed from the literal contents.
-- For the code-span / code-block exclusion, use a tiny markdown
-  scanner — track inside-backtick state and inside-fence state. The
-  `pulldown_cmark` crate is a heavyweight dependency for a Dylint
-  pass; a hand-written byte scanner is enough since we only need to
-  recognise the three delimiters `` ` ``, `` ``` ``, and indented
-  `    ` blocks.
-- **Parser style.** Implement the markdown exclusion scanner as
-  parser-combinator-style `take_*` functions per
-  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md):
+- Use the shared markdown scanner (Tier B — code-region mask) per
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md#markdown-parsing).
   `take_code_span` and `take_code_block` consume the excluded
-  regions in one shot, leaving only the prose slice for the
-  codepoint scan. Sharing this with the analogous step in
-  [`intra-doc-links`](./intra-doc-links.md) and
-  [`em-dash-prose`](./em-dash-prose.md) is the natural follow-up;
-  factor the helper crate-internally rather than re-implementing
-  per lint.
+  regions; the codepoint scan runs over the remaining prose slices.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
   for cross-cutting conventions that apply to every rule in this


### PR DESCRIPTION
## Summary

Documents how the catalogue handles markdown parsing — a recurring concern across six planned rules — and trims the per-rule prose that previously restated the same decision in each file.

## Changes

- **New `## Markdown parsing` section in `planned-rules/IMPLEMENTATION_CONVENTIONS.md`** (placed between "Parser style" and "Lint name namespacing"). Covers:
  - The six rules that scan markdown (`intra-doc-links`, `clap-help-no-markdown`, `bare-issue-reference`, `bare-url`, `unicode-ellipsis-in-docs`, `em-dash-prose`).
  - One shared crate-internal scanner: `src/markdown.rs`.
  - Tier-A (structural classification) vs Tier-B (code-region mask) consumer split.
  - Combinator surface: `take_code_span`, `take_code_block`, `take_link`, `take_autolink`, `take_reference_definition`, `take_html_tag`, `take_heading`.
  - Why hand-rolled rather than `pulldown_cmark` / `comrak` / `markdown-rs` / `markdown-it` (Dylint pass weight; the grammar these rules need is small and fixed).
  - Rustdoc-flavour caveat: intra-doc-link *resolution* is downstream of the markdown parse and stays custom regardless of library choice.
  - Per-rule escape hatch if `clap_help_no_markdown`'s HTML-tag and reference-definition needs come to dominate.

- **Trimmed duplicate prose in six rule files.** Each now back-references the convention via an anchor link instead of restating the combinator inventory or library-rejection rationale. Rule-specific combinators stay (`take_backticked_ident` in `intra-doc-links`, `take_scheme`/etc. in `bare-url`, `take_token_prefix`/`take_digits` in `bare-issue-reference`).

## Why the convention lives in `IMPLEMENTATION_CONVENTIONS.md`

`CLAUDE.md` is workflow guidance (process, not design). `README.md` is an index of one-line rule summaries. A new `SHARED_HELPERS.md` would be cleaner in principle but is speculative scaffolding for one populated section — the split is cheap to do later if a second helper writeup needs it. The conventions doc already names "a markdown span" as an example in "Parser style" and rejects regex/aho-corasick on the same Dylint-weight grounds, so the new section extends an existing argument rather than introducing a new file's worth of context.

## Test plan

- [ ] Read the new section end-to-end and confirm it matches the design.
- [ ] Spot-check the trimmed rule files; confirm anchor links resolve.
- [ ] Confirm no rule file lost rule-specific content (only shared/duplicated prose was removed).