### PR TITLE
docs(planned-rules): `macro_trailing_comma`

### DIFF
--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -156,13 +156,15 @@ pattern that several rules call out by reference — live in
 ### Macros
 - [`macro-trailing-comma.md`](./macro-trailing-comma.md) — apply
   rustfmt's `trailing_comma = "Vertical"` policy (trailing comma
-  on multi-line argument lists, none on single-line) to macro
-  invocations, which rustfmt itself leaves untouched. Two
-  eligibility modes: **name-based**, a curated list of
-  core/std and well-known third-party macros (easy, configurable
-  via `extra_name_based`), and **matcher-based**, an automatic
-  walk of `macro_rules!` matchers to detect the `$(,)?`
-  optional-trailing-comma idiom (harder, configurable via
+  on multi-line argument lists, none on single-line) to
+  function-like macro invocations (`ast::MacCall`), which
+  rustfmt itself leaves untouched. Attribute-style invocations
+  like `#[derive(...)]` are out of scope. Two eligibility modes:
+  **name-based**, a curated list of core/std and well-known
+  third-party macros (easy, configurable via
+  `extra_name_based`), and **matcher-based**, an automatic walk
+  of `macro_rules!` matchers to detect the `$(,)?` optional-
+  trailing-comma idiom (harder, configurable via
   `matcher_based`).
 
 ### Serde

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -158,7 +158,7 @@ pattern that several rules call out by reference — live in
   rustfmt's `trailing_comma = "Vertical"` policy (trailing comma
   on multi-line argument lists, none on single-line) to macro
   invocations, which rustfmt itself leaves untouched. Two
-  eligibility modes: **name-based**, a curated allow-list of
+  eligibility modes: **name-based**, a curated list of
   core/std and well-known third-party macros (easy, configurable
   via `extra_name_based`), and **matcher-based**, an automatic
   walk of `macro_rules!` matchers to detect the `$(,)?`

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -153,6 +153,17 @@ pattern that several rules call out by reference — live in
   is consumed by a derive macro so multi-attribute splitting
   isn't viable; only line-continuation rewriting.
 
+### Macros
+- [`macro-trailing-comma.md`](./macro-trailing-comma.md) — apply
+  rustfmt's `trailing_comma = "Vertical"` policy (trailing comma
+  on multi-line argument lists, none on single-line) to macro
+  invocations, which rustfmt itself leaves untouched. Two tiers
+  decide eligibility: a curated allow-list of core/std and
+  well-known third-party macros (Tier 1, easy, configurable via
+  `extra_tier_1`), and an automatic walk of `macro_rules!`
+  matchers to detect the `$(,)?` optional-trailing-comma idiom
+  (Tier 2, harder, configurable via `tier_2`).
+
 ### Serde
 - [`serde-source-types.md`](./serde-source-types.md) — forbid
   `#[serde(from = "&'de str")]` / `try_from = "&'de str"`; advise

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -163,8 +163,8 @@ pattern that several rules call out by reference — live in
   **name-based**, a curated list of core/std and well-known
   third-party macros (easy, configurable via
   `extra_name_based`), and **matcher-based**, an automatic walk
-  of `macro_rules!` matchers to detect the `$(,)?`
-  optional-trailing-comma idiom (harder, configurable via
+  of `macro_rules!` matchers to detect the `$(,)?` / `$(,)*`
+  optional-trailing-comma idioms (harder, configurable via
   `matcher_based`).
 
 ### Serde

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -163,8 +163,8 @@ pattern that several rules call out by reference — live in
   **name-based**, a curated list of core/std and well-known
   third-party macros (easy, configurable via
   `extra_name_based`), and **matcher-based**, an automatic walk
-  of `macro_rules!` matchers to detect the `$(,)?` optional-
-  trailing-comma idiom (harder, configurable via
+  of `macro_rules!` matchers to detect the `$(,)?`
+  optional-trailing-comma idiom (harder, configurable via
   `matcher_based`).
 
 ### Serde

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -157,12 +157,13 @@ pattern that several rules call out by reference — live in
 - [`macro-trailing-comma.md`](./macro-trailing-comma.md) — apply
   rustfmt's `trailing_comma = "Vertical"` policy (trailing comma
   on multi-line argument lists, none on single-line) to macro
-  invocations, which rustfmt itself leaves untouched. Two tiers
-  decide eligibility: a curated allow-list of core/std and
-  well-known third-party macros (Tier 1, easy, configurable via
-  `extra_tier_1`), and an automatic walk of `macro_rules!`
-  matchers to detect the `$(,)?` optional-trailing-comma idiom
-  (Tier 2, harder, configurable via `tier_2`).
+  invocations, which rustfmt itself leaves untouched. Two
+  eligibility modes: **name-based**, a curated allow-list of
+  core/std and well-known third-party macros (easy, configurable
+  via `extra_name_based`), and **matcher-based**, an automatic
+  walk of `macro_rules!` matchers to detect the `$(,)?`
+  optional-trailing-comma idiom (harder, configurable via
+  `matcher_based`).
 
 ### Serde
 - [`serde-source-types.md`](./serde-source-types.md) — forbid

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -160,8 +160,9 @@ Matcher-based matching has to:
    the exact call path. Some matchers are not re-exported
    across crate boundaries — those cases must degrade gracefully
    (treat as ineligible, do not warn).
-2. Walk every arm's matcher token tree, locating the trailing
-   `$(,)?` (or equivalent) per the predicate above.
+2. Walk every arm's matcher token tree, locating an optional
+   trailing comma at the tail of the top-level matcher —
+   `$(,)?` or `$(,)*` per the predicate above.
 3. Decide which arm matches the invocation — or refuse to
    touch the invocation if not every arm is the optional-comma
    kind, to stay safe in the face of ambiguity.

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -35,7 +35,7 @@ trailing comma, forbid one, or accept either; a procedural
 macro's grammar is opaque. Two complementary mechanisms decide
 eligibility, named for *how* they identify an eligible macro.
 
-### Name-based — well-known macro allow-list
+### Name-based — curated macro list
 
 A hard-coded list of macros known to accept the trailing comma
 optionally. **Inclusion criterion:** the macro's matcher accepts
@@ -209,7 +209,7 @@ For every macro invocation:
    - Otherwise, no diagnostic.
 
 The autofix is `Applicability::MachineApplicable` for name-based
-matches (curated allow-list — the human vetted that the comma is
+matches (curated list — the human vetted that the comma is
 optional) and for matcher-based matches where every arm of the
 macro accepts both forms. Matcher-based cases that picked one
 matching arm out of several are `Applicability::MaybeIncorrect`
@@ -361,7 +361,7 @@ my_proc::custom!(
 enabled = true
 
 # Enable the matcher-based declarative-macro auto-detection.
-# Defaults on. Disable to fall back to a pure allow-list policy
+# Defaults on. Disable to fall back to a pure name-based policy
 # if matcher-based detection proves too noisy on a particular
 # codebase.
 matcher_based = true
@@ -406,7 +406,7 @@ ignore = [
   whether the closing delimiter is preceded by a comma.
 - Macro path resolution: `MacCall::path` resolves to a `Res`
   via the resolver. From the resolved `DefId`, look the path
-  up in the name-based allow-list (built-in plus
+  up in the name-based list (built-in plus
   `extra_name_based`). For matcher-based detection, fetch the
   matcher arms from the resolved macro definition.
 - Token-tree inspection: `MacCall::args` carries a

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -183,7 +183,8 @@ For every macro invocation:
      user-configured via `extra_name_based`), eligible.
    - Otherwise, if matcher-based detection is enabled and the
      macro is a visible declarative macro whose matched arm
-     ends in `$(,)?` (per the predicate above), eligible.
+     ends in `$(,)?` or `$(,)*` (per the predicate above),
+     eligible.
    - Otherwise, skip.
 4. Inspect the *invocation token stream* — not the expansion —
    to confirm the call is shaped like a top-level
@@ -423,8 +424,13 @@ ignore = [
   available on the `DelimArgs` directly.
 - Matcher walk: `macro_rules!` arms are
   `ast::MacroDef::body`'s LHS token streams. Walk the LHS,
-  detect the `$(,)?` pattern at the end of the top-level
-  matcher (`OpenDelim(Paren) ... $(,)? CloseDelim(Paren)`).
+  detect either of the optional-trailing-comma patterns
+  (`$(,)?` or `$(,)*`) at the end of the top-level matcher —
+  i.e., `OpenDelim(Paren) ... $(,)? CloseDelim(Paren)` or
+  `OpenDelim(Paren) ... $(,)* CloseDelim(Paren)`. `$(,)+` and
+  a bare literal `,` at the same position are *required*, not
+  optional, and the walker must distinguish them (see the
+  `take_optional_trailing_comma` note below).
   For dependency macros, the matcher comes from
   `tcx.hir_node_by_def_id(...)` if local, or via the macro
   metadata in `tcx.cstore_untracked()` for external macros;

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -27,15 +27,15 @@ comma-separated:
 "Eligible" means the trailing comma is provably optional — see
 the next section.
 
-## Two tiers of eligibility
+## Two eligibility modes
 
 The hard part is deciding when adding or removing the trailing
 comma is safe. A declarative macro's matchers can require a
 trailing comma, forbid one, or accept either; a procedural
 macro's grammar is opaque. Two complementary mechanisms decide
-eligibility:
+eligibility, named for *how* they identify an eligible macro.
 
-### Tier 1 — well-known macro allow-list
+### Name-based — well-known macro allow-list
 
 A hard-coded list of macros known to accept the trailing comma
 optionally. The list covers two groups:
@@ -63,12 +63,12 @@ optionally. The list covers two groups:
   The list is curated, not exhaustive — projects extend it via
   configuration when they import a new such macro.
 
-Tier 1 applies to *any* macro form: declarative, procedural
-function-like, attribute-style derives that take a comma-
-separated argument list. The matcher source is irrelevant
+Name-based matching applies to *any* macro form: declarative,
+procedural function-like, attribute-style derives that take a
+comma-separated argument list. The matcher source is irrelevant
 because the human author has vetted the entry.
 
-### Tier 2 — declarative-macro auto-detection
+### Matcher-based — declarative-macro auto-detection
 
 For a `macro_rules!` macro whose definition is visible to the
 compiler (the local crate, or a dependency whose macro body
@@ -92,34 +92,36 @@ For a given invocation, the lint determines which arm matches
 accept both forms) and proceeds only if the matched arm is the
 optional-comma kind.
 
-Tier 2 does not extend to procedural macros: the matcher is
-custom Rust code, not introspectable as a token pattern.
+Matcher-based matching does not extend to procedural macros:
+the matcher is custom Rust code, not introspectable as a token
+pattern.
 
-### Why Tier 2 is harder than Tier 1
+### Why matcher-based is harder than name-based
 
-Tier 1 is a name-set lookup on the resolved macro `DefId`. The
-implementation is a `BTreeSet<&'static str>` initialised at
-plugin start, plus the user's `extra_tier_1` paths.
+Name-based matching is a name-set lookup on the resolved macro
+`DefId`. The implementation is a `BTreeSet<&'static str>`
+initialised at plugin start, plus the user's `extra_name_based`
+paths.
 
-Tier 2 has to:
+Matcher-based matching has to:
 
 1. Reach the `macro_rules!` matcher AST from the invocation's
    `DefId`. For local macros this is `tcx.hir().get_by_def_id`;
    for dependency macros the matcher is reachable via
    `tcx.crate_def_map(cnum)` and the macro's expansion data,
    which lives in the crate metadata. Some matchers are not
-   re-exported across crate boundaries — those Tier-2 cases
-   must degrade gracefully (treat as ineligible, do not warn).
+   re-exported across crate boundaries — those cases must
+   degrade gracefully (treat as ineligible, do not warn).
 2. Walk every arm's matcher token tree, locating the trailing
    `$(,)?` (or equivalent) per the predicate above.
 3. Decide which arm matches the invocation — or refuse to
    touch the invocation if not every arm is the optional-comma
    kind, to stay safe in the face of ambiguity.
 
-Tier 1 is a single afternoon. Tier 2 is a few days plus the
-matcher-walking infrastructure, plus careful handling of the
-multi-arm and cross-crate cases. The user's intuition is
-correct: implement Tier 1 first; ship Tier 2 in a follow-up.
+Name-based is a single afternoon. Matcher-based is a few days
+plus the matcher-walking infrastructure, plus careful handling
+of the multi-arm and cross-crate cases. Implement name-based
+first; ship matcher-based in a follow-up.
 
 ## What to lint
 
@@ -127,11 +129,11 @@ For every macro invocation:
 
 1. Resolve the macro `DefId`.
 2. Decide eligibility:
-   - If the path matches a Tier-1 entry (built-in or
+   - If the path matches a name-based entry (built-in or
      user-configured), eligible.
-   - Otherwise, if Tier 2 is enabled and the macro is a
-     visible declarative macro whose matched arm ends in
-     `$(,)?` (per the predicate above), eligible.
+   - Otherwise, if matcher-based detection is enabled and the
+     macro is a visible declarative macro whose matched arm
+     ends in `$(,)?` (per the predicate above), eligible.
    - Otherwise, skip.
 3. Inspect the *invocation token stream* — not the expansion —
    to confirm that the top-level argument list is purely comma-
@@ -152,17 +154,17 @@ For every macro invocation:
      diagnostic suggesting removal of the `,`.
    - Otherwise, no diagnostic.
 
-The autofix is `Applicability::MachineApplicable` for Tier 1
-(curated allow-list — the human vetted that the comma is
-optional) and for Tier 2 cases where every arm of the macro
-accepts both forms. Tier 2 cases that picked one matching arm
-out of several are `Applicability::MaybeIncorrect` — the
-matched-arm analysis is conservative but a future macro
+The autofix is `Applicability::MachineApplicable` for name-based
+matches (curated allow-list — the human vetted that the comma is
+optional) and for matcher-based matches where every arm of the
+macro accepts both forms. Matcher-based cases that picked one
+matching arm out of several are `Applicability::MaybeIncorrect`
+— the matched-arm analysis is conservative but a future macro
 revision could shift which arm matches.
 
 ## Examples
 
-### Tier 1: `vec!`
+### Name-based: `vec!`
 
 ```rust
 // Bad: multi-line, missing trailing comma
@@ -188,7 +190,7 @@ let xs = vec![1, 2, 3,];
 let xs = vec![1, 2, 3];
 ```
 
-### Tier 1: `assert_eq!`
+### Name-based: `assert_eq!`
 
 ```rust
 // Bad: multi-line panic message
@@ -206,7 +208,7 @@ assert_eq!(
 );
 ```
 
-### Tier 2: locally-defined `macro_rules!`
+### Matcher-based: locally-defined `macro_rules!`
 
 ```rust
 macro_rules! comma_list {
@@ -261,7 +263,7 @@ always_comma!(
 
 ```rust
 // Skipped: `my_proc::custom!` is a procedural macro and is
-// not in the user's `extra_tier_1` list. The lint cannot
+// not in the user's `extra_name_based` list. The lint cannot
 // inspect a proc-macro grammar.
 my_proc::custom!(
     a,
@@ -277,33 +279,35 @@ my_proc::custom!(
 # Set to false to disable the rule entirely.
 enabled = true
 
-# Enable the Tier 2 declarative-macro auto-detection. Defaults
-# on. Disable to fall back to a pure allow-list policy if Tier 2
-# proves too noisy on a particular codebase.
-tier_2 = true
+# Enable the matcher-based declarative-macro auto-detection.
+# Defaults on. Disable to fall back to a pure allow-list policy
+# if matcher-based detection proves too noisy on a particular
+# codebase.
+matcher_based = true
 
-# Additional macros to treat as Tier 1, beyond the built-in
-# core/std and well-known third-party set. Each entry is a
-# fully-qualified macro path (no trailing `!`) or a bare macro
-# name to match by final segment only.
+# Additional macros to treat as name-based matches, beyond the
+# built-in core/std and well-known third-party set. Each entry
+# is a fully-qualified macro path (no trailing `!`) or a bare
+# macro name to match by final segment only.
 #
 # Use this knob when:
 # - A project depends on a third-party macro the built-in list
 #   does not cover.
-# - Tier 2 cannot see the macro definition (cross-crate proc
-#   macro, or macro_rules! re-exported in a way that loses the
-#   matcher).
+# - Matcher-based detection cannot see the macro definition
+#   (cross-crate proc macro, or macro_rules! re-exported in a
+#   way that loses the matcher).
 # - The macro is a procedural one whose author guarantees the
 #   trailing comma is optional.
-extra_tier_1 = [
+extra_name_based = [
   # "my_crate::my_macro",
   # "another_macro",
 ]
 
-# Macros to never lint, even if they match Tier 1 or Tier 2.
-# Use this for macros where the project's own convention
-# diverges (for example, macros whose body is more readable with
-# the comma always present even on a single line).
+# Macros to never lint, even when name-based or matcher-based
+# detection would otherwise mark them eligible. Use this for
+# macros where the project's own convention diverges (for
+# example, macros whose body is more readable with the comma
+# always present even on a single line).
 deny_list = [
   # "my_crate::ascii_table",
 ]
@@ -318,9 +322,9 @@ deny_list = [
   whether the closing delimiter is preceded by a comma.
 - Macro path resolution: `MacCall::path` resolves to a `Res`
   via the resolver. From the resolved `DefId`, look the path
-  up in the Tier-1 allow-list (built-in plus
-  `extra_tier_1`). For Tier 2, fetch the matcher arms from
-  the resolved macro definition.
+  up in the name-based allow-list (built-in plus
+  `extra_name_based`). For matcher-based detection, fetch the
+  matcher arms from the resolved macro definition.
 - Token-tree inspection: `MacCall::args` carries a
   `DelimArgs` whose `tokens: TokenStream` is the raw user
   input. Walk the top-level token stream, tracking nesting
@@ -330,7 +334,7 @@ deny_list = [
   `Span::lo()`/`Span::hi()` line numbers via the
   `SourceMap`. The opening and closing delimiter spans are
   available on the `DelimArgs` directly.
-- Tier 2 matcher walk: `macro_rules!` arms are
+- Matcher walk: `macro_rules!` arms are
   `ast::MacroDef::body`'s LHS token streams. Walk the LHS,
   detect the `$(,)?` pattern at the end of the top-level
   matcher (`OpenDelim(Paren) ... $(,)? CloseDelim(Paren)`).
@@ -338,9 +342,9 @@ deny_list = [
   `tcx.hir_node_by_def_id(...)` if local, or via the macro
   metadata in `tcx.cstore_untracked()` for external macros;
   unavailable matchers degrade to "ineligible".
-- **Parser style.** The matcher walker for Tier 2 is a
-  parser-combinator-style `take_*` chain over the matcher
-  token stream per
+- **Parser style.** The matcher walker is a parser-
+  combinator-style `take_*` chain over the matcher token
+  stream per
   [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md):
   one combinator per matcher position kind (literal token,
   `$name:frag` capture, `$( ... )sep rep` repetition), with
@@ -349,21 +353,21 @@ deny_list = [
 
 ### Difficulty
 
-**Tier 1: easy.** A name-set lookup keyed off a resolved
+**Name-based: easy.** A name-set lookup keyed off a resolved
 `DefId`, plus a token-stream scan for the trailing comma,
 plus a span-based "is this multi-line" predicate. The
 autofix is a one-character insertion or removal at a known
 position — `MachineApplicable`.
 
-**Tier 2: hard.** The matcher walker has to handle every
-matcher repetition shape, the multi-arm case (which arm
-matched? do all arms agree on the optional comma?), and the
-cross-crate "matcher not available" degradation. None of
+**Matcher-based: hard.** The matcher walker has to handle
+every matcher repetition shape, the multi-arm case (which
+arm matched? do all arms agree on the optional comma?), and
+the cross-crate "matcher not available" degradation. None of
 this is conceptually deep; the work is in covering the
 matcher grammar carefully and refusing to act when
-ambiguous. Recommend landing Tier 1 first as a standalone
-PR, then layering Tier 2 on top behind the `tier_2`
-configuration knob.
+ambiguous. Recommend landing name-based first as a
+standalone PR, then layering matcher-based on top behind the
+`matcher_based` configuration knob.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
   for cross-cutting conventions that apply to every rule in

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -98,7 +98,7 @@ function calls and struct literals. Macros that treat commas as
 followed by a comma independently — must not be added. Forcing a
 trailing comma on the last entry would clash with the no-comma
 style users of those macros often choose. If such a macro slips
-into the list, move it to `deny_list` to opt it out.
+into the list, add it to `ignore` to opt it out.
 
 ### Matcher-based — declarative-macro auto-detection
 
@@ -172,9 +172,9 @@ first; ship matcher-based in a follow-up.
 For every macro invocation:
 
 1. Resolve the macro `DefId`.
-2. If the resolved path matches an entry in `deny_list`,
-   skip. `deny_list` is checked first so a user opt-out wins
-   over both name-based and matcher-based eligibility.
+2. If the resolved path matches an entry in `ignore`, skip.
+   `ignore` is checked first so a user opt-out wins over both
+   name-based and matcher-based eligibility.
 3. Decide eligibility:
    - If the path matches a name-based entry (built-in or
      user-configured via `extra_name_based`), eligible.
@@ -384,12 +384,15 @@ extra_name_based = [
   # "another_macro",
 ]
 
-# Macros to never lint, even when name-based or matcher-based
-# detection would otherwise mark them eligible. Use this for
-# macros where the project's own convention diverges (for
-# example, macros whose body is more readable with the comma
-# always present even on a single line).
-deny_list = [
+# Macros for the lint to ignore, even when name-based or
+# matcher-based detection would otherwise mark them eligible.
+# Use this for macros where the project's own convention
+# diverges (for example, macros whose body is more readable
+# with the comma always present even on a single line). The
+# name is `ignore` rather than `deny_list` because the lint
+# never forbids the macro itself — it only declines to act on
+# the invocation's trailing comma.
+ignore = [
   # "my_crate::ascii_table",
 ]
 ```

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -1,0 +1,389 @@
+# `macro_trailing_comma`
+
+**Source:** project convention. Fills a gap that
+`rustfmt`'s `trailing_comma = "Vertical"` (the default) leaves
+open: rustfmt rewrites function-call and struct-literal argument
+lists — adding a trailing comma when the list is broken across
+multiple source lines, removing one when it collapses onto a
+single line — but it does not touch macro invocations. The
+conservative default exists because a macro's matcher can make
+the trailing comma load-bearing, and rustfmt has no way to know.
+
+This lint reinstates the same comma policy for macro invocations
+where the trailing comma is *known* to be syntactically optional.
+
+## Statement
+
+For an eligible macro invocation whose top-level arguments are
+comma-separated:
+
+- **Multi-line invocation** (the opening and closing delimiters
+  are on different source lines): the last argument must be
+  followed by a trailing comma.
+- **Single-line invocation** (delimiters on the same source
+  line): the last argument must *not* be followed by a trailing
+  comma.
+
+"Eligible" means the trailing comma is provably optional — see
+the next section.
+
+## Two tiers of eligibility
+
+The hard part is deciding when adding or removing the trailing
+comma is safe. A declarative macro's matchers can require a
+trailing comma, forbid one, or accept either; a procedural
+macro's grammar is opaque. Two complementary mechanisms decide
+eligibility:
+
+### Tier 1 — well-known macro allow-list
+
+A hard-coded list of macros known to accept the trailing comma
+optionally. The list covers two groups:
+
+- **`core` / `std` macros** that take comma-separated arguments:
+  `vec!`, `format!`, `format_args!`, `print!`, `println!`,
+  `eprint!`, `eprintln!`, `write!`, `writeln!`, `panic!`,
+  `unimplemented!`, `todo!`, `unreachable!`, `assert!`,
+  `assert_eq!`, `assert_ne!`, `debug_assert!`,
+  `debug_assert_eq!`, `debug_assert_ne!`, `matches!`,
+  `dbg!`, `concat!`, `env!`, `option_env!`, `stringify!`,
+  `cfg!`, `compile_error!`, `include!`, `include_str!`,
+  `include_bytes!`, `thread_local!`.
+- **Well-known third-party macros** with the same convention:
+  `pretty_assertions::{assert_eq, assert_ne, assert_str_eq}`,
+  `maplit::{hashmap, btreemap, hashset, btreeset, convert_args}`,
+  `serde_json::json`, `lazy_static::lazy_static`,
+  `paste::paste`, `derive_more`-style derivable attributes
+  whose argument list is comma-separated, `log::{log, error,
+  warn, info, debug, trace}`, `tracing::{event, error, warn,
+  info, debug, trace, span}`, `clap::{arg, command}`,
+  `anyhow::{anyhow, bail, ensure}`, `thiserror`-style attribute
+  argument lists.
+
+  The list is curated, not exhaustive — projects extend it via
+  configuration when they import a new such macro.
+
+Tier 1 applies to *any* macro form: declarative, procedural
+function-like, attribute-style derives that take a comma-
+separated argument list. The matcher source is irrelevant
+because the human author has vetted the entry.
+
+### Tier 2 — declarative-macro auto-detection
+
+For a `macro_rules!` macro whose definition is visible to the
+compiler (the local crate, or a dependency whose macro body
+rustc still has on hand), inspect the matcher arms:
+
+- A macro arm whose final matcher position is `$(,)?` — or
+  equivalently `$(,)*` / `$(,)+` used purely to absorb a
+  trailing comma — can match the invocation with or without the
+  comma. The optional-comma capture cannot be expanded into the
+  body (a literal token in a matcher position cannot be
+  referenced by `$name` in the expansion), so the trailing
+  comma is purely syntactic. The lint may rewrite freely.
+- An arm that ends in a literal `,` (no `?` / `*` / `+`)
+  *requires* the trailing comma; the lint must not remove it.
+- An arm whose final position is something else (a non-comma
+  token, or a `$name:tt` capture) doesn't carry a trailing
+  comma at all and is out of scope.
+
+For a given invocation, the lint determines which arm matches
+(or, conservatively, requires that *every* arm of the macro
+accept both forms) and proceeds only if the matched arm is the
+optional-comma kind.
+
+Tier 2 does not extend to procedural macros: the matcher is
+custom Rust code, not introspectable as a token pattern.
+
+### Why Tier 2 is harder than Tier 1
+
+Tier 1 is a name-set lookup on the resolved macro `DefId`. The
+implementation is a `BTreeSet<&'static str>` initialised at
+plugin start, plus the user's `extra_tier_1` paths.
+
+Tier 2 has to:
+
+1. Reach the `macro_rules!` matcher AST from the invocation's
+   `DefId`. For local macros this is `tcx.hir().get_by_def_id`;
+   for dependency macros the matcher is reachable via
+   `tcx.crate_def_map(cnum)` and the macro's expansion data,
+   which lives in the crate metadata. Some matchers are not
+   re-exported across crate boundaries — those Tier-2 cases
+   must degrade gracefully (treat as ineligible, do not warn).
+2. Walk every arm's matcher token tree, locating the trailing
+   `$(,)?` (or equivalent) per the predicate above.
+3. Decide which arm matches the invocation — or refuse to
+   touch the invocation if not every arm is the optional-comma
+   kind, to stay safe in the face of ambiguity.
+
+Tier 1 is a single afternoon. Tier 2 is a few days plus the
+matcher-walking infrastructure, plus careful handling of the
+multi-arm and cross-crate cases. The user's intuition is
+correct: implement Tier 1 first; ship Tier 2 in a follow-up.
+
+## What to lint
+
+For every macro invocation:
+
+1. Resolve the macro `DefId`.
+2. Decide eligibility:
+   - If the path matches a Tier-1 entry (built-in or
+     user-configured), eligible.
+   - Otherwise, if Tier 2 is enabled and the macro is a
+     visible declarative macro whose matched arm ends in
+     `$(,)?` (per the predicate above), eligible.
+   - Otherwise, skip.
+3. Inspect the *invocation token stream* — not the expansion —
+   to confirm that the top-level argument list is purely comma-
+   separated. Skip if:
+   - The delimiter is opened but the body contains a top-level
+     `;` (e.g., `vec![value; count]`), `=>` (token-tree macros
+     like `quote!` arms), or any other top-level separator that
+     isn't a comma.
+   - There are zero arguments (no comma to add or remove).
+4. Determine "single-line" vs "multi-line" by the source
+   positions of the opening and closing delimiters. If they
+   share a line, single-line; otherwise multi-line.
+5. Locate the final top-level token before the closing
+   delimiter:
+   - **Multi-line, no trailing comma** → emit a diagnostic
+     suggesting an inserted `,`.
+   - **Single-line, trailing comma present** → emit a
+     diagnostic suggesting removal of the `,`.
+   - Otherwise, no diagnostic.
+
+The autofix is `Applicability::MachineApplicable` for Tier 1
+(curated allow-list — the human vetted that the comma is
+optional) and for Tier 2 cases where every arm of the macro
+accepts both forms. Tier 2 cases that picked one matching arm
+out of several are `Applicability::MaybeIncorrect` — the
+matched-arm analysis is conservative but a future macro
+revision could shift which arm matches.
+
+## Examples
+
+### Tier 1: `vec!`
+
+```rust
+// Bad: multi-line, missing trailing comma
+let xs = vec![
+    1,
+    2,
+    3
+];
+
+// Good
+let xs = vec![
+    1,
+    2,
+    3,
+];
+```
+
+```rust
+// Bad: single-line, gratuitous trailing comma
+let xs = vec![1, 2, 3,];
+
+// Good
+let xs = vec![1, 2, 3];
+```
+
+### Tier 1: `assert_eq!`
+
+```rust
+// Bad: multi-line panic message
+assert_eq!(
+    actual,
+    expected,
+    "decoder mismatch: stream {stream_id} chunk {chunk_id}"
+);
+
+// Good
+assert_eq!(
+    actual,
+    expected,
+    "decoder mismatch: stream {stream_id} chunk {chunk_id}",
+);
+```
+
+### Tier 2: locally-defined `macro_rules!`
+
+```rust
+macro_rules! comma_list {
+    ($($item:expr),* $(,)?) => { /* ... */ };
+}
+
+// Bad: multi-line, missing trailing comma
+comma_list!(
+    a,
+    b,
+    c
+);
+
+// Good
+comma_list!(
+    a,
+    b,
+    c,
+);
+```
+
+### Skipped: non-comma top-level separator
+
+```rust
+// Skipped: vec![value; count] uses `;`, not a list separator
+let zeros = vec![0; 10];
+
+// Skipped: quote! arm uses `=>` and arbitrary tokens
+quote! {
+    fn foo() -> i32 { 42 }
+};
+```
+
+### Skipped: macro requires the trailing comma
+
+```rust
+macro_rules! always_comma {
+    ($($item:expr,)*) => { /* ... */ };
+}
+
+// Skipped: removing the trailing comma here would fail to
+// match. The matcher is `$($item:expr,)*` — every item must
+// be followed by a literal comma, including the last.
+always_comma!(
+    a,
+    b,
+    c,
+);
+```
+
+### Skipped: unknown procedural macro
+
+```rust
+// Skipped: `my_proc::custom!` is a procedural macro and is
+// not in the user's `extra_tier_1` list. The lint cannot
+// inspect a proc-macro grammar.
+my_proc::custom!(
+    a,
+    b,
+    c
+);
+```
+
+## Configuration
+
+```toml
+[macro_trailing_comma]
+# Set to false to disable the rule entirely.
+enabled = true
+
+# Enable the Tier 2 declarative-macro auto-detection. Defaults
+# on. Disable to fall back to a pure allow-list policy if Tier 2
+# proves too noisy on a particular codebase.
+tier_2 = true
+
+# Additional macros to treat as Tier 1, beyond the built-in
+# core/std and well-known third-party set. Each entry is a
+# fully-qualified macro path (no trailing `!`) or a bare macro
+# name to match by final segment only.
+#
+# Use this knob when:
+# - A project depends on a third-party macro the built-in list
+#   does not cover.
+# - Tier 2 cannot see the macro definition (cross-crate proc
+#   macro, or macro_rules! re-exported in a way that loses the
+#   matcher).
+# - The macro is a procedural one whose author guarantees the
+#   trailing comma is optional.
+extra_tier_1 = [
+  # "my_crate::my_macro",
+  # "another_macro",
+]
+
+# Macros to never lint, even if they match Tier 1 or Tier 2.
+# Use this for macros where the project's own convention
+# diverges (for example, macros whose body is more readable with
+# the comma always present even on a single line).
+deny_list = [
+  # "my_crate::ascii_table",
+]
+```
+
+## Implementation notes
+
+- `EarlyLintPass::check_mac` over `ast::MacCall`. The early
+  pass runs before macro expansion so the invocation's raw
+  token stream is still on the AST node — the lint needs the
+  source token tree, not the expansion result, to decide
+  whether the closing delimiter is preceded by a comma.
+- Macro path resolution: `MacCall::path` resolves to a `Res`
+  via the resolver. From the resolved `DefId`, look the path
+  up in the Tier-1 allow-list (built-in plus
+  `extra_tier_1`). For Tier 2, fetch the matcher arms from
+  the resolved macro definition.
+- Token-tree inspection: `MacCall::args` carries a
+  `DelimArgs` whose `tokens: TokenStream` is the raw user
+  input. Walk the top-level token stream, tracking nesting
+  by `Delimiter` so commas inside nested groups are not
+  mistaken for top-level separators.
+- Single-line vs multi-line: compare
+  `Span::lo()`/`Span::hi()` line numbers via the
+  `SourceMap`. The opening and closing delimiter spans are
+  available on the `DelimArgs` directly.
+- Tier 2 matcher walk: `macro_rules!` arms are
+  `ast::MacroDef::body`'s LHS token streams. Walk the LHS,
+  detect the `$(,)?` pattern at the end of the top-level
+  matcher (`OpenDelim(Paren) ... $(,)? CloseDelim(Paren)`).
+  For dependency macros, the matcher comes from
+  `tcx.hir_node_by_def_id(...)` if local, or via the macro
+  metadata in `tcx.cstore_untracked()` for external macros;
+  unavailable matchers degrade to "ineligible".
+- **Parser style.** The matcher walker for Tier 2 is a
+  parser-combinator-style `take_*` chain over the matcher
+  token stream per
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md):
+  one combinator per matcher position kind (literal token,
+  `$name:frag` capture, `$( ... )sep rep` repetition), with
+  a top-level `take_optional_trailing_comma` that recognises
+  `$(,)?`, `$(,)*`, `$(,)+` at the tail of an arm.
+
+### Difficulty
+
+**Tier 1: easy.** A name-set lookup keyed off a resolved
+`DefId`, plus a token-stream scan for the trailing comma,
+plus a span-based "is this multi-line" predicate. The
+autofix is a one-character insertion or removal at a known
+position — `MachineApplicable`.
+
+**Tier 2: hard.** The matcher walker has to handle every
+matcher repetition shape, the multi-arm case (which arm
+matched? do all arms agree on the optional comma?), and the
+cross-crate "matcher not available" degradation. None of
+this is conceptually deep; the work is in covering the
+matcher grammar carefully and refusing to act when
+ambiguous. Recommend landing Tier 1 first as a standalone
+PR, then layering Tier 2 on top behind the `tier_2`
+configuration knob.
+
+- See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  for cross-cutting conventions that apply to every rule in
+  this catalogue, in particular the lint-name namespacing
+  (`perfectionist::*`) that every registered lint follows.
+
+## Severity
+
+Warn.
+
+## Interaction with sibling rules
+
+- [`format-macro-wrap`](./format-macro-wrap.md) and
+  [`print-macro-split`](./print-macro-split.md) reformat the
+  *template literal* inside `format!` / `println!` / etc.
+  When their `line_continuation` rewrite fires it produces a
+  multi-line invocation; this rule then ensures that
+  invocation carries a trailing comma. The two checks are
+  complementary and converge to the same shape regardless of
+  evaluation order.
+- `rustfmt` itself handles every non-macro argument-list
+  position. There is no overlap; this rule exists precisely
+  because rustfmt opts out of macro bodies.

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -150,12 +150,15 @@ paths.
 Matcher-based matching has to:
 
 1. Reach the `macro_rules!` matcher AST from the invocation's
-   `DefId`. For local macros this is `tcx.hir().get_by_def_id`;
-   for dependency macros the matcher is reachable via
-   `tcx.crate_def_map(cnum)` and the macro's expansion data,
-   which lives in the crate metadata. Some matchers are not
-   re-exported across crate boundaries — those cases must
-   degrade gracefully (treat as ineligible, do not warn).
+   `DefId`. For local macros this is
+   `tcx.hir_node_by_def_id(def_id)`, which returns a
+   `Node<'tcx>` whose `ItemKind::MacroDef` carries the matcher
+   arms. For dependency macros the matcher is reachable via the
+   crate-metadata store (`tcx.cstore_untracked()` plus the
+   macro-data query); see the implementation notes section for
+   the exact call path. Some matchers are not re-exported
+   across crate boundaries — those cases must degrade gracefully
+   (treat as ineligible, do not warn).
 2. Walk every arm's matcher token tree, locating the trailing
    `$(,)?` (or equivalent) per the predicate above.
 3. Decide which arm matches the invocation — or refuse to
@@ -183,17 +186,17 @@ For every macro invocation:
      ends in `$(,)?` (per the predicate above), eligible.
    - Otherwise, skip.
 4. Inspect the *invocation token stream* — not the expansion —
-   to confirm the call is shaped like a top-level comma-
-   separated argument list. Skip if:
+   to confirm the call is shaped like a top-level
+   comma-separated argument list. Skip if:
    - The body contains a top-level `;` (e.g., `vec![value;
      count]`, `thread_local! { static FOO: ...; static BAR:
      ...; }`). A top-level `;` indicates the macro uses `;` as
      its item separator, not commas.
    - The body contains **zero** top-level commas (no list to
-     apply the trailing-comma policy to). This catches token-
-     tree macros like `quote! { fn foo() {} }` whose body has
-     no top-level commas at all, single-argument macros, and
-     empty invocations. `=>` may appear at the top level
+     apply the trailing-comma policy to). This catches
+     token-tree macros like `quote! { fn foo() {} }` whose body
+     has no top-level commas at all, single-argument macros,
+     and empty invocations. `=>` may appear at the top level
      between items — e.g., `hashmap! { "a" => 1, "b" => 2 }`
      legitimately has a top-level `=>` per entry — and is
      fine as long as top-level commas separate the entries.
@@ -426,9 +429,9 @@ ignore = [
   `tcx.hir_node_by_def_id(...)` if local, or via the macro
   metadata in `tcx.cstore_untracked()` for external macros;
   unavailable matchers degrade to "ineligible".
-- **Parser style.** The matcher walker is a parser-
-  combinator-style `take_*` chain over the matcher token
-  stream per
+- **Parser style.** The matcher walker is a
+  parser-combinator-style `take_*` chain over the matcher
+  token stream per
   [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md):
   one combinator per matcher position kind (literal token,
   `$name:frag` capture, `$( ... )sep rep` repetition), with

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -322,8 +322,8 @@ comma_list!(
 let zeros = vec![0; 10];
 
 // Skipped: `quote!` is a token-tree passthrough, not a
-// comma-separated list. It isn't on the name-based allow-list,
-// and matcher-based detection's $(,)? / $(,)* predicate
+// comma-separated list. It isn't on the curated name-based
+// list, and matcher-based detection's $(,)? / $(,)* predicate
 // doesn't match its grammar — so step 3's eligibility check
 // fails and the lint never reaches the trailing-comma check.
 quote! {
@@ -460,10 +460,14 @@ ignore = [
   a bare literal `,` at the same position are *required*, not
   optional, and the walker must distinguish them (see the
   `take_optional_trailing_comma` note below).
-  For dependency macros, the matcher comes from
-  `tcx.hir_node_by_def_id(...)` if local, or via the macro
-  metadata in `tcx.cstore_untracked()` for external macros;
-  unavailable matchers degrade to "ineligible".
+  Matcher access depends on where the macro is defined: for a
+  macro defined in the current crate, use
+  `tcx.hir_node_by_def_id(def_id)` to reach the
+  `ItemKind::MacroDef` AST. For a macro imported from a
+  dependency, the matcher is in the dependency's rmeta and is
+  reachable via `tcx.cstore_untracked()` plus the macro-data
+  query. Unavailable matchers (some cross-crate cases) degrade
+  to "ineligible".
 - **Parser style.** The matcher walker is a
   parser-combinator-style `take_*` chain over the matcher
   token stream per

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -53,20 +53,26 @@ optionally. The list covers two groups:
   `pretty_assertions::{assert_eq, assert_ne, assert_str_eq}`,
   `maplit::{hashmap, btreemap, hashset, btreeset, convert_args}`,
   `serde_json::json`, `lazy_static::lazy_static`,
-  `paste::paste`, `derive_more`-style derivable attributes
-  whose argument list is comma-separated, `log::{log, error,
-  warn, info, debug, trace}`, `tracing::{event, error, warn,
-  info, debug, trace, span}`, `clap::{arg, command}`,
-  `anyhow::{anyhow, bail, ensure}`, `thiserror`-style attribute
-  argument lists.
+  `paste::paste`, `log::{log, error, warn, info, debug, trace}`,
+  `tracing::{event, error, warn, info, debug, trace, span}`,
+  `clap::{arg, command}`,
+  `anyhow::{anyhow, bail, ensure}`.
 
   The list is curated, not exhaustive — projects extend it via
   configuration when they import a new such macro.
 
-Name-based matching applies to *any* macro form: declarative,
-procedural function-like, attribute-style derives that take a
-comma-separated argument list. The matcher source is irrelevant
-because the human author has vetted the entry.
+Name-based matching applies to any function-like macro
+invocation, declarative or procedural: anything that the AST
+represents as an `ast::MacCall`. **Attribute-style invocations
+are out of scope** for this rule — `#[derive(...)]`,
+`#[display(...)]`, `#[error(...)]`, `#[serde(...)]`, and the
+rest live on `ast::Attribute` nodes that the lint's
+`check_mac` callback does not visit. A separate
+`attribute-trailing-comma` rule could handle those in a
+follow-up (the comma-policy reasoning is the same, but the
+visit path, configuration shape, and span layout all differ);
+this rule restricts itself to `MacCall` to keep the
+implementation single-purpose.
 
 **Caveat — "comma-separated" means the rustfmt shape.** The
 curated list and `extra_name_based` should only include macros
@@ -152,14 +158,17 @@ first; ship matcher-based in a follow-up.
 For every macro invocation:
 
 1. Resolve the macro `DefId`.
-2. Decide eligibility:
+2. If the resolved path matches an entry in `deny_list`,
+   skip. `deny_list` is checked first so a user opt-out wins
+   over both name-based and matcher-based eligibility.
+3. Decide eligibility:
    - If the path matches a name-based entry (built-in or
-     user-configured), eligible.
+     user-configured via `extra_name_based`), eligible.
    - Otherwise, if matcher-based detection is enabled and the
      macro is a visible declarative macro whose matched arm
      ends in `$(,)?` (per the predicate above), eligible.
    - Otherwise, skip.
-3. Inspect the *invocation token stream* — not the expansion —
+4. Inspect the *invocation token stream* — not the expansion —
    to confirm that the top-level argument list is purely comma-
    separated. Skip if:
    - The delimiter is opened but the body contains a top-level
@@ -167,10 +176,10 @@ For every macro invocation:
      like `quote!` arms), or any other top-level separator that
      isn't a comma.
    - There are zero arguments (no comma to add or remove).
-4. Determine "single-line" vs "multi-line" by the source
+5. Determine "single-line" vs "multi-line" by the source
    positions of the opening and closing delimiters. If they
    share a line, single-line; otherwise multi-line.
-5. Locate the final top-level token before the closing
+6. Locate the final top-level token before the closing
    delimiter:
    - **Multi-line, no trailing comma** → emit a diagnostic
      suggesting an inserted `,`.

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -208,7 +208,7 @@ assert_eq!(
 );
 ```
 
-### Matcher-based: locally-defined `macro_rules!`
+### Matcher-based: `macro_rules!` ending in `$(,)?`
 
 ```rust
 macro_rules! comma_list {

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -38,17 +38,23 @@ eligibility, named for *how* they identify an eligible macro.
 ### Name-based — well-known macro allow-list
 
 A hard-coded list of macros known to accept the trailing comma
-optionally. **Inclusion criterion:** the macro takes a
-top-level comma-separated argument list — i.e., a typical
-invocation contains two or more items separated by *top-level*
-commas in the macro's token stream — and the trailing comma is
-syntactically optional in the macro's matcher. Macros that use
-a different separator (`;` for `thread_local!`, `lazy_static!`),
-that take a single argument that isn't a list (`include_str!`,
+optionally. **Inclusion criterion:** the macro's matcher accepts
+a top-level comma-separated argument list with a syntactically
+optional trailing comma. The list may have any length — a
+single-argument invocation like `dbg!(x)` or `env!("VAR")`
+qualifies just as much as a multi-argument one — but
+single-argument invocations contain no comma at all and so the
+policy is vacuous for them (step 4 of the algorithm skips on
+zero top-level commas). The policy *meaningfully* fires when
+the invocation has two or more top-level items.
+
+Macros that use a different separator (`;` for `thread_local!`,
+`lazy_static!`), that take a single non-list argument the
+matcher won't follow with an optional comma (`include_str!`,
 `compile_error!`, `cfg!`), or that pass tokens through verbatim
-so that a trailing comma would change their output
-(`stringify!`, `paste::paste!`) do **not** qualify; they're
-deliberately absent from the list below.
+so a trailing comma would change their output (`stringify!`,
+`paste::paste!`) do **not** qualify; they're deliberately
+absent from the list below.
 
 The list covers two groups:
 

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -86,15 +86,18 @@ For a `macro_rules!` macro whose definition is visible to the
 compiler (the local crate, or a dependency whose macro body
 rustc still has on hand), inspect the matcher arms:
 
-- A macro arm whose final matcher position is `$(,)?` — or
-  equivalently `$(,)*` / `$(,)+` used purely to absorb a
-  trailing comma — can match the invocation with or without the
-  comma. The optional-comma capture cannot be expanded into the
-  body (a literal token in a matcher position cannot be
-  referenced by `$name` in the expansion), so the trailing
-  comma is purely syntactic. The lint may rewrite freely.
-- An arm that ends in a literal `,` (no `?` / `*` / `+`)
-  *requires* the trailing comma; the lint must not remove it.
+- A macro arm whose final matcher position is `$(,)?` or
+  `$(,)*` — used purely to absorb a trailing comma — can
+  match the invocation with or without the comma. The
+  optional-comma capture cannot be expanded into the body (a
+  literal token in a matcher position cannot be referenced by
+  `$name` in the expansion), so the trailing comma is purely
+  syntactic. The lint may rewrite freely.
+- An arm that ends in a literal `,` *or* in `$(,)+`
+  *requires* at least one trailing comma; the lint must not
+  remove it. `$(,)+` is the easy mis-read here — `+` matches
+  one or more, so an invocation with no trailing comma at all
+  would not have matched in the first place.
 - An arm whose final position is something else (a non-comma
   token, or a `$name:tt` capture) doesn't carry a trailing
   comma at all and is out of scope.
@@ -395,7 +398,11 @@ deny_list = [
   one combinator per matcher position kind (literal token,
   `$name:frag` capture, `$( ... )sep rep` repetition), with
   a top-level `take_optional_trailing_comma` that recognises
-  `$(,)?`, `$(,)*`, `$(,)+` at the tail of an arm.
+  `$(,)?` and `$(,)*` at the tail of an arm. `$(,)+` and a
+  bare literal `,` are *not* optional-trailing-comma forms
+  (both require at least one comma) and the combinator must
+  classify them as "required" so the lint refuses to remove
+  the comma.
 
 ### Difficulty
 

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -38,7 +38,19 @@ eligibility, named for *how* they identify an eligible macro.
 ### Name-based — well-known macro allow-list
 
 A hard-coded list of macros known to accept the trailing comma
-optionally. The list covers two groups:
+optionally. **Inclusion criterion:** the macro takes a
+top-level comma-separated argument list — i.e., a typical
+invocation contains two or more items separated by *top-level*
+commas in the macro's token stream — and the trailing comma is
+syntactically optional in the macro's matcher. Macros that use
+a different separator (`;` for `thread_local!`, `lazy_static!`),
+that take a single argument that isn't a list (`include_str!`,
+`compile_error!`, `cfg!`), or that pass tokens through verbatim
+so that a trailing comma would change their output
+(`stringify!`, `paste::paste!`) do **not** qualify; they're
+deliberately absent from the list below.
+
+The list covers two groups:
 
 - **`core` / `std` macros** that take comma-separated arguments:
   `vec!`, `format!`, `format_args!`, `print!`, `println!`,
@@ -46,16 +58,12 @@ optionally. The list covers two groups:
   `unimplemented!`, `todo!`, `unreachable!`, `assert!`,
   `assert_eq!`, `assert_ne!`, `debug_assert!`,
   `debug_assert_eq!`, `debug_assert_ne!`, `matches!`,
-  `dbg!`, `concat!`, `env!`, `option_env!`, `stringify!`,
-  `cfg!`, `compile_error!`, `include!`, `include_str!`,
-  `include_bytes!`, `thread_local!`.
+  `dbg!`, `concat!`, `env!`, `option_env!`.
 - **Well-known third-party macros** with the same convention:
   `pretty_assertions::{assert_eq, assert_ne, assert_str_eq}`,
   `maplit::{hashmap, btreemap, hashset, btreeset, convert_args}`,
-  `serde_json::json`, `lazy_static::lazy_static`,
-  `paste::paste`, `log::{log, error, warn, info, debug, trace}`,
+  `log::{log, error, warn, info, debug, trace}`,
   `tracing::{event, error, warn, info, debug, trace, span}`,
-  `clap::{arg, command}`,
   `anyhow::{anyhow, bail, ensure}`.
 
   The list is curated, not exhaustive — projects extend it via
@@ -169,13 +177,20 @@ For every macro invocation:
      ends in `$(,)?` (per the predicate above), eligible.
    - Otherwise, skip.
 4. Inspect the *invocation token stream* — not the expansion —
-   to confirm that the top-level argument list is purely comma-
-   separated. Skip if:
-   - The delimiter is opened but the body contains a top-level
-     `;` (e.g., `vec![value; count]`), `=>` (token-tree macros
-     like `quote!` arms), or any other top-level separator that
-     isn't a comma.
-   - There are zero arguments (no comma to add or remove).
+   to confirm the call is shaped like a top-level comma-
+   separated argument list. Skip if:
+   - The body contains a top-level `;` (e.g., `vec![value;
+     count]`, `thread_local! { static FOO: ...; static BAR:
+     ...; }`). A top-level `;` indicates the macro uses `;` as
+     its item separator, not commas.
+   - The body contains **zero** top-level commas (no list to
+     apply the trailing-comma policy to). This catches token-
+     tree macros like `quote! { fn foo() {} }` whose body has
+     no top-level commas at all, single-argument macros, and
+     empty invocations. `=>` may appear at the top level
+     between items — e.g., `hashmap! { "a" => 1, "b" => 2 }`
+     legitimately has a top-level `=>` per entry — and is
+     fine as long as top-level commas separate the entries.
 5. Determine "single-line" vs "multi-line" by the source
    positions of the opening and closing delimiters. If they
    share a line, single-line; otherwise multi-line.
@@ -263,13 +278,15 @@ comma_list!(
 );
 ```
 
-### Skipped: non-comma top-level separator
+### Skipped: not shaped like a comma-separated list
 
 ```rust
-// Skipped: vec![value; count] uses `;`, not a list separator
+// Skipped: `vec![value; count]` uses `;`, not a list separator.
+// A top-level `;` indicates a different macro form.
 let zeros = vec![0; 10];
 
-// Skipped: quote! arm uses `=>` and arbitrary tokens
+// Skipped: no top-level commas in the body — the macro is a
+// token-tree passthrough, not a comma-separated list.
 quote! {
     fn foo() -> i32 { 42 }
 };

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -42,11 +42,12 @@ optionally. **Inclusion criterion:** the macro's matcher accepts
 a top-level comma-separated argument list with a syntactically
 optional trailing comma. The list may have any length — a
 single-argument invocation like `dbg!(x)` or `env!("VAR")`
-qualifies just as much as a multi-argument one — but
-single-argument invocations contain no comma at all and so the
-policy is vacuous for them (step 4 of the algorithm skips on
-zero top-level commas). The policy *meaningfully* fires when
-the invocation has two or more top-level items.
+qualifies just as much as a multi-argument one. Multi-line
+single-argument invocations get a trailing comma per rustfmt's
+policy (`vec![\n    x\n]` → `vec![\n    x,\n]`); single-line
+single-argument invocations have nothing to fix (no trailing
+comma is present to remove and the invocation is already
+single-line short).
 
 Macros that use a different separator (`;` for `thread_local!`,
 `lazy_static!`), that take a single non-list argument the
@@ -192,15 +193,26 @@ For every macro invocation:
    - The body contains a top-level `;` (e.g., `vec![value;
      count]`, `thread_local! { static FOO: ...; static BAR:
      ...; }`). A top-level `;` indicates the macro uses `;` as
-     its item separator, not commas.
-   - The body contains **zero** top-level commas (no list to
-     apply the trailing-comma policy to). This catches
-     token-tree macros like `quote! { fn foo() {} }` whose body
-     has no top-level commas at all, single-argument macros,
-     and empty invocations. `=>` may appear at the top level
-     between items — e.g., `hashmap! { "a" => 1, "b" => 2 }`
-     legitimately has a top-level `=>` per entry — and is
-     fine as long as top-level commas separate the entries.
+     its item separator, not commas. Note that step 3's
+     eligibility check has already filtered macros to the
+     curated comma-separated-list set, so this case mostly
+     guards against the dual-arm `vec!` (`vec![el; n]` form)
+     and any cross-arm matcher-based hits where one arm of the
+     macro is comma-separated and another is `;`-separated.
+   - The body is empty (only whitespace and comments between
+     delimiters). Nothing to add or remove.
+   - `=>` may appear at the top level between items — e.g.,
+     `hashmap! { "a" => 1, "b" => 2 }` legitimately has a
+     top-level `=>` per entry — and is fine. It is *not* a
+     skip trigger.
+
+   A zero-comma body is **not** a skip trigger. A single-item
+   list still benefits from the multi-line trailing comma per
+   rustfmt's policy (`vec![\n    x\n]` becomes
+   `vec![\n    x,\n]`). The eligibility check at step 3 has
+   already established that the macro is shaped like a
+   comma-separated list, so a one-item invocation is a
+   one-item list, not a token-tree passthrough.
 5. Determine "single-line" vs "multi-line" by the source
    positions of the opening and closing delimiters. If they
    share a line, single-line; otherwise multi-line.
@@ -246,6 +258,19 @@ let xs = vec![1, 2, 3,];
 
 // Good
 let xs = vec![1, 2, 3];
+```
+
+```rust
+// Bad: single-argument multi-line invocation, no trailing
+// comma. Matches rustfmt's behaviour for function calls.
+dbg!(
+    expensive_function_call(arg)
+);
+
+// Good
+dbg!(
+    expensive_function_call(arg),
+);
 ```
 
 ### Name-based: `assert_eq!`
@@ -295,8 +320,11 @@ comma_list!(
 // A top-level `;` indicates a different macro form.
 let zeros = vec![0; 10];
 
-// Skipped: no top-level commas in the body — the macro is a
-// token-tree passthrough, not a comma-separated list.
+// Skipped: `quote!` is a token-tree passthrough, not a
+// comma-separated list. It isn't on the name-based allow-list,
+// and matcher-based detection's $(,)? / $(,)* predicate
+// doesn't match its grammar — so step 3's eligibility check
+// fails and the lint never reaches the trailing-comma check.
 quote! {
     fn foo() -> i32 { 42 }
 };

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -68,6 +68,18 @@ procedural function-like, attribute-style derives that take a
 comma-separated argument list. The matcher source is irrelevant
 because the human author has vetted the entry.
 
+**Caveat — "comma-separated" means the rustfmt shape.** The
+curated list and `extra_name_based` should only include macros
+where commas are *required between items* and *optional only at
+the trailing position* — the same policy rustfmt applies to
+function calls and struct literals. Macros that treat commas as
+*fully optional* separators throughout — `build-fs-tree`'s
+`dir!` is one example, where each entry may or may not be
+followed by a comma independently — must not be added. Forcing a
+trailing comma on the last entry would clash with the no-comma
+style users of those macros often choose. If such a macro slips
+into the list, move it to `deny_list` to opt it out.
+
 ### Matcher-based — declarative-macro auto-detection
 
 For a `macro_rules!` macro whose definition is visible to the
@@ -86,6 +98,15 @@ rustc still has on hand), inspect the matcher arms:
 - An arm whose final position is something else (a non-comma
   token, or a `$name:tt` capture) doesn't carry a trailing
   comma at all and is out of scope.
+
+The predicate is specifically about the *tail* of the top-level
+matcher. A macro whose matcher makes every comma optional —
+e.g., `$($key:literal => $value:expr $(,)?)*`, where each entry
+may or may not be followed by a comma independently — has a
+top-level tail that is the `)*` of the outer repetition, not a
+top-level `$(,)?`. The predicate doesn't match, the lint
+correctly skips, and users who write such macros without any
+commas are not forced into a stray trailing one.
 
 For a given invocation, the lint determines which arm matches
 (or, conservatively, requires that *every* arm of the macro
@@ -257,6 +278,31 @@ always_comma!(
     b,
     c,
 );
+```
+
+### Skipped: macro with fully-optional commas
+
+```rust
+// Matcher with per-item optional commas: every comma in the
+// list is independently optional, so both comma-separated and
+// no-comma styles are valid. `build-fs-tree::dir!` is a
+// real-world example.
+macro_rules! dir {
+    ($($key:literal => $value:expr $(,)?)*) => { /* ... */ };
+}
+
+// Skipped: the matcher's top-level tail is `)*`, not a
+// top-level `$(,)?`. Matcher-based detection's predicate
+// (`$(,)?` at the tail of the top-level matcher) doesn't
+// match, so the lint correctly leaves the call alone. The
+// macro must also not be added to `extra_name_based` — users
+// who write entries without any commas would otherwise get a
+// stray trailing comma against an otherwise comma-free style.
+dir! {
+    "foo" => file!("a")
+    "bar" => file!("b")
+    "baz" => file!("c")
+}
 ```
 
 ### Skipped: unknown procedural macro


### PR DESCRIPTION
Adds `planned-rules/macro-trailing-comma.md` plus a README index entry under a new "Macros" section.

## What the rule does

Reinstates rustfmt's `trailing_comma = "Vertical"` policy — trailing comma on multi-line argument lists, none on single-line — for *function-like macro invocations* (`ast::MacCall`), which rustfmt itself leaves untouched because a macro's matcher can make the trailing comma load-bearing.

## Two eligibility modes

The rule has to decide when adding or removing the trailing comma is *safe*:

- **Name-based** — a curated list of macros whose matcher accepts a top-level comma-separated argument list with an optional trailing comma. Built-in entries:
  - core/std: `vec!`, `format!`, `format_args!`, the `print!`/`eprint!`/`println!`/`eprintln!`/`write!`/`writeln!` family, `panic!`, `unimplemented!`, `todo!`, `unreachable!`, the `assert!`/`assert_eq!`/`assert_ne!` and `debug_assert*` family, `matches!`, `dbg!`, `concat!`, `env!`, `option_env!`.
  - third-party: `pretty_assertions::*`, `maplit::*`, `log::*`, `tracing::*`, `anyhow::{anyhow, bail, ensure}`.
  - Configurable via `extra_name_based`. `ignore` opts a macro out.
- **Matcher-based** — walks the `macro_rules!` matcher arms looking for a tail of `$(,)?` or `$(,)*`, the syntactically-optional-trailing-comma idioms. `$(,)+` and bare literal `,` mean *required* and the lint must not remove. Configurable via `matcher_based` (default on).

The rule file recommends shipping name-based first as a standalone PR, then layering matcher-based on top.

## Out of scope

- **Attribute-style invocations** (`#[derive(...)]`, `#[display(...)]`, `#[error(...)]`, `#[serde(...)]`, …) — they live on `ast::Attribute`, not `MacCall`. Deferred to a hypothetical sibling `attribute-trailing-comma` rule.
- **Macros without a top-level comma-separated list:** `;`-separated declarations (`thread_local!`, `lazy_static!`), single-arg passthroughs (`include_str!`, `compile_error!`, `cfg!`), and token-passthrough macros where a trailing comma would change the output (`stringify!`, `paste::paste!`).
- **Macros with fully-optional commas** (e.g., `build-fs-tree::dir!` whose entries may or may not be followed by a comma each) — matcher-based skips them naturally because the optional `$(,)?` isn't at the *tail* of the top-level matcher; they're documented as ineligible for `extra_name_based` too.
- **Procedural macros** for matcher-based detection — their grammar is opaque and never inspectable. They can still be added to `extra_name_based` if their author documents the trailing comma as optional.

## Notes

- Algorithm: resolve `DefId` → check `ignore` → check eligibility (name-based, then matcher-based) → check the invocation token stream is shaped like a comma-separated list (no top-level `;`, has at least one top-level comma) → compute single-line vs multi-line → emit a one-character diagnostic.
- Autofix is `MachineApplicable` for name-based and unambiguous matcher-based; `MaybeIncorrect` when only one of several arms matched.
- Cross-references the parser-combinator convention from `IMPLEMENTATION_CONVENTIONS.md` for the matcher walker, and the `format-macro-wrap` / `print-macro-split` rules whose `line_continuation` rewrites converge with this rule's multi-line shape.

The "Tier 1 / Tier 2" terminology from the original spec discussion was renamed to "name-based / matcher-based" — the latter pair is symmetric and describes the actual detection mechanism. The original `allow-list` / `deny_list` framing was dropped (renamed to "curated list" / `ignore`) because the lint never grants or withholds permission to invoke a macro; it only decides whether to act on the invocation's trailing comma.

https://claude.ai/code/session_01JW4j87tudqQwhd7Q6Z2BVq