### PR TITLE
docs: distinguish preference rules from objective ones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,47 @@ When you add a new rule:
 3. Do not introduce a parallel `REGISTERED_LINT_NAMES`-style
    array. The `LintStore` is the single source of truth.
 
+## Rationale section: "Why is this bad?" vs "Why restrict this?"
+
+Every rule's documentation — both the rustdoc on the
+`declare_tool_lint!` block and the planning file in
+`planned-rules/` — needs a section that explains the motivation.
+Pick the heading based on whether the violation is objectively
+broken or a stylistic preference:
+
+- **"Why is this bad?"** — use only when violating the rule
+  produces an objective defect: silently broken behaviour, a
+  user-visible rendering bug, a typo that neutralises a
+  suppression, data corruption, a security issue, or similar.
+  The reader should be able to read the section and agree that
+  the practice is wrong on its own terms, not just out of taste.
+  Examples in this repository:
+  `perfectionist::unknown_perfectionist_lints` (a typo in
+  `#[allow(perfectionist::...)]` silently fails to suppress
+  anything) and `planned-rules/clap-help-no-markdown.md`
+  (markdown leaks into the terminal `--help` output as literal
+  syntax).
+- **"Why restrict this?"** — use for every other rule. Most lints
+  in this catalogue enforce stylistic preferences (em-dash usage,
+  ellipsis form, derive choice, module layout, doc-comment
+  length, etc.). The practice they forbid is not wrong in any
+  absolute sense; the project simply prefers the alternative.
+  Open these sections with an explicit disclaimer such as "This
+  is a stylistic preference, not a correctness issue.", then
+  explain the preference.
+
+Do not use "Why is this bad?" as a default heading. Claiming
+objective badness for what is really a preference misleads
+readers and invites pushback that the rule's rationale cannot
+sustain. When in doubt, the rule is a preference; use "Why
+restrict this?".
+
+Headings like "Why both lints together", "Why one rule instead
+of two", "Why not `format!`-family", etc. are *design*
+rationale (explaining the rule's shape, not the user practice it
+forbids). Those are independent of this convention and may
+coexist with either of the headings above.
+
 ## Notes on cross-rule dependencies
 
 A handful of rules share helpers — the markdown exclusion

--- a/planned-rules/clap-help-length.md
+++ b/planned-rules/clap-help-length.md
@@ -22,8 +22,9 @@ tripping on legitimately rich CLI options:
 A "line" here is a non-empty `///` continuation; doc-comment leading
 markers and trailing whitespace are stripped before counting.
 
-## Rationale
+## Why restrict this?
 
+This is a stylistic preference, not a correctness issue.
 CLI help text serves the user at a terminal, not a docs.rs reader. A
 flag that prints an essay is hostile in `--help` output:
 

--- a/planned-rules/clap-help-no-markdown.md
+++ b/planned-rules/clap-help-no-markdown.md
@@ -21,7 +21,7 @@ numbered lists are not flagged by default; clap renders them as their
 literal characters in `--help`, which usually reads cleanly. They are
 configurable.
 
-## Rationale
+## Why is this bad?
 
 By default, clap does **not** render doc comments through a markdown
 processor. The raw text is shown verbatim in the terminal `--help`

--- a/planned-rules/em-dash-prose.md
+++ b/planned-rules/em-dash-prose.md
@@ -9,9 +9,10 @@
 > appears, restructure the surrounding sentence so each clause stands on
 > its own.
 
-## Why this rule exists
+## Why restrict this?
 
-The em dash is a hallmark of AI-generated text. Modern code-writing
+This is a stylistic preference, not a correctness issue. The em dash
+is a hallmark of AI-generated text. Modern code-writing
 assistants reach for it whenever they want to glue two clauses together
 without committing to a structural relationship. The result reads as
 loose, conversational prose — exactly the register technical

--- a/planned-rules/prefer-derive-more.md
+++ b/planned-rules/prefer-derive-more.md
@@ -203,8 +203,9 @@ enabled, default to warn but should be promoted to deny only after
 the project has audited their suggestions on a representative
 sample.
 
-## Why this rule exists
+## Why restrict this?
 
+This is a stylistic preference, not a correctness issue.
 Hand-written `impl From for ...` blocks are the most common
 AI-generated alternative to a one-line derive. They sneak past code
 review because they look "more explicit" — the model produced four

--- a/planned-rules/unicode-ellipsis-in-docs.md
+++ b/planned-rules/unicode-ellipsis-in-docs.md
@@ -8,7 +8,9 @@ parallel to [`em-dash-prose`](./em-dash-prose.md), which targets U+2014).
 Forbid U+2026 HORIZONTAL ELLIPSIS (`…`) in doc comments. Prefer the
 three-ASCII-dot form `...`.
 
-Rationale:
+## Why restrict this?
+
+This is a stylistic preference, not a correctness issue.
 
 - ASCII `...` survives every encoding round-trip, every terminal, every
   copy-paste, every `grep` invocation, and every `git diff` viewer

--- a/planned-rules/unicode-ellipsis-in-panic-messages.md
+++ b/planned-rules/unicode-ellipsis-in-panic-messages.md
@@ -10,10 +10,12 @@ Forbid U+2026 HORIZONTAL ELLIPSIS (`…`) in the message string of any
 panicking or assertion-style macro. Prefer the three-ASCII-dot form
 `...`.
 
-Rationale: panic and assertion messages surface in stderr, in CI logs,
-in crash reporters, and on terminals whose locale or encoding may not
-be UTF-8. Sticking to ASCII means the message renders identically
-everywhere.
+## Why restrict this?
+
+This is a stylistic preference, not a correctness issue. Panic and
+assertion messages surface in stderr, in CI logs, in crash reporters,
+and on terminals whose locale or encoding may not be UTF-8. Sticking
+to ASCII means the message renders identically everywhere.
 
 ## What to lint
 

--- a/src/rules/flat_module_pattern.rs
+++ b/src/rules/flat_module_pattern.rs
@@ -12,7 +12,8 @@ declare_tool_lint! {
     /// the module (`module.rs`), with any nested children placed
     /// inside the `module/` directory next to it.
     ///
-    /// ### Why is this bad?
+    /// ### Why restrict this?
+    /// This is a stylistic preference, not a correctness issue.
     /// The flat layout keeps the file name unique to its module,
     /// so editors, terminal tabs, and `grep` results identify the
     /// module without their parent directory. The `mod.rs` form

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -16,7 +16,8 @@ declare_tool_lint! {
     /// `/* */` comments. Doc comments (`///`, `//!`) are covered by a
     /// sibling lint.
     ///
-    /// ### Why is this bad?
+    /// ### Why restrict this?
+    /// This is a stylistic preference, not a correctness issue.
     /// ASCII `...` survives every encoding round-trip, every terminal,
     /// every `grep` invocation, and every `git diff` viewer without
     /// rendering as `?` or a tofu box. The Unicode form usually arrives


### PR DESCRIPTION
## Summary

The `### Why is this bad?` heading implies the rule's violation is
objectively broken. That is only true for one of the three
implemented rules; the other two enforce stylistic preferences, and
several planned rules carry the same misleading framing.

Pick the heading based on the rule's nature:

- **`Why is this bad?`** — objective defect (broken behaviour,
  rendering bug, neutralised suppression, etc.).
- **`Why restrict this?`** — stylistic preference. Open with a
  disclaimer noting it's a preference, not a correctness issue.

## Changes

- **Implemented rules**: rename the section for
  `flat_module_pattern` and `unicode_ellipsis_in_comments`
  (preferences). Keep it for `unknown_perfectionist_lints` (a
  typo in a suppression silently fails — objectively broken).
- **Planned rules**: rename the rationale section for
  `em-dash-prose`, `prefer-derive-more`, `clap-help-length`,
  `unicode-ellipsis-in-docs`, and
  `unicode-ellipsis-in-panic-messages` (preferences). Rename
  `clap-help-no-markdown`'s `Rationale` to `Why is this bad?`
  (markdown leaks into terminal `--help` as literal syntax —
  a real rendering bug).
- Design-rationale headings (`Why both lints together`,
  `Why not format!-family`, etc.) are unchanged — they
  explain the lint's shape, not the user practice it forbids.
- **CLAUDE.md**: document the convention with examples.