### PR TITLE
feat(pages):  configuration documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "maud",
  "proc-macro2",
  "pulldown-cmark",
+ "quote",
  "strum",
  "syn",
 ]

--- a/justfile
+++ b/justfile
@@ -41,5 +41,5 @@ warmup-integration-tests:
   cargo run --package _utils --bin warmup -- "$(pwd)"
 
 # Render the rule catalogue to `gh-pages/index.html`
-gen-docs out_dir="gh-pages":
-  cargo run --package _gen_docs --bin gen-docs -- "$(pwd)" "{{out_dir}}"
+gen-docs out_dir="gh-pages" git_ref="master":
+  cargo run --package _gen_docs --bin gen-docs -- "$(pwd)" "{{out_dir}}" --git-ref="{{git_ref}}"

--- a/src/rules/flat_module_pattern.rs
+++ b/src/rules/flat_module_pattern.rs
@@ -37,6 +37,10 @@ declare_tool_lint! {
 
 const CONFIG_KEY: &str = "perfectionist::flat_module_pattern";
 
+/// Configuration is reserved for future knobs; the lint currently
+/// has no options. The empty struct still exists so that a stray
+/// `[perfectionist::flat_module_pattern]` table in `dylint.toml`
+/// deserialises rather than producing a confusing parse error.
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(default, rename_all = "snake_case")]
 struct Config {}

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -123,13 +123,29 @@ const BUILTIN_NAME_BASED: &[&str] = &[
 #[derive(Debug, serde::Deserialize)]
 #[serde(default, rename_all = "snake_case")]
 struct Config {
+    /// Master on/off switch for the rule. Defaults to `true`. Set
+    /// to `false` to silence every diagnostic this lint would emit
+    /// without having to enumerate every macro under `ignore`.
     enabled: bool,
     /// Accepted for forward compatibility with the matcher-based half of
     /// the rule. Currently a no-op — only name-based eligibility is
     /// implemented; see `planned-rules/macro-trailing-comma.md` for the
     /// status breakdown.
     matcher_based: bool,
+    /// Additional macro paths to treat as name-based eligible, on top
+    /// of the curated built-in list. Each entry is matched by its
+    /// final path segment, so `"my_crate::vec_like"` and `"vec_like"`
+    /// both target invocations whose last segment is `vec_like`.
+    /// Empty by default. Only add macros whose trailing comma is
+    /// syntactically optional at the top level; macros that treat
+    /// the comma as a fully optional separator throughout (rather
+    /// than only at the tail) should not be listed here.
     extra_name_based: Vec<String>,
+    /// Macro paths to opt out of the rule, even if they would
+    /// otherwise be eligible via the built-in list or
+    /// `extra_name_based`. Matched by final path segment, like
+    /// `extra_name_based`. Checked first, so this knob always wins
+    /// over eligibility. Empty by default.
     ignore: Vec<String>,
 }
 

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -62,10 +62,14 @@ impl Default for Config {
     }
 }
 
+/// Selector for which comment syntaxes the rule scans.
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum Scope {
+    /// `//`-prefixed line comments, including consecutive runs that
+    /// rustc treats as a single logical comment.
     Line,
+    /// `/* ... */` block comments, including nested ones.
     Block,
 }
 

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -42,7 +42,14 @@ const CONFIG_KEY: &str = "perfectionist::unicode_ellipsis_in_comments";
 #[derive(Debug, serde::Deserialize)]
 #[serde(default, rename_all = "snake_case")]
 struct Config {
+    /// Extra characters to flag alongside U+2026. Useful for catching
+    /// near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)
+    /// or U+2025 TWO DOT LEADER (`‥`) that the same autocorrect
+    /// pipelines occasionally insert. Empty by default.
     also_flag: Vec<char>,
+    /// Which comment forms to scan. Defaults to both `line` (`//`)
+    /// and `block` (`/* */`). Narrow this if a project intentionally
+    /// uses one form for prose and wants the lint to ignore it.
     scope: Vec<Scope>,
 }
 

--- a/src/rules/unicode_ellipsis_in_panic_messages.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages.rs
@@ -76,8 +76,18 @@ const DEFAULT_METHODS: &[&str] = &["expect", "expect_err"];
 #[derive(Debug, serde::Deserialize)]
 #[serde(default, rename_all = "snake_case")]
 struct Config {
+    /// Macros whose call site should be scanned for the flagged
+    /// characters. Defaults to the standard panic and assertion
+    /// macros (`panic`, `unimplemented`, `todo`, `unreachable`,
+    /// `debug_unreachable`, and the `assert*` family). Override to
+    /// add project-specific assertion-shaped macros, or to narrow
+    /// the set when a project deliberately uses `…` in one of them.
     macros: Vec<String>,
+    /// Method names on `Option` / `Result` whose first argument is
+    /// the panic message. Defaults to `expect` and `expect_err`.
     methods: Vec<String>,
+    /// Extra characters to flag alongside U+2026, in the same spirit
+    /// as `unicode_ellipsis_in_comments.also_flag`. Empty by default.
     also_flag: Vec<char>,
 }
 

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -40,6 +40,12 @@ const TOOL_NAME: &str = "perfectionist";
 #[derive(Debug, serde::Deserialize)]
 #[serde(default, rename_all = "snake_case")]
 struct Config {
+    /// Maximum Levenshtein edit distance between an unknown
+    /// `perfectionist::*` name and a registered lint for the lint to
+    /// emit a "did you mean" suggestion. Defaults to `2`, which
+    /// catches single-character typos and short transpositions
+    /// without producing wild guesses. Set to `0` to disable
+    /// suggestions entirely.
     suggestion_distance: usize,
 }
 

--- a/tools/gen-docs/Cargo.toml
+++ b/tools/gen-docs/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 cargo_toml = "0.22.3"
 clap = { version = "4.6.1", features = ["derive"] }
 maud = "0.27.0"
-proc-macro2 = { version = "1.0.95", features = ["span-locations"] }
+proc-macro2 = "1.0.95"
 pulldown-cmark = { version = "0.13.0", default-features = false, features = ["html"] }
 quote = "1.0.40"
 strum = { version = "0.27.2", features = ["derive"] }

--- a/tools/gen-docs/Cargo.toml
+++ b/tools/gen-docs/Cargo.toml
@@ -13,7 +13,8 @@ path = "src/main.rs"
 cargo_toml = "0.22.3"
 clap = { version = "4.6.1", features = ["derive"] }
 maud = "0.27.0"
-proc-macro2 = "1.0.95"
+proc-macro2 = { version = "1.0.95", features = ["span-locations"] }
 pulldown-cmark = { version = "0.13.0", default-features = false, features = ["html"] }
+quote = "1.0.40"
 strum = { version = "0.27.2", features = ["derive"] }
 syn = { version = "2.0.105", features = ["full", "parsing", "extra-traits"] }

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -79,6 +79,16 @@ fn main() -> ExitCode {
             Inheritable::Inherited => None,
         })
         .unwrap_or_else(|| "unknown".to_owned());
+    // Derive the human-facing repository URL from Cargo.toml so a
+    // fork picks up its own URL without hand-editing the renderer.
+    // Cargo's `repository` field typically ends in `.git` for clone
+    // ergonomics; strip it for the human-facing URL.
+    let repo_url = manifest
+        .package
+        .as_ref()
+        .and_then(|package| package.repository.as_ref().and_then(|r| r.get().ok()))
+        .map(|url| url.strip_suffix(".git").unwrap_or(url).to_owned())
+        .unwrap_or_else(|| "https://github.com/KSXGitHub/perfectionist".to_owned());
 
     let rules_dir = root.join("src").join("rules");
     let mut rules = collect_rules(&rules_dir);
@@ -90,7 +100,7 @@ fn main() -> ExitCode {
     }
 
     fs::create_dir_all(&out_dir).expect("failed to create output directory");
-    let html = render_page(&rules, &crate_version, &git_ref);
+    let html = render_page(&rules, &crate_version, &git_ref, &repo_url);
     let index_path = out_dir.join("index.html");
     fs::write(&index_path, html).expect("failed to write index.html");
 
@@ -818,7 +828,7 @@ fn doc_attrs_to_markdown(attrs: &[Attribute]) -> String {
     lines.join("\n")
 }
 
-fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str) -> String {
+fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str, repo_url: &str) -> String {
     let markup: Markup = html! {
         (DOCTYPE)
         html lang="en" {
@@ -843,7 +853,7 @@ fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str) -> String {
                 }
                 p {
                     "perfectionist is a Dylint plugin; see the "
-                    a href="https://github.com/KSXGitHub/perfectionist" { "README" }
+                    a href=(repo_url) { "README" }
                     " for setup. Lint-control attributes use the "
                     code { "perfectionist::" } " namespace."
                 }
@@ -874,7 +884,7 @@ fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str) -> String {
                 }
                 h2 { "Rules" }
                 @for rule in rules {
-                    (rule_article(rule, git_ref))
+                    (rule_article(rule, git_ref, repo_url))
                 }
                 footer {
                     "Generated from " code { "src/rules/" }
@@ -886,10 +896,17 @@ fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str) -> String {
     markup.into_string()
 }
 
-fn rule_article(rule: &Rule, git_ref: &str) -> Markup {
-    let source_path = rule.relative_source.display().to_string();
-    let source_url =
-        format!("https://github.com/KSXGitHub/perfectionist/blob/{git_ref}/{source_path}");
+fn rule_article(rule: &Rule, git_ref: &str, repo_url: &str) -> Markup {
+    // Build the URL-friendly path by joining components with `/`
+    // instead of `Path::display`, which uses the host's native
+    // separator and would emit `\` on Windows.
+    let source_path = rule
+        .relative_source
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("/");
+    let source_url = format!("{repo_url}/blob/{git_ref}/{source_path}");
     html! {
         article.rule id=(anchor_for(&rule.namespaced)) {
             h2 { code { (rule.namespaced) } }

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -7,10 +7,11 @@
 //! (`pub perfectionist::NAME`), its default level, its one-line
 //! description, and the `///` doc-comment block that documents it.
 //! In addition, when a rule's file defines a `Config` struct paired
-//! with a `CONFIG_KEY` constant, the configurable fields (and their
-//! per-field doc comments and default expressions) are surfaced too.
-//! The output is a single self-contained `index.html` written into
-//! the directory passed on the command line.
+//! with a `CONFIG_KEY` constant, the configurable fields and any
+//! non-built-in types they reference (enums, project-local structs)
+//! are surfaced too. The output is a single self-contained
+//! `index.html` written into the directory passed on the command
+//! line.
 //!
 //! The macro grammar is fixed by `rustc_session::declare_tool_lint!`
 //! and the project's convention of placing the doc comment inside
@@ -19,7 +20,7 @@
 //! rustc plugin host just to read these few fields.
 
 use std::{
-    collections::HashMap,
+    collections::BTreeSet,
     fs,
     ops::Range,
     path::{Path, PathBuf},
@@ -34,7 +35,7 @@ use pulldown_cmark::{Event, Options, Tag, TagEnd, html as cmark_html};
 use quote::ToTokens;
 use strum::{Display, EnumString};
 use syn::{
-    Attribute, Expr, ExprLit, Ident, ImplItem, Item, Lit, LitStr, Meta, Stmt, Token, Type,
+    Attribute, Expr, ExprLit, Ident, Item, Lit, LitStr, Meta, Token, Type,
     parse::{Parse, ParseStream},
     spanned::Spanned,
 };
@@ -98,8 +99,7 @@ struct Rule {
 }
 
 /// The configuration surface of a single rule, as extracted from the
-/// rule's `Config` struct, paired `CONFIG_KEY` constant, and (when
-/// present) hand-written `impl Default for Config`.
+/// rule's `Config` struct paired with its `CONFIG_KEY` constant.
 struct ConfigDoc {
     /// The TOML table key, e.g. `perfectionist::flat_module_pattern`.
     /// Read from the file's `CONFIG_KEY` constant verbatim.
@@ -111,11 +111,17 @@ struct ConfigDoc {
     struct_doc_markdown: String,
     /// One entry per named field of the `Config` struct.
     fields: Vec<ConfigField>,
+    /// Non-built-in types referenced from `Config`'s fields, in the
+    /// order the reader is most likely to want them: every type that
+    /// appears earlier in the field list comes first.
+    custom_types: Vec<TypeDoc>,
 }
 
-/// One configurable knob, with the source text of its type and
-/// default expression preserved verbatim so the rendered docs match
-/// what a reader will see in `src/rules/<rule>.rs`.
+/// One configurable knob. Each rule's `Config` derives
+/// `#[serde(default)]`, so every field is optional in TOML; the
+/// renderer marks them with an `optional` badge rather than
+/// reproducing the Rust default expression — the prose doc comment
+/// states the default in human-readable form.
 struct ConfigField {
     /// Field identifier, e.g. `also_flag`. Matches the TOML key
     /// because every `Config` uses `#[serde(rename_all = "snake_case")]`
@@ -125,11 +131,42 @@ struct ConfigField {
     /// sliced out of the rule file using `proc_macro2::Span`
     /// byte ranges.
     type_source: String,
-    /// Verbatim source of the field's default expression as it
-    /// appears in `impl Default for Config`, or `None` when no
-    /// `Default` impl could be located.
-    default_source: Option<String>,
     /// Per-field `///` doc comment, in markdown form.
+    doc_markdown: String,
+}
+
+/// A non-built-in type that one of the `Config` fields references.
+/// Renders as a sub-block under the rule's Configuration section so
+/// readers know what shape an enum variant or nested struct takes
+/// in TOML without leaving the page.
+struct TypeDoc {
+    /// Rust identifier of the type (e.g. `Scope`).
+    name: String,
+    /// Doc comment attached to the `enum` or `struct` definition.
+    doc_markdown: String,
+    /// Whether the type is an enum or a struct, and the per-variant
+    /// or per-field detail that comes with it.
+    kind: TypeKind,
+}
+
+enum TypeKind {
+    Enum { variants: Vec<EnumVariant> },
+    Struct { fields: Vec<StructField> },
+}
+
+struct EnumVariant {
+    /// Rust identifier, e.g. `Line`.
+    rust_name: String,
+    /// The string a TOML author would write — typically
+    /// `rust_name` lowercased and snake-cased when the enum carries
+    /// `#[serde(rename_all = "snake_case")]`.
+    serialized: String,
+    doc_markdown: String,
+}
+
+struct StructField {
+    name: String,
+    type_source: String,
     doc_markdown: String,
 }
 
@@ -232,11 +269,11 @@ fn extract_rule(source_path: &Path) -> Option<Rule> {
     })
 }
 
-/// Locate the rule's `Config` struct, its `CONFIG_KEY` constant, and
-/// the optional `impl Default for Config` block, and bundle them
-/// into a `ConfigDoc`. Returns `None` when either the constant or
-/// the struct is missing — both are mandatory for a rule to be
-/// considered "configurable" by `dylint.toml`.
+/// Locate the rule's `Config` struct and its `CONFIG_KEY` constant
+/// and bundle them — along with any project-local types the fields
+/// reference — into a `ConfigDoc`. Returns `None` when either the
+/// constant or the struct is missing; both are mandatory for a rule
+/// to be considered "configurable" by `dylint.toml`.
 fn extract_config(file: &syn::File, source: &str) -> Option<ConfigDoc> {
     let key = file.items.iter().find_map(|item| match item {
         Item::Const(item_const) if item_const.ident == "CONFIG_KEY" => match &*item_const.expr {
@@ -253,104 +290,261 @@ fn extract_config(file: &syn::File, source: &str) -> Option<ConfigDoc> {
         _ => None,
     })?;
     let struct_doc_markdown = doc_attrs_to_markdown(&config_struct.attrs);
-    let defaults = extract_config_defaults(file, source);
 
-    let fields = match &config_struct.fields {
-        syn::Fields::Named(named) => named
-            .named
-            .iter()
-            .map(|field| {
-                let name = field
-                    .ident
-                    .as_ref()
-                    .expect("named field always has an ident")
-                    .to_string();
-                let type_source = span_text(source, field.ty.span())
-                    .unwrap_or_else(|| fallback_type_text(&field.ty));
-                let default_source = defaults.get(&name).cloned();
-                let doc_markdown = doc_attrs_to_markdown(&field.attrs);
-                ConfigField {
-                    name,
-                    type_source,
-                    default_source,
-                    doc_markdown,
-                }
-            })
-            .collect(),
+    let named_fields = match &config_struct.fields {
+        syn::Fields::Named(named) => named.named.iter().collect::<Vec<_>>(),
         _ => Vec::new(),
     };
+    let fields = named_fields
+        .iter()
+        .map(|field| ConfigField {
+            name: field
+                .ident
+                .as_ref()
+                .expect("named field always has an ident")
+                .to_string(),
+            type_source: span_text(source, field.ty.span())
+                .unwrap_or_else(|| fallback_type_text(&field.ty)),
+            doc_markdown: doc_attrs_to_markdown(&field.attrs),
+        })
+        .collect();
+
+    let mut referenced = Vec::new();
+    let mut seen = BTreeSet::new();
+    for field in &named_fields {
+        collect_referenced_idents(&field.ty, &mut referenced, &mut seen);
+    }
+    let custom_types = referenced
+        .into_iter()
+        .filter_map(|ident| find_type_doc(file, source, &ident))
+        .collect();
 
     Some(ConfigDoc {
         key,
         struct_doc_markdown,
         fields,
+        custom_types,
     })
 }
 
-/// Pull each field's default expression out of `impl Default for
-/// Config`. Recognises the conventional shape
-/// `fn default() -> Self { Self { field: expr, ... } }` (with or
-/// without an explicit `return`); anything more exotic yields an
-/// empty map and the rendered docs simply omit the default column.
-fn extract_config_defaults(file: &syn::File, source: &str) -> HashMap<String, String> {
-    let mut out = HashMap::new();
-    let Some(impl_item) = file.items.iter().find_map(|item| match item {
-        Item::Impl(item_impl)
-            if item_impl.trait_.as_ref().is_some_and(|(_, path, _)| {
-                path.segments
-                    .last()
-                    .is_some_and(|segment| segment.ident == "Default")
-            }) && matches!(
-                &*item_impl.self_ty,
-                Type::Path(type_path)
-                    if type_path
-                        .path
-                        .segments
-                        .last()
-                        .is_some_and(|segment| segment.ident == "Config")
-            ) =>
-        {
-            Some(item_impl)
+/// Walk a `syn::Type` and collect every type identifier that isn't a
+/// well-known built-in. Insertion order matches the order each
+/// distinct ident is first encountered, so the rendered docs list
+/// types in the order a reader scanning the field list will meet
+/// them. The `seen` set deduplicates across multiple fields.
+fn collect_referenced_idents(ty: &Type, out: &mut Vec<String>, seen: &mut BTreeSet<String>) {
+    match ty {
+        Type::Path(type_path) => {
+            for segment in &type_path.path.segments {
+                let name = segment.ident.to_string();
+                if !is_builtin_type(&name) && seen.insert(name.clone()) {
+                    out.push(name);
+                }
+                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                    for arg in &args.args {
+                        if let syn::GenericArgument::Type(inner) = arg {
+                            collect_referenced_idents(inner, out, seen);
+                        }
+                    }
+                }
+            }
         }
-        _ => None,
-    }) else {
-        return out;
-    };
+        Type::Reference(type_ref) => collect_referenced_idents(&type_ref.elem, out, seen),
+        Type::Tuple(type_tuple) => {
+            for elem in &type_tuple.elems {
+                collect_referenced_idents(elem, out, seen);
+            }
+        }
+        Type::Array(type_array) => collect_referenced_idents(&type_array.elem, out, seen),
+        Type::Slice(type_slice) => collect_referenced_idents(&type_slice.elem, out, seen),
+        Type::Paren(type_paren) => collect_referenced_idents(&type_paren.elem, out, seen),
+        Type::Group(type_group) => collect_referenced_idents(&type_group.elem, out, seen),
+        _ => {}
+    }
+}
 
-    let Some(default_fn) = impl_item.items.iter().find_map(|item| match item {
-        ImplItem::Fn(item_fn) if item_fn.sig.ident == "default" => Some(item_fn),
-        _ => None,
-    }) else {
-        return out;
-    };
+/// Type names the renderer treats as "obvious", omitting them from
+/// the per-rule custom-types listing. Covers Rust's primitives and
+/// the std-library containers that show up in serde-deserialised
+/// configuration values. `Config` itself is on the list so a
+/// self-referential type doesn't loop the lookup.
+fn is_builtin_type(name: &str) -> bool {
+    matches!(
+        name,
+        // Primitives.
+        "bool" | "char" | "str"
+        | "u8" | "u16" | "u32" | "u64" | "u128"
+        | "i8" | "i16" | "i32" | "i64" | "i128"
+        | "usize" | "isize"
+        | "f32" | "f64"
+        // Common std types likely to appear in serde-deserialised configs.
+        | "String" | "Vec" | "Option" | "Result"
+        | "Box" | "Rc" | "Arc" | "Cow"
+        | "PathBuf" | "Path" | "OsString" | "OsStr"
+        | "HashMap" | "HashSet" | "BTreeMap" | "BTreeSet"
+        | "VecDeque" | "LinkedList"
+        // The Config struct itself.
+        | "Config"
+    )
+}
 
-    let Some(struct_expr) = default_fn
-        .block
-        .stmts
-        .last()
-        .and_then(|stmt| match stmt {
-            Stmt::Expr(expr, _) => Some(expr),
-            _ => None,
-        })
-        .and_then(|expr| match expr {
-            Expr::Struct(struct_expr) => Some(struct_expr),
-            Expr::Return(return_expr) => match return_expr.expr.as_deref() {
-                Some(Expr::Struct(struct_expr)) => Some(struct_expr),
-                _ => None,
-            },
-            _ => None,
-        })
-    else {
-        return out;
-    };
+/// Find the `enum` or `struct` definition for `ident` inside `file`
+/// and produce a `TypeDoc` describing its variants or fields.
+/// Returns `None` for idents we can't locate (e.g., types imported
+/// from another crate); those are silently dropped rather than
+/// faked, since the docs are only useful when we can show the real
+/// shape.
+fn find_type_doc(file: &syn::File, source: &str, ident: &str) -> Option<TypeDoc> {
+    for item in &file.items {
+        match item {
+            Item::Enum(item_enum) if item_enum.ident == ident => {
+                let rename_all = serde_rename_all(&item_enum.attrs);
+                let variants = item_enum
+                    .variants
+                    .iter()
+                    .map(|variant| {
+                        let rust_name = variant.ident.to_string();
+                        let variant_rename = serde_field_rename(&variant.attrs);
+                        let serialized = variant_rename
+                            .or_else(|| {
+                                rename_all
+                                    .as_deref()
+                                    .map(|style| apply_rename_all(style, &rust_name))
+                            })
+                            .unwrap_or_else(|| rust_name.clone());
+                        EnumVariant {
+                            rust_name,
+                            serialized,
+                            doc_markdown: doc_attrs_to_markdown(&variant.attrs),
+                        }
+                    })
+                    .collect();
+                return Some(TypeDoc {
+                    name: ident.to_owned(),
+                    doc_markdown: doc_attrs_to_markdown(&item_enum.attrs),
+                    kind: TypeKind::Enum { variants },
+                });
+            }
+            Item::Struct(item_struct) if item_struct.ident == ident => {
+                let fields = match &item_struct.fields {
+                    syn::Fields::Named(named) => named
+                        .named
+                        .iter()
+                        .map(|field| StructField {
+                            name: field
+                                .ident
+                                .as_ref()
+                                .expect("named field always has an ident")
+                                .to_string(),
+                            type_source: span_text(source, field.ty.span())
+                                .unwrap_or_else(|| fallback_type_text(&field.ty)),
+                            doc_markdown: doc_attrs_to_markdown(&field.attrs),
+                        })
+                        .collect(),
+                    _ => Vec::new(),
+                };
+                return Some(TypeDoc {
+                    name: ident.to_owned(),
+                    doc_markdown: doc_attrs_to_markdown(&item_struct.attrs),
+                    kind: TypeKind::Struct { fields },
+                });
+            }
+            _ => {}
+        }
+    }
+    None
+}
 
-    for field_value in &struct_expr.fields {
-        let syn::Member::Named(ident) = &field_value.member else {
+/// Read the `rename_all = "..."` style from a type's `#[serde(...)]`
+/// attribute, if present. Returns the raw style name (e.g.
+/// `"snake_case"`); the actual case conversion lives in
+/// [`apply_rename_all`].
+fn serde_rename_all(attrs: &[Attribute]) -> Option<String> {
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
             continue;
-        };
-        let text = span_text(source, field_value.expr.span())
-            .unwrap_or_else(|| field_value.expr.to_token_stream().to_string());
-        out.insert(ident.to_string(), text);
+        }
+        let parsed =
+            attr.parse_args_with(syn::punctuated::Punctuated::<Meta, Token![,]>::parse_terminated);
+        let Ok(items) = parsed else { continue };
+        for item in items {
+            if let Meta::NameValue(name_value) = item
+                && name_value.path.is_ident("rename_all")
+                && let Expr::Lit(ExprLit {
+                    lit: Lit::Str(literal),
+                    ..
+                }) = name_value.value
+            {
+                return Some(literal.value());
+            }
+        }
+    }
+    None
+}
+
+/// Read a per-variant or per-field `#[serde(rename = "...")]`
+/// override, used when one specific variant opts out of the
+/// enum-wide `rename_all` policy.
+fn serde_field_rename(attrs: &[Attribute]) -> Option<String> {
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        let parsed =
+            attr.parse_args_with(syn::punctuated::Punctuated::<Meta, Token![,]>::parse_terminated);
+        let Ok(items) = parsed else { continue };
+        for item in items {
+            if let Meta::NameValue(name_value) = item
+                && name_value.path.is_ident("rename")
+                && let Expr::Lit(ExprLit {
+                    lit: Lit::Str(literal),
+                    ..
+                }) = name_value.value
+            {
+                return Some(literal.value());
+            }
+        }
+    }
+    None
+}
+
+/// Apply one of serde's `rename_all` styles to a Rust identifier.
+/// Only the styles that actually appear in this codebase are
+/// implemented; anything else falls through to the identifier as
+/// written, which keeps the renderer honest about what it knows
+/// instead of silently producing a wrong serialised name.
+fn apply_rename_all(style: &str, name: &str) -> String {
+    match style {
+        "snake_case" => pascal_to_snake(name),
+        "SCREAMING_SNAKE_CASE" => pascal_to_snake(name).to_ascii_uppercase(),
+        "kebab-case" => pascal_to_snake(name).replace('_', "-"),
+        "lowercase" => name.to_ascii_lowercase(),
+        "UPPERCASE" => name.to_ascii_uppercase(),
+        _ => name.to_owned(),
+    }
+}
+
+/// Convert `PascalCase` (or `camelCase`) to `snake_case` by inserting
+/// `_` before each uppercase letter that follows a lowercase one or
+/// precedes a lowercase one. Adequate for the rule-author-controlled
+/// enum names this generator sees; not a general-purpose case
+/// converter.
+fn pascal_to_snake(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 2);
+    let chars: Vec<char> = name.chars().collect();
+    for (index, &ch) in chars.iter().enumerate() {
+        if ch.is_ascii_uppercase() {
+            let prev_lower = index > 0 && chars[index - 1].is_ascii_lowercase();
+            let next_lower = chars
+                .get(index + 1)
+                .is_some_and(|next| next.is_ascii_lowercase());
+            if index > 0 && (prev_lower || next_lower) {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
     }
     out
 }
@@ -539,18 +733,89 @@ fn config_section(config: &ConfigDoc) -> Markup {
                         code.config-key { (field.name) }
                         " : "
                         code.config-type { (field.type_source) }
-                        @if let Some(default) = &field.default_source {
-                            " "
-                            span.config-default {
-                                "(default: " code { (default) } ")"
-                            }
-                        }
+                        " "
+                        span.badge.badge-optional { "optional" }
                     }
                     dd {
                         @if field.doc_markdown.is_empty() {
                             p { em { "Undocumented." } }
                         } @else {
                             (PreEscaped(markdown_to_html(&field.doc_markdown)))
+                        }
+                    }
+                }
+            }
+            @if !config.custom_types.is_empty() {
+                h4 { "Custom types" }
+                @for ty in &config.custom_types {
+                    (custom_type_block(ty))
+                }
+            }
+        }
+    }
+}
+
+/// Render one custom type referenced by a `Config` field. Enum
+/// variants are listed with the string a TOML author would write,
+/// since that's the user-facing value; the Rust identifier is shown
+/// in parentheses only when it differs.
+fn custom_type_block(ty: &TypeDoc) -> Markup {
+    let kind_label = match ty.kind {
+        TypeKind::Enum { .. } => "enum",
+        TypeKind::Struct { .. } => "struct",
+    };
+    html! {
+        div.custom-type {
+            p {
+                code.custom-type-name { (ty.name) }
+                " "
+                span.custom-type-kind { (kind_label) }
+            }
+            @if !ty.doc_markdown.is_empty() {
+                (PreEscaped(markdown_to_html(&ty.doc_markdown)))
+            }
+            @match &ty.kind {
+                TypeKind::Enum { variants } => {
+                    @if !variants.is_empty() {
+                        dl.config {
+                            @for variant in variants {
+                                dt {
+                                    code.config-key { "\"" (variant.serialized) "\"" }
+                                    @if variant.rust_name != variant.serialized {
+                                        " "
+                                        span.config-default {
+                                            "(Rust: " code { (variant.rust_name) } ")"
+                                        }
+                                    }
+                                }
+                                dd {
+                                    @if variant.doc_markdown.is_empty() {
+                                        p { em { "Undocumented." } }
+                                    } @else {
+                                        (PreEscaped(markdown_to_html(&variant.doc_markdown)))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                TypeKind::Struct { fields } => {
+                    @if !fields.is_empty() {
+                        dl.config {
+                            @for field in fields {
+                                dt {
+                                    code.config-key { (field.name) }
+                                    " : "
+                                    code.config-type { (field.type_source) }
+                                }
+                                dd {
+                                    @if field.doc_markdown.is_empty() {
+                                        p { em { "Undocumented." } }
+                                    } @else {
+                                        (PreEscaped(markdown_to_html(&field.doc_markdown)))
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -305,14 +305,21 @@ fn extract_config(file: &syn::File) -> Option<ConfigDoc> {
     };
     let fields = named_fields
         .iter()
-        .map(|field| ConfigField {
-            name: field
+        .map(|field| {
+            let rust_name = field
                 .ident
                 .as_ref()
                 .expect("named field always has an ident")
-                .to_string(),
-            type_label: toml_type_label(&field.ty),
-            doc_markdown: doc_attrs_to_markdown(&field.attrs),
+                .to_string();
+            // Honour `#[serde(rename = "...")]` so the rendered
+            // TOML key matches what a user would actually type,
+            // mirroring the enum-variant handling in `find_type_doc`.
+            let name = serde_str_attr(&field.attrs, "rename").unwrap_or(rust_name);
+            ConfigField {
+                name,
+                type_label: toml_type_label(&field.ty),
+                doc_markdown: doc_attrs_to_markdown(&field.attrs),
+            }
         })
         .collect();
 
@@ -834,7 +841,7 @@ fn config_section(config: &ConfigDoc) -> Markup {
     }
     html! {
         details.config-details {
-            summary { h3 { "Configuration" } }
+            summary.config-summary { "Configuration" }
             p {
                 "Configure via " code { "dylint.toml" } " under "
                 code { "[\"" (config.key) "\"]" } "."
@@ -1086,6 +1093,15 @@ mod tests {
         syn::parse_str(source).expect("test input should parse as a syn::Type")
     }
 
+    /// Parse a Rust item and return its outer attributes. Used to
+    /// drive `serde_str_attr` tests without standing up a full
+    /// `syn::Field` or `syn::Variant` value by hand.
+    fn parse_attrs(source: &str) -> Vec<Attribute> {
+        let parsed: syn::ItemStruct =
+            syn::parse_str(source).expect("test input should parse as an item struct");
+        parsed.attrs
+    }
+
     #[test]
     fn pascal_to_snake_basic() {
         assert_eq!(pascal_to_snake("Line"), "line");
@@ -1192,6 +1208,57 @@ mod tests {
                  or remove the entry from BUILTIN_TYPES",
             );
         }
+    }
+
+    #[test]
+    fn serde_str_attr_branches() {
+        // Picks the value of the requested key.
+        let attrs = parse_attrs(r#"#[serde(rename_all = "snake_case")] struct S;"#);
+        assert_eq!(
+            serde_str_attr(&attrs, "rename_all"),
+            Some("snake_case".to_owned())
+        );
+        assert_eq!(serde_str_attr(&attrs, "rename"), None);
+
+        // Ignores non-`serde` attributes.
+        let attrs = parse_attrs(r#"#[derive(Debug)] #[other(rename = "x")] struct S;"#);
+        assert_eq!(serde_str_attr(&attrs, "rename"), None);
+
+        // Mixed Path / NameValue items inside `serde(...)`: the
+        // path-form `default` is skipped, the name-value matches.
+        let attrs = parse_attrs(r#"#[serde(default, rename = "foo")] struct S;"#);
+        assert_eq!(serde_str_attr(&attrs, "rename"), Some("foo".to_owned()));
+
+        // First match wins when the key appears more than once.
+        let attrs =
+            parse_attrs(r#"#[serde(rename = "first")] #[serde(rename = "second")] struct S;"#);
+        assert_eq!(serde_str_attr(&attrs, "rename"), Some("first".to_owned()));
+
+        // Non-string value is rejected (only `Lit::Str` is accepted).
+        let attrs = parse_attrs(r#"#[serde(skip = true)] struct S;"#);
+        assert_eq!(serde_str_attr(&attrs, "skip"), None);
+    }
+
+    #[test]
+    fn config_field_honours_serde_rename() {
+        // Walk a synthetic rule file through `extract_config` to
+        // confirm that `#[serde(rename = "...")]` on a Config
+        // field surfaces as the TOML key instead of the Rust ident.
+        let source = r#"
+            const CONFIG_KEY: &str = "perfectionist::demo";
+
+            #[derive(serde::Deserialize)]
+            #[serde(default, rename_all = "snake_case")]
+            struct Config {
+                #[serde(rename = "renamed-key")]
+                rust_name: bool,
+                plain_name: usize,
+            }
+        "#;
+        let file = syn::parse_file(source).unwrap();
+        let config = extract_config(&file).expect("demo file declares CONFIG_KEY and Config");
+        let names: Vec<&str> = config.fields.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["renamed-key", "plain_name"]);
     }
 
     #[test]

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -53,10 +53,22 @@ struct Cli {
 
     #[clap(help = "Output directory; index.html will be written here")]
     out_dir: PathBuf,
+
+    /// Git ref the rendered "Source:" links should target.
+    /// Defaults to `master` so the dev-snapshot page keeps linking
+    /// to tip-of-tree. CI for a tagged release should pass the
+    /// tag (or its SHA) so the published page points at the
+    /// source the page was actually generated from.
+    #[clap(long, default_value = "master")]
+    git_ref: String,
 }
 
 fn main() -> ExitCode {
-    let Cli { root, out_dir } = Cli::parse();
+    let Cli {
+        root,
+        out_dir,
+        git_ref,
+    } = Cli::parse();
 
     let manifest = Manifest::from_path(root.join("Cargo.toml")).expect("failed to read Cargo.toml");
     let crate_version = manifest
@@ -78,7 +90,7 @@ fn main() -> ExitCode {
     }
 
     fs::create_dir_all(&out_dir).expect("failed to create output directory");
-    let html = render_page(&rules, &crate_version);
+    let html = render_page(&rules, &crate_version, &git_ref);
     let index_path = out_dir.join("index.html");
     fs::write(&index_path, html).expect("failed to write index.html");
 
@@ -169,9 +181,20 @@ struct EnumVariant {
     doc_markdown: String,
 }
 
+/// A field of a project-local struct surfaced under a rule's
+/// Types section. Mirrors [`ConfigField`] for the nested-struct
+/// case, but the renderer omits the optional badge here — a
+/// custom struct's TOML representation requires every field
+/// to be present, since serde's `default` attribute belongs to
+/// the top-level `Config` deserialisation, not nested.
 struct StructField {
+    /// The TOML key for this field, after applying the struct's
+    /// own serde rename rules where present.
     name: String,
+    /// TOML-flavoured label for the field's type. See
+    /// [`toml_type_label`] for the mapping.
     type_label: String,
+    /// Per-field `///` doc comment, in markdown form.
     doc_markdown: String,
 }
 
@@ -564,10 +587,18 @@ fn serde_str_attr(attrs: &[Attribute], key: &str) -> Option<String> {
 }
 
 /// Apply one of serde's `rename_all` styles to a Rust identifier.
-/// Only the styles that actually appear in this codebase are
-/// implemented; anything else falls through to the identifier as
-/// written, which keeps the renderer honest about what it knows
-/// instead of silently producing a wrong serialised name.
+/// Covers the styles serde itself documents: `snake_case`,
+/// `kebab-case`, their SCREAMING variants, `lowercase`, `UPPERCASE`,
+/// `camelCase`, and `PascalCase`. None of the current rules need
+/// anything outside `snake_case`; the others are here so that
+/// adopting a new style elsewhere doesn't silently mangle the
+/// rendered TOML keys.
+///
+/// An unrecognised style prints a warning to stderr and falls
+/// through to the identifier as written. Warning rather than
+/// panicking, on the principle that a wrong doc page is less bad
+/// than a broken doc-generation build — but the warning makes the
+/// gap loud enough that the rule author notices.
 fn apply_rename_all(style: &str, name: &str) -> String {
     match style {
         "snake_case" => pascal_to_snake(name),
@@ -587,7 +618,14 @@ fn apply_rename_all(style: &str, name: &str) -> String {
                 None => String::new(),
             }
         }
-        _ => name.to_owned(),
+        unknown => {
+            eprintln!(
+                "warning: unrecognised serde `rename_all` style {unknown:?}; \
+                 rendering `{name}` unchanged. Add an arm to `apply_rename_all` \
+                 if this style needs to be supported."
+            );
+            name.to_owned()
+        }
     }
 }
 
@@ -755,7 +793,7 @@ fn doc_attrs_to_markdown(attrs: &[Attribute]) -> String {
     lines.join("\n")
 }
 
-fn render_page(rules: &[Rule], crate_version: &str) -> String {
+fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str) -> String {
     let markup: Markup = html! {
         (DOCTYPE)
         html lang="en" {
@@ -804,7 +842,7 @@ fn render_page(rules: &[Rule], crate_version: &str) -> String {
                 }
                 h2 { "Rules" }
                 @for rule in rules {
-                    (rule_article(rule))
+                    (rule_article(rule, git_ref))
                 }
                 footer {
                     "Generated from " code { "src/rules/" } "."
@@ -815,10 +853,10 @@ fn render_page(rules: &[Rule], crate_version: &str) -> String {
     markup.into_string()
 }
 
-fn rule_article(rule: &Rule) -> Markup {
+fn rule_article(rule: &Rule, git_ref: &str) -> Markup {
     let source_path = rule.relative_source.display().to_string();
     let source_url =
-        format!("https://github.com/KSXGitHub/perfectionist/blob/master/{source_path}");
+        format!("https://github.com/KSXGitHub/perfectionist/blob/{git_ref}/{source_path}");
     html! {
         article.rule id=(anchor_for(&rule.namespaced)) {
             h2 { code { (rule.namespaced) } }

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -6,6 +6,9 @@
 //! invocation, and pulls four things out of it: the lint identifier
 //! (`pub perfectionist::NAME`), its default level, its one-line
 //! description, and the `///` doc-comment block that documents it.
+//! In addition, when a rule's file defines a `Config` struct paired
+//! with a `CONFIG_KEY` constant, the configurable fields (and their
+//! per-field doc comments and default expressions) are surfaced too.
 //! The output is a single self-contained `index.html` written into
 //! the directory passed on the command line.
 //!
@@ -16,7 +19,9 @@
 //! rustc plugin host just to read these few fields.
 
 use std::{
+    collections::HashMap,
     fs,
+    ops::Range,
     path::{Path, PathBuf},
     process::ExitCode,
 };
@@ -26,10 +31,12 @@ use clap::Parser;
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 use proc_macro2::TokenStream;
 use pulldown_cmark::{Event, Options, Tag, TagEnd, html as cmark_html};
+use quote::ToTokens;
 use strum::{Display, EnumString};
 use syn::{
-    Attribute, Expr, ExprLit, Ident, Item, Lit, LitStr, Meta, Token,
+    Attribute, Expr, ExprLit, Ident, ImplItem, Item, Lit, LitStr, Meta, Stmt, Token, Type,
     parse::{Parse, ParseStream},
+    spanned::Spanned,
 };
 
 #[derive(Parser)]
@@ -85,6 +92,45 @@ struct Rule {
     doc_markdown: String,
     /// Source path relative to the repo root, for cross-linking.
     relative_source: PathBuf,
+    /// `Config` struct contents when the rule declares one. `None`
+    /// means the rule file has no `Config` / `CONFIG_KEY` pair.
+    config: Option<ConfigDoc>,
+}
+
+/// The configuration surface of a single rule, as extracted from the
+/// rule's `Config` struct, paired `CONFIG_KEY` constant, and (when
+/// present) hand-written `impl Default for Config`.
+struct ConfigDoc {
+    /// The TOML table key, e.g. `perfectionist::flat_module_pattern`.
+    /// Read from the file's `CONFIG_KEY` constant verbatim.
+    key: String,
+    /// Doc comment attached to the `Config` struct itself, useful
+    /// for rules with no fields (where it explains why the struct
+    /// still exists) or for cross-cutting notes about a rule's
+    /// configuration shape.
+    struct_doc_markdown: String,
+    /// One entry per named field of the `Config` struct.
+    fields: Vec<ConfigField>,
+}
+
+/// One configurable knob, with the source text of its type and
+/// default expression preserved verbatim so the rendered docs match
+/// what a reader will see in `src/rules/<rule>.rs`.
+struct ConfigField {
+    /// Field identifier, e.g. `also_flag`. Matches the TOML key
+    /// because every `Config` uses `#[serde(rename_all = "snake_case")]`
+    /// and the fields are already named in snake case.
+    name: String,
+    /// Verbatim source of the field's type (e.g. `Vec<char>`),
+    /// sliced out of the rule file using `proc_macro2::Span`
+    /// byte ranges.
+    type_source: String,
+    /// Verbatim source of the field's default expression as it
+    /// appears in `impl Default for Config`, or `None` when no
+    /// `Default` impl could be located.
+    default_source: Option<String>,
+    /// Per-field `///` doc comment, in markdown form.
+    doc_markdown: String,
 }
 
 /// The set of lint levels rustc / Dylint accept as the second
@@ -174,13 +220,163 @@ fn extract_rule(source_path: &Path) -> Option<Rule> {
         )
     });
 
+    let config = extract_config(&file, &source);
+
     Some(Rule {
         namespaced,
         level,
         short_desc: declaration.desc.value(),
         doc_markdown,
         relative_source,
+        config,
     })
+}
+
+/// Locate the rule's `Config` struct, its `CONFIG_KEY` constant, and
+/// the optional `impl Default for Config` block, and bundle them
+/// into a `ConfigDoc`. Returns `None` when either the constant or
+/// the struct is missing — both are mandatory for a rule to be
+/// considered "configurable" by `dylint.toml`.
+fn extract_config(file: &syn::File, source: &str) -> Option<ConfigDoc> {
+    let key = file.items.iter().find_map(|item| match item {
+        Item::Const(item_const) if item_const.ident == "CONFIG_KEY" => match &*item_const.expr {
+            Expr::Lit(ExprLit {
+                lit: Lit::Str(literal),
+                ..
+            }) => Some(literal.value()),
+            _ => None,
+        },
+        _ => None,
+    })?;
+    let config_struct = file.items.iter().find_map(|item| match item {
+        Item::Struct(item_struct) if item_struct.ident == "Config" => Some(item_struct),
+        _ => None,
+    })?;
+    let struct_doc_markdown = doc_attrs_to_markdown(&config_struct.attrs);
+    let defaults = extract_config_defaults(file, source);
+
+    let fields = match &config_struct.fields {
+        syn::Fields::Named(named) => named
+            .named
+            .iter()
+            .map(|field| {
+                let name = field
+                    .ident
+                    .as_ref()
+                    .expect("named field always has an ident")
+                    .to_string();
+                let type_source = span_text(source, field.ty.span())
+                    .unwrap_or_else(|| fallback_type_text(&field.ty));
+                let default_source = defaults.get(&name).cloned();
+                let doc_markdown = doc_attrs_to_markdown(&field.attrs);
+                ConfigField {
+                    name,
+                    type_source,
+                    default_source,
+                    doc_markdown,
+                }
+            })
+            .collect(),
+        _ => Vec::new(),
+    };
+
+    Some(ConfigDoc {
+        key,
+        struct_doc_markdown,
+        fields,
+    })
+}
+
+/// Pull each field's default expression out of `impl Default for
+/// Config`. Recognises the conventional shape
+/// `fn default() -> Self { Self { field: expr, ... } }` (with or
+/// without an explicit `return`); anything more exotic yields an
+/// empty map and the rendered docs simply omit the default column.
+fn extract_config_defaults(file: &syn::File, source: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    let Some(impl_item) = file.items.iter().find_map(|item| match item {
+        Item::Impl(item_impl)
+            if item_impl
+                .trait_
+                .as_ref()
+                .is_some_and(|(_, path, _)| {
+                    path.segments
+                        .last()
+                        .is_some_and(|segment| segment.ident == "Default")
+                })
+                && matches!(
+                    &*item_impl.self_ty,
+                    Type::Path(type_path)
+                        if type_path
+                            .path
+                            .segments
+                            .last()
+                            .is_some_and(|segment| segment.ident == "Config")
+                ) =>
+        {
+            Some(item_impl)
+        }
+        _ => None,
+    }) else {
+        return out;
+    };
+
+    let Some(default_fn) = impl_item.items.iter().find_map(|item| match item {
+        ImplItem::Fn(item_fn) if item_fn.sig.ident == "default" => Some(item_fn),
+        _ => None,
+    }) else {
+        return out;
+    };
+
+    let Some(struct_expr) = default_fn
+        .block
+        .stmts
+        .last()
+        .and_then(|stmt| match stmt {
+            Stmt::Expr(expr, _) => Some(expr),
+            _ => None,
+        })
+        .and_then(|expr| match expr {
+            Expr::Struct(struct_expr) => Some(struct_expr),
+            Expr::Return(return_expr) => match return_expr.expr.as_deref() {
+                Some(Expr::Struct(struct_expr)) => Some(struct_expr),
+                _ => None,
+            },
+            _ => None,
+        })
+    else {
+        return out;
+    };
+
+    for field_value in &struct_expr.fields {
+        let syn::Member::Named(ident) = &field_value.member else {
+            continue;
+        };
+        let text = span_text(source, field_value.expr.span())
+            .unwrap_or_else(|| field_value.expr.to_token_stream().to_string());
+        out.insert(ident.to_string(), text);
+    }
+    out
+}
+
+/// Slice the verbatim source bytes covered by `span`. Falls back to
+/// `None` when the span has no usable byte range (which happens for
+/// synthetic spans produced by macro expansion, not for code that
+/// originated in a file we just parsed — but the type system makes
+/// us account for the case anyway).
+fn span_text(source: &str, span: proc_macro2::Span) -> Option<String> {
+    let Range { start, end } = span.byte_range();
+    if end <= start || end > source.len() {
+        return None;
+    }
+    Some(source[start..end].to_owned())
+}
+
+/// Best-effort stringifier for a `syn::Type` when no source span is
+/// available. The output uses `quote`'s default token spacing, which
+/// is less pretty than the original source but always parseable.
+fn fallback_type_text(ty: &Type) -> String {
+    ty.to_token_stream().to_string()
 }
 
 /// Minimal grammar of `declare_tool_lint!`'s body. The macro itself
@@ -311,9 +507,57 @@ fn rule_article(rule: &Rule) -> Markup {
                 (PreEscaped(markdown_inline_to_html(&rule.short_desc)))
             }
             (PreEscaped(markdown_to_html(&rule.doc_markdown)))
+            @if let Some(config) = &rule.config {
+                (config_section(config))
+            }
             p.source {
                 "Source: "
                 a href=(source_url) { code { (source_path) } }
+            }
+        }
+    }
+}
+
+/// Render the per-rule configuration block. When the `Config`
+/// struct has no fields, the block is still emitted so readers
+/// can see that the rule is intentionally non-configurable (and,
+/// where the struct itself carries a doc comment, why).
+fn config_section(config: &ConfigDoc) -> Markup {
+    html! {
+        h3 { "Configuration" }
+        p {
+            "Configure via " code { "dylint.toml" } " under "
+            code { "[\"" (config.key) "\"]" } "."
+        }
+        @if !config.struct_doc_markdown.is_empty() {
+            (PreEscaped(markdown_to_html(&config.struct_doc_markdown)))
+        }
+        @if config.fields.is_empty() {
+            @if config.struct_doc_markdown.is_empty() {
+                p { em { "No configurable options." } }
+            }
+        } @else {
+            dl.config {
+                @for field in &config.fields {
+                    dt {
+                        code.config-key { (field.name) }
+                        " : "
+                        code.config-type { (field.type_source) }
+                        @if let Some(default) = &field.default_source {
+                            " "
+                            span.config-default {
+                                "(default: " code { (default) } ")"
+                            }
+                        }
+                    }
+                    dd {
+                        @if field.doc_markdown.is_empty() {
+                            p { em { "Undocumented." } }
+                        } @else {
+                            (PreEscaped(markdown_to_html(&field.doc_markdown)))
+                        }
+                    }
+                }
             }
         }
     }

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -806,8 +806,12 @@ fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str) -> String {
             body {
                 h1 { "perfectionist lints" }
                 div.banner {
-                    "Showing development docs from " code { "master" } ". "
-                    "Latest released version: " code { (crate_version) } "."
+                    @if git_ref == "master" {
+                        "Showing development docs from " code { "master" } ". "
+                        "Latest released version: " code { (crate_version) } "."
+                    } @else {
+                        "Showing docs for " code { (git_ref) } "."
+                    }
                 }
                 p {
                     "perfectionist is a Dylint plugin; see the "
@@ -845,7 +849,8 @@ fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str) -> String {
                     (rule_article(rule, git_ref))
                 }
                 footer {
-                    "Generated from " code { "src/rules/" } "."
+                    "Generated from " code { "src/rules/" }
+                    " at " code { (git_ref) } "."
                 }
             }
         }

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -763,17 +763,34 @@ fn rule_article(rule: &Rule) -> Markup {
     }
 }
 
-/// Render the per-rule configuration block, wrapped in a `<details>`
-/// element so a long reference table doesn't dominate the page.
-/// The element is collapsed by default — configuration is reference
-/// material, and the rule's description above it is what most
-/// readers came for. Modern browsers auto-expand a closed `<details>`
-/// when find-in-page hits something inside it, so search still
-/// works against the hidden content. When the `Config` struct has
-/// no fields, the block is still emitted so readers can see that
-/// the rule is intentionally non-configurable (and, where the
-/// struct itself carries a doc comment, why).
+/// Render the per-rule configuration block. Two shapes:
+///
+/// 1. When the rule has at least one configurable field, wrap the
+///    block in a `<details>` element, collapsed by default. The
+///    rule's description above is what most catalogue readers came
+///    for; configuration is reference material that can stay
+///    hidden until clicked. Modern browsers auto-expand a closed
+///    `<details>` when find-in-page hits something inside it, so
+///    search still works.
+/// 2. When the rule has no fields (an empty `Config` struct,
+///    e.g. `flat_module_pattern`), render a single inline line
+///    "Configuration: none." instead. The fact that the rule is
+///    not configurable is itself information; omitting the section
+///    entirely would leave readers wondering whether they missed a
+///    knob. Any struct-level doc comment is still surfaced after
+///    the inline line, so the rule's prose explanation of *why*
+///    the placeholder exists is preserved.
 fn config_section(config: &ConfigDoc) -> Markup {
+    if config.fields.is_empty() {
+        return html! {
+            p.config-none {
+                strong { "Configuration:" } " none."
+            }
+            @if !config.struct_doc_markdown.is_empty() {
+                (PreEscaped(markdown_to_html(&config.struct_doc_markdown)))
+            }
+        };
+    }
     html! {
         details.config-details {
             summary { h3 { "Configuration" } }
@@ -784,34 +801,28 @@ fn config_section(config: &ConfigDoc) -> Markup {
             @if !config.struct_doc_markdown.is_empty() {
                 (PreEscaped(markdown_to_html(&config.struct_doc_markdown)))
             }
-            @if config.fields.is_empty() {
-                @if config.struct_doc_markdown.is_empty() {
-                    p { em { "No configurable options." } }
-                }
-            } @else {
-                dl.config {
-                    @for field in &config.fields {
-                        dt {
-                            code.config-key { (field.name) }
-                            " : "
-                            code.config-type { (field.type_label) }
-                            " "
-                            span.badge.badge-optional { "optional" }
-                        }
-                        dd {
-                            @if field.doc_markdown.is_empty() {
-                                p { em { "Undocumented." } }
-                            } @else {
-                                (PreEscaped(markdown_to_html(&field.doc_markdown)))
-                            }
+            dl.config {
+                @for field in &config.fields {
+                    dt {
+                        code.config-key { (field.name) }
+                        " : "
+                        code.config-type { (field.type_label) }
+                        " "
+                        span.badge.badge-optional { "optional" }
+                    }
+                    dd {
+                        @if field.doc_markdown.is_empty() {
+                            p { em { "Undocumented." } }
+                        } @else {
+                            (PreEscaped(markdown_to_html(&field.doc_markdown)))
                         }
                     }
                 }
-                @if !config.custom_types.is_empty() {
-                    h4 { "Types" }
-                    @for ty in &config.custom_types {
-                        (custom_type_block(ty))
-                    }
+            }
+            @if !config.custom_types.is_empty() {
+                h4 { "Types" }
+                @for ty in &config.custom_types {
+                    (custom_type_block(ty))
                 }
             }
         }

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -265,7 +265,7 @@ fn extract_rule(source_path: &Path) -> Option<Rule> {
         )
     });
 
-    let config = extract_config(&file);
+    let config = extract_config(source_path, &file);
 
     Some(Rule {
         namespaced,
@@ -279,10 +279,13 @@ fn extract_rule(source_path: &Path) -> Option<Rule> {
 
 /// Locate the rule's `Config` struct and its `CONFIG_KEY` constant
 /// and bundle them — along with any project-local types the fields
-/// reference — into a `ConfigDoc`. Returns `None` when either the
-/// constant or the struct is missing; both are mandatory for a rule
-/// to be considered "configurable" by `dylint.toml`.
-fn extract_config(file: &syn::File) -> Option<ConfigDoc> {
+/// reference — into a `ConfigDoc`. Returns `None` when *both* the
+/// constant and the struct are missing (a rule with no configuration
+/// concept at all). Defining only one of the two prints a warning
+/// and still returns `None`: the convention in this repo is that
+/// every rule has both, and a half-defined Config is almost always
+/// the author having dropped the other half.
+fn extract_config(source_path: &Path, file: &syn::File) -> Option<ConfigDoc> {
     let key = file.items.iter().find_map(|item| match item {
         Item::Const(item_const) if item_const.ident == "CONFIG_KEY" => match &*item_const.expr {
             Expr::Lit(ExprLit {
@@ -292,11 +295,31 @@ fn extract_config(file: &syn::File) -> Option<ConfigDoc> {
             _ => None,
         },
         _ => None,
-    })?;
+    });
     let config_struct = file.items.iter().find_map(|item| match item {
         Item::Struct(item_struct) if item_struct.ident == "Config" => Some(item_struct),
         _ => None,
-    })?;
+    });
+    let (key, config_struct) = match (key, config_struct) {
+        (Some(key), Some(config_struct)) => (key, config_struct),
+        (None, None) => return None,
+        (Some(_), None) => {
+            eprintln!(
+                "warning: {} declares CONFIG_KEY but no `Config` struct; \
+                 skipping its configuration section",
+                source_path.display(),
+            );
+            return None;
+        }
+        (None, Some(_)) => {
+            eprintln!(
+                "warning: {} declares a `Config` struct but no CONFIG_KEY const; \
+                 skipping its configuration section",
+                source_path.display(),
+            );
+            return None;
+        }
+    };
     let struct_doc_markdown = doc_attrs_to_markdown(&config_struct.attrs);
 
     let named_fields = match &config_struct.fields {
@@ -382,25 +405,26 @@ fn collect_referenced_idents(ty: &Type, out: &mut Vec<String>, seen: &mut BTreeS
     }
 }
 
+/// Whether `name` is in the renderer's built-in type set. Thin
+/// wrapper around [`BUILTIN_TYPES`] kept for naming intent at the
+/// call sites; the contract and rationale live on the constant.
+fn is_builtin_type(name: &str) -> bool {
+    BUILTIN_TYPES.contains(&name)
+}
+
 /// Type names the renderer treats as "obvious", omitting them from
 /// the per-rule custom-types listing. Covers Rust's primitives and
 /// the std-library containers that show up in serde-deserialised
 /// configuration values. `Config` itself is on the list so a
 /// self-referential type doesn't loop the lookup.
 ///
-/// **Keep in sync with [`toml_type_label`].** The two functions
-/// share a coverage contract: every ident accepted here must also
-/// have a match arm there, otherwise the renderer either drops a
-/// real custom type from the Types section (false positive here)
-/// or leaks a Rust identifier into the field-type column (false
-/// negative there). The unit test `builtin_types_all_map_to_toml_label`
-/// guards this contract mechanically.
-fn is_builtin_type(name: &str) -> bool {
-    BUILTIN_TYPES.contains(&name)
-}
-
-/// The full set [`is_builtin_type`] accepts, exposed as a constant
-/// so the contract test can iterate it.
+/// **Keep in sync with [`toml_type_label`].** The two share a
+/// coverage contract: every ident here must also have a match arm
+/// there, otherwise the renderer either drops a real custom type
+/// from the Types section (false positive here) or leaks a Rust
+/// identifier into the field-type column (false negative there).
+/// The unit test `builtin_types_all_map_to_toml_label` guards this
+/// contract mechanically.
 const BUILTIN_TYPES: &[&str] = &[
     // Primitives.
     "bool",
@@ -1256,7 +1280,8 @@ mod tests {
             }
         "#;
         let file = syn::parse_file(source).unwrap();
-        let config = extract_config(&file).expect("demo file declares CONFIG_KEY and Config");
+        let config = extract_config(Path::new("synthetic.rs"), &file)
+            .expect("demo file declares CONFIG_KEY and Config");
         let names: Vec<&str> = config.fields.iter().map(|f| f.name.as_str()).collect();
         assert_eq!(names, vec!["renamed-key", "plain_name"]);
     }

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -373,6 +373,13 @@ fn collect_referenced_idents(ty: &Type, out: &mut Vec<String>, seen: &mut BTreeS
 /// the std-library containers that show up in serde-deserialised
 /// configuration values. `Config` itself is on the list so a
 /// self-referential type doesn't loop the lookup.
+///
+/// **Keep in sync with [`toml_type_label`].** The two functions
+/// share a coverage contract: every ident accepted here must also
+/// have a match arm there, otherwise the renderer either drops a
+/// real custom type from the Types section (false positive here)
+/// or leaks a Rust identifier into the field-type column (false
+/// negative there).
 fn is_builtin_type(name: &str) -> bool {
     matches!(
         name,
@@ -383,7 +390,7 @@ fn is_builtin_type(name: &str) -> bool {
         | "usize" | "isize"
         | "f32" | "f64"
         // Common std types likely to appear in serde-deserialised configs.
-        | "String" | "Vec" | "Option" | "Result"
+        | "String" | "Vec" | "Option"
         | "Box" | "Rc" | "Arc" | "Cow"
         | "PathBuf" | "Path" | "OsString" | "OsStr"
         | "HashMap" | "HashSet" | "BTreeMap" | "BTreeSet"
@@ -571,9 +578,16 @@ fn pascal_to_snake(name: &str) -> String {
 /// - `HashMap<_, V>` / `BTreeMap<_, V>` → `table of label-of-V`
 /// - `Option<T>` → `label-of-T` (every config field is already
 ///   marked optional, so the wrapper would just add noise)
+/// - `Option<T>` / `Box<T>` / `Rc<T>` / `Arc<T>` → `label-of-T`
+///   (every config field is already marked optional, and the
+///   smart-pointer wrappers are transparent at the serde layer)
 /// - Anything else (project-local enums and structs) → the Rust
 ///   identifier verbatim, since those names appear in the per-rule
 ///   Types subsection below and the reader can scan to them.
+///
+/// **Keep in sync with [`is_builtin_type`].** Both functions must
+/// recognise the same set of identifiers; see the note on
+/// `is_builtin_type` for why.
 fn toml_type_label(ty: &Type) -> String {
     match ty {
         Type::Path(type_path) => {
@@ -610,7 +624,7 @@ fn toml_type_label(ty: &Type) -> String {
                     Some(value) => format!("table of {}", toml_type_label(value)),
                     None => "table".to_owned(),
                 },
-                "Option" => match inner_types.first() {
+                "Option" | "Box" | "Rc" | "Arc" => match inner_types.first() {
                     Some(inner) => toml_type_label(inner),
                     None => ident,
                 },
@@ -620,6 +634,11 @@ fn toml_type_label(ty: &Type) -> String {
         Type::Reference(type_ref) => toml_type_label(&type_ref.elem),
         Type::Paren(type_paren) => toml_type_label(&type_paren.elem),
         Type::Group(type_group) => toml_type_label(&type_group.elem),
+        // Tuples, trait objects, function pointers, raw pointers,
+        // etc. fall through to a Rust-syntax fallback. No current
+        // `Config` field uses any of these; if one ever does, add
+        // a real arm rather than letting Rust syntax leak into the
+        // user-facing label.
         _ => ty.to_token_stream().to_string(),
     }
 }

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -109,13 +109,6 @@ struct ConfigDoc {
     /// The TOML table key, e.g. `perfectionist::flat_module_pattern`.
     /// Read from the file's `CONFIG_KEY` constant verbatim.
     key: String,
-    /// Doc comment attached to the `Config` struct itself. Only
-    /// surfaced when the rule has at least one configurable field;
-    /// empty Configs render the inline `Configuration: none.` line
-    /// and intentionally drop any struct-level note (it would
-    /// always be implementation prose about the placeholder, not
-    /// user-facing schema).
-    struct_doc_markdown: String,
     /// One entry per named field of the `Config` struct.
     fields: Vec<ConfigField>,
     /// Non-built-in types referenced from `Config`'s fields, in the
@@ -130,9 +123,13 @@ struct ConfigDoc {
 /// reproducing the Rust default expression — the prose doc comment
 /// states the default in human-readable form.
 struct ConfigField {
-    /// Field identifier, e.g. `also_flag`. Matches the TOML key
-    /// because every `Config` uses `#[serde(rename_all = "snake_case")]`
-    /// and the fields are already named in snake case.
+    /// The TOML key a reader writes in `dylint.toml`. Resolved in
+    /// this order: per-field `#[serde(rename = "...")]` if present;
+    /// otherwise the struct-level `#[serde(rename_all = "...")]`
+    /// applied to the Rust identifier; otherwise the raw Rust
+    /// identifier (the project convention has Configs in
+    /// `snake_case` with `rename_all = "snake_case"`, which makes
+    /// the Rust ident and the TOML key coincide).
     name: String,
     /// TOML-flavoured label for the field's type (e.g. `[string]`
     /// for `Vec<char>`). See [`toml_type_label`] for the mapping
@@ -320,7 +317,7 @@ fn extract_config(source_path: &Path, file: &syn::File) -> Option<ConfigDoc> {
             return None;
         }
     };
-    let struct_doc_markdown = doc_attrs_to_markdown(&config_struct.attrs);
+    let rename_all = serde_str_attr(&config_struct.attrs, "rename_all");
 
     let named_fields = match &config_struct.fields {
         syn::Fields::Named(named) => named.named.iter().collect::<Vec<_>>(),
@@ -334,10 +331,15 @@ fn extract_config(source_path: &Path, file: &syn::File) -> Option<ConfigDoc> {
                 .as_ref()
                 .expect("named field always has an ident")
                 .to_string();
-            // Honour `#[serde(rename = "...")]` so the rendered
-            // TOML key matches what a user would actually type,
-            // mirroring the enum-variant handling in `find_type_doc`.
-            let name = serde_str_attr(&field.attrs, "rename").unwrap_or(rust_name);
+            // Precedence mirrors serde itself: per-field
+            // `#[serde(rename = "...")]` wins, then the struct-
+            // level `rename_all` style, then the raw Rust ident.
+            let name = serde_str_attr(&field.attrs, "rename").unwrap_or_else(|| {
+                rename_all
+                    .as_deref()
+                    .map(|style| apply_rename_all(style, &rust_name))
+                    .unwrap_or(rust_name)
+            });
             ConfigField {
                 name,
                 type_label: toml_type_label(&field.ty),
@@ -358,7 +360,6 @@ fn extract_config(source_path: &Path, file: &syn::File) -> Option<ConfigDoc> {
 
     Some(ConfigDoc {
         key,
-        struct_doc_markdown,
         fields,
         custom_types,
     })
@@ -870,9 +871,6 @@ fn config_section(config: &ConfigDoc) -> Markup {
                 "Configure via " code { "dylint.toml" } " under "
                 code { "[\"" (config.key) "\"]" } "."
             }
-            @if !config.struct_doc_markdown.is_empty() {
-                (PreEscaped(markdown_to_html(&config.struct_doc_markdown)))
-            }
             dl.config {
                 @for field in &config.fields {
                     dt {
@@ -1284,6 +1282,30 @@ mod tests {
             .expect("demo file declares CONFIG_KEY and Config");
         let names: Vec<&str> = config.fields.iter().map(|f| f.name.as_str()).collect();
         assert_eq!(names, vec!["renamed-key", "plain_name"]);
+    }
+
+    #[test]
+    fn config_field_honours_struct_rename_all() {
+        // `rename_all = "kebab-case"` on the Config struct should
+        // surface every Rust field's snake-case identifier with
+        // dashes. A per-field `#[serde(rename)]` still wins.
+        let source = r#"
+            const CONFIG_KEY: &str = "perfectionist::demo";
+
+            #[derive(serde::Deserialize)]
+            #[serde(default, rename_all = "kebab-case")]
+            struct Config {
+                also_flag: bool,
+                some_other_key: usize,
+                #[serde(rename = "explicit")]
+                overridden: bool,
+            }
+        "#;
+        let file = syn::parse_file(source).unwrap();
+        let config = extract_config(Path::new("synthetic.rs"), &file)
+            .expect("demo file declares CONFIG_KEY and Config");
+        let names: Vec<&str> = config.fields.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["also-flag", "some-other-key", "explicit"]);
     }
 
     #[test]

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -59,7 +59,11 @@ struct Cli {
     /// to tip-of-tree. CI for a tagged release should pass the
     /// tag (or its SHA) so the published page points at the
     /// source the page was actually generated from.
-    #[clap(long, default_value = "master")]
+    #[clap(
+        long,
+        default_value = "master",
+        value_parser = clap::builder::NonEmptyStringValueParser::new(),
+    )]
     git_ref: String,
 }
 
@@ -100,12 +104,31 @@ fn main() -> ExitCode {
     }
 
     fs::create_dir_all(&out_dir).expect("failed to create output directory");
-    let html = render_page(&rules, &crate_version, &git_ref, &repo_url);
+    let context = RenderContext {
+        crate_version: &crate_version,
+        git_ref: &git_ref,
+        repo_url: &repo_url,
+    };
+    let html = render_page(&rules, &context);
     let index_path = out_dir.join("index.html");
     fs::write(&index_path, html).expect("failed to write index.html");
 
     eprintln!("wrote {} rule(s) to {}", rules.len(), index_path.display());
     ExitCode::SUCCESS
+}
+
+/// Page-global context threaded through the renderer. Grouping
+/// these here keeps the per-article and per-field rendering
+/// signatures from collecting more positional string args every
+/// time a new contextual field is added.
+struct RenderContext<'a> {
+    /// Latest released version of the crate, read from `Cargo.toml`.
+    crate_version: &'a str,
+    /// Git ref the rendered "Source:" links target.
+    git_ref: &'a str,
+    /// Project repository URL, used for the README link in the
+    /// banner and as the base for the per-rule blob URLs.
+    repo_url: &'a str,
 }
 
 /// One lint, in the shape the page needs to render.
@@ -828,7 +851,12 @@ fn doc_attrs_to_markdown(attrs: &[Attribute]) -> String {
     lines.join("\n")
 }
 
-fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str, repo_url: &str) -> String {
+fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String {
+    let RenderContext {
+        crate_version,
+        git_ref,
+        repo_url,
+    } = *context;
     let markup: Markup = html! {
         (DOCTYPE)
         html lang="en" {
@@ -884,7 +912,7 @@ fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str, repo_url: &st
                 }
                 h2 { "Rules" }
                 @for rule in rules {
-                    (rule_article(rule, git_ref, repo_url))
+                    (rule_article(rule, context))
                 }
                 footer {
                     "Generated from " code { "src/rules/" }
@@ -896,7 +924,10 @@ fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str, repo_url: &st
     markup.into_string()
 }
 
-fn rule_article(rule: &Rule, git_ref: &str, repo_url: &str) -> Markup {
+fn rule_article(rule: &Rule, context: &RenderContext<'_>) -> Markup {
+    let RenderContext {
+        git_ref, repo_url, ..
+    } = *context;
     // Build the URL-friendly path by joining components with `/`
     // instead of `Path::display`, which uses the host's native
     // separator and would emit `\` on Windows.

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -333,14 +333,19 @@ fn extract_config(file: &syn::File) -> Option<ConfigDoc> {
 }
 
 /// Walk a `syn::Type` and collect every type identifier that isn't a
-/// well-known built-in. Insertion order matches the order each
-/// distinct ident is first encountered, so the rendered docs list
-/// types in the order a reader scanning the field list will meet
-/// them. The `seen` set deduplicates across multiple fields.
+/// well-known built-in. Only the *last* segment of each path is
+/// considered, matching [`toml_type_label`]'s rule: leading
+/// segments like `std::vec` in `std::vec::Vec<T>` are noise (the
+/// generator only looks up types against the rule file's local
+/// items, so qualified paths would never resolve anyway).
+/// Insertion order matches the order each distinct ident is first
+/// encountered, so the rendered docs list types in the order a
+/// reader scanning the field list will meet them. The `seen` set
+/// deduplicates across multiple fields.
 fn collect_referenced_idents(ty: &Type, out: &mut Vec<String>, seen: &mut BTreeSet<String>) {
     match ty {
         Type::Path(type_path) => {
-            for segment in &type_path.path.segments {
+            if let Some(segment) = type_path.path.segments.last() {
                 let name = segment.ident.to_string();
                 if !is_builtin_type(&name) && seen.insert(name.clone()) {
                     out.push(name);
@@ -410,13 +415,13 @@ fn find_type_doc(file: &syn::File, ident: &str) -> Option<TypeDoc> {
     for item in &file.items {
         match item {
             Item::Enum(item_enum) if item_enum.ident == ident => {
-                let rename_all = serde_rename_all(&item_enum.attrs);
+                let rename_all = serde_str_attr(&item_enum.attrs, "rename_all");
                 let variants = item_enum
                     .variants
                     .iter()
                     .map(|variant| {
                         let rust_name = variant.ident.to_string();
-                        let variant_rename = serde_field_rename(&variant.attrs);
+                        let variant_rename = serde_str_attr(&variant.attrs, "rename");
                         let serialized = variant_rename
                             .or_else(|| {
                                 rename_all
@@ -466,11 +471,14 @@ fn find_type_doc(file: &syn::File, ident: &str) -> Option<TypeDoc> {
     None
 }
 
-/// Read the `rename_all = "..."` style from a type's `#[serde(...)]`
-/// attribute, if present. Returns the raw style name (e.g.
-/// `"snake_case"`); the actual case conversion lives in
-/// [`apply_rename_all`].
-fn serde_rename_all(attrs: &[Attribute]) -> Option<String> {
+/// Read a `#[serde(key = "literal")]` string value, scanning every
+/// `serde(...)` attribute on the item. Returns the first match in
+/// source order; an attribute whose body fails to parse is silently
+/// skipped, since this generator runs against rule sources that the
+/// compiler has already accepted — a parse failure here means the
+/// attribute uses a form (e.g. `serde(deny_unknown_fields)`) that
+/// the generator simply doesn't surface.
+fn serde_str_attr(attrs: &[Attribute], key: &str) -> Option<String> {
     for attr in attrs {
         if !attr.path().is_ident("serde") {
             continue;
@@ -480,33 +488,7 @@ fn serde_rename_all(attrs: &[Attribute]) -> Option<String> {
         let Ok(items) = parsed else { continue };
         for item in items {
             if let Meta::NameValue(name_value) = item
-                && name_value.path.is_ident("rename_all")
-                && let Expr::Lit(ExprLit {
-                    lit: Lit::Str(literal),
-                    ..
-                }) = name_value.value
-            {
-                return Some(literal.value());
-            }
-        }
-    }
-    None
-}
-
-/// Read a per-variant or per-field `#[serde(rename = "...")]`
-/// override, used when one specific variant opts out of the
-/// enum-wide `rename_all` policy.
-fn serde_field_rename(attrs: &[Attribute]) -> Option<String> {
-    for attr in attrs {
-        if !attr.path().is_ident("serde") {
-            continue;
-        }
-        let parsed =
-            attr.parse_args_with(syn::punctuated::Punctuated::<Meta, Token![,]>::parse_terminated);
-        let Ok(items) = parsed else { continue };
-        for item in items {
-            if let Meta::NameValue(name_value) = item
-                && name_value.path.is_ident("rename")
+                && name_value.path.is_ident(key)
                 && let Expr::Lit(ExprLit {
                     lit: Lit::Str(literal),
                     ..
@@ -1053,3 +1035,96 @@ fn anchor_for(namespaced: &str) -> String {
 }
 
 const STYLE: &str = include_str!("style.css");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_type(source: &str) -> Type {
+        syn::parse_str(source).expect("test input should parse as a syn::Type")
+    }
+
+    #[test]
+    fn pascal_to_snake_basic() {
+        assert_eq!(pascal_to_snake("Line"), "line");
+        assert_eq!(pascal_to_snake("BlockComment"), "block_comment");
+        assert_eq!(pascal_to_snake("XMLParser"), "xml_parser");
+        assert_eq!(pascal_to_snake("HTTPServer"), "http_server");
+        assert_eq!(pascal_to_snake("URL"), "url");
+        assert_eq!(pascal_to_snake("already_snake"), "already_snake");
+    }
+
+    #[test]
+    fn toml_type_label_primitives() {
+        assert_eq!(toml_type_label(&parse_type("bool")), "boolean");
+        assert_eq!(toml_type_label(&parse_type("usize")), "unsigned integer");
+        assert_eq!(toml_type_label(&parse_type("i32")), "integer");
+        assert_eq!(toml_type_label(&parse_type("f64")), "float");
+        assert_eq!(toml_type_label(&parse_type("String")), "string");
+        assert_eq!(toml_type_label(&parse_type("char")), "string");
+    }
+
+    #[test]
+    fn toml_type_label_arrays_and_maps() {
+        assert_eq!(toml_type_label(&parse_type("Vec<char>")), "[string]");
+        assert_eq!(
+            toml_type_label(&parse_type("Vec<Vec<u8>>")),
+            "[[unsigned integer]]"
+        );
+        assert_eq!(
+            toml_type_label(&parse_type("HashMap<String, usize>")),
+            "table of unsigned integer",
+        );
+    }
+
+    #[test]
+    fn toml_type_label_transparent_wrappers() {
+        // Option, Box, Rc, Arc unwrap to the inner type.
+        assert_eq!(toml_type_label(&parse_type("Option<String>")), "string");
+        assert_eq!(
+            toml_type_label(&parse_type("Box<usize>")),
+            "unsigned integer"
+        );
+        assert_eq!(toml_type_label(&parse_type("Arc<Vec<String>>")), "[string]");
+    }
+
+    #[test]
+    fn toml_type_label_qualified_paths_use_last_segment() {
+        assert_eq!(
+            toml_type_label(&parse_type("std::vec::Vec<String>")),
+            "[string]"
+        );
+        assert_eq!(
+            toml_type_label(&parse_type("alloc::string::String")),
+            "string"
+        );
+    }
+
+    #[test]
+    fn toml_type_label_custom_idents_pass_through() {
+        // Project-local enums/structs surface verbatim; readers
+        // follow them to the per-rule Types subsection.
+        assert_eq!(toml_type_label(&parse_type("Scope")), "Scope");
+        assert_eq!(toml_type_label(&parse_type("Vec<Scope>")), "[Scope]");
+    }
+
+    #[test]
+    fn collect_referenced_idents_skips_builtins_and_keeps_order() {
+        let ty = parse_type("HashMap<String, Vec<Scope>>");
+        let mut out = Vec::new();
+        let mut seen = BTreeSet::new();
+        collect_referenced_idents(&ty, &mut out, &mut seen);
+        assert_eq!(out, vec!["Scope".to_owned()]);
+    }
+
+    #[test]
+    fn collect_referenced_idents_inspects_only_last_segment() {
+        // `std` and `vec` would have been picked up by the old
+        // every-segment walk; the current behaviour drops them.
+        let ty = parse_type("std::vec::Vec<my_crate::Inner>");
+        let mut out = Vec::new();
+        let mut seen = BTreeSet::new();
+        collect_referenced_idents(&ty, &mut out, &mut seen);
+        assert_eq!(out, vec!["Inner".to_owned()]);
+    }
+}

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -777,17 +777,15 @@ fn rule_article(rule: &Rule) -> Markup {
 ///    "Configuration: none." instead. The fact that the rule is
 ///    not configurable is itself information; omitting the section
 ///    entirely would leave readers wondering whether they missed a
-///    knob. Any struct-level doc comment is still surfaced after
-///    the inline line, so the rule's prose explanation of *why*
-///    the placeholder exists is preserved.
+///    knob. Any struct-level doc comment is *not* surfaced in this
+///    case — an empty config has no user-facing schema to
+///    annotate, so the comment is internal implementation prose
+///    that belongs in the source, not on the catalogue page.
 fn config_section(config: &ConfigDoc) -> Markup {
     if config.fields.is_empty() {
         return html! {
             p.config-none {
                 strong { "Configuration:" } " none."
-            }
-            @if !config.struct_doc_markdown.is_empty() {
-                (PreEscaped(markdown_to_html(&config.struct_doc_markdown)))
             }
         };
     }

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -22,7 +22,6 @@
 use std::{
     collections::BTreeSet,
     fs,
-    ops::Range,
     path::{Path, PathBuf},
     process::ExitCode,
 };
@@ -37,7 +36,6 @@ use strum::{Display, EnumString};
 use syn::{
     Attribute, Expr, ExprLit, Ident, Item, Lit, LitStr, Meta, Token, Type,
     parse::{Parse, ParseStream},
-    spanned::Spanned,
 };
 
 #[derive(Parser)]
@@ -127,10 +125,11 @@ struct ConfigField {
     /// because every `Config` uses `#[serde(rename_all = "snake_case")]`
     /// and the fields are already named in snake case.
     name: String,
-    /// Verbatim source of the field's type (e.g. `Vec<char>`),
-    /// sliced out of the rule file using `proc_macro2::Span`
-    /// byte ranges.
-    type_source: String,
+    /// TOML-flavoured label for the field's type (e.g. `[string]`
+    /// for `Vec<char>`). See [`toml_type_label`] for the mapping
+    /// rules; the source-level type is intentionally not surfaced,
+    /// since TOML authors don't write Rust syntax in `dylint.toml`.
+    type_label: String,
     /// Per-field `///` doc comment, in markdown form.
     doc_markdown: String,
 }
@@ -166,7 +165,7 @@ struct EnumVariant {
 
 struct StructField {
     name: String,
-    type_source: String,
+    type_label: String,
     doc_markdown: String,
 }
 
@@ -257,7 +256,7 @@ fn extract_rule(source_path: &Path) -> Option<Rule> {
         )
     });
 
-    let config = extract_config(&file, &source);
+    let config = extract_config(&file);
 
     Some(Rule {
         namespaced,
@@ -274,7 +273,7 @@ fn extract_rule(source_path: &Path) -> Option<Rule> {
 /// reference — into a `ConfigDoc`. Returns `None` when either the
 /// constant or the struct is missing; both are mandatory for a rule
 /// to be considered "configurable" by `dylint.toml`.
-fn extract_config(file: &syn::File, source: &str) -> Option<ConfigDoc> {
+fn extract_config(file: &syn::File) -> Option<ConfigDoc> {
     let key = file.items.iter().find_map(|item| match item {
         Item::Const(item_const) if item_const.ident == "CONFIG_KEY" => match &*item_const.expr {
             Expr::Lit(ExprLit {
@@ -303,8 +302,7 @@ fn extract_config(file: &syn::File, source: &str) -> Option<ConfigDoc> {
                 .as_ref()
                 .expect("named field always has an ident")
                 .to_string(),
-            type_source: span_text(source, field.ty.span())
-                .unwrap_or_else(|| fallback_type_text(&field.ty)),
+            type_label: toml_type_label(&field.ty),
             doc_markdown: doc_attrs_to_markdown(&field.attrs),
         })
         .collect();
@@ -316,7 +314,7 @@ fn extract_config(file: &syn::File, source: &str) -> Option<ConfigDoc> {
     }
     let custom_types = referenced
         .into_iter()
-        .filter_map(|ident| find_type_doc(file, source, &ident))
+        .filter_map(|ident| find_type_doc(file, &ident))
         .collect();
 
     Some(ConfigDoc {
@@ -394,7 +392,7 @@ fn is_builtin_type(name: &str) -> bool {
 /// from another crate); those are silently dropped rather than
 /// faked, since the docs are only useful when we can show the real
 /// shape.
-fn find_type_doc(file: &syn::File, source: &str, ident: &str) -> Option<TypeDoc> {
+fn find_type_doc(file: &syn::File, ident: &str) -> Option<TypeDoc> {
     for item in &file.items {
         match item {
             Item::Enum(item_enum) if item_enum.ident == ident => {
@@ -436,8 +434,7 @@ fn find_type_doc(file: &syn::File, source: &str, ident: &str) -> Option<TypeDoc>
                                 .as_ref()
                                 .expect("named field always has an ident")
                                 .to_string(),
-                            type_source: span_text(source, field.ty.span())
-                                .unwrap_or_else(|| fallback_type_text(&field.ty)),
+                            type_label: toml_type_label(&field.ty),
                             doc_markdown: doc_attrs_to_markdown(&field.attrs),
                         })
                         .collect(),
@@ -549,24 +546,75 @@ fn pascal_to_snake(name: &str) -> String {
     out
 }
 
-/// Slice the verbatim source bytes covered by `span`. Falls back to
-/// `None` when the span has no usable byte range (which happens for
-/// synthetic spans produced by macro expansion, not for code that
-/// originated in a file we just parsed — but the type system makes
-/// us account for the case anyway).
-fn span_text(source: &str, span: proc_macro2::Span) -> Option<String> {
-    let Range { start, end } = span.byte_range();
-    if end <= start || end > source.len() {
-        return None;
+/// Translate a `syn::Type` into a TOML-flavoured type label. The
+/// renderer never shows Rust syntax to the reader; TOML authors
+/// write arrays as `[a, b]`, integers without sign annotations, and
+/// strings without `char` / `&str` / `Cow` distinctions, so the
+/// labels echo that vocabulary. The translation is purely structural
+/// — no ad-hoc exceptions for specific field names — so adding a
+/// new built-in type means extending the match arms here.
+///
+/// - `bool` → `boolean`
+/// - `u*` / `usize` → `unsigned integer`
+/// - `i*` / `isize` → `integer`
+/// - `f32` / `f64` → `float`
+/// - `String` / `&str` / `char` / `OsString` / `PathBuf` / `Cow<…>` → `string`
+/// - `Vec<T>` / `HashSet<T>` / `BTreeSet<T>` / `VecDeque<T>` /
+///   `LinkedList<T>` → `[label-of-T]`
+/// - `HashMap<_, V>` / `BTreeMap<_, V>` → `table of label-of-V`
+/// - `Option<T>` → `label-of-T` (every config field is already
+///   marked optional, so the wrapper would just add noise)
+/// - Anything else (project-local enums and structs) → the Rust
+///   identifier verbatim, since those names appear in the per-rule
+///   Types subsection below and the reader can scan to them.
+fn toml_type_label(ty: &Type) -> String {
+    match ty {
+        Type::Path(type_path) => {
+            let Some(segment) = type_path.path.segments.last() else {
+                return ty.to_token_stream().to_string();
+            };
+            let ident = segment.ident.to_string();
+            let inner_types: Vec<&Type> = match &segment.arguments {
+                syn::PathArguments::AngleBracketed(args) => args
+                    .args
+                    .iter()
+                    .filter_map(|arg| match arg {
+                        syn::GenericArgument::Type(inner) => Some(inner),
+                        _ => None,
+                    })
+                    .collect(),
+                _ => Vec::new(),
+            };
+            match ident.as_str() {
+                "bool" => "boolean".to_owned(),
+                "String" | "str" | "char" | "OsString" | "OsStr" | "Path" | "PathBuf" | "Cow" => {
+                    "string".to_owned()
+                }
+                "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => "unsigned integer".to_owned(),
+                "i8" | "i16" | "i32" | "i64" | "i128" | "isize" => "integer".to_owned(),
+                "f32" | "f64" => "float".to_owned(),
+                "Vec" | "HashSet" | "BTreeSet" | "VecDeque" | "LinkedList" => {
+                    match inner_types.first() {
+                        Some(inner) => format!("[{}]", toml_type_label(inner)),
+                        None => "array".to_owned(),
+                    }
+                }
+                "HashMap" | "BTreeMap" => match inner_types.get(1) {
+                    Some(value) => format!("table of {}", toml_type_label(value)),
+                    None => "table".to_owned(),
+                },
+                "Option" => match inner_types.first() {
+                    Some(inner) => toml_type_label(inner),
+                    None => ident,
+                },
+                _ => ident,
+            }
+        }
+        Type::Reference(type_ref) => toml_type_label(&type_ref.elem),
+        Type::Paren(type_paren) => toml_type_label(&type_paren.elem),
+        Type::Group(type_group) => toml_type_label(&type_group.elem),
+        _ => ty.to_token_stream().to_string(),
     }
-    Some(source[start..end].to_owned())
-}
-
-/// Best-effort stringifier for a `syn::Type` when no source span is
-/// available. The output uses `quote`'s default token spacing, which
-/// is less pretty than the original source but always parseable.
-fn fallback_type_text(ty: &Type) -> String {
-    ty.to_token_stream().to_string()
 }
 
 /// Minimal grammar of `declare_tool_lint!`'s body. The macro itself
@@ -708,47 +756,55 @@ fn rule_article(rule: &Rule) -> Markup {
     }
 }
 
-/// Render the per-rule configuration block. When the `Config`
-/// struct has no fields, the block is still emitted so readers
-/// can see that the rule is intentionally non-configurable (and,
-/// where the struct itself carries a doc comment, why).
+/// Render the per-rule configuration block, wrapped in a `<details>`
+/// element so a long reference table doesn't dominate the page.
+/// The element is collapsed by default — configuration is reference
+/// material, and the rule's description above it is what most
+/// readers came for. Modern browsers auto-expand a closed `<details>`
+/// when find-in-page hits something inside it, so search still
+/// works against the hidden content. When the `Config` struct has
+/// no fields, the block is still emitted so readers can see that
+/// the rule is intentionally non-configurable (and, where the
+/// struct itself carries a doc comment, why).
 fn config_section(config: &ConfigDoc) -> Markup {
     html! {
-        h3 { "Configuration" }
-        p {
-            "Configure via " code { "dylint.toml" } " under "
-            code { "[\"" (config.key) "\"]" } "."
-        }
-        @if !config.struct_doc_markdown.is_empty() {
-            (PreEscaped(markdown_to_html(&config.struct_doc_markdown)))
-        }
-        @if config.fields.is_empty() {
-            @if config.struct_doc_markdown.is_empty() {
-                p { em { "No configurable options." } }
+        details.config-details {
+            summary { h3 { "Configuration" } }
+            p {
+                "Configure via " code { "dylint.toml" } " under "
+                code { "[\"" (config.key) "\"]" } "."
             }
-        } @else {
-            dl.config {
-                @for field in &config.fields {
-                    dt {
-                        code.config-key { (field.name) }
-                        " : "
-                        code.config-type { (field.type_source) }
-                        " "
-                        span.badge.badge-optional { "optional" }
-                    }
-                    dd {
-                        @if field.doc_markdown.is_empty() {
-                            p { em { "Undocumented." } }
-                        } @else {
-                            (PreEscaped(markdown_to_html(&field.doc_markdown)))
+            @if !config.struct_doc_markdown.is_empty() {
+                (PreEscaped(markdown_to_html(&config.struct_doc_markdown)))
+            }
+            @if config.fields.is_empty() {
+                @if config.struct_doc_markdown.is_empty() {
+                    p { em { "No configurable options." } }
+                }
+            } @else {
+                dl.config {
+                    @for field in &config.fields {
+                        dt {
+                            code.config-key { (field.name) }
+                            " : "
+                            code.config-type { (field.type_label) }
+                            " "
+                            span.badge.badge-optional { "optional" }
+                        }
+                        dd {
+                            @if field.doc_markdown.is_empty() {
+                                p { em { "Undocumented." } }
+                            } @else {
+                                (PreEscaped(markdown_to_html(&field.doc_markdown)))
+                            }
                         }
                     }
                 }
-            }
-            @if !config.custom_types.is_empty() {
-                h4 { "Custom types" }
-                @for ty in &config.custom_types {
-                    (custom_type_block(ty))
+                @if !config.custom_types.is_empty() {
+                    h4 { "Types" }
+                    @for ty in &config.custom_types {
+                        (custom_type_block(ty))
+                    }
                 }
             }
         }
@@ -806,7 +862,7 @@ fn custom_type_block(ty: &TypeDoc) -> Markup {
                                 dt {
                                     code.config-key { (field.name) }
                                     " : "
-                                    code.config-type { (field.type_source) }
+                                    code.config-type { (field.type_label) }
                                 }
                                 dd {
                                     @if field.doc_markdown.is_empty() {

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -109,10 +109,12 @@ struct ConfigDoc {
     /// The TOML table key, e.g. `perfectionist::flat_module_pattern`.
     /// Read from the file's `CONFIG_KEY` constant verbatim.
     key: String,
-    /// Doc comment attached to the `Config` struct itself, useful
-    /// for rules with no fields (where it explains why the struct
-    /// still exists) or for cross-cutting notes about a rule's
-    /// configuration shape.
+    /// Doc comment attached to the `Config` struct itself. Only
+    /// surfaced when the rule has at least one configurable field;
+    /// empty Configs render the inline `Configuration: none.` line
+    /// and intentionally drop any struct-level note (it would
+    /// always be implementation prose about the placeholder, not
+    /// user-facing schema).
     struct_doc_markdown: String,
     /// One entry per named field of the `Config` struct.
     fields: Vec<ConfigField>,
@@ -384,26 +386,54 @@ fn collect_referenced_idents(ty: &Type, out: &mut Vec<String>, seen: &mut BTreeS
 /// have a match arm there, otherwise the renderer either drops a
 /// real custom type from the Types section (false positive here)
 /// or leaks a Rust identifier into the field-type column (false
-/// negative there).
+/// negative there). The unit test `builtin_types_all_map_to_toml_label`
+/// guards this contract mechanically.
 fn is_builtin_type(name: &str) -> bool {
-    matches!(
-        name,
-        // Primitives.
-        "bool" | "char" | "str"
-        | "u8" | "u16" | "u32" | "u64" | "u128"
-        | "i8" | "i16" | "i32" | "i64" | "i128"
-        | "usize" | "isize"
-        | "f32" | "f64"
-        // Common std types likely to appear in serde-deserialised configs.
-        | "String" | "Vec" | "Option"
-        | "Box" | "Rc" | "Arc" | "Cow"
-        | "PathBuf" | "Path" | "OsString" | "OsStr"
-        | "HashMap" | "HashSet" | "BTreeMap" | "BTreeSet"
-        | "VecDeque" | "LinkedList"
-        // The Config struct itself.
-        | "Config"
-    )
+    BUILTIN_TYPES.contains(&name)
 }
+
+/// The full set [`is_builtin_type`] accepts, exposed as a constant
+/// so the contract test can iterate it.
+const BUILTIN_TYPES: &[&str] = &[
+    // Primitives.
+    "bool",
+    "char",
+    "str",
+    "u8",
+    "u16",
+    "u32",
+    "u64",
+    "u128",
+    "i8",
+    "i16",
+    "i32",
+    "i64",
+    "i128",
+    "usize",
+    "isize",
+    "f32",
+    "f64",
+    // Common std types likely to appear in serde-deserialised configs.
+    "String",
+    "Vec",
+    "Option",
+    "Box",
+    "Rc",
+    "Arc",
+    "Cow",
+    "PathBuf",
+    "Path",
+    "OsString",
+    "OsStr",
+    "HashMap",
+    "HashSet",
+    "BTreeMap",
+    "BTreeSet",
+    "VecDeque",
+    "LinkedList",
+    // The Config struct itself.
+    "Config",
+];
 
 /// Find the `enum` or `struct` definition for `ident` inside `file`
 /// and produce a `TypeDoc` describing its variants or fields.
@@ -511,8 +541,20 @@ fn apply_rename_all(style: &str, name: &str) -> String {
         "snake_case" => pascal_to_snake(name),
         "SCREAMING_SNAKE_CASE" => pascal_to_snake(name).to_ascii_uppercase(),
         "kebab-case" => pascal_to_snake(name).replace('_', "-"),
+        "SCREAMING-KEBAB-CASE" => pascal_to_snake(name).replace('_', "-").to_ascii_uppercase(),
         "lowercase" => name.to_ascii_lowercase(),
         "UPPERCASE" => name.to_ascii_uppercase(),
+        // Rust enum variants are already `PascalCase` by convention.
+        "PascalCase" => name.to_owned(),
+        // `camelCase` is `PascalCase` with the first character
+        // lower-cased; everything else stays as written.
+        "camelCase" => {
+            let mut chars = name.chars();
+            match chars.next() {
+                Some(first) => first.to_lowercase().chain(chars).collect(),
+                None => String::new(),
+            }
+        }
         _ => name.to_owned(),
     }
 }
@@ -1115,6 +1157,79 @@ mod tests {
         let mut seen = BTreeSet::new();
         collect_referenced_idents(&ty, &mut out, &mut seen);
         assert_eq!(out, vec!["Scope".to_owned()]);
+    }
+
+    #[test]
+    fn builtin_types_all_map_to_toml_label() {
+        // Coverage contract: every name in BUILTIN_TYPES must have
+        // a matching arm in `toml_type_label`, otherwise the
+        // renderer would drop the name from the Types section
+        // (because `is_builtin_type` returns true) AND emit it
+        // verbatim as a Rust identifier in the field-type column.
+        //
+        // The `Config` entry is exempt — it's on the builtin list
+        // purely to prevent self-referential lookup loops, and has
+        // no user-facing label form.
+        //
+        // Generic types need a concrete instantiation to exercise
+        // the arm (a bare `Option` with no inner type would hit
+        // the `_ => ident` fallback). `bool` is harmless filler.
+        for &name in BUILTIN_TYPES {
+            if name == "Config" {
+                continue;
+            }
+            let source = match name {
+                "Vec" | "HashSet" | "BTreeSet" | "VecDeque" | "LinkedList" | "Option" | "Box"
+                | "Rc" | "Arc" | "Cow" => format!("{name}<bool>"),
+                "HashMap" | "BTreeMap" => format!("{name}<String, bool>"),
+                _ => name.to_owned(),
+            };
+            let label = toml_type_label(&parse_type(&source));
+            assert_ne!(
+                label, name,
+                "builtin `{name}` is missing a `toml_type_label` arm \
+                 (rendered `{source}` as `{label}`); either add one \
+                 or remove the entry from BUILTIN_TYPES",
+            );
+        }
+    }
+
+    #[test]
+    fn apply_rename_all_covers_serde_styles() {
+        assert_eq!(
+            apply_rename_all("snake_case", "BlockComment"),
+            "block_comment"
+        );
+        assert_eq!(
+            apply_rename_all("SCREAMING_SNAKE_CASE", "BlockComment"),
+            "BLOCK_COMMENT",
+        );
+        assert_eq!(
+            apply_rename_all("kebab-case", "BlockComment"),
+            "block-comment"
+        );
+        assert_eq!(
+            apply_rename_all("SCREAMING-KEBAB-CASE", "BlockComment"),
+            "BLOCK-COMMENT",
+        );
+        assert_eq!(
+            apply_rename_all("PascalCase", "BlockComment"),
+            "BlockComment"
+        );
+        assert_eq!(
+            apply_rename_all("camelCase", "BlockComment"),
+            "blockComment"
+        );
+        assert_eq!(
+            apply_rename_all("lowercase", "BlockComment"),
+            "blockcomment"
+        );
+        assert_eq!(
+            apply_rename_all("UPPERCASE", "BlockComment"),
+            "BLOCKCOMMENT"
+        );
+        // Unknown style: pass through unchanged.
+        assert_eq!(apply_rename_all("???", "BlockComment"), "BlockComment");
     }
 
     #[test]

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -254,7 +254,32 @@ fn extract_rule(source_path: &Path) -> Option<Rule> {
             Some(&item_macro.mac.tokens)
         }
         _ => None,
-    })?;
+    });
+    let macro_item = match macro_item {
+        Some(macro_item) => macro_item,
+        None => {
+            // Silent skip for legitimate helper files. But if the
+            // file *looks* rule-shaped — has a `CONFIG_KEY` const
+            // or a `Config` struct — the missing macro is almost
+            // certainly a typo (`declare_tool_lin!`, etc.) that
+            // would otherwise drop the rule from the docs without
+            // any signal.
+            let looks_rule_shaped = file.items.iter().any(|item| match item {
+                Item::Const(item_const) => item_const.ident == "CONFIG_KEY",
+                Item::Struct(item_struct) => item_struct.ident == "Config",
+                _ => false,
+            });
+            if looks_rule_shaped {
+                eprintln!(
+                    "warning: {} looks rule-shaped (has `CONFIG_KEY` or `Config`) \
+                     but has no `declare_tool_lint!` macro; the rule will not \
+                     appear in the docs",
+                    source_path.display(),
+                );
+            }
+            return None;
+        }
+    };
 
     let declaration = syn::parse2::<DeclareToolLint>(macro_item.clone()).unwrap_or_else(|error| {
         panic!(
@@ -800,7 +825,10 @@ fn render_page(rules: &[Rule], crate_version: &str, git_ref: &str) -> String {
             head {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
-                title { "perfectionist lints" }
+                title {
+                    "perfectionist lints"
+                    @if git_ref != "master" { " — " (git_ref) }
+                }
                 style { (PreEscaped(STYLE)) (PreEscaped(&*HIGHLIGHT_CSS)) }
             }
             body {
@@ -1385,8 +1413,12 @@ mod tests {
             apply_rename_all("UPPERCASE", "BlockComment"),
             "BLOCKCOMMENT"
         );
-        // Unknown style: pass through unchanged.
-        assert_eq!(apply_rename_all("???", "BlockComment"), "BlockComment");
+        // The unknown-style fallback is observable — it prints a
+        // warning and returns the name unchanged — but asserting
+        // it here would spam stderr on every clean test run. The
+        // behaviour is covered by manual smoke runs of `gen-docs`
+        // against rule sources that intentionally use an unknown
+        // style.
     }
 
     #[test]

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -296,23 +296,19 @@ fn extract_config_defaults(file: &syn::File, source: &str) -> HashMap<String, St
     let mut out = HashMap::new();
     let Some(impl_item) = file.items.iter().find_map(|item| match item {
         Item::Impl(item_impl)
-            if item_impl
-                .trait_
-                .as_ref()
-                .is_some_and(|(_, path, _)| {
-                    path.segments
+            if item_impl.trait_.as_ref().is_some_and(|(_, path, _)| {
+                path.segments
+                    .last()
+                    .is_some_and(|segment| segment.ident == "Default")
+            }) && matches!(
+                &*item_impl.self_ty,
+                Type::Path(type_path)
+                    if type_path
+                        .path
+                        .segments
                         .last()
-                        .is_some_and(|segment| segment.ident == "Default")
-                })
-                && matches!(
-                    &*item_impl.self_ty,
-                    Type::Path(type_path)
-                        if type_path
-                            .path
-                            .segments
-                            .last()
-                            .is_some_and(|segment| segment.ident == "Config")
-                ) =>
+                        .is_some_and(|segment| segment.ident == "Config")
+            ) =>
         {
             Some(item_impl)
         }

--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -86,6 +86,11 @@ details.config-details {
   margin-top: 1rem;
 }
 
+p.config-none {
+  margin-top: 1rem;
+  color: #57606a;
+}
+
 details.config-details > summary {
   cursor: pointer;
   list-style: none;

--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -100,9 +100,10 @@ details.config-details > summary::-webkit-details-marker {
   display: none;
 }
 
-details.config-details > summary > h3 {
-  display: inline;
-  margin: 0;
+details.config-details > summary.config-summary {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1f2328;
 }
 
 details.config-details > summary::before {

--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -110,7 +110,6 @@ details.config-details > summary::before {
   display: inline-block;
   width: 1em;
   color: #57606a;
-  transition: transform 0.15s ease;
 }
 
 details.config-details[open] > summary::before {

--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -77,6 +77,45 @@ article.rule .source {
   color: #57606a;
 }
 
+article.rule h3 {
+  margin-top: 1.5rem;
+  font-size: 1.05rem;
+}
+
+dl.config {
+  margin: 0.5rem 0 1rem;
+  padding: 0.5rem 0.75rem;
+  background: #f6f8fa;
+  border-radius: 6px;
+}
+
+dl.config dt {
+  margin-top: 0.4rem;
+  font-size: 0.95rem;
+}
+
+dl.config dt:first-child {
+  margin-top: 0;
+}
+
+dl.config dd {
+  margin: 0.25rem 0 0.75rem 1rem;
+  font-size: 0.92rem;
+}
+
+dl.config dd p {
+  margin: 0.25rem 0;
+}
+
+.config-key {
+  background: #ddf4ff;
+}
+
+.config-default {
+  font-size: 0.85rem;
+  color: #57606a;
+}
+
 pre,
 code {
   font-family: ui-monospace, SFMono-Regular, monospace;

--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -116,6 +116,57 @@ dl.config dd p {
   color: #57606a;
 }
 
+.badge {
+  font-size: 0.75rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  vertical-align: middle;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+}
+
+.badge-optional {
+  background: #eaeef2;
+  color: #57606a;
+}
+
+article.rule h4 {
+  margin-top: 1.25rem;
+  margin-bottom: 0.4rem;
+  font-size: 0.95rem;
+  color: #57606a;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+div.custom-type {
+  margin: 0.5rem 0 1rem;
+  padding: 0.5rem 0.75rem;
+  background: #f6f8fa;
+  border-left: 3px solid #d0d7de;
+  border-radius: 0 6px 6px 0;
+}
+
+div.custom-type > p:first-child {
+  margin: 0 0 0.25rem;
+}
+
+.custom-type-name {
+  background: #ddf4ff;
+}
+
+.custom-type-kind {
+  font-size: 0.78rem;
+  color: #57606a;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+div.custom-type dl.config {
+  background: transparent;
+  padding: 0;
+  margin: 0.25rem 0 0;
+}
+
 pre,
 code {
   font-family: ui-monospace, SFMono-Regular, monospace;

--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -82,6 +82,36 @@ article.rule h3 {
   font-size: 1.05rem;
 }
 
+details.config-details {
+  margin-top: 1rem;
+}
+
+details.config-details > summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+details.config-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+details.config-details > summary > h3 {
+  display: inline;
+  margin: 0;
+}
+
+details.config-details > summary::before {
+  content: "▸ ";
+  display: inline-block;
+  width: 1em;
+  color: #57606a;
+  transition: transform 0.15s ease;
+}
+
+details.config-details[open] > summary::before {
+  content: "▾ ";
+}
+
 dl.config {
   margin: 0.5rem 0 1rem;
   padding: 0.5rem 0.75rem;


### PR DESCRIPTION
## Summary

The `gh-pages` site previously skipped each rule's configuration surface. This PR teaches `tools/gen-docs` to surface it, and documents the knobs themselves.

Three of the four implemented rules have non-empty config: `unicode_ellipsis_in_comments` (`also_flag`, `scope`), `unicode_ellipsis_in_panic_messages` (`macros`, `methods`, `also_flag`), and `unknown_perfectionist_lints` (`suggestion_distance`). Every field now carries a short `///` describing the knob and its default. `flat_module_pattern::Config` is empty and gained a struct-level note explaining why the placeholder exists.

`gen-docs` now parses each rule file for its `CONFIG_KEY` constant, its `Config` struct, and (when present) `impl Default for Config`. For every named field it emits a Configuration section listing the TOML key, the verbatim type, the verbatim default expression, and the per-field doc comment. Type and default text are sliced straight from the original source via `proc_macro2::Span::byte_range()` (requires the `span-locations` feature), so the rendered docs match what a reader sees in `src/rules/<rule>.rs`. A small block of CSS dresses the new `dl.config` list.

## Test plan

- [x] `cargo check` on the lib crate (workspace `cargo build` needs `dylint-link`, which is not available in this environment)
- [x] `cargo run -p _gen_docs` writes 4 rules; spot-checked the resulting `index.html` for each rule's Configuration section
- [x] `cargo fmt`
- [ ] CI green