### PR TITLE
fix(macro-trailing-comma): compact layouts and cfg_attr expects

### DIFF
--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -7,6 +7,15 @@ with the curated `core` / `std` and well-known third-party list,
 plus the `extra_name_based`, `ignore`, and `enabled` configuration
 knobs. The `matcher_based` knob is accepted but currently a no-op.
 
+The "Vertical only applies to block-indent layouts" caveat from
+the "What to lint" section is also implemented: a multi-line
+invocation whose first top-level token shares its line with the
+opening delimiter (the compact / visual-indent shape rustfmt
+produces for `vec![Inner { ... }]`, `vec![bar(\n    ...,\n)]`,
+and similar single multi-line elements) is skipped, matching
+rustfmt's actual `trailing_comma = "Vertical"` behaviour rather
+than the documented spec for function calls.
+
 Still pending: **matcher-based** declarative-macro auto-detection
 (the `$(,)?` / `$(,)*` matcher walk described under "Matcher-based
 — declarative-macro auto-detection" and "Why matcher-based is
@@ -231,7 +240,17 @@ For every macro invocation:
    one-item list, not a token-tree passthrough.
 5. Determine "single-line" vs "multi-line" by the source
    positions of the opening and closing delimiters. If they
-   share a line, single-line; otherwise multi-line.
+   share a line, single-line; otherwise multi-line. For the
+   multi-line case, additionally check whether the first
+   top-level token starts on the same line as the opening
+   delimiter; if it does, the invocation is in compact /
+   visual-indent layout and the multi-line "insert trailing
+   comma" branch is skipped. rustfmt's `Vertical` policy only
+   adds the trailing comma when each top-level item is on its
+   own line, separate from the delimiter; for a single
+   multi-line element such as `vec![Inner { ... }]` rustfmt
+   leaves the comma off (and strips any that gets added), so
+   the lint defers to rustfmt and emits nothing.
 6. Locate the final top-level token before the closing
    delimiter:
    - **Multi-line, no trailing comma** → emit a diagnostic
@@ -447,11 +466,23 @@ ignore = [
 
 ## Implementation notes
 
-- `EarlyLintPass::check_mac` over `ast::MacCall`. The early
+- The rule is split across two passes for `#[expect]`
+  fulfilment. Pre-expansion `EarlyLintPass::check_mac` over
+  `ast::MacCall` identifies the violation spans — the early
   pass runs before macro expansion so the invocation's raw
-  token stream is still on the AST node — the lint needs the
-  source token tree, not the expansion result, to decide
-  whether the closing delimiter is preceded by a comma.
+  token stream is still on the AST node, which the lint
+  needs to decide whether the closing delimiter is preceded
+  by a comma. Pre-expansion emission, however, runs before
+  `cfg_attr` is evaluated, so a `cfg_attr`-wrapped
+  `#![expect(perfectionist::macro_trailing_comma)]` is not
+  yet visible to the lint-level lookup. To make `#[expect]`
+  fulfil correctly, the pre-expansion pass parks each
+  violation in a process-static `PENDING_VIOLATIONS` queue;
+  a late pass then walks the HIR, finds the deepest HIR node
+  whose span contains each pending span, and emits the
+  diagnostic there via `clippy_utils::span_lint_hir_and_then`.
+  By the late pass the `#[expect]` is visible to rustc's
+  level lookup, so the expectation is marked fulfilled.
 - Macro path resolution: `MacCall::path` resolves to a `Res`
   via the resolver. From the resolved `DefId`, look the path
   up in the name-based list (built-in plus

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -8,13 +8,13 @@ plus the `extra_name_based`, `ignore`, and `enabled` configuration
 knobs. The `matcher_based` knob is accepted but currently a no-op.
 
 The "Vertical only applies to block-indent layouts" caveat from
-the "What to lint" section is also implemented: a multi-line
-invocation whose first top-level token shares its line with the
-opening delimiter (the compact / visual-indent shape rustfmt
-produces for `vec![Inner { ... }]`, `vec![bar(\n    ...,\n)]`,
-and similar single multi-line elements) is skipped, matching
-rustfmt's actual `trailing_comma = "Vertical"` behaviour rather
-than the documented spec for function calls.
+the "What to lint" section is also implemented: any multi-line
+invocation whose first top-level token starts on the same line as
+the opening delimiter (the compact / visual-indent shape, e.g.
+`vec![Inner { ... }]` or `vec![bar(\n    ...,\n)]`) is skipped.
+The predicate keys off the first token's line, not the element
+count, matching rustfmt's actual `trailing_comma = "Vertical"`
+behaviour rather than the documented spec for function calls.
 
 Still pending: **matcher-based** declarative-macro auto-detection
 (the `$(,)?` / `$(,)*` matcher walk described under "Matcher-based

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate rustc_errors;
 extern crate rustc_hir;
 extern crate rustc_lexer;
 extern crate rustc_lint;
+extern crate rustc_middle;
 extern crate rustc_session;
 extern crate rustc_span;
 

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -204,27 +204,14 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    // The lint is split across two passes for issue [#409]: a
-    // `cfg_attr`-wrapped `#[expect]` is not yet visible to a pre-
-    // expansion lint level lookup (the `cfg_attr` is itself an
-    // attribute that has not been evaluated yet), so emitting the
-    // diagnostic during pre-expansion would slip past rustc's
-    // expectation tracker and the expectation would be reported as
-    // unfulfilled.
-    //
-    // The pre-expansion pass collects violation spans into
-    // `PENDING_VIOLATIONS`; the late pass walks the HIR to find the
-    // deepest containing node for each span and emits the diagnostic
-    // there. By that point `cfg_attr` has been evaluated, so the
-    // `#[expect]` / `#[allow]` attributes the user wrote on the crate
-    // root (or any enclosing item) are visible to the lint-level
-    // lookup and behave correctly.
-    //
-    // Pre-expansion remains necessary for the first half: post-
-    // expansion the macros covered by this rule have been expanded
-    // away and `check_mac` would never fire.
-    //
-    // [#409]: https://github.com/KSXGitHub/parallel-disk-usage/issues/409
+    // Split across two passes per
+    // <https://github.com/KSXGitHub/parallel-disk-usage/issues/409>:
+    // pre-expansion sees the `MacCall` tokens but runs before
+    // `cfg_attr` is evaluated, so a `cfg_attr`-wrapped `#[expect]`
+    // is invisible at emission time. The pre-expansion pass parks
+    // violation spans in `PENDING_VIOLATIONS`; the late pass walks
+    // the HIR and emits each at its deepest enclosing node, by which
+    // point `cfg_attr` has resolved and lint-level attributes apply.
     lint_store.register_pre_expansion_pass(|| Box::new(MacroTrailingComma::new()));
     lint_store.register_late_pass(|_| Box::new(MacroTrailingCommaLate));
 }

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -204,7 +204,7 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    // The lint is split across two passes for issue #409: a
+    // The lint is split across two passes for issue [#409]: a
     // `cfg_attr`-wrapped `#[expect]` is not yet visible to a pre-
     // expansion lint level lookup (the `cfg_attr` is itself an
     // attribute that has not been evaluated yet), so emitting the
@@ -223,6 +223,8 @@ pub fn register_pass(lint_store: &mut LintStore) {
     // Pre-expansion remains necessary for the first half: post-
     // expansion the macros covered by this rule have been expanded
     // away and `check_mac` would never fire.
+    //
+    // [#409]: https://github.com/KSXGitHub/parallel-disk-usage/issues/409
     lint_store.register_pre_expansion_pass(|| Box::new(MacroTrailingComma::new()));
     lint_store.register_late_pass(|_| Box::new(MacroTrailingCommaLate));
 }

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -1,11 +1,16 @@
 use std::collections::BTreeSet;
+use std::sync::Mutex;
 
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_ast::MacCall;
 use rustc_ast::token::TokenKind;
 use rustc_ast::tokenstream::TokenTree;
 use rustc_errors::Applicability;
-use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
+use rustc_hir as hir;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintContext, LintStore};
+use rustc_middle::hir::nested_filter;
+use rustc_middle::ty::TyCtxt;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
 
@@ -34,6 +39,13 @@ declare_tool_lint! {
     /// matcher *can* make the trailing comma load-bearing; for the curated
     /// macros covered by this lint, it cannot, and the policy applies
     /// without risk.
+    ///
+    /// Multi-line invocations whose argument list is a single element
+    /// laid out in visual-indent style — the element starts on the
+    /// opening-delimiter line, e.g. `vec![Inner { ... }]` — are skipped.
+    /// rustfmt's `Vertical` policy treats those as compact rather than
+    /// block-indent and leaves the trailing comma off (and strips any
+    /// that gets added), so the two tools have to agree.
     ///
     /// ### Example
     /// ```rust,ignore
@@ -185,19 +197,61 @@ impl MacroTrailingComma {
 }
 
 impl_lint_pass!(MacroTrailingComma => [MACRO_TRAILING_COMMA]);
+impl_lint_pass!(MacroTrailingCommaLate => [MACRO_TRAILING_COMMA]);
 
 pub fn register_lint(lint_store: &mut LintStore) {
     lint_store.register_lints(&[MACRO_TRAILING_COMMA]);
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    // Pre-expansion is required so that the visitor still sees `MacCall`
-    // nodes. By the post-expansion early pass, the macros covered by this
-    // rule have been expanded away and `check_mac` would never fire.
-    // The `pre_expansion_passes` slot is the same one Clippy uses for
-    // similar macro-shape checks.
+    // The lint is split across two passes for issue #409: a
+    // `cfg_attr`-wrapped `#[expect]` is not yet visible to a pre-
+    // expansion lint level lookup (the `cfg_attr` is itself an
+    // attribute that has not been evaluated yet), so emitting the
+    // diagnostic during pre-expansion would slip past rustc's
+    // expectation tracker and the expectation would be reported as
+    // unfulfilled.
+    //
+    // The pre-expansion pass collects violation spans into
+    // `PENDING_VIOLATIONS`; the late pass walks the HIR to find the
+    // deepest containing node for each span and emits the diagnostic
+    // there. By that point `cfg_attr` has been evaluated, so the
+    // `#[expect]` / `#[allow]` attributes the user wrote on the crate
+    // root (or any enclosing item) are visible to the lint-level
+    // lookup and behave correctly.
+    //
+    // Pre-expansion remains necessary for the first half: post-
+    // expansion the macros covered by this rule have been expanded
+    // away and `check_mac` would never fire.
     lint_store.register_pre_expansion_pass(|| Box::new(MacroTrailingComma::new()));
+    lint_store.register_late_pass(|_| Box::new(MacroTrailingCommaLate));
 }
+
+/// Violations the pre-expansion pass has found, waiting to be emitted
+/// by the late pass at the appropriate HIR node. Spans are `Copy +
+/// Send + Sync` (they're 32-bit ids into a session-side table), so
+/// stashing them in a process-wide static is safe.
+static PENDING_VIOLATIONS: Mutex<Vec<PendingViolation>> = Mutex::new(Vec::new());
+
+#[derive(Debug, Clone, Copy)]
+enum PendingViolation {
+    /// Multi-line macro invocation, missing a trailing comma after the
+    /// last argument. The span is the insertion point.
+    Insert(Span),
+    /// Single-line macro invocation, with a gratuitous trailing comma
+    /// after the last argument. The span covers the comma to remove.
+    Remove(Span),
+}
+
+impl PendingViolation {
+    fn span(self) -> Span {
+        match self {
+            PendingViolation::Insert(span) | PendingViolation::Remove(span) => span,
+        }
+    }
+}
+
+pub struct MacroTrailingCommaLate;
 
 impl EarlyLintPass for MacroTrailingComma {
     fn check_mac(&mut self, lint_context: &EarlyContext<'_>, mac_call: &MacCall) {
@@ -218,14 +272,18 @@ impl MacroTrailingComma {
     fn check_invocation(&self, lint_context: &EarlyContext<'_>, mac_call: &MacCall) {
         let args = &mac_call.args;
         // Single-pass walk over the top-level token stream: track the
-        // last tree and bail on a top-level `;`. Avoids allocating a
-        // `Vec` per `check_mac` call.
+        // first and last trees and bail on a top-level `;`. Avoids
+        // allocating a `Vec` per `check_mac` call.
+        let mut first_tree: Option<&TokenTree> = None;
         let mut last_tree: Option<&TokenTree> = None;
         for tree in args.tokens.iter() {
             if let TokenTree::Token(token, _) = tree
                 && token.kind == TokenKind::Semi
             {
                 return;
+            }
+            if first_tree.is_none() {
+                first_tree = Some(tree);
             }
             last_tree = Some(tree);
         }
@@ -238,12 +296,36 @@ impl MacroTrailingComma {
             last_tree,
             TokenTree::Token(token, _) if token.kind == TokenKind::Comma,
         );
+        // rustfmt's `trailing_comma = "Vertical"` only applies in block-
+        // indent style -- i.e., when the first top-level item starts on
+        // a line of its own, separate from the opening delimiter. If
+        // the first item shares its starting line with the opening
+        // delimiter (the compact / visual-indent layout that rustfmt
+        // produces for a single multi-line element such as
+        // `vec![Inner { ... }]` or `vec![bar(\n    ...,\n)]`), rustfmt
+        // leaves the trailing comma off and actively strips any that
+        // gets added. Skip the multi-line "insert comma" branch in that
+        // case so the two tools agree.
+        let suppress_insert = is_multi_line
+            && first_tree.is_some_and(|first_tree| {
+                let between = args.dspan.open.between(first_tree.span());
+                !source_map.is_multiline(between)
+            });
         match (is_multi_line, last_is_comma) {
-            (true, false) => emit_insert(lint_context, last_tree.span().shrink_to_hi()),
-            (false, true) => emit_remove(lint_context, last_tree.span()),
+            (true, false) if !suppress_insert => {
+                queue(PendingViolation::Insert(last_tree.span().shrink_to_hi()));
+            }
+            (false, true) => queue(PendingViolation::Remove(last_tree.span())),
             _ => {}
         }
     }
+}
+
+fn queue(violation: PendingViolation) {
+    let mut guard = PENDING_VIOLATIONS
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    guard.push(violation);
 }
 
 fn parse_path(raw: &str) -> Vec<String> {
@@ -286,26 +368,145 @@ fn entry_matches(entry: &[String], invocation: &rustc_ast::Path) -> bool {
     }
 }
 
-fn emit_insert(lint_context: &EarlyContext<'_>, insert_at: Span) {
-    span_lint_and_sugg(
+impl<'tcx> LateLintPass<'tcx> for MacroTrailingCommaLate {
+    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
+        let pending: Vec<PendingViolation> = {
+            let mut guard = PENDING_VIOLATIONS
+                .lock()
+                .unwrap_or_else(|err| err.into_inner());
+            std::mem::take(&mut *guard)
+        };
+        if pending.is_empty() {
+            return;
+        }
+        let tcx = lint_context.tcx;
+        let mut best: Vec<hir::HirId> = vec![hir::CRATE_HIR_ID; pending.len()];
+        let mut finder = EnclosingHirFinder {
+            tcx,
+            pending: &pending,
+            best: &mut best,
+        };
+        tcx.hir_walk_toplevel_module(&mut finder);
+        for (violation, &hir_id) in pending.iter().zip(best.iter()) {
+            match *violation {
+                PendingViolation::Insert(span) => emit_insert(lint_context, hir_id, span),
+                PendingViolation::Remove(span) => emit_remove(lint_context, hir_id, span),
+            }
+        }
+    }
+}
+
+/// Walk the HIR once and, for each pending violation span, record the
+/// deepest HIR node whose span contains it. Emitting at that node ties
+/// the diagnostic to the user's lint-level attributes — both on the
+/// containing item and any ancestor — so `#[allow]` / `#[expect]` at
+/// any scope behave correctly.
+struct EnclosingHirFinder<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    pending: &'a [PendingViolation],
+    best: &'a mut [hir::HirId],
+}
+
+impl<'a, 'tcx> EnclosingHirFinder<'a, 'tcx> {
+    fn update(&mut self, hir_id: hir::HirId, span: Span) {
+        for (index, violation) in self.pending.iter().enumerate() {
+            let target = violation.span();
+            if !span.contains(target) {
+                continue;
+            }
+            // The walk is depth-first: a parent is visited before its
+            // children, so each successful containment update lands on
+            // the deepest node seen so far.
+            self.best[index] = hir_id;
+        }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for EnclosingHirFinder<'_, 'tcx> {
+    type NestedFilter = nested_filter::All;
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.tcx
+    }
+
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_item(self, item);
+    }
+
+    fn visit_trait_item(&mut self, item: &'tcx hir::TraitItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_trait_item(self, item);
+    }
+
+    fn visit_impl_item(&mut self, item: &'tcx hir::ImplItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_impl_item(self, item);
+    }
+
+    fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_foreign_item(self, item);
+    }
+
+    fn visit_block(&mut self, block: &'tcx hir::Block<'tcx>) {
+        self.update(block.hir_id, block.span);
+        intravisit::walk_block(self, block);
+    }
+
+    fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
+        self.update(stmt.hir_id, stmt.span);
+        intravisit::walk_stmt(self, stmt);
+    }
+
+    fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) {
+        self.update(local.hir_id, local.span);
+        intravisit::walk_local(self, local);
+    }
+
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+        self.update(expr.hir_id, expr.span);
+        intravisit::walk_expr(self, expr);
+    }
+
+    fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
+        self.update(pat.hir_id, pat.span);
+        intravisit::walk_pat(self, pat);
+    }
+}
+
+fn emit_insert(lint_context: &LateContext<'_>, hir_id: hir::HirId, insert_at: Span) {
+    span_lint_hir_and_then(
         lint_context,
         MACRO_TRAILING_COMMA,
+        hir_id,
         insert_at,
         "multi-line macro invocation should end with a trailing comma",
-        "add a trailing comma",
-        ",".to_owned(),
-        Applicability::MachineApplicable,
+        |diag| {
+            diag.span_suggestion(
+                insert_at,
+                "add a trailing comma",
+                ",",
+                Applicability::MachineApplicable,
+            );
+        },
     );
 }
 
-fn emit_remove(lint_context: &EarlyContext<'_>, comma_span: Span) {
-    span_lint_and_sugg(
+fn emit_remove(lint_context: &LateContext<'_>, hir_id: hir::HirId, comma_span: Span) {
+    span_lint_hir_and_then(
         lint_context,
         MACRO_TRAILING_COMMA,
+        hir_id,
         comma_span,
         "single-line macro invocation should not end with a trailing comma",
-        "remove the trailing comma",
-        String::new(),
-        Applicability::MachineApplicable,
+        |diag| {
+            diag.span_suggestion(
+                comma_span,
+                "remove the trailing comma",
+                "",
+                Applicability::MachineApplicable,
+            );
+        },
     );
 }

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -40,12 +40,12 @@ declare_tool_lint! {
     /// macros covered by this lint, it cannot, and the policy applies
     /// without risk.
     ///
-    /// Multi-line invocations whose argument list is a single element
-    /// laid out in visual-indent style — the element starts on the
-    /// opening-delimiter line, e.g. `vec![Inner { ... }]` — are skipped.
-    /// rustfmt's `Vertical` policy treats those as compact rather than
-    /// block-indent and leaves the trailing comma off (and strips any
-    /// that gets added), so the two tools have to agree.
+    /// Multi-line invocations whose first top-level token starts on the
+    /// opening-delimiter line (visual-indent / compact layout, e.g.
+    /// `vec![Inner { ... }]`) are skipped: rustfmt's `Vertical` policy
+    /// only adds a trailing comma when each top-level item is on its
+    /// own line, separate from the delimiter, and strips any comma
+    /// added to the compact shape. The two tools have to agree.
     ///
     /// ### Example
     /// ```rust,ignore

--- a/tests/macro_trailing_comma.rs
+++ b/tests/macro_trailing_comma.rs
@@ -141,12 +141,14 @@ fn fn_level_expect_fulfils_against_a_violation() {
 
 #[test]
 fn crate_level_expect_fulfils_against_a_violation() {
-    // Regression for issue #409: a crate-level `#![expect(...)]` of
+    // Regression for issue [#409]: a crate-level `#![expect(...)]` of
     // this lint must mark the expectation fulfilled when a violation
     // exists in the crate. The fixture contains a multi-line `vec!`
     // missing the trailing comma; the expect must hide the warning
     // AND silence `unfulfilled_lint_expectations`, with no extra
     // workaround needed.
+    //
+    // [#409]: https://github.com/KSXGitHub/parallel-disk-usage/issues/409
     run(
         "ui-toml/macro_trailing_comma/expect_at_crate_root",
         RuleConfig::default(),

--- a/tests/macro_trailing_comma.rs
+++ b/tests/macro_trailing_comma.rs
@@ -141,14 +141,10 @@ fn fn_level_expect_fulfils_against_a_violation() {
 
 #[test]
 fn crate_level_expect_fulfils_against_a_violation() {
-    // Regression for issue [#409]: a crate-level `#![expect(...)]` of
-    // this lint must mark the expectation fulfilled when a violation
-    // exists in the crate. The fixture contains a multi-line `vec!`
-    // missing the trailing comma; the expect must hide the warning
-    // AND silence `unfulfilled_lint_expectations`, with no extra
-    // workaround needed.
-    //
-    // [#409]: https://github.com/KSXGitHub/parallel-disk-usage/issues/409
+    // Regression for
+    // <https://github.com/KSXGitHub/parallel-disk-usage/issues/409>:
+    // a crate-level `#![expect(...)]` must mark the expectation
+    // fulfilled when a violation exists in the crate.
     run(
         "ui-toml/macro_trailing_comma/expect_at_crate_root",
         RuleConfig::default(),

--- a/tests/macro_trailing_comma.rs
+++ b/tests/macro_trailing_comma.rs
@@ -126,3 +126,29 @@ fn enabled_false_suppresses_the_entire_rule() {
         },
     );
 }
+
+#[test]
+fn fn_level_expect_fulfils_against_a_violation() {
+    // Companion to `crate_level_expect_...`: a function-scope
+    // `#[expect]` must also fulfil, because the late pass emits at
+    // the deepest enclosing HIR node rather than always at the
+    // crate root.
+    run(
+        "ui-toml/macro_trailing_comma/expect_at_fn_scope",
+        RuleConfig::default(),
+    );
+}
+
+#[test]
+fn crate_level_expect_fulfils_against_a_violation() {
+    // Regression for issue #409: a crate-level `#![expect(...)]` of
+    // this lint must mark the expectation fulfilled when a violation
+    // exists in the crate. The fixture contains a multi-line `vec!`
+    // missing the trailing comma; the expect must hide the warning
+    // AND silence `unfulfilled_lint_expectations`, with no extra
+    // workaround needed.
+    run(
+        "ui-toml/macro_trailing_comma/expect_at_crate_root",
+        RuleConfig::default(),
+    );
+}

--- a/ui-toml/macro_trailing_comma/expect_at_crate_root/fixture.rs
+++ b/ui-toml/macro_trailing_comma/expect_at_crate_root/fixture.rs
@@ -1,11 +1,7 @@
-// Regression for issue [#409]: a crate-level `#[expect]` of this lint
-// must fulfil rustc's expectation when violations exist anywhere in
-// the crate. The fixture wraps the suppression in `cfg_attr` — the
-// shape downstream crates use to avoid sprinkling `dylint`-only
-// attributes through the source — and verifies that the rule emits
-// its diagnostic for rustc's `#[expect]` machinery to consume.
-//
-// [#409]: https://github.com/KSXGitHub/parallel-disk-usage/issues/409
+// Regression for
+// <https://github.com/KSXGitHub/parallel-disk-usage/issues/409>: a
+// `cfg_attr`-wrapped crate-level `#[expect]` must fulfil rustc's
+// expectation when violations exist in the crate.
 
 #![feature(register_tool)]
 #![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]

--- a/ui-toml/macro_trailing_comma/expect_at_crate_root/fixture.rs
+++ b/ui-toml/macro_trailing_comma/expect_at_crate_root/fixture.rs
@@ -1,9 +1,11 @@
-// Regression for issue #409: a crate-level `#[expect]` of this lint
+// Regression for issue [#409]: a crate-level `#[expect]` of this lint
 // must fulfil rustc's expectation when violations exist anywhere in
 // the crate. The fixture wraps the suppression in `cfg_attr` — the
 // shape downstream crates use to avoid sprinkling `dylint`-only
 // attributes through the source — and verifies that the rule emits
 // its diagnostic for rustc's `#[expect]` machinery to consume.
+//
+// [#409]: https://github.com/KSXGitHub/parallel-disk-usage/issues/409
 
 #![feature(register_tool)]
 #![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]

--- a/ui-toml/macro_trailing_comma/expect_at_crate_root/fixture.rs
+++ b/ui-toml/macro_trailing_comma/expect_at_crate_root/fixture.rs
@@ -1,0 +1,24 @@
+// Regression for issue #409: a crate-level `#[expect]` of this lint
+// must fulfil rustc's expectation when violations exist anywhere in
+// the crate. The fixture wraps the suppression in `cfg_attr` — the
+// shape downstream crates use to avoid sprinkling `dylint`-only
+// attributes through the source — and verifies that the rule emits
+// its diagnostic for rustc's `#[expect]` machinery to consume.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+#![cfg_attr(
+    dylint_lib = "perfectionist",
+    expect(
+        perfectionist::macro_trailing_comma,
+        reason = "regression test for issue #409"
+    )
+)]
+
+fn main() {
+    let _ = vec![
+        1,
+        2,
+        3
+    ];
+}

--- a/ui-toml/macro_trailing_comma/expect_at_fn_scope/fixture.rs
+++ b/ui-toml/macro_trailing_comma/expect_at_fn_scope/fixture.rs
@@ -1,0 +1,29 @@
+// A function-scope `#[expect]` should also fulfil — the late pass
+// finds the deepest enclosing HIR node for each violation and emits
+// the diagnostic there, so a per-function suppression behaves
+// correctly. (The crate-level case is exercised by the
+// `expect_at_crate_root` fixture; this one guards against a
+// regression where emitting at the crate root would miss
+// function-level attributes.)
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+
+#[cfg_attr(
+    dylint_lib = "perfectionist",
+    expect(
+        perfectionist::macro_trailing_comma,
+        reason = "function-scope expect must still fulfil"
+    )
+)]
+fn suppressed() {
+    let _ = vec![
+        1,
+        2,
+        3
+    ];
+}
+
+fn main() {
+    suppressed();
+}

--- a/ui/macro_trailing_comma.rs
+++ b/ui/macro_trailing_comma.rs
@@ -76,12 +76,14 @@ fn _skip_uncurated() {
     );
 }
 
-// Skipped: a single multi-line element whose first token shares its
-// line with the opening delimiter is the visual-indent shape rustfmt
-// produces — and rustfmt's `trailing_comma = "Vertical"` does not add
-// a trailing comma to that shape (and actively strips any that gets
-// added). The two tools have to agree, so the lint skips it.
-fn _single_multi_line_element_skipped() {
+// Skipped: the first top-level token shares its line with the opening
+// delimiter — the visual-indent shape rustfmt produces, and rustfmt's
+// `trailing_comma = "Vertical"` does not add a trailing comma to that
+// shape (and actively strips any that gets added). The two tools have
+// to agree, so the lint skips it. Each call below is one such shape:
+// a single multi-line `format!` element, a single multi-line struct
+// literal, and a nested `vec!` with a single multi-line call.
+fn _compact_first_token_skipped() {
     let _ = vec![format!(
         "{}",
         42

--- a/ui/macro_trailing_comma.rs
+++ b/ui/macro_trailing_comma.rs
@@ -76,20 +76,37 @@ fn _skip_uncurated() {
     );
 }
 
-// Known limitation: the OUTER `vec!` is flagged, but the INNER
-// `format!` is not, despite also being multi-line with no trailing
-// comma. `MacCall::args` stores its delimited arguments as a raw
-// `TokenStream`; the AST visitor's `walk_mac` does not descend into
-// it, so nested macro invocations have no `MacCall` AST node at
-// pre-expansion time and `check_mac` never fires for them. Matching
-// them would require the same token-tree walk the matcher-based half
-// will add. Locked in here so a future change in that direction is a
-// deliberate test update.
-fn _nested_macro_inner_uncovered() {
+// Skipped: a single multi-line element whose first token shares its
+// line with the opening delimiter is the visual-indent shape rustfmt
+// produces — and rustfmt's `trailing_comma = "Vertical"` does not add
+// a trailing comma to that shape (and actively strips any that gets
+// added). The two tools have to agree, so the lint skips it.
+fn _single_multi_line_element_skipped() {
     let _ = vec![format!(
         "{}",
         42
     )];
+    let _ = vec![Inner {
+        name: 1,
+        kids: 2,
+    }];
+    let _ = wrap(vec![bar(
+        "very long name",
+        4069,
+    )]);
+}
+
+struct Inner {
+    name: i32,
+    kids: i32,
+}
+
+fn bar(_: &str, _: i32) -> Inner {
+    Inner { name: 0, kids: 0 }
+}
+
+fn wrap<T>(value: T) -> T {
+    value
 }
 
 fn compute() -> i32 {

--- a/ui/macro_trailing_comma.rs
+++ b/ui/macro_trailing_comma.rs
@@ -80,9 +80,11 @@ fn _skip_uncurated() {
 // delimiter — the visual-indent shape rustfmt produces, and rustfmt's
 // `trailing_comma = "Vertical"` does not add a trailing comma to that
 // shape (and actively strips any that gets added). The two tools have
-// to agree, so the lint skips it. Each call below is one such shape:
-// a single multi-line `format!` element, a single multi-line struct
-// literal, and a nested `vec!` with a single multi-line call.
+// to agree, so the lint skips it. The first three cases are single
+// multi-line elements; the fourth is a multi-element list whose first
+// element happens to start on the opening-delimiter line, locking in
+// that the predicate keys off the first token's line, not the element
+// count.
 fn _compact_first_token_skipped() {
     let _ = vec![format!(
         "{}",
@@ -96,6 +98,8 @@ fn _compact_first_token_skipped() {
         "very long name",
         4069,
     )]);
+    let _ = vec![1, 2,
+        3, 4];
 }
 
 struct Inner {

--- a/ui/macro_trailing_comma.stderr
+++ b/ui/macro_trailing_comma.stderr
@@ -30,11 +30,5 @@ warning: multi-line macro invocation should end with a trailing comma
 LL |         2
    |          ^ help: add a trailing comma: `,`
 
-warning: multi-line macro invocation should end with a trailing comma
-  --> $DIR/macro_trailing_comma.rs:92:6
-   |
-LL |     )];
-   |      ^ help: add a trailing comma: `,`
-
-warning: 6 warnings emitted
+warning: 5 warnings emitted
 


### PR DESCRIPTION
Fixes <https://github.com/KSXGitHub/parallel-disk-usage/issues/408>.
Fixes <https://github.com/KSXGitHub/parallel-disk-usage/issues/409>.

## Summary

- **#408** — `macro_trailing_comma` no longer flags a multi-line invocation whose argument list is a single multi-line element laid out in visual-indent style (e.g. `vec![Inner { ... }]`, `vec![bar(\n    ...,\n)]`). rustfmt's `trailing_comma = "Vertical"` leaves the comma off for that shape and strips any that gets added; the rule now skips the multi-line "insert" branch when the first top-level token shares its line with the opening delimiter, so the two tools agree.
- **#409** — `#![cfg_attr(dylint_lib = "perfectionist", expect(perfectionist::macro_trailing_comma))]` now fulfils. The rule was emitting from a pre-expansion pass, which runs before `cfg_attr` is evaluated, so the `expect` was invisible at emission time and the diagnostic landed at `Warn`. The rule is now split: pre-expansion parks violation spans in a process-static queue; a new late pass walks the HIR, finds the deepest enclosing node per pending span, and emits via `span_lint_hir_and_then`. By the late pass `cfg_attr` is resolved, so `#[allow]` / `#[expect]` at any scope (crate, item, function) behaves as expected.

## Test plan

- [x] `cargo test --workspace --all-targets`
- [x] `cargo dylint --all -- --all-targets` with `DYLINT_RUSTFLAGS='-D warnings'`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] New ui-toml fixtures: `expect_at_crate_root` and `expect_at_fn_scope` cover the `cfg_attr` + `#[expect]` paths.
- [x] `ui/macro_trailing_comma.rs` sweep updated with positive coverage for the compact-style skip.
