### PR TITLE
fix(ci): integration fixtures cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,10 +18,19 @@ jobs:
         timeout-minutes: 1
         continue-on-error: true
         with:
+          # `target/integration-fixtures{,-warmup}/` hold the
+          # warmup's incremental-compilation state. rustc ICEs when
+          # any input to the lint-registration fingerprint (e.g. a
+          # rule's `default_level`) changes against a cache
+          # populated under the previous value, so the dirs are
+          # excluded; the expensive plugin build still lives in the
+          # main `target/` cache.
           path: |
             ~/.cargo
             ~/.dylint_drivers
             target
+            !target/integration-fixtures
+            !target/integration-fixtures-warmup
           key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ github.job }}-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
Fixes <https://github.com/KSXGitHub/perfectionist/issues/32>.

The cached `target/integration-fixtures{,-warmup}/` dirs carry rustc's incremental-compilation fingerprints, which include the registered lints and their default levels. Restoring them across a change to any input of that fingerprint (e.g. flipping a rule's `default_level`) triggers an ICE in `lints_that_dont_need_to_run` instead of a cache invalidation.

Excluding the two dirs from the workflow cache kills the entire class of hazard, not just the `default_level` trigger. The expensive plugin build still lives in the main `target/` cache, so the cost paid per CI run is just the trivial fixture-lib compile plus the dylint check.

Note: an existing stale cache entry will still need to be evicted once (via *Repo Settings → Actions → Caches*) before this PR's `Test` job can succeed on its first run.