### PR TITLE
docs(plan): `macro_argument_binding`

### DIFF
--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -167,15 +167,15 @@ pattern that several rules call out by reference — live in
   Targets the `debug_assert_eq!(map.insert(k, v), None)` footgun
   (release builds skip evaluation entirely) and the general
   class of "macros don't promise exactly-once argument
-  evaluation". Four mutually-exclusive `mode` values plus an
-  optional `expression_bypass` flag layered on top, ordered by
-  implementation cost: a tiny denylist of known-conditional
+  evaluation". Four mutually-exclusive `mode` values ordered
+  by implementation cost — a tiny denylist of known-conditional
   macros (`debug_assert*`), an opt-in blanket ban, the default
-  curated allowlist + denylist, the bypass for pure-accessor
-  call shapes, and matcher-based analysis that counts each
-  `$name:expr` capture's `$name` references in the
-  `macro_rules!` expansion. Curly-brace invocations and `;`-separated forms
-  (`vec![expr; n]`) are out of scope.
+  curated allowlist + denylist, and matcher-based analysis
+  that counts each `$name:expr` capture's `$name` references
+  in the `macro_rules!` expansion — plus an orthogonal
+  `expression_bypass` flag that can layer on any mode to
+  accept pure-accessor call shapes. Curly-brace invocations
+  and `;`-separated forms (`vec![expr; n]`) are out of scope.
 
 ### Serde
 - [`serde-source-types.md`](./serde-source-types.md) — forbid

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -173,8 +173,8 @@ pattern that several rules call out by reference — live in
   macros (`debug_assert*`), an opt-in blanket ban, the default
   curated allowlist + denylist, the bypass for pure-accessor
   call shapes, and matcher-based analysis that counts each
-  `$expr` capture's occurrences in the `macro_rules!`
-  expansion. Curly-brace invocations and `;`-separated forms
+  `$name:expr` capture's `$name` references in the
+  `macro_rules!` expansion. Curly-brace invocations and `;`-separated forms
   (`vec![expr; n]`) are out of scope.
 
 ### Serde

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -161,6 +161,19 @@ pattern that several rules call out by reference — live in
   of `macro_rules!` matchers to detect the `$(,)?` / `$(,)*`
   optional-trailing-comma idioms (harder, configurable via
   `matcher_based`).
+- [`macro-argument-binding.md`](./macro-argument-binding.md) —
+  require non-trivial expressions passed to function-like and
+  array-like macro invocations to be bound to a `let` first.
+  Targets the `debug_assert_eq!(set.insert(x), None)` footgun
+  (release builds skip evaluation entirely) and the general
+  class of "macros don't promise exactly-once argument
+  evaluation". Five eligibility modes from a tiny denylist of
+  known-conditional macros (`debug_assert*`, `cfg!`) through a
+  configurable allowlist/denylist (default), an expression-side
+  bypass for pure accessor calls, up to matcher-based analysis
+  that counts each `$expr` capture's occurrences in the
+  `macro_rules!` expansion. Curly-brace invocations are out of
+  scope.
 
 ### Serde
 - [`serde-source-types.md`](./serde-source-types.md) — forbid

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -168,10 +168,9 @@ pattern that several rules call out by reference — live in
   (release builds skip evaluation entirely) and the general
   class of "macros don't promise exactly-once argument
   evaluation". Five eligibility modes ordered by implementation
-  cost: a tiny **conditional list** of known-conditional macros
-  (`debug_assert*`), an opt-in blanket ban, the default
-  name-based lookup against curated **conditional** and
-  **exactly-once** lists, an expression-side bypass for
+  cost: a tiny denylist of known-conditional macros
+  (`debug_assert*`), an opt-in blanket ban, the default curated
+  allowlist + denylist, an expression-side bypass for
   pure-accessor call shapes, and matcher-based analysis that
   counts each `$expr` capture's occurrences in the
   `macro_rules!` expansion. Curly-brace invocations are out of

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -168,9 +168,10 @@ pattern that several rules call out by reference — live in
   (release builds skip evaluation entirely) and the general
   class of "macros don't promise exactly-once argument
   evaluation". Five eligibility modes ordered by implementation
-  cost: a tiny denylist of known-conditional macros
-  (`debug_assert*`, `cfg!`), an opt-in blanket ban, the default
-  curated allowlist + denylist, an expression-side bypass for
+  cost: a tiny **conditional list** of known-conditional macros
+  (`debug_assert*`), an opt-in blanket ban, the default
+  name-based lookup against curated **conditional** and
+  **exactly-once** lists, an expression-side bypass for
   pure-accessor call shapes, and matcher-based analysis that
   counts each `$expr` capture's occurrences in the
   `macro_rules!` expansion. Curly-brace invocations are out of

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -167,11 +167,12 @@ pattern that several rules call out by reference — live in
   Targets the `debug_assert_eq!(set.insert(x), None)` footgun
   (release builds skip evaluation entirely) and the general
   class of "macros don't promise exactly-once argument
-  evaluation". Five eligibility modes from a tiny denylist of
-  known-conditional macros (`debug_assert*`, `cfg!`) through a
-  configurable allowlist/denylist (default), an expression-side
-  bypass for pure accessor calls, up to matcher-based analysis
-  that counts each `$expr` capture's occurrences in the
+  evaluation". Five eligibility modes ordered by implementation
+  cost: a tiny denylist of known-conditional macros
+  (`debug_assert*`, `cfg!`), an opt-in blanket ban, the default
+  curated allowlist + denylist, an expression-side bypass for
+  pure-accessor call shapes, and matcher-based analysis that
+  counts each `$expr` capture's occurrences in the
   `macro_rules!` expansion. Curly-brace invocations are out of
   scope.
 

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -167,15 +167,12 @@ pattern that several rules call out by reference — live in
   Targets the `debug_assert_eq!(map.insert(k, v), None)` footgun
   (release builds skip evaluation entirely) and the general
   class of "macros don't promise exactly-once argument
-  evaluation". Four mutually-exclusive `mode` values ordered
-  by implementation cost — a tiny denylist of known-conditional
-  macros (`debug_assert*`), an opt-in blanket ban, the default
-  curated allowlist + denylist, and matcher-based analysis
-  that counts each `$name:expr` capture's `$name` references
-  in the `macro_rules!` expansion — plus an orthogonal
-  `expression_bypass` flag that can layer on any mode to
-  accept pure-accessor call shapes. Curly-brace invocations
-  and `;`-separated forms (`vec![expr; n]`) are out of scope.
+  evaluation". Four `mode` values ordered by implementation
+  cost: a tiny denylist of `debug_assert*`, an opt-in blanket
+  ban, the default curated allowlist + denylist, and
+  matcher-based analysis for unknown `macro_rules!` macros that
+  counts each `$name:expr` capture's `$name` references in the
+  expansion. Curly-brace invocations are out of scope.
 
 ### Serde
 - [`serde-source-types.md`](./serde-source-types.md) — forbid

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -168,8 +168,8 @@ pattern that several rules call out by reference — live in
   (release builds skip evaluation entirely) and the general
   class of "macros don't promise exactly-once argument
   evaluation". Four `mode` values ordered by implementation
-  cost: a tiny denylist of `debug_assert*`, an opt-in blanket
-  ban, the default curated allowlist + denylist, and
+  cost: a tiny deny list of `debug_assert*`, an opt-in blanket
+  ban, the default curated allow + deny lists, and
   matcher-based analysis for unknown `macro_rules!` macros that
   counts each `$name:expr` capture's `$name` references in the
   expansion. Curly-brace invocations are out of scope.

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -167,14 +167,15 @@ pattern that several rules call out by reference — live in
   Targets the `debug_assert_eq!(map.insert(k, v), None)` footgun
   (release builds skip evaluation entirely) and the general
   class of "macros don't promise exactly-once argument
-  evaluation". Five eligibility modes ordered by implementation
-  cost: a tiny denylist of known-conditional macros
-  (`debug_assert*`), an opt-in blanket ban, the default curated
-  allowlist + denylist, an expression-side bypass for
-  pure-accessor call shapes, and matcher-based analysis that
-  counts each `$expr` capture's occurrences in the
-  `macro_rules!` expansion. Curly-brace invocations are out of
-  scope.
+  evaluation". Four mutually-exclusive `mode` values plus an
+  optional `expression_bypass` flag layered on top, ordered by
+  implementation cost: a tiny denylist of known-conditional
+  macros (`debug_assert*`), an opt-in blanket ban, the default
+  curated allowlist + denylist, the bypass for pure-accessor
+  call shapes, and matcher-based analysis that counts each
+  `$expr` capture's occurrences in the `macro_rules!`
+  expansion. Curly-brace invocations and `;`-separated forms
+  (`vec![expr; n]`) are out of scope.
 
 ### Serde
 - [`serde-source-types.md`](./serde-source-types.md) — forbid

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -164,7 +164,7 @@ pattern that several rules call out by reference — live in
 - [`macro-argument-binding.md`](./macro-argument-binding.md) —
   require non-trivial expressions passed to function-like and
   array-like macro invocations to be bound to a `let` first.
-  Targets the `debug_assert_eq!(set.insert(x), None)` footgun
+  Targets the `debug_assert_eq!(map.insert(k, v), None)` footgun
   (release builds skip evaluation entirely) and the general
   class of "macros don't promise exactly-once argument
   evaluation". Five eligibility modes ordered by implementation

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -89,9 +89,14 @@ macro invocation:
   shape is unconstrained.
 - For every other macro, behaviour depends on the selected
   mode — see "Five eligibility modes" below. Briefly:
-  `denylist_only` and `matcher_based` (for proc macros) skip
-  the invocation, `blanket` flags it, and `allowlist_denylist`
-  consults the configured `unknown_macro_policy`.
+  `denylist_only` skips the invocation, `blanket` flags it,
+  and `allowlist_denylist` consults the configured
+  `unknown_macro_policy`. `matcher_based` walks the matcher
+  for unknown declarative (`macro_rules!`) macros and treats
+  the result as an allowlist or denylist hit; unknown proc
+  macros are not walkable and fall back to the
+  `allowlist_denylist` behaviour (default skip, configurable
+  to flag via `unknown_macro_policy = "deny"`).
 
 Curly-brace macro invocations (`name! { ... }`) are out of scope.
 They are conventionally DSL bodies where the evaluation contract
@@ -108,11 +113,21 @@ anything about the definition.
 
 ### What counts as a "non-trivial" argument
 
-A "trivial" argument is one whose evaluation has no observable
-effect and produces the same value every time. Trivial arguments
-are accepted even by macros on the denylist, because zero-or-many
-evaluations of a trivial expression are indistinguishable from
-exactly-one.
+A "trivial" argument is one with a *syntactically simple*
+shape — the list below is a purely syntactic heuristic, not a
+guarantee of purity. Some shapes on the trivial list can still
+have observable effects: `base[index]` can panic on
+out-of-bounds, `*ptr` may run a user-defined `Deref` impl,
+autoderef on a field access can invoke trait code, a `Cast`
+between user types can pick up `From`/`Into` plumbing. The lint
+treats these shapes as trivial anyway because in practice their
+evaluation-count behaviour rarely *matters*: across zero / one /
+many evaluations the program reaches the same observable state
+aside from a possible panic, which is a separate class of bug
+this rule does not target. The point of the classification is
+to filter out the "complex enough to plausibly carry a hidden
+side effect" cases (calls, `?`, blocks, control-flow
+expressions) — not to certify mathematical purity.
 
 Trivial:
 

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -103,9 +103,9 @@ hoist them to a `const` if they need to appear inline.
 ## Eligibility modes
 
 Four modes ordered by implementation cost. The default is
-`allowlist_denylist`.
+`allow_and_deny`.
 
-### Mode 0 — `denylist_only`
+### Mode 0 — `deny_only`
 
 Flag only invocations of the curated denylist (`debug_assert!`,
 `debug_assert_eq!`, `debug_assert_ne!`) plus any `deny_extra`
@@ -126,7 +126,7 @@ The maximum-paranoia stance. Not the default because
 `format!("hello {name}", compute())` is fine in practice and
 flagging every macro invocation is exhausting.
 
-### Mode 2 — `allowlist_denylist` (default)
+### Mode 2 — `allow_and_deny` (default)
 
 Three name-set lookups decide each invocation:
 
@@ -288,8 +288,8 @@ let payload = serde_json::json!({ "id": next_id(), "ts": now() });
 # Set to false to disable the rule entirely.
 enabled = true
 
-# Eligibility mode. Defaults to "allowlist_denylist".
-mode = "allowlist_denylist"
+# Eligibility mode. Defaults to "allow_and_deny".
+mode = "allow_and_deny"
 
 # Macros added to the built-in denylist. Each entry is a
 # fully-qualified macro path (no trailing `!`) or a bare macro

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -209,14 +209,33 @@ invocation:
    well-known third-party set as
    [`macro-trailing-comma`](./macro-trailing-comma.md) —
    `format!`, `println!`, `vec!`, `write!`, `assert!`,
-   `assert_eq!`, `anyhow!`, and similar. Notably absent:
-   the `log::*` and `tracing::*` families — those check
-   the configured level before evaluating their arguments
-   (the same conditional-evaluation footgun called out in
-   "Why is this bad?"), so they don't meet the
-   exactly-once criterion. They are left off both default
-   lists; projects that want strict enforcement add them
-   to `deny_extra`.
+   `assert_eq!`, `anyhow!`, and similar.
+
+   Notably absent: the `log::*` and `tracing::*` families
+   — those check the configured level before evaluating
+   their arguments (the same conditional-evaluation
+   footgun called out in "Why is this bad?"), so they
+   don't meet the criterion. They are left off both
+   default lists; projects that want strict enforcement
+   add them to `deny_extra`.
+
+   Caveat for the `assert!` family: `assert!`,
+   `assert_eq!`, `assert_ne!`, and the `debug_assert*`
+   counterparts evaluate their *condition / operand* args
+   exactly once, but their *message-format* args are
+   evaluated only on the failure path (so zero times when
+   the assertion passes). The default allowlist accepts
+   them on the strength of the condition/operand
+   guarantee, since assert messages in practice are
+   either absent or trivial (literal templates plus path
+   references). A side-effecting expression in a message
+   slot — `assert!(check(), "saw {}", set.insert(k))` —
+   is the same hidden-evaluation footgun as the
+   motivating bug, but is rare enough that the default
+   accepts the trade. Projects that find this too loose
+   can add `assert`, `assert_eq`, and `assert_ne` to
+   `deny_extra`; the more precise per-arg-position
+   solution is left to a future enhancement.
 3. **Neither**: skip silently. Unknown macros are not flagged
    by default. A project that wants stricter behaviour
    reaches for mode 1 or mode 4.

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -295,11 +295,15 @@ that classification stays as defined under "What counts as a
 even when the macro would otherwise fire (denylisted, or
 denied under mode 1's blanket), accept the invocation if
 every top-level argument's outermost shape is either trivial
-or a function / method call whose own sub-expressions are all
-trivial. The canonical example is `Arc::clone(&x)`: a `Call`
-whose sole argument `&x` is a reference to a path, both of
-which are trivial. The bypass's recursion stops at any
-non-trivial sub-expression.
+or a single function / method call whose callee/receiver and
+each argument are themselves strictly trivial (per the
+trivial list, no recursion through nested calls). The
+canonical example is `Arc::clone(&x)`: a `Call` whose callee
+`Arc::clone` is a trivial path and whose sole argument `&x`
+is a trivial reference. The bypass does *not* peer inside
+nested calls — a top-level argument of shape
+`Rc::clone(Arc::clone(&x))` is rejected, because the outer
+call's argument is itself a non-trivial expression.
 
 The motivation is that `debug_assert_eq!(my_set.contains(&k),
 true)` is *also* unsafe-feeling but ultimately fine — the
@@ -310,7 +314,7 @@ re-evaluate or skip" by accepting any call whose arguments are
 themselves trivial (typically `&path` / `path`).
 
 The implementation cost over mode 2 is one extra match arm
-plus a recursive descent through `ExprKind::Call` and
+plus a one-level walk over `ExprKind::Call` and
 `ExprKind::MethodCall`. The accuracy gain is large in real
 codebases.
 
@@ -672,11 +676,14 @@ ignore = [
   recursions. Default to non-trivial for any unrecognised
   variant — false positives are better than false negatives
   here.
-- Expression-side bypass (mode 3): a recursive descent
-  through `ExprKind::Call` and `ExprKind::MethodCall`. The
-  callee / receiver must itself be trivial; each argument
-  must be trivial-after-bypass. A bypass match implies the
-  call is "as safe as an accessor".
+- Expression-side bypass (mode 3): a one-level check over
+  `ExprKind::Call` and `ExprKind::MethodCall`. The callee or
+  receiver must itself be strictly trivial (per the trivial
+  predicate above); each call argument must also be strictly
+  trivial. No recursion through nested calls — the bypass is
+  deliberately shallow so the rule stays simple to reason
+  about. A bypass match implies the call is "as safe as an
+  accessor".
 - Matcher walker (mode 4): reuse the `take_*` combinator
   scaffold introduced for
   [`macro-trailing-comma`](./macro-trailing-comma.md)'s

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -77,7 +77,8 @@ macro invocation:
   top-level argument is flagged. The set of accepted argument
   shapes is the trivial set defined under
   "What counts as a 'non-trivial' argument" below — literals,
-  paths, `&path`, `path.field`, `*path`, and casts.
+  paths, `&path`, `path.field`, `base[index]`, `*path`, and
+  casts.
 - If the macro is on the **allowlist** of macros known to
   evaluate each top-level argument exactly once, the argument
   shape is unconstrained.
@@ -304,14 +305,17 @@ recommended landing order.
 | 0 — denylist only | opt-in | smallest | known-conditional macros only |
 | 1 — blanket | opt-in | small | every non-trivial macro arg |
 | 2 — allowlist + denylist | **on** | small | denylist always; unknown configurable |
-| 3 — mode 2 + bypass | opt-in (flag) | small + recursion | mode 2 minus pure-call shapes |
+| 3 — mode 2 + bypass | opt-in | small + recursion | mode 2 minus pure-call shapes |
 | 4 — matcher-based | opt-in | large | mode 2 plus learned `macro_rules!` |
 
-Modes 0, 1, and 2 share the same visitor and differ only in
-the name-lookup table. Mode 3 adds one extra predicate. Mode 4
-adds the matcher walker. The recommended implementation order
-matches the table: mode 0 is the smallest landable step, mode
-4 is the largest.
+Modes 0, 1, 2, and 4 are values of the `mode` enum and are
+mutually exclusive. Mode 3 is the separate `expression_bypass`
+boolean knob and layers on top of whichever `mode` is
+selected. Modes 0, 1, and 2 share the same visitor and differ
+only in the name-lookup table; mode 3 adds one extra
+predicate; mode 4 adds the matcher walker. The recommended
+implementation order matches the table: mode 0 is the
+smallest landable step, mode 4 is the largest.
 
 ## What to lint
 
@@ -355,9 +359,11 @@ For every macro invocation:
    syntactic positions the macro author chose, not normal
    value arguments.
 7. Classify the expression with the trivial / non-trivial
-   split above. If non-trivial, and the `expression_bypass`
-   knob is enabled, apply the bypass recursion before
-   deciding.
+   split above. If trivial, the argument is accepted — skip
+   to the next argument. If non-trivial and
+   `expression_bypass` is enabled, run the bypass recursion;
+   on a bypass match, accept and skip to the next argument.
+   Otherwise continue to step 8.
 8. Emit a diagnostic on the non-trivial argument's span. The
    suggested rewrite is a `let` binding immediately before
    the macro call, with the binding name derived from the

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -88,14 +88,16 @@ macro invocation:
   "What counts as a 'non-trivial' argument" below — literals,
   paths, `&path`, `path.field`, `base[index]`, `*path`, and
   casts.
-- If the macro is on the **allowlist** of macros known to
-  evaluate each top-level argument exactly once on the
-  taken control-flow path, the argument shape is
-  unconstrained. The `assert!`/`assert_eq!`/`assert_ne!`
-  family is included with a caveat — their *message-format*
-  args are evaluated only on the failure path, but they are
-  accepted on the strength of the condition/operand
-  guarantee. See "Mode 2" below for the full discussion.
+- If the macro is on the **allowlist**, the argument shape
+  is unconstrained. The criterion is roughly "operand
+  arguments are evaluated exactly once", and the curated
+  allowlist enumerates the macros that meet it: `format!`,
+  `println!`, `vec!`, `write!`, `anyhow!`, etc. The
+  `assert!`/`assert_eq!`/`assert_ne!` family is included by
+  policy with a known caveat — their *message-format* args
+  are evaluated only on the failure path (zero times when
+  the assertion passes). See "Mode 2" below for the full
+  discussion.
 - For every other macro, behaviour depends on the selected
   mode — see "Five eligibility modes" below. Briefly:
   `denylist_only` skips the invocation, `blanket` flags it,

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -7,471 +7,210 @@ debug_assert_eq!(my_map.insert(key, value), None, "Something went wrong! `key` w
 ```
 
 In debug builds this works: `insert` runs, returns the previous
-value associated with `key` (or `None` if the key was new), and
-the assertion panics if `key` was already present. In release
-builds the `debug_assertions` cfg is off, so the conditional
-that `debug_assert_eq!` expands to — roughly
-`if cfg!(debug_assertions) { ... }` — folds to `if false { ... }`
-and the body is dead-code-eliminated. The key property is that
-the argument expressions are *not evaluated*: `insert` never
-runs, `(key, value)` is silently dropped, and `my_map` ends the
-function in a different state from the one the author intended.
-The bug only shows up when the binary is finally built with
-`--release` and behaves differently from every test run.
+value (or `None` if the key was new), and the assertion panics
+if `key` was already present. In release builds the
+`debug_assertions` cfg is off, the conditional that
+`debug_assert_eq!` expands to folds to `if false { ... }`, and
+the body is dead-code-eliminated. The argument expressions are
+*not evaluated*: `insert` never runs, `(key, value)` is silently
+dropped, and `my_map` ends the function in a different state
+from the one the author intended. The bug only surfaces under
+`--release`.
 
 The fix is to bind the call to a `let` first, then pass the
-binding to the macro:
+binding:
 
 ```rust
 let ejected = my_map.insert(key, value);
 debug_assert_eq!(ejected, None, "Something went wrong! `key` wasn't new");
 ```
 
-`debug_assert*` is the most famous offender, but the trap is
-general: a function-like or array-like macro can evaluate any
-given argument zero times, once, or many times depending on its
-matcher, and the call-site cannot tell which without reading the
-macro's body. Functions guarantee exactly-once evaluation per
-argument; macros do not, even when the call shape looks
-identical.
+`debug_assert*` is the famous offender, but the trap is general:
+a function-like or array-like macro may evaluate any top-level
+argument zero, one, or many times depending on its matcher.
+Functions guarantee exactly-once evaluation per argument; macros
+do not, even when the call shape looks identical.
 
 ## Why is this bad?
 
-The `debug_assert*` case is an objective defect — the program's
-runtime behaviour differs between debug and release builds in a
-way the author did not intend, and the difference is invisible at
-the call site. A duplicate insertion silently succeeds in
-release; a `?` operator that would have short-circuited an
-error in debug never runs in release, so the function proceeds
-past the assert as if the call had returned `Ok`; an iterator's
-`.next()` quietly advances in one build configuration but not
-another. None of these are stylistic preferences — they're
-bugs.
+Code containing such an invocation behaves differently between
+debug and release builds (or between any two configurations the
+macro is conditional on), and the difference is invisible at the
+call site. A duplicate insertion silently succeeds in release; a
+`?` expression that should have short-circuited an error never
+runs; an iterator's `.next()` quietly advances in one build
+configuration but not another. These aren't stylistic
+preferences — they're bugs.
 
-The general form ("any function-like or array-like macro may
-evaluate an argument zero or many times") is partly a correctness
-concern and partly a defensive coding stance:
+The trap covers two shapes:
 
-- **Correctness** for macros that conditionally skip evaluation
-  (`debug_assert*`, custom `#[cfg(test)]` wrappers, log macros
-  below the configured filter level in some implementations).
-  `cfg!` looks like a member of this family but isn't — its
-  argument is `meta` syntax, not a Rust expression, so the
-  "argument-evaluation count" framing doesn't apply and the
-  lint deliberately leaves it alone.
-- **Correctness** for macros that evaluate an argument multiple
-  times (anything implementing a syntactic transformation —
-  `min!`/`max!`-style macros, n-arg-tuple builders, retry-loop
-  macros). A side-effecting expression repeated produces wrong
-  results.
-- **Defensive** for unknown macros where the call-site author
-  doesn't know the evaluation count and cannot find out without
-  reading the matcher. A `let` binding makes the code work
-  regardless.
+- **Conditional evaluation** (`debug_assert*`, log macros below
+  the configured filter level, custom `#[cfg(test)]` wrappers).
+  Side effects vanish in some build configurations.
+- **Repeated evaluation** (anything implementing a syntactic
+  transformation that expands its capture more than once —
+  `min!`/`max!`-style macros, retry-loop macros). A
+  side-effecting expression repeated produces wrong results.
 
-The rule's default configuration flags only known-conditional
-macros — the ones in the curated denylist. Unknown
-macros are skipped under the default
-`unknown_macro_policy = "allow"`; projects that want the
-defensive stance set `unknown_macro_policy = "deny"` or
-switch to the blanket-ban mode.
+A `let` binding upstream of the macro call removes the
+ambiguity: the expression evaluates exactly once, regardless of
+what the macro does with its captures.
 
 ## Statement
 
 For a function-like (`name!(...)`) or array-like (`name![...]`)
 macro invocation:
 
-- If the macro is on the **denylist** of macros known to evaluate
-  arguments conditionally or repeatedly, every non-trivial
-  top-level argument is flagged. The set of accepted argument
-  shapes is the trivial set defined under
-  "What counts as a 'non-trivial' argument" below — literals,
-  paths, `&path`, `path.field`, `base[index]`, `*path`, and
-  casts.
-- If the macro is on the **allowlist**, the argument shape
-  is unconstrained. The criterion is roughly "operand
-  arguments are evaluated exactly once", and the curated
-  allowlist enumerates the macros that meet it: `format!`,
-  `println!`, `vec!`, `write!`, `anyhow!`, etc. The
-  `assert!`/`assert_eq!`/`assert_ne!` family is included by
-  policy with a known caveat — their *message-format* args
-  are evaluated only on the failure path (zero times when
-  the assertion passes). See "Mode 2" below for the full
-  discussion.
-- For every other macro, behaviour depends on the selected
-  mode — see "Five eligibility modes" below. Briefly:
-  `denylist_only` skips the invocation, `blanket` flags it,
-  and `allowlist_denylist` consults the configured
-  `unknown_macro_policy`. `matcher_based` walks the matcher
-  for unknown declarative (`macro_rules!`) macros and treats
-  the result as an allowlist or denylist hit; unknown proc
-  macros are not walkable and fall back to the
-  `allowlist_denylist` behaviour (default skip, configurable
-  to flag via `unknown_macro_policy = "deny"`).
+- If the macro is on the **denylist**, every non-trivial
+  top-level argument is flagged.
+- If the macro is on the **allowlist**, the argument shape is
+  unconstrained.
+- For every other macro, behaviour depends on the configured
+  `mode` (see "Eligibility modes" below).
 
-Curly-brace macro invocations (`name! { ... }`) are out of scope.
-They are conventionally DSL bodies where the evaluation contract
-is intentional (`thread_local! { static FOO: ...; }`,
-`quote! { fn foo() { ... } }`, `html! { <div>{value}</div> }`),
-not function-call-like argument lists.
-
-Function-like and array-like invocations whose top-level token
-stream uses `;` as a separator are also out of scope:
-`vec![expr; n]` (repeated-element form) and similar `;`-shaped
-grammars are not the comma-separated argument list this rule
-targets. Step 5 of "What to lint" detects this mechanically by
-treating a top-level `;` as a skip-the-whole-invocation
-trigger.
-
-The call-site delimiter is the *only* signal the lint uses to
-classify a macro invocation. A declarative macro's body does not
-fix its call shape; the same `macro_rules!` accepts `name!(...)`,
-`name![...]`, and `name! { ... }` interchangeably. The lint
-therefore branches on the invocation's `Delimiter`, not on
-anything about the definition.
+Curly-brace macro invocations (`name! { ... }`) are out of
+scope — they're conventionally DSL bodies
+(`thread_local! { ... }`, `quote! { ... }`, `html! { ... }`)
+where the evaluation contract is the macro's, not the call
+site's. The call-site delimiter is the only signal the lint
+uses: the same `macro_rules!` accepts all three call shapes,
+and the definition site doesn't fix which one the author chose
+at any given call site.
 
 ### What counts as a "non-trivial" argument
 
-A "trivial" argument is one with a *syntactically simple*
-shape — the list below is a purely syntactic heuristic, not a
-guarantee of purity. Some shapes on the trivial list can still
-have observable effects: `base[index]` can panic on
-out-of-bounds, `*ptr` may run a user-defined `Deref` impl,
-autoderef on a field access can invoke trait code, a `Cast`
-between user types can pick up `From`/`Into` plumbing. The lint
-treats these shapes as trivial anyway because in practice their
-evaluation-count behaviour rarely *matters*: across zero / one /
-many evaluations the program reaches the same observable state
-aside from a possible panic, which is a separate class of bug
-this rule does not target. The point of the classification is
-to filter out the "complex enough to plausibly carry a hidden
-side effect" cases (calls, `?`, blocks, control-flow
-expressions) — not to certify mathematical purity.
+The lint accepts any argument whose outermost shape is one of:
 
-Trivial:
-
-- Literals (`42`, `"hello"`, `true`, `'a'`).
-- Path expressions resolving to a `const`, `static`, local
-  binding, function name, or unit / tuple variant
-  (`MAX_VALUE`, `Foo::BAR`, `count`, `Result::Ok`).
-- A reference to a trivial expression (`&count`,
-  `&mut buffer`).
+- A literal (`42`, `"hello"`, `true`, `'a'`).
+- A path resolving to a `const`, `static`, local binding,
+  function name, or unit / tuple variant (`MAX`, `count`,
+  `Foo::BAR`, `Result::Ok`).
+- A reference to a trivial expression (`&count`, `&mut buffer`).
 - A field access or tuple-index on a trivial base
   (`config.threshold`, `point.0`).
-- An index expression `base[index]` where both `base` and
-  `index` are themselves trivial (`buffer[0]`,
-  `lookup[Foo::KEY]`).
+- An index `base[index]` where both `base` and `index` are
+  themselves trivial (`buffer[0]`, `lookup[Foo::KEY]`).
 - A unary deref of a trivial expression (`*ptr`).
-- A trivial expression annotated with a type (`x as u64`,
-  `42_u8`).
+- A trivial expression annotated with a type (`x as u64`).
 
-Non-trivial (anything not in the list above), e.g.:
+Everything else is non-trivial: function and method calls, `?`,
+`.await`, macro invocations, blocks, control-flow expressions,
+assignments, and any binary or range expression whose operands
+are non-trivial. The classification is purely syntactic — `const
+fn` calls and other "morally pure" expressions are non-trivial;
+hoist them to a `const` if they need to appear inline.
 
-- Function calls (`compute()`, `Foo::new()`).
-- Method calls (`map.insert(k, v)`, `iter.next()`).
-- `?` expressions (`fallible()?`).
-- `.await` expressions.
-- Macro invocations (`other_macro!(x)`).
-- Block expressions (`{ ... }`).
-- Closure expressions, even if not invoked here.
-- `if`, `match`, `loop`, `while`, `for`.
-- Assignment / compound-assignment.
-- Range expressions whose endpoints are non-trivial.
-- Binary expressions whose operands are non-trivial.
+## Eligibility modes
 
-The trivial / non-trivial split is purely *syntactic*. The lint
-does not consult the type checker for purity (which Rust does not
-expose anyway). A `const fn` call is treated as non-trivial; the
-author can hoist it to a `const` if they want it accepted.
+Four modes ordered by implementation cost. The default is
+`allowlist_denylist`.
 
-## Five eligibility modes
+### Mode 0 — `denylist_only`
 
-The configuration ladder below covers the spectrum between
-"forbid every non-trivial macro argument" and "fully read the
-macro definition". The modes are ordered by *implementation*
-cost, not by some clean monotone relationship on what they
-flag: Mode 3 relaxes Mode 2's denylist, and Mode 4 reshapes
-it. The default is mode 2 (curated allowlist + denylist).
+Flag only invocations of the curated denylist (`debug_assert!`,
+`debug_assert_eq!`, `debug_assert_ne!`) plus any `deny_extra`
+entries. Every other macro is silently accepted.
 
-### Mode 0 — denylist-only (the smallest landable rule)
+The smallest landable rule. Pick this when a project wants the
+`debug_assert*` footgun caught without auditing third-party
+macros.
 
-Ship a hard-coded denylist of known-conditional macros —
-`debug_assert!`, `debug_assert_eq!`, `debug_assert_ne!`, and a
-handful of similar shapes — and flag only those. Every other
-macro is silently accepted.
+### Mode 1 — `blanket`
 
-The implementation is a syntactic name-set lookup over the
-invocation's `MacCall::path` segments plus a
-non-trivial-argument predicate. No allowlist, no matcher walk;
-the only mode-specific knob is `deny_extra` for
-extending the built-in denylist. The shared knobs (`ignore`,
-`expression_bypass`) still apply per the "What to lint" and
-"Configuration" sections — they're not mode-gated. The rule's
-surface area in this mode is "this exact set of core/std
-macros, for this exact reason".
+Flag every function-like or array-like invocation that carries
+a non-trivial top-level argument, regardless of macro. Add
+specific exceptions to `allow_extra`; there is no built-in
+allowlist in this mode.
 
-This mode exists for projects that want to enable
-`perfectionist::macro_argument_binding` without auditing their
-third-party macro use — they only care about not getting bitten
-by `debug_assert*`. Set `mode = "denylist_only"`.
+The maximum-paranoia stance. Not the default because
+`format!("hello {name}", compute())` is fine in practice and
+flagging every macro invocation is exhausting.
 
-### Mode 1 — blanket ban
+### Mode 2 — `allowlist_denylist` (default)
 
-The maximum-paranoia mode. Every function-like and array-like
-macro invocation is flagged when given a non-trivial top-level
-argument, regardless of whether the macro is known safe.
-Curly-brace invocations remain out of scope per the
-"Statement" section.
+Three name-set lookups decide each invocation:
 
-This mode is deliberately not the default — `format!("hello
-{name}", compute())` is fine in practice and reading every macro
-invocation as a footgun is exhausting. Projects that want the
-maximum-paranoia stance can opt in by setting
-`mode = "blanket"`. Set the `allow_extra` knob to whitelist
-specific macros that the project trusts.
+1. **Denylist hit** (`debug_assert*` plus `deny_extra`) → flag
+   every non-trivial argument.
+2. **Allowlist hit** (the curated set below plus `allow_extra`)
+   → accept unconditionally.
+3. **Neither** → flag every non-trivial argument.
 
-### Mode 2 — curated allowlist + denylist (default)
+The default allowlist tracks the curated set in
+[`macro-trailing-comma`](./macro-trailing-comma.md), with the
+conditional-evaluation families (`log::*`, `tracing::*`)
+removed: `format!`, `format_args!`, `print!`, `println!`,
+`eprint!`, `eprintln!`, `write!`, `writeln!`, `vec!`,
+`panic!`, `unimplemented!`, `todo!`, `unreachable!`,
+`assert!`, `assert_eq!`, `assert_ne!`, `matches!`, `dbg!`,
+`anyhow!`, and similar.
 
-The default mode. Mode 0's denylist plus a curated allowlist
-of macros known to evaluate each top-level argument exactly
-once. Three name-lookups decide each invocation:
+Flagging unlisted macros by default is deliberate: the rule
+isn't useful if every unrecognised proc macro gets a free pass.
+Projects extend `allow_extra` with the third-party macros they
+trust to evaluate each argument exactly once.
 
-1. **Denylist hit**: flag every non-trivial argument.
-   The denylist defaults to `debug_assert!`,
-   `debug_assert_eq!`, `debug_assert_ne!`, and any user-added
-   entries.
-2. **Allowlist hit**: accept unconditionally. The
-   allowlist defaults to a subset of
-   [`macro-trailing-comma`](./macro-trailing-comma.md)'s
-   curated `core` / `std` and well-known third-party set:
-   `format!`, `println!`, `vec!`, `write!`, `assert!`,
-   `assert_eq!`, `anyhow!`, and similar — every macro on
-   that rule's list whose top-level arguments are
-   evaluated exactly once.
+### Mode 3 — `matcher_based`
 
-   Notably absent from *this* rule's allowlist (though
-   present in `macro-trailing-comma`'s): the `log::*` and
-   `tracing::*` families. Those check the configured
-   level before evaluating their arguments — the same
-   conditional-evaluation footgun called out in "Why is
-   this bad?" — so they fail the exactly-once criterion.
-   They are also left off this rule's default *denylist*
-   to avoid noise; projects that want strict enforcement
-   add them to `deny_extra`.
+Layers on top of mode 2. The allowlist and denylist are
+consulted first; the matcher walk runs only on `macro_rules!`
+macros that would otherwise be unknown.
 
-   Caveat for the `assert!` family: `assert!`,
-   `assert_eq!`, and `assert_ne!` evaluate their
-   *condition / operand* args exactly once, but their
-   *message-format* args are evaluated only on the
-   failure path (zero times when the assertion passes).
-   The default allowlist accepts them on the strength of
-   the condition/operand guarantee, since assert messages
-   in practice are either absent or trivial (literal
-   templates plus path references). A side-effecting
-   expression in a message slot — `assert!(check(),
-   "saw {}", set.insert(k))` — is the same hidden-
-   evaluation footgun as the motivating bug, but is rare
-   enough that the default accepts the trade. Projects
-   that find this too loose can add `assert`, `assert_eq`,
-   and `assert_ne` to `deny_extra`; treating the message
-   slot separately from the condition slot is left as a
-   future enhancement.
-3. **Neither**: skip silently. Unknown macros are not flagged
-   by default. A project that wants stricter behaviour
-   reaches for mode 1 or mode 4.
+For an eligible declarative macro, determine which arm matches
+the invocation. For each `$name:expr` capture in that arm,
+count occurrences of `$name` in the expansion:
 
-The default rejecting only the denylist (rather than every
-unlisted macro) is a usability choice. The strict reading —
-flag every macro not on the curated allowlist — produces too
-much noise during initial rule adoption. Projects that want
-that stance set `unknown_macro_policy = "deny"`.
+- Exactly one, not nested inside any `$( ... )*` / `$( ... )+` /
+  `$( ... )?` repetition → the argument is evaluated exactly
+  once. Treat the invocation as allowlisted.
+- Zero, two or more, or any occurrence inside a repetition or
+  conditional fragment → flag the invocation.
 
-### Mode 3 — mode 2 with expression-side bypass
+Procedural macros are not walkable; the lint falls back to the
+mode-2 verdict (flag, by default).
 
-A bypass that layers on top of any of the modes above. The
-bypass does not change the trivial / non-trivial split —
-that classification stays as defined under "What counts as a
-'non-trivial' argument". Instead, it adds an *accept rule*:
-even when the macro would otherwise fire (denylisted, or
-denied under mode 1's blanket), accept the invocation if
-every top-level argument's outermost shape is either trivial
-or a single function / method call whose callee/receiver and
-each argument are themselves strictly trivial (per the
-trivial list, no recursion through nested calls). The
-canonical example is `Arc::clone(&x)`: a `Call` whose callee
-`Arc::clone` is a trivial path and whose sole argument `&x`
-is a trivial reference. The bypass does *not* peer inside
-nested calls — a top-level argument of shape
-`Rc::clone(Arc::clone(&x))` is rejected, because the outer
-call's argument is itself a non-trivial expression.
-
-The motivation is that `debug_assert_eq!(my_set.contains(&k),
-true)` is *also* unsafe-feeling but ultimately fine — the
-worst case is "contains is not called in release", which has
-no observable effect because `contains` is pure. The bypass
-captures the heuristic "non-mutating method calls are safe to
-re-evaluate or skip" by accepting any call whose arguments are
-themselves trivial (typically `&path` / `path`).
-
-The implementation cost over mode 2 is one extra match arm
-plus a one-level walk over `ExprKind::Call` and
-`ExprKind::MethodCall`. The accuracy gain is large in real
-codebases.
-
-Enable with `expression_bypass = true`. Default off — the
-heuristic is approximate (it cannot tell a pure method from an
-impure one), and projects that want the strictest reading
-should leave it off. Projects that find the default too noisy
-turn it on as the first knob to adjust.
-
-### Mode 4 — matcher-based declarative-macro analysis
-
-Layered on top of mode 2: the denylist and allowlist are
-consulted first, and the matcher walk runs only on
-`macro_rules!` macros that *would otherwise be unknown*. An
-invocation that resolves to an allowlisted macro is still
-accepted unconditionally; an invocation that resolves to a
-denylisted macro is still flagged. The matcher walk turns an
-"unknown" verdict into a justified allowlist-or-flag decision
-rather than overriding the curated lists. For a `macro_rules!`
-macro reached by the walk (its definition visible to the
-compiler — current crate, or a dependency whose macro body
-rustc still has on hand):
-
-1. Determine which arm of the macro matches the call.
-2. For each `$name:expr` capture in that arm, count its
-   occurrences in the corresponding RHS.
-   - Exactly one occurrence, with the capture not nested
-     inside any `$( ... )*` / `$( ... )+` / `$( ... )?`
-     repetition that could change its evaluation count:
-     the argument is evaluated exactly once. Eligible
-     (treat the argument's macro as if it were on the
-     allowlist).
-   - Zero occurrences (the capture is matched but discarded):
-     the argument is never evaluated. Flag with a "the
-     argument is unused in this expansion" diagnostic.
-   - Two or more occurrences, or any occurrence inside a
-     repetition / conditional fragment: the argument may be
-     evaluated more than once or skipped. Flag with the
-     "this macro does not evaluate arguments exactly once"
-     diagnostic.
-3. If multiple arms could match the same invocation
-   ambiguously, fall back to the *most conservative* answer
-   across all candidate arms.
-
-Matcher analysis does not extend to procedural macros — the
-expansion is custom Rust code, not introspectable from the
-matcher. Proc macros remain governed by the allowlist /
-denylist configuration.
-
-Set `mode = "matcher_based"` to enable. Defaults off; this
-mode is the most expensive to implement (see "Why
-matcher-based is harder than name-based" in
-[`macro-trailing-comma`](./macro-trailing-comma.md), which
-faces the same matcher-access infrastructure work) and the
-matcher walker can be reused between this rule and
-`macro-trailing-comma`. See the Difficulty section for the
-recommended landing order.
-
-### Picking a mode
-
-| Mode | Default | Cost to implement | Flags |
-| --- | --- | --- | --- |
-| 0 — denylist only | opt-in | smallest | known-conditional macros only |
-| 1 — blanket | opt-in | small | every non-trivial macro arg |
-| 2 — allowlist + denylist | **on** | small | denylist always; unknown configurable |
-| 3 — mode 2 + bypass | opt-in | small + recursion | mode 2 minus pure-call shapes |
-| 4 — matcher-based | opt-in | large | mode 2 plus learned `macro_rules!` |
-
-Modes 0, 1, 2, and 4 are values of the `mode` enum and are
-mutually exclusive. Mode 3 is the separate `expression_bypass`
-boolean knob and layers on top of whichever `mode` is
-selected. Modes 0, 1, and 2 share the same visitor and differ
-only in the name-lookup table; mode 3 adds one extra
-predicate; mode 4 adds the matcher walker. The recommended
-implementation order matches the table: mode 0 is the
-smallest landable step, mode 4 is the largest.
+The most expensive mode to implement. Ship modes 0-2 first; mode
+3 can share matcher-walking infrastructure with the matcher-
+based eligibility check planned for
+[`macro-trailing-comma`](./macro-trailing-comma.md).
 
 ## What to lint
 
 For every macro invocation:
 
-1. Check the invocation's `Delimiter`. If it is `Brace`, skip —
-   curly-brace invocations are out of scope.
-2. Read the invocation's `MacCall::path` segments. The
-   pre-expansion pass runs before name resolution, so this is
-   a raw `rustc_ast::Path` — there's no `Res`/`DefId` to
-   resolve. Name matching against configuration entries is
-   syntactic; see "Implementation notes" for the segment /
-   tail-matching helper that `macro-trailing-comma` already
-   provides.
-3. Consult `ignore`. If the path matches, skip. `ignore` wins
-   over both the denylist and the allowlist; it exists for
-   per-project opt-outs of curated entries.
-4. Apply the configured `mode`:
-   - `denylist_only`: match against the denylist
-     (`debug_assert!`, `debug_assert_eq!`, `debug_assert_ne!`,
-     plus `deny_extra`). Continue to step 5 only on a
-     hit.
-   - `blanket`: continue to step 5 for every macro not on the
-     allowlist (`allow_extra` only — there is
-     no built-in allowlist in this mode, by design).
-   - `allowlist_denylist` (default): denylist hit → continue.
-     Allowlist hit → skip. Otherwise consult
-     `unknown_macro_policy`: `allow` (default) → skip,
-     `deny` → continue.
-   - `matcher_based`: denylist and allowlist as above; for
-     unknown declarative macros, walk the matcher per mode 4.
-     Result is either "treat as allowlisted" (continue: skip)
-     or "treat as denylisted" (continue: lint). Unknown proc
-     macros are not walkable and fall through to
-     `unknown_macro_policy`.
-5. Walk the invocation's *top-level* argument list, using
-   the same token-stream handling as
-   [`macro-trailing-comma`](./macro-trailing-comma.md):
-   track delimiter nesting and split on top-level commas. A
-   top-level `;` is a skip-the-whole-invocation trigger:
-   the macro uses `;` as its separator (`vec![v; count]`'s
-   repeated-element form is the canonical example) and the
-   call shape isn't the comma-separated argument list this
-   rule targets. A top-level `=>` is allowed and walked
-   through as ordinary content
-   (`hashmap!("a" => 1, "b" => 2)` legitimately carries
-   one per entry). The lint only inspects top-level
-   expressions — an argument that itself contains a
-   non-trivial sub-expression is the author's choice, and
-   recursing into nested macros opens the door to false
-   positives.
+1. Skip if the delimiter is `Brace`.
+2. Read `MacCall::path` segments. The pre-expansion pass runs
+   before name resolution, so this is a raw `rustc_ast::Path`
+   matched syntactically against configuration entries.
+3. If the path matches an `ignore` entry, skip.
+4. Apply the configured mode to decide whether to inspect the
+   arguments (see "Eligibility modes").
+5. Walk the invocation's top-level argument list using the
+   same token-stream handling as
+   [`macro-trailing-comma`](./macro-trailing-comma.md): track
+   delimiter nesting and split on top-level commas. Skip the
+   whole invocation if the top-level token stream uses `;` as
+   a separator (`vec![v; count]`); top-level `=>` is ordinary
+   content and walked through.
 6. For each top-level argument, parse the token stream as an
    expression. Skip arguments that don't parse as a single
-   expression (a `name: type` argument shape, a path-only
-   argument like `serde!(foo = bar)`, etc.) — those are
-   syntactic positions the macro author chose, not normal
-   value arguments.
-7. Classify the expression with the trivial / non-trivial
-   split above. If trivial, the argument is accepted — skip
-   to the next argument. If non-trivial and
-   `expression_bypass` is enabled, run the bypass recursion;
-   on a bypass match, accept and skip to the next argument.
-   Otherwise continue to step 8.
-8. Emit a diagnostic on the non-trivial argument's span. The
-   suggested rewrite is a `let` binding immediately before
-   the macro call, with the binding name derived from the
-   expression (a fallback identifier such as `binding` is
-   used when no better name is available).
+   expression (`name: type`, `name = value`, etc. are syntactic
+   positions the macro author chose).
+7. Classify the expression with the trivial / non-trivial split.
+   If trivial, accept; if non-trivial, emit a diagnostic
+   suggesting a `let` binding immediately before the macro
+   call.
 
-The autofix is `Applicability::MaybeIncorrect`. Inserting a
-`let` binding adds a new name to the enclosing scope, which
-may shadow an existing name or be shadowed by a later
-binding. The rewrite is mechanically correct but worth a
-human glance.
+The diagnostic is informational only; no autofix is supplied
+because the right binding name varies per site and the rewrite
+introduces a new name in the enclosing scope.
 
 ## Examples
 
 ### The motivating bug
 
 ```rust
-// Bad — release mode skips `insert` entirely
+// Bad — release skips `insert` entirely
 debug_assert_eq!(my_map.insert(key, value), None, "duplicate key");
 
 // Good
@@ -482,49 +221,22 @@ debug_assert_eq!(ejected, None, "duplicate key");
 ### Trivial arguments stay inline
 
 ```rust
-// Accepted — `count` is a path, `MAX_RETRIES` is a const,
-// `&buffer` is a reference to a path. None of them have
-// side effects.
+// Accepted — `count`, `MAX_RETRIES`, `&buffer` are all trivial.
 debug_assert_eq!(count, MAX_RETRIES, "expected {MAX_RETRIES} retries");
-debug_assert!(buffer.is_empty(), "buffer must start empty");
-//            ^^^^^^^^^^^^^^^^^ method call → flagged with
-//                              `expression_bypass = false`
-//                              (the built-in default);
-//                              accepted with
-//                              `expression_bypass = true`
-//                              because the call has the
-//                              shape `trivial.method()` and
-//                              the bypass's syntactic
-//                              heuristic accepts any such
-//                              shape (even though the lint
-//                              cannot prove `is_empty` is
-//                              actually pure).
 ```
-
-In practice nearly every `debug_assert!` argument is a
-boolean-returning method or function call. Without
-`expression_bypass = true` the lint flags essentially every
-reasonable `debug_assert!` invocation, which is not a
-recommended deployment shape. Projects that keep
-`debug_assert!` on the denylist (to catch the
-`insert`-style bug above) almost always set
-`expression_bypass = true` at the same time; the two
-settings are typically paired in real configurations even
-though their built-in defaults sit at opposite ends.
 
 ### Allowlisted macros pass through
 
 ```rust
-// Accepted under default config — `format!` is on the
-// curated allowlist; arguments are evaluated exactly once.
+// Accepted — `format!` is on the curated allowlist; arguments
+// are evaluated exactly once.
 let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Ordering::Relaxed));
 ```
 
-### Array-like invocation is also in scope
+### Array-like invocation is in scope
 
 ```rust
-// Accepted under default config — vec! is on the curated
-// allowlist; each element is evaluated exactly once.
+// Accepted under default config — `vec!` is on the allowlist.
 let xs = vec![compute(), compute(), compute()];
 ```
 
@@ -533,21 +245,11 @@ let xs = vec![compute(), compute(), compute()];
 // a candidate, allowlist or not.
 let xs = vec![compute(), compute(), compute()];
 
-// Good (blanket mode rewrite)
+// Good (blanket-mode rewrite)
 let a = compute();
 let b = compute();
 let c = compute();
 let xs = vec![a, b, c];
-```
-
-### Curly-brace invocation is out of scope
-
-```rust
-// Skipped — curly-brace invocation. The DSL contract is the
-// macro's, not the call site's.
-thread_local! {
-    static COUNTER: Cell<u32> = Cell::new(compute_initial());
-}
 ```
 
 ### Multiple-evaluation trap
@@ -557,7 +259,7 @@ macro_rules! double_use {
     ($e:expr) => { $e + $e };
 }
 
-// Bad — `next` is consumed twice. `total` ends up as
+// Bad — `iter.next()` runs twice. `total` ends up as
 // `current_item + next_item`, not `2 * current_item`.
 let total = double_use!(iter.next().unwrap());
 
@@ -566,18 +268,16 @@ let v = iter.next().unwrap();
 let total = double_use!(v);
 ```
 
-This is the kind of misuse mode 4 (matcher-based) catches
-automatically: the matcher walker sees `$e` referenced twice in
-the RHS and flags every non-trivial argument to `double_use!`
-even though the macro is otherwise unknown to the lint.
+Mode 3 catches this automatically: `$e` is referenced twice in
+the expansion, so the macro fails the exactly-once check.
 
 ### Procedural macros require explicit configuration
 
 ```rust
 // Whether this is safe depends on the proc macro's expansion,
-// which the lint cannot read. A project adds `serde_json::json`
-// to `allow_extra` once, project-wide, after confirming each
-// argument is evaluated exactly once by the macro's expansion.
+// which the lint cannot inspect. A project adds
+// `serde_json::json` to `allow_extra` once project-wide after
+// confirming each argument is evaluated exactly once.
 let payload = serde_json::json!({ "id": next_id(), "ts": now() });
 ```
 
@@ -589,26 +289,7 @@ let payload = serde_json::json!({ "id": next_id(), "ts": now() });
 enabled = true
 
 # Eligibility mode. Defaults to "allowlist_denylist".
-#   "denylist_only"      — flag only macros in the curated denylist
-#   "blanket"            — flag everything not on allow_extra
-#   "allowlist_denylist" — flag denylist hits + unknowns per policy
-#   "matcher_based"      — allowlist_denylist + matcher walking for unknown declarative macros
 mode = "allowlist_denylist"
-
-# Behaviour for macros that match neither the denylist nor the
-# allowlist. Consulted under `allowlist_denylist` (the default)
-# for every unknown macro, and under `matcher_based` as the
-# fallback for unknown proc macros (which the matcher walker
-# cannot inspect). `allow` (default) silently skips; `deny`
-# treats the macro as denylisted. Ignored under
-# `denylist_only` and `blanket`.
-unknown_macro_policy = "allow"
-
-# When true, accept calls and method calls whose arguments are
-# themselves trivial — even on denylisted macros. Default off;
-# turn on if the lint is too noisy with read-only accessor
-# calls inside `debug_assert*`.
-expression_bypass = false
 
 # Macros added to the built-in denylist. Each entry is a
 # fully-qualified macro path (no trailing `!`) or a bare macro
@@ -617,17 +298,13 @@ deny_extra = [
   # "my_crate::sometimes_evaluates",
 ]
 
-# Macros added to the built-in allowlist. Same path syntax as
-# deny_extra. Use for third-party macros the project
-# trusts to evaluate each argument exactly once.
+# Macros added to the built-in allowlist.
 allow_extra = [
   # "serde_json::json",
 ]
 
 # Macros to skip entirely, regardless of which list they would
-# otherwise hit. Use for project-internal macros whose
-# arguments are intentionally expressions (the author knows
-# the matcher).
+# otherwise hit.
 ignore = [
   # "my_crate::ad_hoc",
 ]
@@ -635,125 +312,61 @@ ignore = [
 
 ## Implementation notes
 
-- `EarlyLintPass::check_mac` over `ast::MacCall`. The early
-  pass sees the raw invocation token stream, which the lint
-  needs to split into top-level arguments before any
-  expansion has happened. The same `#[expect]`-fulfilment
-  workaround that
-  [`macro-trailing-comma`](./macro-trailing-comma.md) uses
-  (park spans in a process-static queue, emit from a late
-  pass that walks HIR) applies here.
-- Macro path matching: the pre-expansion pass runs before
-  name resolution, so `MacCall::path` is a raw
-  `rustc_ast::Path` with no `Res`/`DefId` attached. Match
-  syntactically against `path.segments` the way
+- `EarlyLintPass::check_mac` over `ast::MacCall`. The
+  `#[expect]`-fulfilment machinery (park spans pre-expansion,
+  emit from a late HIR pass) follows the pattern documented
+  in [`macro-trailing-comma`](./macro-trailing-comma.md).
+- Macro path matching is syntactic over `path.segments` — the
+  pre-expansion pass runs before name resolution, so there's
+  no `Res` / `DefId` to consult. Reuse
   [`macro-trailing-comma`](./macro-trailing-comma.md)'s
-  `matches_any` / `entry_matches` helpers do: single-segment
-  configuration entries (like `"my_macro"`) match against the
-  invocation path's final segment so `my_macro!`,
-  `crate_x::my_macro!`, and `::crate_x::my_macro!` all
-  qualify; multi-segment entries (like `"crate_x::my_macro"`)
-  tail-match the invocation path's segments, accommodating
-  optional leading crate prefixes. Reuse the same helpers
-  rather than rolling new ones.
-- Argument splitting: walk `MacCall::args.tokens` tracking
-  delimiter nesting and split on top-level commas. Reuse the
-  helper that
+  `matches_any` / `entry_matches` helpers; single-segment
+  entries tail-match the path, multi-segment entries
+  tail-match the segment sequence.
+- Argument splitting walks `MacCall::args.tokens`, tracks
+  delimiter nesting, and splits on top-level commas. Share
+  the splitter with `macro-trailing-comma`.
+- Per-argument expression re-parse uses `rustc_parse`'s
+  `Parser::parse_expr` (or the equivalent restriction-
+  respecting helper for the surrounding context).
+- Trivial/non-trivial predicate: a `match` on `ast::ExprKind`
+  over the seven trivial variants (`Lit`, `Path`, `AddrOf`,
+  `Field`, `Index`, `Unary(Deref, _)`, `Cast`) with recursive
+  triviality checks on the sub-expressions. Default any
+  unrecognised variant to non-trivial.
+- Matcher walker (mode 3): builds on the matcher-access
+  infrastructure
   [`macro-trailing-comma`](./macro-trailing-comma.md)
-  introduces (or factor it out the other way around,
-  whichever rule lands first).
-- Per-argument re-parse: each top-level argument is a token
-  stream; reparse it as an expression with `rustc_parse`'s
-  `Parser::parse_expr` (or the equivalent
-  restriction-respecting helper if the surrounding context
-  needs it). Arguments that fail to parse as an expression
-  are skipped (they are not value-shaped — `name = value`,
-  `name: type`, and similar syntactic positions that some
-  macros consume).
-- Trivial / non-trivial predicate: a `match` on
-  `ast::ExprKind` covering `Lit`, `Path`, `AddrOf`, `Field`,
-  `Index`, `Unary(Deref, _)`, `Cast`, and the trivial-base
-  recursions. Default to non-trivial for any unrecognised
-  variant — false positives are better than false negatives
-  here.
-- Expression-side bypass (mode 3): a one-level check over
-  `ExprKind::Call` and `ExprKind::MethodCall`. The callee or
-  receiver must itself be strictly trivial (per the trivial
-  predicate above); each call argument must also be strictly
-  trivial. No recursion through nested calls — the bypass is
-  deliberately shallow so the rule stays simple to reason
-  about. A bypass match implies the call is "as safe as an
-  accessor".
-- Matcher walker (mode 4): reuse the `take_*` combinator
-  scaffold introduced for
-  [`macro-trailing-comma`](./macro-trailing-comma.md)'s
-  matcher-based mode. The two rules ask different questions
-  of the matcher (trailing-comma-optional vs.
-  capture-evaluation-count) but consume the same token
-  grammar and the same cross-crate access path
-  (`tcx.hir_node_by_def_id` for local macros,
-  `tcx.cstore_untracked()` for dependency macros). Factor
-  the matcher access into a crate-internal module and have
-  both rules consume it.
-- Suggested rewrite: render `let <name> = <expr>;\n<indent>`
-  immediately before the macro invocation. Name derivation
-  is a best-effort heuristic — pick the receiver / callee
-  identifier when the expression is a method or function
-  call, fall back to `binding` otherwise. The fix is
-  `Applicability::MaybeIncorrect` because the inserted name
-  may shadow an existing binding or change scoping.
+  introduces for its own matcher-based eligibility check.
 
 ### Difficulty
 
-**Mode 0 / 1 / 2: easy.** A name-set lookup, a top-level
-argument splitter (reused from `macro-trailing-comma`), and a
-syntactic predicate on `ast::ExprKind`. The three modes share
-the entire pipeline and differ only in which lookup table the
-name resolution consults.
+**Modes 0 / 1 / 2: easy.** A syntactic name-set lookup, a
+top-level argument splitter, and the trivial / non-trivial
+predicate. The three modes differ only in which lookup table
+the matcher consults.
 
-**Mode 3: easy.** One extra predicate layered on the
-expression classifier; recursion bottoms out at the trivial
-cases.
-
-**Mode 4: hard.** Same matcher-walking infrastructure as
+**Mode 3: hard.** Same matcher-walking infrastructure as
 [`macro-trailing-comma`](./macro-trailing-comma.md)'s
-matcher-based mode, plus capture-occurrence counting and the
-nested-repetition case analysis. Recommended landing order is
-modes 0-3 in a single PR (they share the pipeline), then mode
-4 as a follow-up that also lights up `macro-trailing-comma`'s
-own matcher-based detection.
+matcher-based mode, plus capture-occurrence counting. Ship
+modes 0-2 first; mode 3 as a follow-up.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
-  for cross-cutting conventions that apply to every rule in
-  this catalogue, in particular the lint-name namespacing
-  (`perfectionist::*`) that every registered lint follows.
+  for cross-cutting conventions, in particular the lint-name
+  namespacing under `perfectionist::*`.
 
 ## Severity
 
-Warn. The denylist default — `debug_assert*` —
-flags a genuine correctness bug. Promoting the lint to deny
-crate-wide via
-`#![deny(perfectionist::macro_argument_binding)]` is viable
-but presumes the project has already turned
-`expression_bypass = true` on (or has narrowed the denylist):
-under the strict default, every `debug_assert!` invocation
-with a non-trivial argument fires, which is the majority of
-them, and deny would refuse to compile the project.
+Warn.
 
 ## Interaction with sibling rules
 
 - [`macro-trailing-comma`](./macro-trailing-comma.md) shares
   the top-level argument splitter and (eventually) the
-  declarative-macro matcher walker. The two rules ask
-  different questions of the same invocation; both register
-  for `ast::MacCall` and both restrict themselves to
-  function-like and array-like delimiters. Factor the shared
-  scanner into a crate-internal helper so neither rule grows
-  its own copy.
+  declarative-macro matcher walker. Both register for
+  `ast::MacCall` and both restrict themselves to function-like
+  and array-like delimiters.
 - [`format-macro-wrap`](./format-macro-wrap.md) and
-  [`print-macro-split`](./print-macro-split.md) operate on
-  the *template literal* inside their target macros and
-  treat the surrounding macro as a known-safe call. Those
-  rules' target macros are all on this rule's default
-  allowlist, so the two never disagree about whether a
-  given invocation needs intervention.
+  [`print-macro-split`](./print-macro-split.md) operate on the
+  *template literal* inside their target macros. Those rules'
+  target macros are all on this rule's default allowlist.

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -167,21 +167,19 @@ author can hoist it to a `const` if they want it accepted.
 
 ## Five eligibility modes
 
-The user's question — what difficulty levels exist between
-"forbid everything" and "fully read the macro definition" — is
-answered by the configuration ladder below. The modes are
-ordered by *implementation* cost, not by some clean monotone
-relationship on what they flag: Mode 3 relaxes Mode 2's
-denylist, and Mode 4 reshapes it. The default is mode 2
-(curated allowlist + denylist).
+The configuration ladder below covers the spectrum between
+"forbid every non-trivial macro argument" and "fully read the
+macro definition". The modes are ordered by *implementation*
+cost, not by some clean monotone relationship on what they
+flag: Mode 3 relaxes Mode 2's denylist, and Mode 4 reshapes
+it. The default is mode 2 (curated allowlist + denylist).
 
-### Mode 0 — denylist-only (the simplest possible rule)
+### Mode 0 — denylist-only (the smallest landable rule)
 
-*Easier than the user's "easiest".* Ship a hard-coded denylist
-of known-conditional macros — `debug_assert!`,
-`debug_assert_eq!`, `debug_assert_ne!`, and a handful of
-similar shapes — and flag only those. Every other macro is
-silently accepted.
+Ship a hard-coded denylist of known-conditional macros —
+`debug_assert!`, `debug_assert_eq!`, `debug_assert_ne!`, and a
+handful of similar shapes — and flag only those. Every other
+macro is silently accepted.
 
 The implementation is a name-set lookup keyed on the resolved
 `DefId` plus a non-trivial-argument predicate. No allowlist, no
@@ -196,10 +194,10 @@ by `debug_assert*`. Set `mode = "denylist_only"`.
 
 ### Mode 1 — blanket ban
 
-The user's "easiest, dumbest" mode. Every function-like and
-array-like macro invocation is flagged when given a non-trivial
-top-level argument, regardless of whether the macro is known
-safe. Curly-brace invocations remain out of scope per the
+The maximum-paranoia mode. Every function-like and array-like
+macro invocation is flagged when given a non-trivial top-level
+argument, regardless of whether the macro is known safe.
+Curly-brace invocations remain out of scope per the
 "Statement" section.
 
 This mode is deliberately not the default — `format!("hello
@@ -211,56 +209,59 @@ specific macros that the project trusts.
 
 ### Mode 2 — curated allowlist + denylist (default)
 
-The user's "still easy" mode, augmented with the denylist
-spelled out in mode 0. Three name-lookups decide each
-invocation:
+The default mode. Mode 0's denylist plus a curated allowlist
+of macros known to evaluate each top-level argument exactly
+once. Three name-lookups decide each invocation:
 
 1. **Denylist hit**: flag every non-trivial argument.
    The denylist defaults to `debug_assert!`,
    `debug_assert_eq!`, `debug_assert_ne!`, and any user-added
    entries.
 2. **Allowlist hit**: accept unconditionally. The
-   allowlist defaults to the same `core` / `std` and
-   well-known third-party set as
-   [`macro-trailing-comma`](./macro-trailing-comma.md) —
+   allowlist defaults to a subset of
+   [`macro-trailing-comma`](./macro-trailing-comma.md)'s
+   curated `core` / `std` and well-known third-party set:
    `format!`, `println!`, `vec!`, `write!`, `assert!`,
-   `assert_eq!`, `anyhow!`, and similar.
+   `assert_eq!`, `anyhow!`, and similar — every macro on
+   that rule's list whose top-level arguments are
+   evaluated exactly once.
 
-   Notably absent: the `log::*` and `tracing::*` families
-   — those check the configured level before evaluating
-   their arguments (the same conditional-evaluation
-   footgun called out in "Why is this bad?"), so they
-   don't meet the criterion. They are left off both
-   default lists; projects that want strict enforcement
+   Notably absent from *this* rule's allowlist (though
+   present in `macro-trailing-comma`'s): the `log::*` and
+   `tracing::*` families. Those check the configured
+   level before evaluating their arguments — the same
+   conditional-evaluation footgun called out in "Why is
+   this bad?" — so they fail the exactly-once criterion.
+   They are also left off this rule's default *denylist*
+   to avoid noise; projects that want strict enforcement
    add them to `deny_extra`.
 
    Caveat for the `assert!` family: `assert!`,
-   `assert_eq!`, `assert_ne!`, and the `debug_assert*`
-   counterparts evaluate their *condition / operand* args
-   exactly once, but their *message-format* args are
-   evaluated only on the failure path (so zero times when
-   the assertion passes). The default allowlist accepts
-   them on the strength of the condition/operand
-   guarantee, since assert messages in practice are
-   either absent or trivial (literal templates plus path
-   references). A side-effecting expression in a message
-   slot — `assert!(check(), "saw {}", set.insert(k))` —
-   is the same hidden-evaluation footgun as the
-   motivating bug, but is rare enough that the default
-   accepts the trade. Projects that find this too loose
-   can add `assert`, `assert_eq`, and `assert_ne` to
-   `deny_extra`; the more precise per-arg-position
-   solution is left to a future enhancement.
+   `assert_eq!`, and `assert_ne!` evaluate their
+   *condition / operand* args exactly once, but their
+   *message-format* args are evaluated only on the
+   failure path (zero times when the assertion passes).
+   The default allowlist accepts them on the strength of
+   the condition/operand guarantee, since assert messages
+   in practice are either absent or trivial (literal
+   templates plus path references). A side-effecting
+   expression in a message slot — `assert!(check(),
+   "saw {}", set.insert(k))` — is the same hidden-
+   evaluation footgun as the motivating bug, but is rare
+   enough that the default accepts the trade. Projects
+   that find this too loose can add `assert`, `assert_eq`,
+   and `assert_ne` to `deny_extra`; treating the message
+   slot separately from the condition slot is left as a
+   future enhancement.
 3. **Neither**: skip silently. Unknown macros are not flagged
    by default. A project that wants stricter behaviour
    reaches for mode 1 or mode 4.
 
 The default rejecting only the denylist (rather than every
-unlisted macro) is a usability choice. The user's framing of
-"still easy" was that unlisted macros get flagged; in practice
-that produces too much noise during initial rule adoption.
-Projects can set `unknown_macro_policy = "deny"` to recover
-the strict variant.
+unlisted macro) is a usability choice. The strict reading —
+flag every macro not on the curated allowlist — produces too
+much noise during initial rule adoption. Projects that want
+that stance set `unknown_macro_policy = "deny"`.
 
 ### Mode 3 — mode 2 with expression-side bypass
 
@@ -268,7 +269,7 @@ A bypass that layers on top of any of the modes above. The
 bypass does not change the trivial / non-trivial split —
 that classification stays as defined under "What counts as a
 'non-trivial' argument". Instead, it adds an *accept rule*:
-even when the macro would otherwise fire (conditional, or
+even when the macro would otherwise fire (denylisted, or
 denied under mode 1's blanket), accept the invocation if
 every top-level argument's outermost shape is either trivial
 or a function / method call whose own sub-expressions are all
@@ -298,18 +299,17 @@ turn it on as the first knob to adjust.
 
 ### Mode 4 — matcher-based declarative-macro analysis
 
-The user's "hard" mode. Layered on top of mode 2: the
-denylist and allowlist are consulted first, and the matcher
-walk runs only on `macro_rules!` macros that *would otherwise
-be unknown*. An invocation that resolves to an exactly-once
-macro is still accepted unconditionally; an invocation that
-resolves to a denylisted macro is still flagged. The matcher
-walk turns an "unknown" verdict into a justified
-allowlist-or-deny decision rather than overriding
-the curated lists. For a `macro_rules!` macro reached by the
-walk (its
-definition visible to the compiler — current crate, or a
-dependency whose macro body rustc still has on hand):
+Layered on top of mode 2: the denylist and allowlist are
+consulted first, and the matcher walk runs only on
+`macro_rules!` macros that *would otherwise be unknown*. An
+invocation that resolves to an allowlisted macro is still
+accepted unconditionally; an invocation that resolves to a
+denylisted macro is still flagged. The matcher walk turns an
+"unknown" verdict into a justified allowlist-or-flag decision
+rather than overriding the curated lists. For a `macro_rules!`
+macro reached by the walk (its definition visible to the
+compiler — current crate, or a dependency whose macro body
+rustc still has on hand):
 
 1. Determine which arm of the macro matches the call.
 2. For each `$name:expr` capture in that arm, count its
@@ -334,7 +334,7 @@ dependency whose macro body rustc still has on hand):
 
 Matcher analysis does not extend to procedural macros — the
 expansion is custom Rust code, not introspectable from the
-matcher. Proc macros remain governed by the user's allowlist /
+matcher. Proc macros remain governed by the allowlist /
 denylist configuration.
 
 Set `mode = "matcher_based"` to enable. Defaults off; this
@@ -387,11 +387,12 @@ For every macro invocation:
      Allowlist hit → skip. Otherwise consult
      `unknown_macro_policy`: `allow` (default) → skip,
      `deny` → continue.
-   - `matcher_based`: conditional / allowlists as
-     above; for unknown declarative macros, walk the matcher
-     per mode 4. Result is either "treat as allowlisted"
-     (continue: skip) or "treat as denylisted" (continue:
-     lint).
+   - `matcher_based`: denylist and allowlist as above; for
+     unknown declarative macros, walk the matcher per mode 4.
+     Result is either "treat as allowlisted" (continue: skip)
+     or "treat as denylisted" (continue: lint). Unknown proc
+     macros are not walkable and fall through to
+     `unknown_macro_policy`.
 5. Walk the invocation's *top-level* argument list. The lint
    only inspects top-level expressions — an argument that
    itself contains a non-trivial sub-expression is the
@@ -446,23 +447,26 @@ debug_assert!(was_new, "duplicate insert");
 // side effects.
 debug_assert_eq!(count, MAX_RETRIES, "expected {MAX_RETRIES} retries");
 debug_assert!(buffer.is_empty(), "buffer must start empty");
-//            ^^^^^^^^^^^^^^^^^ method call → flagged under
-//                              the strict default;
-//                              accepted under
+//            ^^^^^^^^^^^^^^^^^ method call → flagged with
+//                              `expression_bypass = false`
+//                              (the built-in default);
+//                              accepted with
 //                              `expression_bypass = true`
 //                              because `is_empty` takes only
-//                              `&self`.
+//                              `&self` and is treated as a
+//                              pure accessor.
 ```
 
 In practice nearly every `debug_assert!` argument is a
 boolean-returning method or function call. Without
 `expression_bypass = true` the lint flags essentially every
 reasonable `debug_assert!` invocation, which is not a
-recommended deployment shape. Projects that adopt the default
-denylist for the `insert`-style bug above almost always want
-the bypass on at the same time; the two knobs are paired in
-typical configurations even though they default to opposite
-positions out of the box.
+recommended deployment shape. Projects that keep
+`debug_assert!` on the denylist (to catch the
+`insert`-style bug above) almost always set
+`expression_bypass = true` at the same time; the two
+settings are typically paired in real configurations even
+though their built-in defaults sit at opposite ends.
 
 ### Allowlisted macros pass through
 
@@ -509,8 +513,8 @@ macro_rules! double_use {
     ($e:expr) => { $e + $e };
 }
 
-// Bad — `next` is consumed twice. The current value plus the
-// next value, not "doubled current".
+// Bad — `next` is consumed twice. `total` ends up as
+// `current_item + next_item`, not `2 * current_item`.
 let total = double_use!(iter.next().unwrap());
 
 // Good
@@ -523,12 +527,12 @@ automatically: the matcher walker sees `$e` referenced twice in
 the RHS and flags every non-trivial argument to `double_use!`
 even though the macro is otherwise unknown to the lint.
 
-### Procedural macro stays in user-config territory
+### Procedural macros require explicit configuration
 
 ```rust
 // Whether this is safe depends on the proc macro's expansion,
-// which the lint cannot read. The user adds `serde_json::json`
-// to `allow_extra` once, project-wide after confirming each
+// which the lint cannot read. A project adds `serde_json::json`
+// to `allow_extra` once, project-wide, after confirming each
 // argument is evaluated exactly once by the macro's expansion.
 let payload = serde_json::json!({ "id": next_id(), "ts": now() });
 ```

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -66,7 +66,7 @@ concern and partly a defensive coding stance:
   regardless.
 
 The rule's default configuration flags only known-conditional
-macros — the ones in the curated conditional list. Unknown
+macros — the ones in the curated denylist. Unknown
 macros are skipped under the default
 `unknown_macro_policy = "allow"`; projects that want the
 defensive stance set `unknown_macro_policy = "deny"` or
@@ -77,20 +77,20 @@ switch to the blanket-ban mode.
 For a function-like (`name!(...)`) or array-like (`name![...]`)
 macro invocation:
 
-- If the macro is on the **conditional list** of macros known to evaluate
+- If the macro is on the **denylist** of macros known to evaluate
   arguments conditionally or repeatedly, every non-trivial
   top-level argument is flagged. The set of accepted argument
   shapes is the trivial set defined under
   "What counts as a 'non-trivial' argument" below — literals,
   paths, `&path`, `path.field`, `base[index]`, `*path`, and
   casts.
-- If the macro is on the **exactly-once list** of macros known to
+- If the macro is on the **allowlist** of macros known to
   evaluate each top-level argument exactly once, the argument
   shape is unconstrained.
 - For every other macro, behaviour depends on the selected
   mode — see "Five eligibility modes" below. Briefly:
-  `conditional_only` and `matcher_based` (for proc macros) skip
-  the invocation, `blanket` flags it, and `name_based`
+  `denylist_only` and `matcher_based` (for proc macros) skip
+  the invocation, `blanket` flags it, and `allowlist_denylist`
   consults the configured `unknown_macro_policy`.
 
 Curly-brace macro invocations (`name! { ... }`) are out of scope.
@@ -110,7 +110,7 @@ anything about the definition.
 
 A "trivial" argument is one whose evaluation has no observable
 effect and produces the same value every time. Trivial arguments
-are accepted even by macros on the conditional list, because zero-or-many
+are accepted even by macros on the denylist, because zero-or-many
 evaluations of a trivial expression are indistinguishable from
 exactly-one.
 
@@ -157,27 +157,27 @@ The user's question — what difficulty levels exist between
 answered by the configuration ladder below. The modes are
 ordered by *implementation* cost, not by some clean monotone
 relationship on what they flag: Mode 3 relaxes Mode 2's
-conditional list, and Mode 4 reshapes it. The default is mode 2
-(name-based lookup against the two curated lists).
+denylist, and Mode 4 reshapes it. The default is mode 2
+(curated allowlist + denylist).
 
-### Mode 0 — conditional-only (the simplest possible rule)
+### Mode 0 — denylist-only (the simplest possible rule)
 
-*Easier than the user's "easiest".* Ship a hard-coded conditional
-list of known-conditional macros — `debug_assert!`,
+*Easier than the user's "easiest".* Ship a hard-coded denylist
+of known-conditional macros — `debug_assert!`,
 `debug_assert_eq!`, `debug_assert_ne!`, and a handful of
 similar shapes — and flag only those. Every other macro is
 silently accepted.
 
 The implementation is a name-set lookup keyed on the resolved
-`DefId` plus a non-trivial-argument predicate. No exactly-once list, no
+`DefId` plus a non-trivial-argument predicate. No allowlist, no
 matcher walk, no user configuration beyond extending the
-conditional list. The rule's surface area is "this exact set of
+denylist. The rule's surface area is "this exact set of
 core/std macros, for this exact reason".
 
 This mode exists for projects that want to enable
 `perfectionist::macro_argument_binding` without auditing their
 third-party macro use — they only care about not getting bitten
-by `debug_assert*`. Set `mode = "conditional_only"`.
+by `debug_assert*`. Set `mode = "denylist_only"`.
 
 ### Mode 1 — blanket ban
 
@@ -191,21 +191,21 @@ This mode is deliberately not the default — `format!("hello
 {name}", compute())` is fine in practice and reading every macro
 invocation as a footgun is exhausting. Projects that want the
 maximum-paranoia stance can opt in by setting
-`mode = "blanket"`. Set the `extra_exactly_once` knob to whitelist
+`mode = "blanket"`. Set the `allow_extra` knob to whitelist
 specific macros that the project trusts.
 
-### Mode 2 — curated name-based lookup (default)
+### Mode 2 — curated allowlist + denylist (default)
 
-The user's "still easy" mode, augmented with the conditional list
+The user's "still easy" mode, augmented with the denylist
 spelled out in mode 0. Three name-lookups decide each
 invocation:
 
-1. **Conditional-list hit**: flag every non-trivial argument.
-   The conditional list defaults to `debug_assert!`,
+1. **Denylist hit**: flag every non-trivial argument.
+   The denylist defaults to `debug_assert!`,
    `debug_assert_eq!`, `debug_assert_ne!`, and any user-added
    entries.
-2. **Exactly-once-list hit**: accept unconditionally. The
-   exactly-once list defaults to the same `core` / `std` and
+2. **Allowlist hit**: accept unconditionally. The
+   allowlist defaults to the same `core` / `std` and
    well-known third-party set as
    [`macro-trailing-comma`](./macro-trailing-comma.md) —
    `format!`, `println!`, `vec!`, `write!`, `assert!`,
@@ -215,7 +215,7 @@ invocation:
    by default. A project that wants stricter behaviour
    reaches for mode 1 or mode 4.
 
-The default rejecting only the conditional list (rather than every
+The default rejecting only the denylist (rather than every
 unlisted macro) is a usability choice. The user's framing of
 "still easy" was that unlisted macros get flagged; in practice
 that produces too much noise during initial rule adoption.
@@ -259,13 +259,13 @@ turn it on as the first knob to adjust.
 ### Mode 4 — matcher-based declarative-macro analysis
 
 The user's "hard" mode. Layered on top of mode 2: the
-conditional list and exactly-once list are consulted first, and the matcher
+denylist and allowlist are consulted first, and the matcher
 walk runs only on `macro_rules!` macros that *would otherwise
 be unknown*. An invocation that resolves to an exactly-once
 macro is still accepted unconditionally; an invocation that
-resolves to a conditional macro is still flagged. The matcher
+resolves to a denylisted macro is still flagged. The matcher
 walk turns an "unknown" verdict into a justified
-exactly-once-vs-conditional decision rather than overriding
+allowlist-or-deny decision rather than overriding
 the curated lists. For a `macro_rules!` macro reached by the
 walk (its
 definition visible to the compiler — current crate, or a
@@ -279,7 +279,7 @@ dependency whose macro body rustc still has on hand):
      repetition that could change its evaluation count:
      the argument is evaluated exactly once. Eligible
      (treat the argument's macro as if it were on the
-     exactly-once list).
+     allowlist).
    - Zero occurrences (the capture is matched but discarded):
      the argument is never evaluated. Flag with a "the
      argument is unused in this expansion" diagnostic.
@@ -294,8 +294,8 @@ dependency whose macro body rustc still has on hand):
 
 Matcher analysis does not extend to procedural macros — the
 expansion is custom Rust code, not introspectable from the
-matcher. Proc macros remain governed by the user's exactly-once list /
-conditional list configuration.
+matcher. Proc macros remain governed by the user's allowlist /
+denylist configuration.
 
 Set `mode = "matcher_based"` to enable. Defaults off; this
 mode is the most expensive to implement (see "Why
@@ -310,9 +310,9 @@ recommended landing order.
 
 | Mode | Default | Cost to implement | Flags |
 | --- | --- | --- | --- |
-| 0 — conditional only | opt-in | smallest | known-conditional macros only |
+| 0 — denylist only | opt-in | smallest | known-conditional macros only |
 | 1 — blanket | opt-in | small | every non-trivial macro arg |
-| 2 — name-based | **on** | small | conditional list always; unknown configurable |
+| 2 — allowlist + denylist | **on** | small | denylist always; unknown configurable |
 | 3 — mode 2 + bypass | opt-in | small + recursion | mode 2 minus pure-call shapes |
 | 4 — matcher-based | opt-in | large | mode 2 plus learned `macro_rules!` |
 
@@ -333,24 +333,24 @@ For every macro invocation:
    curly-brace invocations are out of scope.
 2. Resolve the macro `DefId`.
 3. Consult `ignore`. If the path matches, skip. `ignore` wins
-   over both the conditional list and the exactly-once list; it exists for
+   over both the denylist and the allowlist; it exists for
    per-project opt-outs of curated entries.
 4. Apply the configured `mode`:
-   - `conditional_only`: match against the conditional list
+   - `denylist_only`: match against the denylist
      (`debug_assert!`, `debug_assert_eq!`, `debug_assert_ne!`,
-     plus `extra_conditional`). Continue to step 5 only on a
+     plus `deny_extra`). Continue to step 5 only on a
      hit.
    - `blanket`: continue to step 5 for every macro not on the
-     exactly-once list (`extra_exactly_once` only — there is
-     no built-in exactly-once list in this mode, by design).
-   - `name_based` (default): conditional-list hit → continue.
-     Exactly-once-list hit → skip. Otherwise consult
+     allowlist (`allow_extra` only — there is
+     no built-in allowlist in this mode, by design).
+   - `allowlist_denylist` (default): denylist hit → continue.
+     Allowlist hit → skip. Otherwise consult
      `unknown_macro_policy`: `allow` (default) → skip,
      `deny` → continue.
-   - `matcher_based`: conditional / exactly-once lists as
+   - `matcher_based`: conditional / allowlists as
      above; for unknown declarative macros, walk the matcher
-     per mode 4. Result is either "treat as exactly-once"
-     (continue: skip) or "treat as conditional" (continue:
+     per mode 4. Result is either "treat as allowlisted"
+     (continue: skip) or "treat as denylisted" (continue:
      lint).
 5. Walk the invocation's *top-level* argument list. The lint
    only inspects top-level expressions — an argument that
@@ -419,16 +419,16 @@ boolean-returning method or function call. Without
 `expression_bypass = true` the lint flags essentially every
 reasonable `debug_assert!` invocation, which is not a
 recommended deployment shape. Projects that adopt the default
-conditional list for the `insert`-style bug above almost always want
+denylist for the `insert`-style bug above almost always want
 the bypass on at the same time; the two knobs are paired in
 typical configurations even though they default to opposite
 positions out of the box.
 
-### Exactly-once macros pass through
+### Allowlisted macros pass through
 
 ```rust
 // Accepted under default config — `format!` is on the
-// curated exactly-once list; arguments are evaluated exactly once.
+// curated allowlist; arguments are evaluated exactly once.
 let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Ordering::Relaxed));
 ```
 
@@ -436,13 +436,13 @@ let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Orde
 
 ```rust
 // Accepted under default config — vec! is on the curated
-// exactly-once list; each element is evaluated exactly once.
+// allowlist; each element is evaluated exactly once.
 let xs = vec![compute(), compute(), compute()];
 ```
 
 ```rust
 // Flagged under blanket mode — every non-trivial argument is
-// a candidate, exactly-once list or not.
+// a candidate, allowlist or not.
 let xs = vec![compute(), compute(), compute()];
 
 // Good (blanket mode rewrite)
@@ -488,7 +488,7 @@ even though the macro is otherwise unknown to the lint.
 ```rust
 // Whether this is safe depends on the proc macro's expansion,
 // which the lint cannot read. The user adds `tracing::info`
-// to `extra_exactly_once` once, project-wide.
+// to `allow_extra` once, project-wide.
 tracing::info!(latency = stopwatch.elapsed().as_millis(), "done");
 ```
 
@@ -499,36 +499,36 @@ tracing::info!(latency = stopwatch.elapsed().as_millis(), "done");
 # Set to false to disable the rule entirely.
 enabled = true
 
-# Eligibility mode. Defaults to "name_based".
-#   "conditional_only" — flag only macros in the curated conditional list
-#   "blanket"          — flag everything not on extra_exactly_once
-#   "name_based"       — flag conditional-list hits + unknowns per policy
-#   "matcher_based"    — name_based + matcher walking for unknown declarative macros
-mode = "name_based"
+# Eligibility mode. Defaults to "allowlist_denylist".
+#   "denylist_only"      — flag only macros in the curated denylist
+#   "blanket"            — flag everything not on allow_extra
+#   "allowlist_denylist" — flag denylist hits + unknowns per policy
+#   "matcher_based"      — allowlist_denylist + matcher walking for unknown declarative macros
+mode = "allowlist_denylist"
 
-# Behaviour for macros that match neither the conditional list nor the
-# exactly-once list under "name_based" mode. `allow` (default)
-# silently skips them; `deny` treats them as conditional.
+# Behaviour for macros that match neither the denylist nor the
+# allowlist under "allowlist_denylist" mode. `allow` (default)
+# silently skips them; `deny` treats them as denylisted.
 # Ignored under other modes.
 unknown_macro_policy = "allow"
 
 # When true, accept calls and method calls whose arguments are
-# themselves trivial — even on conditional macros. Default off;
+# themselves trivial — even on denylisted macros. Default off;
 # turn on if the lint is too noisy with read-only accessor
 # calls inside `debug_assert*`.
 expression_bypass = false
 
-# Macros added to the built-in conditional list. Each entry is a
+# Macros added to the built-in denylist. Each entry is a
 # fully-qualified macro path (no trailing `!`) or a bare macro
 # name to match by final segment only.
-extra_conditional = [
+deny_extra = [
   # "my_crate::sometimes_evaluates",
 ]
 
-# Macros added to the built-in exactly-once list. Same path syntax as
-# extra_conditional. Use for third-party macros the project
+# Macros added to the built-in allowlist. Same path syntax as
+# deny_extra. Use for third-party macros the project
 # trusts to evaluate each argument exactly once.
-extra_exactly_once = [
+allow_extra = [
   # "tracing::info",
   # "tracing::debug",
 ]
@@ -555,7 +555,7 @@ ignore = [
 - Macro path resolution: `MacCall::path` resolves to a `Res`;
   use the resolved `DefId` for the name-lookup. Bare-name
   matching falls back to the path's final segment so
-  `extra_exactly_once = ["my_macro"]` works without forcing the
+  `allow_extra = ["my_macro"]` works without forcing the
   user to spell out the crate path.
 - Argument splitting: walk `MacCall::args.tokens` tracking
   delimiter nesting and split on top-level commas. Reuse the
@@ -628,12 +628,12 @@ own matcher-based detection.
 
 ## Severity
 
-Warn. The conditional list default — `debug_assert*` —
+Warn. The denylist default — `debug_assert*` —
 flags a genuine correctness bug. Promoting the lint to deny
 crate-wide via
 `#![deny(perfectionist::macro_argument_binding)]` is viable
 but presumes the project has already turned
-`expression_bypass = true` on (or has narrowed the conditional list):
+`expression_bypass = true` on (or has narrowed the denylist):
 under the strict default, every `debug_assert!` invocation
 with a non-trivial argument fires, which is the majority of
 them, and deny would refuse to compile the project.
@@ -653,5 +653,5 @@ them, and deny would refuse to compile the project.
   the *template literal* inside their target macros and
   treat the surrounding macro as a known-safe call. Those
   rules' target macros are all on this rule's default
-  exactly-once list, so the two never disagree about whether a
+  allowlist, so the two never disagree about whether a
   given invocation needs intervention.

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -89,8 +89,13 @@ macro invocation:
   paths, `&path`, `path.field`, `base[index]`, `*path`, and
   casts.
 - If the macro is on the **allowlist** of macros known to
-  evaluate each top-level argument exactly once, the argument
-  shape is unconstrained.
+  evaluate each top-level argument exactly once on the
+  taken control-flow path, the argument shape is
+  unconstrained. The `assert!`/`assert_eq!`/`assert_ne!`
+  family is included with a caveat — their *message-format*
+  args are evaluated only on the failure path, but they are
+  accepted on the strength of the condition/operand
+  guarantee. See "Mode 2" below for the full discussion.
 - For every other macro, behaviour depends on the selected
   mode — see "Five eligibility modes" below. Briefly:
   `denylist_only` skips the invocation, `blanket` flags it,
@@ -412,11 +417,12 @@ For every macro invocation:
    the same token-stream handling as
    [`macro-trailing-comma`](./macro-trailing-comma.md):
    track delimiter nesting and split on top-level commas. A
-   top-level `;` is a skip-the-whole-invocation trigger
-   (the macro uses `;` as its separator — `vec![v; count]`,
-   `thread_local! { ... }` — so it doesn't fit this rule's
-   "comma-separated argument list" shape). A top-level `=>`
-   is allowed and walked through as ordinary content
+   top-level `;` is a skip-the-whole-invocation trigger:
+   the macro uses `;` as its separator (`vec![v; count]`'s
+   repeated-element form is the canonical example) and the
+   call shape isn't the comma-separated argument list this
+   rule targets. A top-level `=>` is allowed and walked
+   through as ordinary content
    (`hashmap! { "a" => 1, "b" => 2 }` legitimately carries
    one per entry). The lint only inspects top-level
    expressions — an argument that itself contains a

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -198,9 +198,10 @@ Ship a hard-coded denylist of known-conditional macros —
 handful of similar shapes — and flag only those. Every other
 macro is silently accepted.
 
-The implementation is a name-set lookup keyed on the resolved
-`DefId` plus a non-trivial-argument predicate. No allowlist, no
-matcher walk; the only mode-specific knob is `deny_extra` for
+The implementation is a syntactic name-set lookup over the
+invocation's `MacCall::path` segments plus a
+non-trivial-argument predicate. No allowlist, no matcher walk;
+the only mode-specific knob is `deny_extra` for
 extending the built-in denylist. The shared knobs (`ignore`,
 `expression_bypass`) still apply per the "What to lint" and
 "Configuration" sections — they're not mode-gated. The rule's
@@ -391,7 +392,13 @@ For every macro invocation:
 
 1. Check the invocation's `Delimiter`. If it is `Brace`, skip —
    curly-brace invocations are out of scope.
-2. Resolve the macro `DefId`.
+2. Read the invocation's `MacCall::path` segments. The
+   pre-expansion pass runs before name resolution, so this is
+   a raw `rustc_ast::Path` — there's no `Res`/`DefId` to
+   resolve. Name matching against configuration entries is
+   syntactic; see "Implementation notes" for the segment /
+   tail-matching helper that `macro-trailing-comma` already
+   provides.
 3. Consult `ignore`. If the path matches, skip. `ignore` wins
    over both the denylist and the allowlist; it exists for
    per-project opt-outs of curated entries.
@@ -423,7 +430,7 @@ For every macro invocation:
    call shape isn't the comma-separated argument list this
    rule targets. A top-level `=>` is allowed and walked
    through as ordinary content
-   (`hashmap! { "a" => 1, "b" => 2 }` legitimately carries
+   (`hashmap!("a" => 1, "b" => 2)` legitimately carries
    one per entry). The lint only inspects top-level
    expressions — an argument that itself contains a
    non-trivial sub-expression is the author's choice, and
@@ -630,11 +637,19 @@ ignore = [
   [`macro-trailing-comma`](./macro-trailing-comma.md) uses
   (park spans in a process-static queue, emit from a late
   pass that walks HIR) applies here.
-- Macro path resolution: `MacCall::path` resolves to a `Res`;
-  use the resolved `DefId` for the name-lookup. Bare-name
-  matching falls back to the path's final segment so
-  `allow_extra = ["my_macro"]` works without forcing the
-  user to spell out the crate path.
+- Macro path matching: the pre-expansion pass runs before
+  name resolution, so `MacCall::path` is a raw
+  `rustc_ast::Path` with no `Res`/`DefId` attached. Match
+  syntactically against `path.segments` the way
+  [`macro-trailing-comma`](./macro-trailing-comma.md)'s
+  `matches_any` / `entry_matches` helpers do: single-segment
+  configuration entries (like `"my_macro"`) match against the
+  invocation path's final segment so `my_macro!`,
+  `crate_x::my_macro!`, and `::crate_x::my_macro!` all
+  qualify; multi-segment entries (like `"crate_x::my_macro"`)
+  tail-match the invocation path's segments, accommodating
+  optional leading crate prefixes. Reuse the same helpers
+  rather than rolling new ones.
 - Argument splitting: walk `MacCall::args.tokens` tracking
   delimiter nesting and split on top-level commas. Reuse the
   helper that

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -3,14 +3,15 @@
 **Source:** project convention. The motivating bug:
 
 ```rust
-debug_assert_eq!(my_set.insert(new_item), None, "Something went wrong! `new_item` wasn't new");
+debug_assert_eq!(my_map.insert(key, value), None, "Something went wrong! `key` wasn't new");
 ```
 
-In debug builds this works: `insert` runs, the result is compared
-against `None`, and the assertion panics if `new_item` was a
-duplicate. In release builds `debug_assert_eq!` expands to nothing
-at all — the arguments are *not evaluated* — so `insert` never
-runs, `new_item` is silently dropped, and `my_set` ends the
+In debug builds this works: `insert` runs, returns the previous
+value associated with `key` (or `None` if the key was new), and
+the assertion panics if `key` was already present. In release
+builds `debug_assert_eq!` expands to nothing at all — the
+arguments are *not evaluated* — so `insert` never runs,
+`(key, value)` is silently dropped, and `my_map` ends the
 function in a different state from the one the author intended.
 The bug only shows up when the binary is finally built with
 `--release` and behaves differently from every test run.
@@ -19,8 +20,8 @@ The fix is to bind the call to a `let` first, then pass the
 binding to the macro:
 
 ```rust
-let was_new = my_set.insert(new_item).is_none();
-debug_assert!(was_new, "Something went wrong! `new_item` wasn't new");
+let was_new = my_map.insert(key, value).is_none();
+debug_assert!(was_new, "Something went wrong! `key` wasn't new");
 ```
 
 `debug_assert*` is the most famous offender, but the trap is
@@ -432,11 +433,11 @@ human glance.
 
 ```rust
 // Bad — release mode skips `insert` entirely
-debug_assert_eq!(my_set.insert(new_item), None, "duplicate insert");
+debug_assert_eq!(my_map.insert(key, value), None, "duplicate key");
 
 // Good
-let was_new = my_set.insert(new_item).is_none();
-debug_assert!(was_new, "duplicate insert");
+let was_new = my_map.insert(key, value).is_none();
+debug_assert!(was_new, "duplicate key");
 ```
 
 ### Trivial arguments stay inline
@@ -452,9 +453,13 @@ debug_assert!(buffer.is_empty(), "buffer must start empty");
 //                              (the built-in default);
 //                              accepted with
 //                              `expression_bypass = true`
-//                              because `is_empty` takes only
-//                              `&self` and is treated as a
-//                              pure accessor.
+//                              because the call has the
+//                              shape `trivial.method()` and
+//                              the bypass's syntactic
+//                              heuristic accepts any such
+//                              shape (even though the lint
+//                              cannot prove `is_empty` is
+//                              actually pure).
 ```
 
 In practice nearly every `debug_assert!` argument is a

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -20,8 +20,8 @@ The fix is to bind the call to a `let` first, then pass the
 binding to the macro:
 
 ```rust
-let was_new = my_map.insert(key, value).is_none();
-debug_assert!(was_new, "Something went wrong! `key` wasn't new");
+let rejected = my_map.insert(key, value);
+debug_assert_eq!(rejected, None, "Something went wrong! `key` wasn't new");
 ```
 
 `debug_assert*` is the most famous offender, but the trap is
@@ -436,8 +436,8 @@ human glance.
 debug_assert_eq!(my_map.insert(key, value), None, "duplicate key");
 
 // Good
-let was_new = my_map.insert(key, value).is_none();
-debug_assert!(was_new, "duplicate key");
+let rejected = my_map.insert(key, value);
+debug_assert_eq!(rejected, None, "duplicate key");
 ```
 
 ### Trivial arguments stay inline

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -583,9 +583,12 @@ enabled = true
 mode = "allowlist_denylist"
 
 # Behaviour for macros that match neither the denylist nor the
-# allowlist under "allowlist_denylist" mode. `allow` (default)
-# silently skips them; `deny` treats them as denylisted.
-# Ignored under other modes.
+# allowlist. Consulted under `allowlist_denylist` (the default)
+# for every unknown macro, and under `matcher_based` as the
+# fallback for unknown proc macros (which the matcher walker
+# cannot inspect). `allow` (default) silently skips; `deny`
+# treats the macro as denylisted. Ignored under
+# `denylist_only` and `blanket`.
 unknown_macro_policy = "allow"
 
 # When true, accept calls and method calls whose arguments are

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -139,10 +139,11 @@ author can hoist it to a `const` if they want it accepted.
 
 The user's question — what difficulty levels exist between
 "forbid everything" and "fully read the macro definition" — is
-answered by the configuration ladder below. Each mode is a strict
-superset of the previous one in terms of work avoided, and a
-strict subset in terms of false positives. The default is mode
-2 (curated allowlist + denylist).
+answered by the configuration ladder below. The modes are
+ordered by *implementation* cost, not by some clean monotone
+relationship on what they flag: Mode 3 relaxes Mode 2's
+denial set, and Mode 4 reshapes it. The default is mode 2
+(curated allowlist + denylist).
 
 ### Mode 0 — denylist-only (the simplest possible rule)
 
@@ -210,13 +211,12 @@ the strict variant.
 ### Mode 3 — mode 2 with expression-side bypass
 
 A bypass that layers on top of any of the modes above. Even
-when the macro is on the denylist (or every macro is denied
-under mode 1), accept the invocation if every non-trivial
-top-level argument is *also* a single name binding — i.e.,
-arguments are limited to identifiers, paths, and the other
-trivial shapes above plus single-name calls like
-`Arc::clone(&x)` (a function call whose only argument is a
-trivial expression).
+when the macro would otherwise fire (denylisted, or denied
+under mode 1's blanket), accept the invocation if every
+top-level argument is either trivial *or* a function / method
+call whose own arguments are themselves trivial. The canonical
+example is `Arc::clone(&x)`: a `Call` whose sole argument
+`&x` is a reference to a path, both of which are trivial.
 
 The bypass widens the trivial-expression definition: a
 function or method call is acceptable when every one of its
@@ -377,11 +377,23 @@ debug_assert!(was_new, "duplicate insert");
 // side effects.
 debug_assert_eq!(count, MAX_RETRIES, "expected {MAX_RETRIES} retries");
 debug_assert!(buffer.is_empty(), "buffer must start empty");
-//            ^^^^^^^^^^^^^^^^^ method call → flagged when
-//                              `expression_bypass = false`;
-//                              accepted under bypass because
-//                              `is_empty` takes only `&self`.
+//            ^^^^^^^^^^^^^^^^^ method call → flagged under
+//                              the strict default;
+//                              accepted under
+//                              `expression_bypass = true`
+//                              because `is_empty` takes only
+//                              `&self`.
 ```
+
+In practice nearly every `debug_assert!` argument is a
+boolean-returning method or function call. Without
+`expression_bypass = true` the lint flags essentially every
+reasonable `debug_assert!` invocation, which is not a
+recommended deployment shape. Projects that adopt the default
+denylist for the `insert`-style bug above almost always want
+the bypass on at the same time; the two knobs are paired in
+typical configurations even though they default to opposite
+positions out of the box.
 
 ### Allowlisted macros pass through
 
@@ -394,11 +406,15 @@ let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Orde
 ### Array-like invocation is also in scope
 
 ```rust
-// Bad — vec! is on the allowlist, so this is fine by default,
-// but in blanket mode the `compute()` call would be flagged.
+// Accepted under default config — vec! is on the curated
+// allowlist; each element is evaluated exactly once.
 let xs = vec![compute(), compute(), compute()];
 
-// Good (blanket mode)
+// Flagged under blanket mode — every non-trivial argument is
+// a candidate, allowlist or not.
+let xs = vec![compute(), compute(), compute()];
+
+// Good (blanket mode rewrite)
 let a = compute();
 let b = compute();
 let c = compute();
@@ -517,11 +533,13 @@ ignore = [
   introduces (or factor it out the other way around,
   whichever rule lands first).
 - Per-argument re-parse: each top-level argument is a token
-  stream; reparse it as an expression with
-  `rustc_parse::parser::Parser::parse_expr_anon`. Arguments
-  that fail to parse as an expression are skipped (they are
-  not value-shaped — `name = value`, `name: type`, and similar
-  syntactic positions that some macros consume).
+  stream; reparse it as an expression with `rustc_parse`'s
+  `Parser::parse_expr` (or the equivalent
+  restriction-respecting helper if the surrounding context
+  needs it). Arguments that fail to parse as an expression
+  are skipped (they are not value-shaped — `name = value`,
+  `name: type`, and similar syntactic positions that some
+  macros consume).
 - Trivial / non-trivial predicate: a `match` on
   `ast::ExprKind` covering `Lit`, `Path`, `AddrOf`, `Field`,
   `Index`, `Unary(Deref, _)`, `Cast`, and the trivial-base

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -209,8 +209,14 @@ invocation:
    well-known third-party set as
    [`macro-trailing-comma`](./macro-trailing-comma.md) —
    `format!`, `println!`, `vec!`, `write!`, `assert!`,
-   `assert_eq!`, the `log::*` and `tracing::*` families,
-   `anyhow!`, and similar.
+   `assert_eq!`, `anyhow!`, and similar. Notably absent:
+   the `log::*` and `tracing::*` families — those check
+   the configured level before evaluating their arguments
+   (the same conditional-evaluation footgun called out in
+   "Why is this bad?"), so they don't meet the
+   exactly-once criterion. They are left off both default
+   lists; projects that want strict enforcement add them
+   to `deny_extra`.
 3. **Neither**: skip silently. Unknown macros are not flagged
    by default. A project that wants stricter behaviour
    reaches for mode 1 or mode 4.
@@ -487,9 +493,10 @@ even though the macro is otherwise unknown to the lint.
 
 ```rust
 // Whether this is safe depends on the proc macro's expansion,
-// which the lint cannot read. The user adds `tracing::info`
-// to `allow_extra` once, project-wide.
-tracing::info!(latency = stopwatch.elapsed().as_millis(), "done");
+// which the lint cannot read. The user adds `serde_json::json`
+// to `allow_extra` once, project-wide after confirming each
+// argument is evaluated exactly once by the macro's expansion.
+let payload = serde_json::json!({ "id": next_id(), "ts": now() });
 ```
 
 ## Configuration
@@ -529,8 +536,7 @@ deny_extra = [
 # deny_extra. Use for third-party macros the project
 # trusts to evaluate each argument exactly once.
 allow_extra = [
-  # "tracing::info",
-  # "tracing::debug",
+  # "serde_json::json",
 ]
 
 # Macros to skip entirely, regardless of which list they would

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -199,10 +199,7 @@ invocation:
    [`macro-trailing-comma`](./macro-trailing-comma.md) —
    `format!`, `println!`, `vec!`, `write!`, `assert!`,
    `assert_eq!`, the `log::*` and `tracing::*` families,
-   `anyhow!`, and similar. (Built-in macros that match either
-   the denylist or the allowlist agree with this rule's policy
-   only when the user uses them as documented; the curated
-   list reflects upstream semantics, not project taste.)
+   `anyhow!`, and similar.
 3. **Neither**: skip silently. Unknown macros are not flagged
    by default. A project that wants stricter behaviour
    reaches for mode 1 or mode 4.
@@ -216,21 +213,18 @@ the strict variant.
 
 ### Mode 3 — mode 2 with expression-side bypass
 
-A bypass that layers on top of any of the modes above. Even
-when the macro would otherwise fire (denylisted, or denied
-under mode 1's blanket), accept the invocation if every
-top-level argument is either trivial *or* a function / method
-call whose own arguments are themselves trivial. The canonical
-example is `Arc::clone(&x)`: a `Call` whose sole argument
-`&x` is a reference to a path, both of which are trivial.
-
-The bypass does not change the trivial / non-trivial split —
-that classification stays as defined above. Instead, the
-bypass adds an additional *accept rule* layered on top: even
-a non-trivial argument is accepted if its outermost shape is
-a function or method call whose own sub-expressions are all
-trivial. The bypass's recursion stops at any non-trivial
-sub-expression.
+A bypass that layers on top of any of the modes above. The
+bypass does not change the trivial / non-trivial split —
+that classification stays as defined under "What counts as a
+'non-trivial' argument". Instead, it adds an *accept rule*:
+even when the macro would otherwise fire (denylisted, or
+denied under mode 1's blanket), accept the invocation if
+every top-level argument's outermost shape is either trivial
+or a function / method call whose own sub-expressions are all
+trivial. The canonical example is `Arc::clone(&x)`: a `Call`
+whose sole argument `&x` is a reference to a path, both of
+which are trivial. The bypass's recursion stops at any
+non-trivial sub-expression.
 
 The motivation is that `debug_assert_eq!(my_set.contains(&k),
 true)` is *also* unsafe-feeling but ultimately fine — the
@@ -253,8 +247,16 @@ turn it on as the first knob to adjust.
 
 ### Mode 4 — matcher-based declarative-macro analysis
 
-The user's "hard" mode. For a `macro_rules!` macro whose
-definition is visible to the compiler (current crate, or a
+The user's "hard" mode. Layered on top of mode 2: the
+denylist and allowlist are consulted first, and the matcher
+walk runs only on `macro_rules!` macros that *would otherwise
+be unknown*. An invocation that resolves to an allowlisted
+macro is still accepted unconditionally; an invocation that
+resolves to a denylisted macro is still flagged. The matcher
+walk turns an "unknown" verdict into a justified
+allowlist-or-flag decision rather than overriding the curated
+lists. For a `macro_rules!` macro reached by the walk (its
+definition visible to the compiler — current crate, or a
 dependency whose macro body rustc still has on hand):
 
 1. Determine which arm of the macro matches the call.
@@ -556,10 +558,10 @@ ignore = [
   variant — false positives are better than false negatives
   here.
 - Expression-side bypass (mode 3): a recursive descent
-  through `Call`, `MethodCall`, and `Field`. Each callee /
-  receiver must itself be trivial; each argument must be
-  trivial-after-bypass. A bypass match implies the call is
-  "as safe as an accessor".
+  through `ExprKind::Call` and `ExprKind::MethodCall`. The
+  callee / receiver must itself be trivial; each argument
+  must be trivial-after-bypass. A bypass match implies the
+  call is "as safe as an accessor".
 - Matcher walker (mode 4): reuse the `take_*` combinator
   scaffold introduced for
   [`macro-trailing-comma`](./macro-trailing-comma.md)'s
@@ -607,9 +609,14 @@ own matcher-based detection.
 ## Severity
 
 Warn. The denylist defaults — `debug_assert*` and `cfg!` —
-flag a genuine correctness bug, and projects that want
-stronger behaviour can promote the lint to deny per file or
-crate-wide via `#![deny(perfectionist::macro_argument_binding)]`.
+flag a genuine correctness bug. Promoting the lint to deny
+crate-wide via
+`#![deny(perfectionist::macro_argument_binding)]` is viable
+but presumes the project has already turned
+`expression_bypass = true` on (or has narrowed the denylist):
+under the strict default, every `debug_assert!` invocation
+with a non-trivial argument fires, which is the majority of
+them, and deny would refuse to compile the project.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -1,0 +1,603 @@
+# `macro_argument_binding`
+
+**Source:** project convention. The motivating bug:
+
+```rust
+debug_assert_eq!(my_set.insert(new_item), None, "Something went wrong! `new_item` wasn't new");
+```
+
+In debug builds this works: `insert` runs, the result is compared
+against `None`, and the assertion panics if `new_item` was a
+duplicate. In release builds `debug_assert_eq!` expands to nothing
+at all — the arguments are *not evaluated* — so `insert` never
+runs, `new_item` is silently dropped, and `my_set` ends the
+function in a different state from the one the author intended.
+The bug only shows up when the binary is finally built with
+`--release` and behaves differently from every test run.
+
+The fix is to bind the call to a `let` first, then pass the
+binding to the macro:
+
+```rust
+let was_new = my_set.insert(new_item).is_none();
+debug_assert!(was_new, "Something went wrong! `new_item` wasn't new");
+```
+
+`debug_assert*` is the most famous offender, but the trap is
+general: a function-like or array-like macro can evaluate any
+given argument zero times, once, or many times depending on its
+matcher, and the call-site cannot tell which without reading the
+macro's body. Functions guarantee exactly-once evaluation per
+argument; macros do not, even when the call shape looks
+identical.
+
+## Why is this bad?
+
+The `debug_assert*` case is an objective defect — the program's
+runtime behaviour differs between debug and release builds in a
+way the author did not intend, and the difference is invisible at
+the call site. A duplicate insertion silently succeeds in
+release; a "should never happen" `?` operator silently returns
+`Ok(_)` early in debug-stripped code; an iterator's `.next()`
+quietly advances in one build configuration but not another.
+None of these are stylistic preferences — they're bugs.
+
+The general form ("any function-like or array-like macro may
+evaluate an argument zero or many times") is partly a correctness
+concern and partly a defensive coding stance:
+
+- **Correctness** for macros that conditionally skip evaluation
+  (`debug_assert*`, `cfg!`, custom `#[cfg(test)]` wrappers, log
+  macros below the configured filter level in some
+  implementations).
+- **Correctness** for macros that evaluate an argument multiple
+  times (anything implementing a syntactic transformation —
+  `min!`/`max!`-style macros, n-arg-tuple builders, retry-loop
+  macros). A side-effecting expression repeated produces wrong
+  results.
+- **Defensive** for unknown macros where the call-site author
+  doesn't know the evaluation count and cannot find out without
+  reading the matcher. A `let` binding makes the code work
+  regardless.
+
+The rule's default configuration flags only the cases where the
+trap is real (known-conditional macros and macros not on the
+curated safe list). The blanket-ban mode is opt-in for projects
+that want the defensive stance everywhere.
+
+## Statement
+
+For a function-like (`name!(...)`) or array-like (`name![...]`)
+macro invocation:
+
+- If the macro is on the **denylist** of macros known to evaluate
+  arguments conditionally or repeatedly, every non-trivial
+  top-level argument must be a path expression (a `let` binding,
+  a constant, or a function/method-less reference). A non-trivial
+  argument that is not bound to a name is flagged.
+- If the macro is on the **allowlist** of macros known to
+  evaluate each top-level argument exactly once, the argument
+  shape is unconstrained.
+- For every other macro, behaviour depends on the configured
+  *unknown-macro policy* (see "Five eligibility modes" below).
+
+Curly-brace macro invocations (`name! { ... }`) are out of scope.
+They are conventionally DSL bodies where the evaluation contract
+is intentional (`thread_local! { static FOO: ...; }`,
+`quote! { fn foo() { ... } }`, `html! { <div>{value}</div> }`),
+not function-call-like argument lists.
+
+The call-site delimiter is the *only* signal the lint uses to
+classify a macro invocation. A declarative macro's body does not
+fix its call shape; the same `macro_rules!` accepts `name!(...)`,
+`name![...]`, and `name! { ... }` interchangeably. The lint
+therefore branches on the invocation's `Delimiter`, not on
+anything about the definition.
+
+### What counts as a "non-trivial" argument
+
+A "trivial" argument is one whose evaluation has no observable
+effect and produces the same value every time. Trivial arguments
+are accepted even by macros on the denylist, because zero-or-many
+evaluations of a trivial expression are indistinguishable from
+exactly-one.
+
+Trivial:
+
+- Literals (`42`, `"hello"`, `true`, `'a'`).
+- Path expressions resolving to a `const`, `static`, local
+  binding, function name, or unit / tuple variant
+  (`MAX_VALUE`, `Foo::BAR`, `count`, `Result::Ok`).
+- A reference to a trivial expression (`&count`,
+  `&mut buffer`).
+- A field access or tuple-index on a trivial base
+  (`config.threshold`, `point.0`).
+- A unary deref of a trivial expression (`*ptr`).
+- A trivial expression annotated with a type (`x as u64`,
+  `42_u8`).
+
+Non-trivial (anything not in the list above), e.g.:
+
+- Function calls (`compute()`, `Foo::new()`).
+- Method calls (`map.insert(k, v)`, `iter.next()`).
+- `?` expressions (`fallible()?`).
+- `.await` expressions.
+- Macro invocations (`other_macro!(x)`).
+- Block expressions (`{ ... }`).
+- Closure expressions, even if not invoked here.
+- `if`, `match`, `loop`, `while`, `for`.
+- Assignment / compound-assignment.
+- Range expressions whose endpoints are non-trivial.
+- Binary expressions whose operands are non-trivial.
+
+The trivial / non-trivial split is purely *syntactic*. The lint
+does not consult the type checker for purity (which Rust does not
+expose anyway). A `const fn` call is treated as non-trivial; the
+author can hoist it to a `const` if they want it accepted.
+
+## Five eligibility modes
+
+The user's question — what difficulty levels exist between
+"forbid everything" and "fully read the macro definition" — is
+answered by the configuration ladder below. Each mode is a strict
+superset of the previous one in terms of work avoided, and a
+strict subset in terms of false positives. The default is mode
+2 (curated allowlist + denylist).
+
+### Mode 0 — denylist-only (the simplest possible rule)
+
+*Easier than the user's "easiest".* Ship a hard-coded denylist of
+known-conditional macros — `debug_assert!`, `debug_assert_eq!`,
+`debug_assert_ne!`, `cfg!`, and a handful of similar shapes — and
+flag only those. Every other macro is silently accepted.
+
+The implementation is a name-set lookup keyed on the resolved
+`DefId` plus a non-trivial-argument predicate. No allowlist, no
+matcher walk, no user configuration beyond extending the
+denylist. The rule's surface area is "this exact set of
+core/std macros, for this exact reason".
+
+This mode exists for projects that want to enable
+`perfectionist::macro_argument_binding` without auditing their
+third-party macro use — they only care about not getting bitten
+by `debug_assert*`. Set `mode = "denylist_only"`.
+
+### Mode 1 — blanket ban
+
+The user's "easiest, dumbest" mode. Every function-like and
+array-like macro invocation is flagged when given a non-trivial
+top-level argument, regardless of whether the macro is known
+safe. Curly-brace invocations remain out of scope per the
+"Statement" section.
+
+This mode is deliberately not the default — `format!("hello
+{name}", compute())` is fine in practice and reading every macro
+invocation as a footgun is exhausting. Projects that want the
+maximum-paranoia stance can opt in by setting
+`mode = "blanket"`. Set the `extra_allowlist` knob to whitelist
+specific macros that the project trusts.
+
+### Mode 2 — curated allowlist + denylist (default)
+
+The user's "still easy" mode, augmented with the denylist
+spelled out in mode 0. Three name-lookups decide each
+invocation:
+
+1. **Denylist hit**: flag every non-trivial argument. The
+   denylist defaults to `debug_assert!`, `debug_assert_eq!`,
+   `debug_assert_ne!`, `cfg!`, and any user-added entries.
+2. **Allowlist hit**: accept unconditionally. The allowlist
+   defaults to the same `core` / `std` and well-known
+   third-party set as
+   [`macro-trailing-comma`](./macro-trailing-comma.md) —
+   `format!`, `println!`, `vec!`, `write!`, `assert!`,
+   `assert_eq!`, the `log::*` and `tracing::*` families,
+   `anyhow!`, and similar. (Built-in macros that match either
+   the denylist or the allowlist agree with this rule's policy
+   only when the user uses them as documented; the curated
+   list reflects upstream semantics, not project taste.)
+3. **Neither**: skip silently. Unknown macros are not flagged
+   by default. A project that wants stricter behaviour
+   reaches for mode 1 or mode 4.
+
+The default rejecting only the denylist (rather than every
+unlisted macro) is a usability choice. The user's framing of
+"still easy" was that unlisted macros get flagged; in practice
+that produces too much noise during initial rule adoption.
+Projects can set `unknown_macro_policy = "deny"` to recover
+the strict variant.
+
+### Mode 3 — mode 2 with expression-side bypass
+
+A bypass that layers on top of any of the modes above. Even
+when the macro is on the denylist (or every macro is denied
+under mode 1), accept the invocation if every non-trivial
+top-level argument is *also* a single name binding — i.e.,
+arguments are limited to identifiers, paths, and the other
+trivial shapes above plus single-name calls like
+`Arc::clone(&x)` (a function call whose only argument is a
+trivial expression).
+
+The bypass widens the trivial-expression definition: a
+function or method call is acceptable when every one of its
+arguments is itself trivial. The recursion stops at any
+non-trivial sub-expression.
+
+The motivation is that `debug_assert_eq!(my_set.contains(&k),
+true)` is *also* unsafe-feeling but ultimately fine — the
+worst case is "contains is not called in release", which has
+no observable effect because `contains` is pure. The bypass
+captures the heuristic "non-mutating method calls are safe to
+re-evaluate or skip" by accepting any call whose arguments are
+themselves trivial (typically `&path` / `path`).
+
+The implementation cost over mode 2 is one extra match arm
+plus a recursive descent through `ExprKind::Call`,
+`ExprKind::MethodCall`, and `ExprKind::Field`. The accuracy
+gain is large in real codebases.
+
+Enable with `expression_bypass = true`. Default off — the
+heuristic is approximate (it cannot tell a pure method from an
+impure one), and projects that want the strictest reading
+should leave it off. Projects that find the default too noisy
+turn it on as the first knob to adjust.
+
+### Mode 4 — matcher-based declarative-macro analysis
+
+The user's "hard" mode. For a `macro_rules!` macro whose
+definition is visible to the compiler (current crate, or a
+dependency whose macro body rustc still has on hand):
+
+1. Determine which arm of the macro matches the call.
+2. For each `$name:expr` capture in that arm, count its
+   occurrences in the corresponding RHS.
+   - Exactly one occurrence, with the capture not nested
+     inside any `$( ... )*` / `$( ... )+` / `$( ... )?`
+     repetition that could change its evaluation count:
+     the argument is evaluated exactly once. Eligible
+     (treat the argument's macro as if it were on the
+     allowlist).
+   - Zero occurrences (the capture is matched but discarded):
+     the argument is never evaluated. Flag with a "the
+     argument is unused in this expansion" diagnostic.
+   - Two or more occurrences, or any occurrence inside a
+     repetition / conditional fragment: the argument may be
+     evaluated more than once or skipped. Flag with the
+     "this macro does not evaluate arguments exactly once"
+     diagnostic.
+3. If multiple arms could match the same invocation
+   ambiguously, fall back to the *most conservative* answer
+   across all candidate arms.
+
+Matcher analysis does not extend to procedural macros — the
+expansion is custom Rust code, not introspectable from the
+matcher. Proc macros remain governed by the user's allowlist /
+denylist configuration.
+
+Set `mode = "matcher_based"` to enable. Defaults off; this
+mode is the most expensive to implement (see "Why
+matcher-based is harder than name-based" in
+[`macro-trailing-comma`](./macro-trailing-comma.md), which
+faces the same matcher-access infrastructure work) and the
+matcher walker can be reused between this rule and
+`macro-trailing-comma`. Recommended landing order is
+mode 0 → 2 → 3 → 4; mode 1 falls out of mode 2 trivially.
+
+### Picking a mode
+
+| Mode | Default | Cost to implement | Flags |
+| --- | --- | --- | --- |
+| 0 — denylist only | opt-in | smallest | known-conditional macros only |
+| 1 — blanket | opt-in | small | every non-trivial macro arg |
+| 2 — allowlist + denylist | **on** | small | denylist always; unknown configurable |
+| 3 — mode 2 + bypass | opt-in (flag) | small + recursion | mode 2 minus pure-call shapes |
+| 4 — matcher-based | opt-in | large | mode 2 plus learned `macro_rules!` |
+
+Modes 0, 1, and 2 share the same visitor and differ only in
+the name-lookup table. Mode 3 adds one extra predicate. Mode 4
+adds the matcher walker. The recommended implementation order
+matches the table: mode 0 is the smallest landable step, mode
+4 is the largest.
+
+## What to lint
+
+For every macro invocation:
+
+1. Check the invocation's `Delimiter`. If it is `Brace`, skip —
+   curly-brace invocations are out of scope.
+2. Resolve the macro `DefId`.
+3. Consult `ignore`. If the path matches, skip. `ignore` wins
+   over both the denylist and the allowlist; it exists for
+   per-project opt-outs of curated entries.
+4. Apply the configured `mode`:
+   - `denylist_only`: match against the denylist
+     (`debug_assert!`, `debug_assert_eq!`, `debug_assert_ne!`,
+     `cfg!`, plus `extra_denylist`). Continue to step 5 only
+     on a hit.
+   - `blanket`: continue to step 5 for every macro not on the
+     allowlist (`extra_allowlist` only — there is no built-in
+     allowlist in this mode, by design).
+   - `allowlist_denylist` (default): denylist hit → continue.
+     Allowlist hit → skip. Otherwise consult
+     `unknown_macro_policy`: `allow` (default) → skip,
+     `deny` → continue.
+   - `matcher_based`: denylist / allowlist as above; for
+     unknown macros, walk the matcher per mode 4. Result is
+     either "treat as allowlisted" (continue: skip) or
+     "treat as denylisted" (continue: lint).
+5. Walk the invocation's *top-level* argument list. The lint
+   only inspects top-level expressions — an argument that
+   itself contains a non-trivial sub-expression is the
+   author's choice, and recursing into nested macros opens
+   the door to false positives. Top-level argument boundaries
+   are recovered from the invocation token stream the same
+   way [`macro-trailing-comma`](./macro-trailing-comma.md)
+   does it (track delimiter nesting; split on top-level
+   commas; skip top-level `;` and `=>`).
+6. For each top-level argument, parse the token stream as an
+   expression. Skip arguments that don't parse as a single
+   expression (a `name: type` argument shape, a path-only
+   argument like `serde!(foo = bar)`, etc.) — those are
+   syntactic positions the macro author chose, not normal
+   value arguments.
+7. Classify the expression with the trivial / non-trivial
+   split above. If non-trivial, and the `expression_bypass`
+   knob is enabled, apply the bypass recursion before
+   deciding.
+8. Emit a diagnostic on the non-trivial argument's span. The
+   suggested rewrite is a `let` binding immediately before
+   the macro call, with the binding name derived from the
+   expression (a fallback identifier such as `binding` is
+   used when no better name is available).
+
+The autofix is `Applicability::MaybeIncorrect`. Inserting a
+`let` binding adds a new name to the enclosing scope, which
+may shadow an existing name or be shadowed by a later
+binding. The rewrite is mechanically correct but worth a
+human glance.
+
+## Examples
+
+### The motivating bug
+
+```rust
+// Bad — release mode skips `insert` entirely
+debug_assert_eq!(my_set.insert(new_item), None, "duplicate insert");
+
+// Good
+let was_new = my_set.insert(new_item).is_none();
+debug_assert!(was_new, "duplicate insert");
+```
+
+### Trivial arguments stay inline
+
+```rust
+// Accepted — `count` is a path, `MAX_RETRIES` is a const,
+// `&buffer` is a reference to a path. None of them have
+// side effects.
+debug_assert_eq!(count, MAX_RETRIES, "expected {MAX_RETRIES} retries");
+debug_assert!(buffer.is_empty(), "buffer must start empty");
+//            ^^^^^^^^^^^^^^^^^ method call → flagged when
+//                              `expression_bypass = false`;
+//                              accepted under bypass because
+//                              `is_empty` takes only `&self`.
+```
+
+### Allowlisted macros pass through
+
+```rust
+// Accepted under default config — `format!` is on the
+// curated allowlist; arguments are evaluated exactly once.
+let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Ordering::Relaxed));
+```
+
+### Array-like invocation is also in scope
+
+```rust
+// Bad — vec! is on the allowlist, so this is fine by default,
+// but in blanket mode the `compute()` call would be flagged.
+let xs = vec![compute(), compute(), compute()];
+
+// Good (blanket mode)
+let a = compute();
+let b = compute();
+let c = compute();
+let xs = vec![a, b, c];
+```
+
+### Curly-brace invocation is out of scope
+
+```rust
+// Skipped — curly-brace invocation. The DSL contract is the
+// macro's, not the call site's.
+thread_local! {
+    static COUNTER: Cell<u32> = Cell::new(compute_initial());
+}
+```
+
+### Multiple-evaluation trap
+
+```rust
+macro_rules! double_use {
+    ($e:expr) => { $e + $e };
+}
+
+// Bad — `next` is consumed twice. The current value plus the
+// next value, not "doubled current".
+let total = double_use!(iter.next().unwrap());
+
+// Good
+let v = iter.next().unwrap();
+let total = double_use!(v);
+```
+
+This is the kind of misuse mode 4 (matcher-based) catches
+automatically: the matcher walker sees `$e` referenced twice in
+the RHS and flags every non-trivial argument to `double_use!`
+even though the macro is otherwise unknown to the lint.
+
+### Procedural macro stays in user-config territory
+
+```rust
+// Whether this is safe depends on the proc macro's expansion,
+// which the lint cannot read. The user adds `tracing::info`
+// to `extra_allowlist` once, project-wide.
+tracing::info!(latency = stopwatch.elapsed().as_millis(), "done");
+```
+
+## Configuration
+
+```toml
+[macro_argument_binding]
+# Set to false to disable the rule entirely.
+enabled = true
+
+# Eligibility mode. Defaults to "allowlist_denylist".
+#   "denylist_only"     — flag only the curated denylist
+#   "blanket"           — flag everything not on extra_allowlist
+#   "allowlist_denylist" — flag denylist hits + unknowns per policy
+#   "matcher_based"     — allowlist_denylist + matcher walking
+mode = "allowlist_denylist"
+
+# Behaviour for macros that match neither the denylist nor the
+# allowlist under "allowlist_denylist" mode. `allow` (default)
+# silently skips them; `deny` treats them as denylisted.
+# Ignored under other modes.
+unknown_macro_policy = "allow"
+
+# When true, accept calls and method calls whose arguments are
+# themselves trivial — even on denylisted macros. Default off;
+# turn on if the lint is too noisy with read-only accessor
+# calls inside `debug_assert*`.
+expression_bypass = false
+
+# Macros added to the built-in denylist. Each entry is a
+# fully-qualified macro path (no trailing `!`) or a bare macro
+# name to match by final segment only.
+extra_denylist = [
+  # "my_crate::sometimes_evaluates",
+]
+
+# Macros added to the built-in allowlist. Same path syntax as
+# extra_denylist. Use for third-party macros the project
+# trusts to evaluate each argument exactly once.
+extra_allowlist = [
+  # "tracing::info",
+  # "tracing::debug",
+]
+
+# Macros to skip entirely, regardless of which list they would
+# otherwise hit. Use for project-internal macros whose
+# arguments are intentionally expressions (the author knows
+# the matcher).
+ignore = [
+  # "my_crate::ad_hoc",
+]
+```
+
+## Implementation notes
+
+- `EarlyLintPass::check_mac` over `ast::MacCall`. The early
+  pass sees the raw invocation token stream, which the lint
+  needs to split into top-level arguments before any
+  expansion has happened. The same `#[expect]`-fulfilment
+  workaround that
+  [`macro-trailing-comma`](./macro-trailing-comma.md) uses
+  (park spans in a process-static queue, emit from a late
+  pass that walks HIR) applies here.
+- Macro path resolution: `MacCall::path` resolves to a `Res`;
+  use the resolved `DefId` for the name-lookup. Bare-name
+  matching falls back to the path's final segment so
+  `extra_allowlist = ["my_macro"]` works without forcing the
+  user to spell out the crate path.
+- Argument splitting: walk `MacCall::args.tokens` tracking
+  delimiter nesting and split on top-level commas. Reuse the
+  helper that
+  [`macro-trailing-comma`](./macro-trailing-comma.md)
+  introduces (or factor it out the other way around,
+  whichever rule lands first).
+- Per-argument re-parse: each top-level argument is a token
+  stream; reparse it as an expression with
+  `rustc_parse::parser::Parser::parse_expr_anon`. Arguments
+  that fail to parse as an expression are skipped (they are
+  not value-shaped — `name = value`, `name: type`, and similar
+  syntactic positions that some macros consume).
+- Trivial / non-trivial predicate: a `match` on
+  `ast::ExprKind` covering `Lit`, `Path`, `AddrOf`, `Field`,
+  `Index`, `Unary(Deref, _)`, `Cast`, and the trivial-base
+  recursions. Default to non-trivial for any unrecognised
+  variant — false positives are better than false negatives
+  here.
+- Expression-side bypass (mode 3): a recursive descent
+  through `Call`, `MethodCall`, and `Field`. Each callee /
+  receiver must itself be trivial; each argument must be
+  trivial-after-bypass. A bypass match implies the call is
+  "as safe as an accessor".
+- Matcher walker (mode 4): reuse the `take_*` combinator
+  scaffold introduced for
+  [`macro-trailing-comma`](./macro-trailing-comma.md)'s
+  matcher-based mode. The two rules ask different questions
+  of the matcher (trailing-comma-optional vs.
+  capture-evaluation-count) but consume the same token
+  grammar and the same cross-crate access path
+  (`tcx.hir_node_by_def_id` for local macros,
+  `tcx.cstore_untracked()` for dependency macros). Factor
+  the matcher access into a crate-internal module and have
+  both rules consume it.
+- Suggested rewrite: render `let <name> = <expr>;\n<indent>`
+  immediately before the macro invocation. Name derivation
+  is a best-effort heuristic — pick the receiver / callee
+  identifier when the expression is a method or function
+  call, fall back to `binding` otherwise. The fix is
+  `Applicability::MaybeIncorrect` because the inserted name
+  may shadow an existing binding or change scoping.
+
+### Difficulty
+
+**Mode 0 / 1 / 2: easy.** A name-set lookup, a top-level
+argument splitter (reused from `macro-trailing-comma`), and a
+syntactic predicate on `ast::ExprKind`. The three modes share
+the entire pipeline and differ only in which lookup table the
+name resolution consults.
+
+**Mode 3: easy.** One extra predicate layered on the
+expression classifier; recursion bottoms out at the trivial
+cases.
+
+**Mode 4: hard.** Same matcher-walking infrastructure as
+[`macro-trailing-comma`](./macro-trailing-comma.md)'s
+matcher-based mode, plus capture-occurrence counting and the
+nested-repetition case analysis. Recommended landing order is
+modes 0-3 in a single PR (they share the pipeline), then mode
+4 as a follow-up that also lights up `macro-trailing-comma`'s
+own matcher-based detection.
+
+- See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  for cross-cutting conventions that apply to every rule in
+  this catalogue, in particular the lint-name namespacing
+  (`perfectionist::*`) that every registered lint follows.
+
+## Severity
+
+Warn. The denylist defaults — `debug_assert*` and `cfg!` —
+flag a genuine correctness bug, and projects that want
+stronger behaviour can promote the lint to deny per file or
+crate-wide via `#![deny(perfectionist::macro_argument_binding)]`.
+
+## Interaction with sibling rules
+
+- [`macro-trailing-comma`](./macro-trailing-comma.md) shares
+  the top-level argument splitter and (eventually) the
+  declarative-macro matcher walker. The two rules ask
+  different questions of the same invocation; both register
+  for `ast::MacCall` and both restrict themselves to
+  function-like and array-like delimiters. Factor the shared
+  scanner into a crate-internal helper so neither rule grows
+  its own copy.
+- [`format-macro-wrap`](./format-macro-wrap.md) and
+  [`print-macro-split`](./print-macro-split.md) operate on
+  the *template literal* inside their target macros and
+  treat the surrounding macro as a known-safe call. Those
+  rules' target macros are all on this rule's default
+  allowlist, so the two never disagree about whether a
+  given invocation needs intervention.

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -20,8 +20,8 @@ The fix is to bind the call to a `let` first, then pass the
 binding to the macro:
 
 ```rust
-let rejected = my_map.insert(key, value);
-debug_assert_eq!(rejected, None, "Something went wrong! `key` wasn't new");
+let ejected = my_map.insert(key, value);
+debug_assert_eq!(ejected, None, "Something went wrong! `key` wasn't new");
 ```
 
 `debug_assert*` is the most famous offender, but the trap is
@@ -184,9 +184,12 @@ macro is silently accepted.
 
 The implementation is a name-set lookup keyed on the resolved
 `DefId` plus a non-trivial-argument predicate. No allowlist, no
-matcher walk, no user configuration beyond extending the
-denylist. The rule's surface area is "this exact set of
-core/std macros, for this exact reason".
+matcher walk; the only mode-specific knob is `deny_extra` for
+extending the built-in denylist. The shared knobs (`ignore`,
+`expression_bypass`) still apply per the "What to lint" and
+"Configuration" sections — they're not mode-gated. The rule's
+surface area in this mode is "this exact set of core/std
+macros, for this exact reason".
 
 This mode exists for projects that want to enable
 `perfectionist::macro_argument_binding` without auditing their
@@ -436,8 +439,8 @@ human glance.
 debug_assert_eq!(my_map.insert(key, value), None, "duplicate key");
 
 // Good
-let rejected = my_map.insert(key, value);
-debug_assert_eq!(rejected, None, "duplicate key");
+let ejected = my_map.insert(key, value);
+debug_assert_eq!(ejected, None, "duplicate key");
 ```
 
 ### Trivial arguments stay inline

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -118,6 +118,9 @@ Trivial:
   `&mut buffer`).
 - A field access or tuple-index on a trivial base
   (`config.threshold`, `point.0`).
+- An index expression `base[index]` where both `base` and
+  `index` are themselves trivial (`buffer[0]`,
+  `lookup[Foo::KEY]`).
 - A unary deref of a trivial expression (`*ptr`).
 - A trivial expression annotated with a type (`x as u64`,
   `42_u8`).
@@ -235,9 +238,9 @@ re-evaluate or skip" by accepting any call whose arguments are
 themselves trivial (typically `&path` / `path`).
 
 The implementation cost over mode 2 is one extra match arm
-plus a recursive descent through `ExprKind::Call`,
-`ExprKind::MethodCall`, and `ExprKind::Field`. The accuracy
-gain is large in real codebases.
+plus a recursive descent through `ExprKind::Call` and
+`ExprKind::MethodCall`. The accuracy gain is large in real
+codebases.
 
 Enable with `expression_bypass = true`. Default off — the
 heuristic is approximate (it cannot tell a pure method from an
@@ -291,8 +294,8 @@ matcher-based is harder than name-based" in
 [`macro-trailing-comma`](./macro-trailing-comma.md), which
 faces the same matcher-access infrastructure work) and the
 matcher walker can be reused between this rule and
-`macro-trailing-comma`. Recommended landing order is
-mode 0 → 2 → 3 → 4; mode 1 falls out of mode 2 trivially.
+`macro-trailing-comma`. See the Difficulty section for the
+recommended landing order.
 
 ### Picking a mode
 
@@ -420,7 +423,9 @@ let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Orde
 // Accepted under default config — vec! is on the curated
 // allowlist; each element is evaluated exactly once.
 let xs = vec![compute(), compute(), compute()];
+```
 
+```rust
 // Flagged under blanket mode — every non-trivial argument is
 // a candidate, allowlist or not.
 let xs = vec![compute(), compute(), compute()];

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -61,9 +61,9 @@ what the macro does with its captures.
 For a function-like (`name!(...)`) or array-like (`name![...]`)
 macro invocation:
 
-- If the macro is on the **denylist**, every non-trivial
+- If the macro is on the **deny list**, every non-trivial
   top-level argument is flagged.
-- If the macro is on the **allowlist**, the argument shape is
+- If the macro is on the **allow list**, the argument shape is
   unconstrained.
 - For every other macro, behaviour depends on the configured
   `mode` (see "Eligibility modes" below).
@@ -107,7 +107,7 @@ Four modes ordered by implementation cost. The default is
 
 ### Mode 0 — `deny_only`
 
-Flag only invocations of the curated denylist (`debug_assert!`,
+Flag only invocations of the curated deny list (`debug_assert!`,
 `debug_assert_eq!`, `debug_assert_ne!`) plus any `deny_extra`
 entries. Every other macro is silently accepted.
 
@@ -120,7 +120,7 @@ macros.
 Flag every function-like or array-like invocation that carries
 a non-trivial top-level argument, regardless of macro. Add
 specific exceptions to `allow_extra`; there is no built-in
-allowlist in this mode.
+allow list in this mode.
 
 The maximum-paranoia stance. Not the default because
 `format!("hello {name}", compute())` is fine in practice and
@@ -130,13 +130,13 @@ flagging every macro invocation is exhausting.
 
 Three name-set lookups decide each invocation:
 
-1. **Denylist hit** (`debug_assert*` plus `deny_extra`) → flag
+1. **Deny-list hit** (`debug_assert*` plus `deny_extra`) → flag
    every non-trivial argument.
-2. **Allowlist hit** (the curated set below plus `allow_extra`)
+2. **Allow-list hit** (the curated set below plus `allow_extra`)
    → accept unconditionally.
 3. **Neither** → flag every non-trivial argument.
 
-The default allowlist tracks the curated set in
+The default allow list tracks the curated set in
 [`macro-trailing-comma`](./macro-trailing-comma.md), with the
 conditional-evaluation families (`log::*`, `tracing::*`)
 removed: `format!`, `format_args!`, `print!`, `println!`,
@@ -152,7 +152,7 @@ trust to evaluate each argument exactly once.
 
 ### Mode 3 — `matcher_based`
 
-Layers on top of mode 2. The allowlist and denylist are
+Layers on top of mode 2. The allow list and deny list are
 consulted first; the matcher walk runs only on `macro_rules!`
 macros that would otherwise be unknown.
 
@@ -162,7 +162,7 @@ count occurrences of `$name` in the expansion:
 
 - Exactly one, not nested inside any `$( ... )*` / `$( ... )+` /
   `$( ... )?` repetition → the argument is evaluated exactly
-  once. Treat the invocation as allowlisted.
+  once. Treat the invocation as allow-listed.
 - Zero, two or more, or any occurrence inside a repetition or
   conditional fragment → flag the invocation.
 
@@ -225,10 +225,10 @@ debug_assert_eq!(ejected, None, "duplicate key");
 debug_assert_eq!(count, MAX_RETRIES, "expected {MAX_RETRIES} retries");
 ```
 
-### Allowlisted macros pass through
+### Allow-listed macros pass through
 
 ```rust
-// Accepted — `format!` is on the curated allowlist; arguments
+// Accepted — `format!` is on the curated allow list; arguments
 // are evaluated exactly once.
 let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Ordering::Relaxed));
 ```
@@ -236,13 +236,13 @@ let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Orde
 ### Array-like invocation is in scope
 
 ```rust
-// Accepted under default config — `vec!` is on the allowlist.
+// Accepted under default config — `vec!` is on the allow list.
 let xs = vec![compute(), compute(), compute()];
 ```
 
 ```rust
 // Flagged under blanket mode — every non-trivial argument is
-// a candidate, allowlist or not.
+// a candidate, allow list or not.
 let xs = vec![compute(), compute(), compute()];
 
 // Good (blanket-mode rewrite)
@@ -291,14 +291,14 @@ enabled = true
 # Eligibility mode. Defaults to "allow_and_deny".
 mode = "allow_and_deny"
 
-# Macros added to the built-in denylist. Each entry is a
+# Macros added to the built-in deny list. Each entry is a
 # fully-qualified macro path (no trailing `!`) or a bare macro
 # name to match by final segment only.
 deny_extra = [
   # "my_crate::sometimes_evaluates",
 ]
 
-# Macros added to the built-in allowlist.
+# Macros added to the built-in allow list.
 allow_extra = [
   # "serde_json::json",
 ]
@@ -369,4 +369,4 @@ Warn.
 - [`format-macro-wrap`](./format-macro-wrap.md) and
   [`print-macro-split`](./print-macro-split.md) operate on the
   *template literal* inside their target macros. Those rules'
-  target macros are all on this rule's default allowlist.
+  target macros are all on this rule's default allow list.

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -108,6 +108,14 @@ is intentional (`thread_local! { static FOO: ...; }`,
 `quote! { fn foo() { ... } }`, `html! { <div>{value}</div> }`),
 not function-call-like argument lists.
 
+Function-like and array-like invocations whose top-level token
+stream uses `;` as a separator are also out of scope:
+`vec![expr; n]` (repeated-element form) and similar `;`-shaped
+grammars are not the comma-separated argument list this rule
+targets. Step 5 of "What to lint" detects this mechanically by
+treating a top-level `;` as a skip-the-whole-invocation
+trigger.
+
 The call-site delimiter is the *only* signal the lint uses to
 classify a macro invocation. A declarative macro's body does not
 fix its call shape; the same `macro_rules!` accepts `name!(...)`,

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -49,9 +49,12 @@ evaluate an argument zero or many times") is partly a correctness
 concern and partly a defensive coding stance:
 
 - **Correctness** for macros that conditionally skip evaluation
-  (`debug_assert*`, `cfg!`, custom `#[cfg(test)]` wrappers, log
-  macros below the configured filter level in some
-  implementations).
+  (`debug_assert*`, custom `#[cfg(test)]` wrappers, log macros
+  below the configured filter level in some implementations).
+  `cfg!` looks like a member of this family but isn't — its
+  argument is `meta` syntax, not a Rust expression, so the
+  "argument-evaluation count" framing doesn't apply and the
+  lint deliberately leaves it alone.
 - **Correctness** for macros that evaluate an argument multiple
   times (anything implementing a syntactic transformation —
   `min!`/`max!`-style macros, n-arg-tuple builders, retry-loop
@@ -62,30 +65,32 @@ concern and partly a defensive coding stance:
   reading the matcher. A `let` binding makes the code work
   regardless.
 
-The rule's default configuration flags only the cases where the
-trap is real (known-conditional macros and macros not on the
-curated safe list). The blanket-ban mode is opt-in for projects
-that want the defensive stance everywhere.
+The rule's default configuration flags only known-conditional
+macros — the ones in the curated conditional list. Unknown
+macros are skipped under the default
+`unknown_macro_policy = "allow"`; projects that want the
+defensive stance set `unknown_macro_policy = "deny"` or
+switch to the blanket-ban mode.
 
 ## Statement
 
 For a function-like (`name!(...)`) or array-like (`name![...]`)
 macro invocation:
 
-- If the macro is on the **denylist** of macros known to evaluate
+- If the macro is on the **conditional list** of macros known to evaluate
   arguments conditionally or repeatedly, every non-trivial
   top-level argument is flagged. The set of accepted argument
   shapes is the trivial set defined under
   "What counts as a 'non-trivial' argument" below — literals,
   paths, `&path`, `path.field`, `base[index]`, `*path`, and
   casts.
-- If the macro is on the **allowlist** of macros known to
+- If the macro is on the **exactly-once list** of macros known to
   evaluate each top-level argument exactly once, the argument
   shape is unconstrained.
 - For every other macro, behaviour depends on the selected
   mode — see "Five eligibility modes" below. Briefly:
-  `denylist_only` and `matcher_based` (for proc macros) skip
-  the invocation, `blanket` flags it, and `allowlist_denylist`
+  `conditional_only` and `matcher_based` (for proc macros) skip
+  the invocation, `blanket` flags it, and `name_based`
   consults the configured `unknown_macro_policy`.
 
 Curly-brace macro invocations (`name! { ... }`) are out of scope.
@@ -105,7 +110,7 @@ anything about the definition.
 
 A "trivial" argument is one whose evaluation has no observable
 effect and produces the same value every time. Trivial arguments
-are accepted even by macros on the denylist, because zero-or-many
+are accepted even by macros on the conditional list, because zero-or-many
 evaluations of a trivial expression are indistinguishable from
 exactly-one.
 
@@ -152,26 +157,27 @@ The user's question — what difficulty levels exist between
 answered by the configuration ladder below. The modes are
 ordered by *implementation* cost, not by some clean monotone
 relationship on what they flag: Mode 3 relaxes Mode 2's
-denial set, and Mode 4 reshapes it. The default is mode 2
-(curated allowlist + denylist).
+conditional list, and Mode 4 reshapes it. The default is mode 2
+(name-based lookup against the two curated lists).
 
-### Mode 0 — denylist-only (the simplest possible rule)
+### Mode 0 — conditional-only (the simplest possible rule)
 
-*Easier than the user's "easiest".* Ship a hard-coded denylist of
-known-conditional macros — `debug_assert!`, `debug_assert_eq!`,
-`debug_assert_ne!`, `cfg!`, and a handful of similar shapes — and
-flag only those. Every other macro is silently accepted.
+*Easier than the user's "easiest".* Ship a hard-coded conditional
+list of known-conditional macros — `debug_assert!`,
+`debug_assert_eq!`, `debug_assert_ne!`, and a handful of
+similar shapes — and flag only those. Every other macro is
+silently accepted.
 
 The implementation is a name-set lookup keyed on the resolved
-`DefId` plus a non-trivial-argument predicate. No allowlist, no
+`DefId` plus a non-trivial-argument predicate. No exactly-once list, no
 matcher walk, no user configuration beyond extending the
-denylist. The rule's surface area is "this exact set of
+conditional list. The rule's surface area is "this exact set of
 core/std macros, for this exact reason".
 
 This mode exists for projects that want to enable
 `perfectionist::macro_argument_binding` without auditing their
 third-party macro use — they only care about not getting bitten
-by `debug_assert*`. Set `mode = "denylist_only"`.
+by `debug_assert*`. Set `mode = "conditional_only"`.
 
 ### Mode 1 — blanket ban
 
@@ -185,21 +191,22 @@ This mode is deliberately not the default — `format!("hello
 {name}", compute())` is fine in practice and reading every macro
 invocation as a footgun is exhausting. Projects that want the
 maximum-paranoia stance can opt in by setting
-`mode = "blanket"`. Set the `extra_allowlist` knob to whitelist
+`mode = "blanket"`. Set the `extra_exactly_once` knob to whitelist
 specific macros that the project trusts.
 
-### Mode 2 — curated allowlist + denylist (default)
+### Mode 2 — curated name-based lookup (default)
 
-The user's "still easy" mode, augmented with the denylist
+The user's "still easy" mode, augmented with the conditional list
 spelled out in mode 0. Three name-lookups decide each
 invocation:
 
-1. **Denylist hit**: flag every non-trivial argument. The
-   denylist defaults to `debug_assert!`, `debug_assert_eq!`,
-   `debug_assert_ne!`, `cfg!`, and any user-added entries.
-2. **Allowlist hit**: accept unconditionally. The allowlist
-   defaults to the same `core` / `std` and well-known
-   third-party set as
+1. **Conditional-list hit**: flag every non-trivial argument.
+   The conditional list defaults to `debug_assert!`,
+   `debug_assert_eq!`, `debug_assert_ne!`, and any user-added
+   entries.
+2. **Exactly-once-list hit**: accept unconditionally. The
+   exactly-once list defaults to the same `core` / `std` and
+   well-known third-party set as
    [`macro-trailing-comma`](./macro-trailing-comma.md) —
    `format!`, `println!`, `vec!`, `write!`, `assert!`,
    `assert_eq!`, the `log::*` and `tracing::*` families,
@@ -208,7 +215,7 @@ invocation:
    by default. A project that wants stricter behaviour
    reaches for mode 1 or mode 4.
 
-The default rejecting only the denylist (rather than every
+The default rejecting only the conditional list (rather than every
 unlisted macro) is a usability choice. The user's framing of
 "still easy" was that unlisted macros get flagged; in practice
 that produces too much noise during initial rule adoption.
@@ -221,7 +228,7 @@ A bypass that layers on top of any of the modes above. The
 bypass does not change the trivial / non-trivial split —
 that classification stays as defined under "What counts as a
 'non-trivial' argument". Instead, it adds an *accept rule*:
-even when the macro would otherwise fire (denylisted, or
+even when the macro would otherwise fire (conditional, or
 denied under mode 1's blanket), accept the invocation if
 every top-level argument's outermost shape is either trivial
 or a function / method call whose own sub-expressions are all
@@ -252,14 +259,15 @@ turn it on as the first knob to adjust.
 ### Mode 4 — matcher-based declarative-macro analysis
 
 The user's "hard" mode. Layered on top of mode 2: the
-denylist and allowlist are consulted first, and the matcher
+conditional list and exactly-once list are consulted first, and the matcher
 walk runs only on `macro_rules!` macros that *would otherwise
-be unknown*. An invocation that resolves to an allowlisted
+be unknown*. An invocation that resolves to an exactly-once
 macro is still accepted unconditionally; an invocation that
-resolves to a denylisted macro is still flagged. The matcher
+resolves to a conditional macro is still flagged. The matcher
 walk turns an "unknown" verdict into a justified
-allowlist-or-flag decision rather than overriding the curated
-lists. For a `macro_rules!` macro reached by the walk (its
+exactly-once-vs-conditional decision rather than overriding
+the curated lists. For a `macro_rules!` macro reached by the
+walk (its
 definition visible to the compiler — current crate, or a
 dependency whose macro body rustc still has on hand):
 
@@ -271,7 +279,7 @@ dependency whose macro body rustc still has on hand):
      repetition that could change its evaluation count:
      the argument is evaluated exactly once. Eligible
      (treat the argument's macro as if it were on the
-     allowlist).
+     exactly-once list).
    - Zero occurrences (the capture is matched but discarded):
      the argument is never evaluated. Flag with a "the
      argument is unused in this expansion" diagnostic.
@@ -286,8 +294,8 @@ dependency whose macro body rustc still has on hand):
 
 Matcher analysis does not extend to procedural macros — the
 expansion is custom Rust code, not introspectable from the
-matcher. Proc macros remain governed by the user's allowlist /
-denylist configuration.
+matcher. Proc macros remain governed by the user's exactly-once list /
+conditional list configuration.
 
 Set `mode = "matcher_based"` to enable. Defaults off; this
 mode is the most expensive to implement (see "Why
@@ -302,9 +310,9 @@ recommended landing order.
 
 | Mode | Default | Cost to implement | Flags |
 | --- | --- | --- | --- |
-| 0 — denylist only | opt-in | smallest | known-conditional macros only |
+| 0 — conditional only | opt-in | smallest | known-conditional macros only |
 | 1 — blanket | opt-in | small | every non-trivial macro arg |
-| 2 — allowlist + denylist | **on** | small | denylist always; unknown configurable |
+| 2 — name-based | **on** | small | conditional list always; unknown configurable |
 | 3 — mode 2 + bypass | opt-in | small + recursion | mode 2 minus pure-call shapes |
 | 4 — matcher-based | opt-in | large | mode 2 plus learned `macro_rules!` |
 
@@ -325,24 +333,25 @@ For every macro invocation:
    curly-brace invocations are out of scope.
 2. Resolve the macro `DefId`.
 3. Consult `ignore`. If the path matches, skip. `ignore` wins
-   over both the denylist and the allowlist; it exists for
+   over both the conditional list and the exactly-once list; it exists for
    per-project opt-outs of curated entries.
 4. Apply the configured `mode`:
-   - `denylist_only`: match against the denylist
+   - `conditional_only`: match against the conditional list
      (`debug_assert!`, `debug_assert_eq!`, `debug_assert_ne!`,
-     `cfg!`, plus `extra_denylist`). Continue to step 5 only
-     on a hit.
+     plus `extra_conditional`). Continue to step 5 only on a
+     hit.
    - `blanket`: continue to step 5 for every macro not on the
-     allowlist (`extra_allowlist` only — there is no built-in
-     allowlist in this mode, by design).
-   - `allowlist_denylist` (default): denylist hit → continue.
-     Allowlist hit → skip. Otherwise consult
+     exactly-once list (`extra_exactly_once` only — there is
+     no built-in exactly-once list in this mode, by design).
+   - `name_based` (default): conditional-list hit → continue.
+     Exactly-once-list hit → skip. Otherwise consult
      `unknown_macro_policy`: `allow` (default) → skip,
      `deny` → continue.
-   - `matcher_based`: denylist / allowlist as above; for
-     unknown macros, walk the matcher per mode 4. Result is
-     either "treat as allowlisted" (continue: skip) or
-     "treat as denylisted" (continue: lint).
+   - `matcher_based`: conditional / exactly-once lists as
+     above; for unknown declarative macros, walk the matcher
+     per mode 4. Result is either "treat as exactly-once"
+     (continue: skip) or "treat as conditional" (continue:
+     lint).
 5. Walk the invocation's *top-level* argument list. The lint
    only inspects top-level expressions — an argument that
    itself contains a non-trivial sub-expression is the
@@ -410,16 +419,16 @@ boolean-returning method or function call. Without
 `expression_bypass = true` the lint flags essentially every
 reasonable `debug_assert!` invocation, which is not a
 recommended deployment shape. Projects that adopt the default
-denylist for the `insert`-style bug above almost always want
+conditional list for the `insert`-style bug above almost always want
 the bypass on at the same time; the two knobs are paired in
 typical configurations even though they default to opposite
 positions out of the box.
 
-### Allowlisted macros pass through
+### Exactly-once macros pass through
 
 ```rust
 // Accepted under default config — `format!` is on the
-// curated allowlist; arguments are evaluated exactly once.
+// curated exactly-once list; arguments are evaluated exactly once.
 let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Ordering::Relaxed));
 ```
 
@@ -427,13 +436,13 @@ let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Orde
 
 ```rust
 // Accepted under default config — vec! is on the curated
-// allowlist; each element is evaluated exactly once.
+// exactly-once list; each element is evaluated exactly once.
 let xs = vec![compute(), compute(), compute()];
 ```
 
 ```rust
 // Flagged under blanket mode — every non-trivial argument is
-// a candidate, allowlist or not.
+// a candidate, exactly-once list or not.
 let xs = vec![compute(), compute(), compute()];
 
 // Good (blanket mode rewrite)
@@ -479,7 +488,7 @@ even though the macro is otherwise unknown to the lint.
 ```rust
 // Whether this is safe depends on the proc macro's expansion,
 // which the lint cannot read. The user adds `tracing::info`
-// to `extra_allowlist` once, project-wide.
+// to `extra_exactly_once` once, project-wide.
 tracing::info!(latency = stopwatch.elapsed().as_millis(), "done");
 ```
 
@@ -490,36 +499,36 @@ tracing::info!(latency = stopwatch.elapsed().as_millis(), "done");
 # Set to false to disable the rule entirely.
 enabled = true
 
-# Eligibility mode. Defaults to "allowlist_denylist".
-#   "denylist_only"     — flag only the curated denylist
-#   "blanket"           — flag everything not on extra_allowlist
-#   "allowlist_denylist" — flag denylist hits + unknowns per policy
-#   "matcher_based"     — allowlist_denylist + matcher walking
-mode = "allowlist_denylist"
+# Eligibility mode. Defaults to "name_based".
+#   "conditional_only" — flag only macros in the curated conditional list
+#   "blanket"          — flag everything not on extra_exactly_once
+#   "name_based"       — flag conditional-list hits + unknowns per policy
+#   "matcher_based"    — name_based + matcher walking for unknown declarative macros
+mode = "name_based"
 
-# Behaviour for macros that match neither the denylist nor the
-# allowlist under "allowlist_denylist" mode. `allow` (default)
-# silently skips them; `deny` treats them as denylisted.
+# Behaviour for macros that match neither the conditional list nor the
+# exactly-once list under "name_based" mode. `allow` (default)
+# silently skips them; `deny` treats them as conditional.
 # Ignored under other modes.
 unknown_macro_policy = "allow"
 
 # When true, accept calls and method calls whose arguments are
-# themselves trivial — even on denylisted macros. Default off;
+# themselves trivial — even on conditional macros. Default off;
 # turn on if the lint is too noisy with read-only accessor
 # calls inside `debug_assert*`.
 expression_bypass = false
 
-# Macros added to the built-in denylist. Each entry is a
+# Macros added to the built-in conditional list. Each entry is a
 # fully-qualified macro path (no trailing `!`) or a bare macro
 # name to match by final segment only.
-extra_denylist = [
+extra_conditional = [
   # "my_crate::sometimes_evaluates",
 ]
 
-# Macros added to the built-in allowlist. Same path syntax as
-# extra_denylist. Use for third-party macros the project
+# Macros added to the built-in exactly-once list. Same path syntax as
+# extra_conditional. Use for third-party macros the project
 # trusts to evaluate each argument exactly once.
-extra_allowlist = [
+extra_exactly_once = [
   # "tracing::info",
   # "tracing::debug",
 ]
@@ -546,7 +555,7 @@ ignore = [
 - Macro path resolution: `MacCall::path` resolves to a `Res`;
   use the resolved `DefId` for the name-lookup. Bare-name
   matching falls back to the path's final segment so
-  `extra_allowlist = ["my_macro"]` works without forcing the
+  `extra_exactly_once = ["my_macro"]` works without forcing the
   user to spell out the crate path.
 - Argument splitting: walk `MacCall::args.tokens` tracking
   delimiter nesting and split on top-level commas. Reuse the
@@ -619,12 +628,12 @@ own matcher-based detection.
 
 ## Severity
 
-Warn. The denylist defaults — `debug_assert*` and `cfg!` —
-flag a genuine correctness bug. Promoting the lint to deny
+Warn. The conditional list default — `debug_assert*` —
+flags a genuine correctness bug. Promoting the lint to deny
 crate-wide via
 `#![deny(perfectionist::macro_argument_binding)]` is viable
 but presumes the project has already turned
-`expression_bypass = true` on (or has narrowed the denylist):
+`expression_bypass = true` on (or has narrowed the conditional list):
 under the strict default, every `debug_assert!` invocation
 with a non-trivial argument fires, which is the majority of
 them, and deny would refuse to compile the project.
@@ -644,5 +653,5 @@ them, and deny would refuse to compile the project.
   the *template literal* inside their target macros and
   treat the surrounding macro as a known-safe call. Those
   rules' target macros are all on this rule's default
-  allowlist, so the two never disagree about whether a
+  exactly-once list, so the two never disagree about whether a
   given invocation needs intervention.

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -9,9 +9,12 @@ debug_assert_eq!(my_map.insert(key, value), None, "Something went wrong! `key` w
 In debug builds this works: `insert` runs, returns the previous
 value associated with `key` (or `None` if the key was new), and
 the assertion panics if `key` was already present. In release
-builds `debug_assert_eq!` expands to nothing at all — the
-arguments are *not evaluated* — so `insert` never runs,
-`(key, value)` is silently dropped, and `my_map` ends the
+builds the `debug_assertions` cfg is off, so the conditional
+that `debug_assert_eq!` expands to — roughly
+`if cfg!(debug_assertions) { ... }` — folds to `if false { ... }`
+and the body is dead-code-eliminated. The key property is that
+the argument expressions are *not evaluated*: `insert` never
+runs, `(key, value)` is silently dropped, and `my_map` ends the
 function in a different state from the one the author intended.
 The bug only shows up when the binary is finally built with
 `--release` and behaves differently from every test run.
@@ -397,15 +400,21 @@ For every macro invocation:
      or "treat as denylisted" (continue: lint). Unknown proc
      macros are not walkable and fall through to
      `unknown_macro_policy`.
-5. Walk the invocation's *top-level* argument list. The lint
-   only inspects top-level expressions — an argument that
-   itself contains a non-trivial sub-expression is the
-   author's choice, and recursing into nested macros opens
-   the door to false positives. Top-level argument boundaries
-   are recovered from the invocation token stream the same
-   way [`macro-trailing-comma`](./macro-trailing-comma.md)
-   does it (track delimiter nesting; split on top-level
-   commas; skip top-level `;` and `=>`).
+5. Walk the invocation's *top-level* argument list, using
+   the same token-stream handling as
+   [`macro-trailing-comma`](./macro-trailing-comma.md):
+   track delimiter nesting and split on top-level commas. A
+   top-level `;` is a skip-the-whole-invocation trigger
+   (the macro uses `;` as its separator — `vec![v; count]`,
+   `thread_local! { ... }` — so it doesn't fit this rule's
+   "comma-separated argument list" shape). A top-level `=>`
+   is allowed and walked through as ordinary content
+   (`hashmap! { "a" => 1, "b" => 2 }` legitimately carries
+   one per entry). The lint only inspects top-level
+   expressions — an argument that itself contains a
+   non-trivial sub-expression is the author's choice, and
+   recursing into nested macros opens the door to false
+   positives.
 6. For each top-level argument, parse the token stream as an
    expression. Skip arguments that don't parse as a single
    expression (a `name: type` argument shape, a path-only

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -37,10 +37,12 @@ The `debug_assert*` case is an objective defect — the program's
 runtime behaviour differs between debug and release builds in a
 way the author did not intend, and the difference is invisible at
 the call site. A duplicate insertion silently succeeds in
-release; a "should never happen" `?` operator silently returns
-`Ok(_)` early in debug-stripped code; an iterator's `.next()`
-quietly advances in one build configuration but not another.
-None of these are stylistic preferences — they're bugs.
+release; a `?` operator that would have short-circuited an
+error in debug never runs in release, so the function proceeds
+past the assert as if the call had returned `Ok`; an iterator's
+`.next()` quietly advances in one build configuration but not
+another. None of these are stylistic preferences — they're
+bugs.
 
 The general form ("any function-like or array-like macro may
 evaluate an argument zero or many times") is partly a correctness
@@ -72,14 +74,18 @@ macro invocation:
 
 - If the macro is on the **denylist** of macros known to evaluate
   arguments conditionally or repeatedly, every non-trivial
-  top-level argument must be a path expression (a `let` binding,
-  a constant, or a function/method-less reference). A non-trivial
-  argument that is not bound to a name is flagged.
+  top-level argument is flagged. The set of accepted argument
+  shapes is the trivial set defined under
+  "What counts as a 'non-trivial' argument" below — literals,
+  paths, `&path`, `path.field`, `*path`, and casts.
 - If the macro is on the **allowlist** of macros known to
   evaluate each top-level argument exactly once, the argument
   shape is unconstrained.
-- For every other macro, behaviour depends on the configured
-  *unknown-macro policy* (see "Five eligibility modes" below).
+- For every other macro, behaviour depends on the selected
+  mode — see "Five eligibility modes" below. Briefly:
+  `denylist_only` and `matcher_based` (for proc macros) skip
+  the invocation, `blanket` flags it, and `allowlist_denylist`
+  consults the configured `unknown_macro_policy`.
 
 Curly-brace macro invocations (`name! { ... }`) are out of scope.
 They are conventionally DSL bodies where the evaluation contract
@@ -218,10 +224,13 @@ call whose own arguments are themselves trivial. The canonical
 example is `Arc::clone(&x)`: a `Call` whose sole argument
 `&x` is a reference to a path, both of which are trivial.
 
-The bypass widens the trivial-expression definition: a
-function or method call is acceptable when every one of its
-arguments is itself trivial. The recursion stops at any
-non-trivial sub-expression.
+The bypass does not change the trivial / non-trivial split —
+that classification stays as defined above. Instead, the
+bypass adds an additional *accept rule* layered on top: even
+a non-trivial argument is accepted if its outermost shape is
+a function or method call whose own sub-expressions are all
+trivial. The bypass's recursion stops at any non-trivial
+sub-expression.
 
 The motivation is that `debug_assert_eq!(my_set.contains(&k),
 true)` is *also* unsafe-feeling but ultimately fine — the


### PR DESCRIPTION
Adds a planning file for a new lint, `perfectionist::macro_argument_binding`, that flags expressions passed directly into function-like and array-like macros where evaluation count is not guaranteed.

## The footgun

```rust
debug_assert_eq!(my_map.insert(key, value), None, "duplicate key");
```

In release builds `debug_assert_eq!` expands to nothing — the arguments are *never evaluated*. `insert` doesn't run, `(key, value)` is silently dropped, and the binary behaves differently from every test run. The fix is to bind the call to a `let` first.

## Five eligibility modes

Laid out from least to most implementation effort:

1. **Denylist-only** (`mode = "denylist_only"`) — hard-coded `debug_assert*` only. Ships first, no config audit required.
2. **Blanket ban** (`mode = "blanket"`) — every non-trivial macro arg, opt-in.
3. **Allowlist + denylist** (`mode = "allowlist_denylist"`, default) — curated safe list (`format!`, `vec!`, …) + denylist; unknowns configurable via `unknown_macro_policy`.
4. **Expression-side bypass** (`expression_bypass = true`, opt-in flag layered on any mode) — accept `Arc::clone(&x)` / `buffer.is_empty()`-shaped calls whose own sub-expressions are trivial.
5. **Matcher-based** (`mode = "matcher_based"`) — for unknown `macro_rules!`, count each `$expr` capture's occurrences in the matched arm's RHS. Reuses the matcher-walker infrastructure planned for `macro-trailing-comma`.

A trivial/non-trivial syntactic split (literals, paths, `&path`, `path.field`, `base[index]`, `*path`, casts) lets even denylisted macros accept harmless arguments inline.

Curly-brace invocations are out of scope: they're conventionally DSL bodies, not argument lists. Classification is by call-site delimiter, not macro definition, since `macro_rules!` doesn't fix its call shape.

## Files

- `planned-rules/macro-argument-binding.md` — the rule.
- `planned-rules/README.md` — index entry under "Macros".