### PR TITLE
feat(pages): deemphasize the shared prefix in rule name

### DIFF
--- a/tools/gen-docs/src/extract.rs
+++ b/tools/gen-docs/src/extract.rs
@@ -21,7 +21,7 @@ use syn::{
 
 use crate::extract::config::extract_config;
 use crate::extract::serde_attrs::doc_attrs_to_markdown;
-use crate::model::{Level, Rule};
+use crate::model::{Level, NAMESPACE, Rule};
 
 pub(crate) fn collect_rules(rules_dir: &Path) -> Vec<Rule> {
     let entries = fs::read_dir(rules_dir).expect("failed to read src/rules/");
@@ -109,7 +109,7 @@ fn extract_rules(source_path: &Path) -> Vec<Rule> {
                     )
                 });
             let namespaced = format!(
-                "perfectionist::{}",
+                "{NAMESPACE}{}",
                 declaration.name.to_string().to_ascii_lowercase()
             );
             let doc_markdown = doc_attrs_to_markdown(&declaration.attrs);

--- a/tools/gen-docs/src/model.rs
+++ b/tools/gen-docs/src/model.rs
@@ -6,6 +6,13 @@ use std::path::PathBuf;
 
 use strum::{Display, EnumString};
 
+/// The tool namespace every `perfectionist` lint registers under,
+/// including the trailing `::`. Shared between the extractor (which
+/// prepends it to build `Rule::namespaced`) and the renderer (which
+/// strips it for the index column and re-emits it as a separately
+/// styled span in each rule's heading).
+pub(crate) const NAMESPACE: &str = "perfectionist::";
+
 /// Page-global context threaded through the renderer. Grouping
 /// these here keeps the per-article and per-field rendering
 /// signatures from collecting more positional string args every

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -9,7 +9,7 @@ pub(crate) mod markdown;
 
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 
-use crate::model::{Level, RenderContext, Rule};
+use crate::model::{Level, NAMESPACE, RenderContext, Rule};
 use crate::render::config::config_section;
 use crate::render::markdown::{HIGHLIGHT_CSS, markdown_inline_to_html, markdown_to_html};
 
@@ -47,7 +47,7 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
                     "perfectionist is a Dylint plugin; see the "
                     a href=(repo_url) { "README" }
                     " for setup. Lint-control attributes use the "
-                    code { "perfectionist::" } " namespace."
+                    code { (NAMESPACE) } " namespace."
                 }
                 h2 { "Index" }
                 table.index {
@@ -106,7 +106,7 @@ fn rule_article(rule: &Rule, context: &RenderContext<'_>) -> Markup {
         article.rule id=(anchor_for(&rule.namespaced)) {
             h2 {
                 code {
-                    span.lint-prefix { "perfectionist::" }
+                    span.lint-prefix { (NAMESPACE) }
                     span.lint-name { (unnamespaced(&rule.namespaced)) }
                 }
             }
@@ -138,7 +138,5 @@ fn anchor_for(namespaced: &str) -> String {
 }
 
 fn unnamespaced(namespaced: &str) -> &str {
-    namespaced
-        .strip_prefix("perfectionist::")
-        .unwrap_or(namespaced)
+    namespaced.strip_prefix(NAMESPACE).unwrap_or(namespaced)
 }

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -63,7 +63,7 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
                             tr {
                                 td {
                                     a href={ "#" (anchor_for(&rule.namespaced)) } {
-                                        code { (rule.namespaced) }
+                                        code { (unnamespaced(&rule.namespaced)) }
                                     }
                                 }
                                 td { (level_badge(rule.level)) }
@@ -104,7 +104,12 @@ fn rule_article(rule: &Rule, context: &RenderContext<'_>) -> Markup {
     let source_url = format!("{repo_url}/blob/{git_ref}/{source_path}");
     html! {
         article.rule id=(anchor_for(&rule.namespaced)) {
-            h2 { code { (rule.namespaced) } }
+            h2 {
+                code {
+                    span.lint-prefix { "perfectionist::" }
+                    span.lint-name { (unnamespaced(&rule.namespaced)) }
+                }
+            }
             p {
                 (level_badge(rule.level))
                 (PreEscaped(markdown_inline_to_html(&rule.short_desc)))
@@ -130,4 +135,10 @@ fn level_badge(level: Level) -> Markup {
 
 fn anchor_for(namespaced: &str) -> String {
     namespaced.replace("::", "-")
+}
+
+fn unnamespaced(namespaced: &str) -> &str {
+    namespaced
+        .strip_prefix("perfectionist::")
+        .unwrap_or(namespaced)
 }

--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -73,12 +73,12 @@ article.rule h2 {
 }
 
 article.rule h2 .lint-prefix {
-  font-size: 0.75em;
+  font-size: 0.89em;
   color: #57606a;
 }
 
 article.rule h2 .lint-name {
-  font-size: 1.1em;
+  font-size: 1.11em;
 }
 
 article.rule .source {

--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -72,6 +72,15 @@ article.rule h2 {
   font-family: ui-monospace, SFMono-Regular, monospace;
 }
 
+article.rule h2 .lint-prefix {
+  font-size: 0.75em;
+  color: #57606a;
+}
+
+article.rule h2 .lint-name {
+  font-size: 1.1em;
+}
+
 article.rule .source {
   font-size: 0.85rem;
   color: #57606a;


### PR DESCRIPTION
## Summary

In `gh-pages/index.html`, every lint name was prefixed with `perfectionist::`. Since the prefix is uniform across every row, it carries no per-row information.

- **Index table**: drop the `perfectionist::` prefix from the "Lint" column entirely. Anchor targets are unchanged.
- **Per-rule `<h2>` headings**: keep the prefix for context, but render it smaller and dimmer (`0.89em`, muted grey) than the rule name (`1.11em`).
- **Refactor**: pull the `"perfectionist::"` literal into a single `model::NAMESPACE` constant shared by the extractor and the renderer.

Both the index table and the article headings are rendered by `maud` in `tools/gen-docs/src/render.rs` — only the rule body markdown goes through `pulldown_cmark`, so these changes don't touch the markdown pipeline.

## Test plan

- [ ] Run `just gen-docs` and open `gh-pages/index.html`.
- [ ] Index "Lint" column shows bare names (e.g. `arc_rc_clone`), and the in-page links still jump to the right anchors.
- [ ] Each rule's `<h2>` shows `perfectionist::` smaller/dimmer next to a larger rule name.
- [ ] The preamble paragraph still mentions `perfectionist::` at full size (unchanged).