### PR TITLE
chore(task): default `gen-docs` git ref to current HEAD

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,5 +41,5 @@ warmup-integration-tests:
   time cargo run --package _utils --bin warmup -- "$(pwd)"
 
 # Render the rule catalogue to `gh-pages/index.html`
-gen-docs out_dir="gh-pages" git_ref="master":
+gen-docs out_dir="gh-pages" git_ref=`git rev-parse HEAD`:
   cargo run --package _gen_docs --bin gen-docs -- "$(pwd)" "{{out_dir}}" --git-ref="{{git_ref}}"


### PR DESCRIPTION
`master` as a default is stale by the time anyone clicks a "Source:" link from the generated docs. Use the current HEAD commit instead so the links pin to the tree that produced them.