### PR TITLE
feat(pages): permalinks to source files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,9 @@ version = "0.0.0"
 dependencies = [
  "cargo_toml",
  "clap",
+ "command-extra",
  "maud",
+ "pipe-trait",
  "proc-macro2",
  "pulldown-cmark",
  "quote",

--- a/tools/gen-docs/Cargo.toml
+++ b/tools/gen-docs/Cargo.toml
@@ -12,7 +12,9 @@ path = "src/main.rs"
 [dependencies]
 cargo_toml = "0.22.3"
 clap = { version = "4.6.1", features = ["derive"] }
+command-extra = "1.0.0"
 maud = "0.27.0"
+pipe-trait = "0.4.0"
 proc-macro2 = "1.0.95"
 pulldown-cmark = { version = "0.13.0", default-features = false, features = ["html"] }
 quote = "1.0.40"

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -18,8 +18,8 @@ mod model;
 mod render;
 
 use std::fs;
-use std::path::PathBuf;
-use std::process::ExitCode;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
 
 use cargo_toml::{Inheritable, Manifest};
 use clap::Parser;
@@ -41,9 +41,33 @@ struct Cli {
         long,
         default_value = "master",
         value_parser = clap::builder::NonEmptyStringValueParser::new(),
-        help = r#"Git ref the rendered "Source:" links should target"#,
+        help = r#"Git ref the rendered "Source:" links should target; resolved to a commit SHA via `git rev-parse` so the links are permalinks"#,
     )]
     git_ref: String,
+}
+
+fn resolve_git_ref(root: &Path, git_ref: &str) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .arg("rev-parse")
+        .arg("--verify")
+        .arg(format!("{git_ref}^{{commit}}"))
+        .output()
+        .expect("failed to invoke `git rev-parse`");
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!("`git rev-parse {git_ref}` failed: {}", stderr.trim());
+    }
+    let sha = String::from_utf8(output.stdout)
+        .expect("`git rev-parse` produced non-UTF-8 output")
+        .trim()
+        .to_owned();
+    assert!(
+        !sha.is_empty(),
+        "`git rev-parse {git_ref}` produced empty output",
+    );
+    sha
 }
 
 fn main() -> ExitCode {
@@ -52,6 +76,11 @@ fn main() -> ExitCode {
         out_dir,
         git_ref,
     } = Cli::parse();
+
+    // Resolve the user-supplied ref (typically a branch like `master`)
+    // to a commit SHA so the rendered "Source:" links are permalinks
+    // that survive future commits to the branch.
+    let git_ref = resolve_git_ref(&root, &git_ref);
 
     let manifest = Manifest::from_path(root.join("Cargo.toml")).expect("failed to read Cargo.toml");
     let crate_version = manifest

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -23,6 +23,8 @@ use std::process::{Command, ExitCode};
 
 use cargo_toml::{Inheritable, Manifest};
 use clap::Parser;
+use command_extra::CommandExtra;
+use pipe_trait::Pipe;
 
 use crate::extract::collect_rules;
 use crate::model::RenderContext;
@@ -47,19 +49,21 @@ struct Cli {
 }
 
 fn resolve_git_ref(root: &Path, git_ref: &str) -> String {
-    let output = Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .arg("rev-parse")
-        .arg("--verify")
-        .arg(format!("{git_ref}^{{commit}}"))
+    let output = "git"
+        .pipe(Command::new)
+        .with_current_dir(root)
+        .with_arg("rev-parse")
+        .with_arg("--verify")
+        .with_arg(format!("{git_ref}^{{commit}}"))
         .output()
         .expect("failed to invoke `git rev-parse`");
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         panic!("`git rev-parse {git_ref}` failed: {}", stderr.trim());
     }
-    let sha = String::from_utf8(output.stdout)
+    let sha = output
+        .stdout
+        .pipe(String::from_utf8)
         .expect("`git rev-parse` produced non-UTF-8 output")
         .trim()
         .to_owned();

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -83,8 +83,10 @@ fn main() -> ExitCode {
 
     // Resolve the user-supplied ref (typically a branch like `master`)
     // to a commit SHA so the rendered "Source:" links are permalinks
-    // that survive future commits to the branch.
-    let git_ref = resolve_git_ref(&root, &git_ref);
+    // that survive future commits to the branch. The original ref is
+    // kept for the page title and banner, which want to read as
+    // "Showing docs for `master`" rather than a bare SHA.
+    let commit_sha = resolve_git_ref(&root, &git_ref);
 
     let manifest = Manifest::from_path(root.join("Cargo.toml")).expect("failed to read Cargo.toml");
     let crate_version = manifest
@@ -119,6 +121,7 @@ fn main() -> ExitCode {
     let context = RenderContext {
         crate_version: &crate_version,
         git_ref: &git_ref,
+        commit_sha: &commit_sha,
         repo_url: &repo_url,
     };
     let html = render_page(&rules, &context);

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -49,17 +49,22 @@ struct Cli {
 }
 
 fn resolve_git_ref(root: &Path, git_ref: &str) -> String {
+    let revision = format!("{git_ref}^{{commit}}");
     let output = "git"
         .pipe(Command::new)
         .with_current_dir(root)
         .with_arg("rev-parse")
         .with_arg("--verify")
-        .with_arg(format!("{git_ref}^{{commit}}"))
+        .with_arg(&revision)
         .output()
         .expect("failed to invoke `git rev-parse`");
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        panic!("`git rev-parse {git_ref}` failed: {}", stderr.trim());
+        panic!(
+            "`git rev-parse --verify {revision}` failed ({}): {}",
+            output.status,
+            stderr.trim(),
+        );
     }
     output
         .stdout

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -61,17 +61,12 @@ fn resolve_git_ref(root: &Path, git_ref: &str) -> String {
         let stderr = String::from_utf8_lossy(&output.stderr);
         panic!("`git rev-parse {git_ref}` failed: {}", stderr.trim());
     }
-    let sha = output
+    output
         .stdout
         .pipe(String::from_utf8)
         .expect("`git rev-parse` produced non-UTF-8 output")
         .trim()
-        .to_owned();
-    assert!(
-        !sha.is_empty(),
-        "`git rev-parse {git_ref}` produced empty output",
-    );
-    sha
+        .to_owned()
 }
 
 fn main() -> ExitCode {

--- a/tools/gen-docs/src/model.rs
+++ b/tools/gen-docs/src/model.rs
@@ -20,8 +20,18 @@ pub(crate) const NAMESPACE: &str = "perfectionist::";
 pub(crate) struct RenderContext<'a> {
     /// Latest released version of the crate, read from `Cargo.toml`.
     pub(crate) crate_version: &'a str,
-    /// Git ref the rendered "Source:" links target.
+    /// Human-facing git ref (typically a branch like `master`, a
+    /// tag, or whatever the user passed via `--git-ref`). Used in
+    /// the page title and banner so a reader can tell *which*
+    /// branch they're looking at — those strings would be useless
+    /// if they read "Showing docs for `60c4549b...`".
     pub(crate) git_ref: &'a str,
+    /// Commit SHA `git_ref` resolved to. Used for the per-rule
+    /// "Source:" blob URLs (which must be permalinks so they don't
+    /// rot when the branch advances) and for the footer's
+    /// generated-from line, where the exact commit is the useful
+    /// piece of information.
+    pub(crate) commit_sha: &'a str,
     /// Project repository URL, used for the README link in the
     /// banner and as the base for the per-rule blob URLs.
     pub(crate) repo_url: &'a str,

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -19,6 +19,7 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
     let RenderContext {
         crate_version,
         git_ref,
+        commit_sha,
         repo_url,
     } = *context;
     let markup: Markup = html! {
@@ -80,7 +81,7 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
                 }
                 footer {
                     "Generated from " code { "src/rules/" }
-                    " at " code { (git_ref) } "."
+                    " at " code { (commit_sha) } "."
                 }
             }
         }
@@ -90,7 +91,9 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
 
 fn rule_article(rule: &Rule, context: &RenderContext<'_>) -> Markup {
     let RenderContext {
-        git_ref, repo_url, ..
+        commit_sha,
+        repo_url,
+        ..
     } = *context;
     // Build the URL-friendly path by joining components with `/`
     // instead of `Path::display`, which uses the host's native
@@ -101,7 +104,7 @@ fn rule_article(rule: &Rule, context: &RenderContext<'_>) -> Markup {
         .map(|component| component.as_os_str().to_string_lossy().into_owned())
         .collect::<Vec<_>>()
         .join("/");
-    let source_url = format!("{repo_url}/blob/{git_ref}/{source_path}");
+    let source_url = format!("{repo_url}/blob/{commit_sha}/{source_path}");
     html! {
         article.rule id=(anchor_for(&rule.namespaced)) {
             h2 {


### PR DESCRIPTION
The per-rule `Source:` links on the GitHub Pages site previously embedded `--git-ref` (typically `master`) verbatim, so they rotted as soon as new commits landed.

`gen-docs` now runs `git rev-parse --verify <ref>^{commit}` against the supplied ref, and `RenderContext` carries two related fields:

- `git_ref` — the user-supplied ref, used in the page title and banner so "Showing docs for `master`" still reads naturally.
- `commit_sha` — the resolved hash, used for per-rule blob URLs (now permalinks) and the footer's "Generated from `src/rules/` at &lt;sha&gt;" line.

The command is assembled with the `pipe-trait` + `command-extra` style already established in `utils/src/dylint.rs`. No workflow change required — `.github/workflows/pages.yaml` still passes `master` as the ref; resolution happens inside `gen-docs`.