### PR TITLE
feat: `macro_argument_binding` (simple)

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,6 +40,18 @@ self-lint:
 warmup-integration-tests:
   time cargo run --package _utils --bin warmup -- "$(pwd)"
 
-# Render the rule catalogue to `gh-pages/index.html`
-gen-docs out_dir="gh-pages" git_ref=`git branch --show-current`:
-  cargo run --package _gen_docs --bin gen-docs -- "$(pwd)" "{{out_dir}}" --git-ref="{{git_ref}}"
+# Render the rule catalogue to `gh-pages/index.html`.
+# `git_ref` defaults to the current branch name, falling back to the
+# commit SHA when checked out detached (e.g., the `actions/checkout`
+# default in CI). gen-docs requires a non-empty value.
+gen-docs out_dir="gh-pages" git_ref="":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  ref="{{git_ref}}"
+  if [ -z "$ref" ]; then
+    ref="$(git branch --show-current)"
+  fi
+  if [ -z "$ref" ]; then
+    ref="$(git rev-parse HEAD)"
+  fi
+  cargo run --package _gen_docs --bin gen-docs -- "$(pwd)" "{{out_dir}}" --git-ref="$ref"

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -27,6 +27,16 @@ Still pending:
   These should be trivial per the spec's intent ("a path resolving to
   a function name, or unit / tuple variant"); extend `take_path_tail`
   to consume an optional `::<...>` token-tree per segment.
+- **Keyword idents as path starts.** The trivial-atom matcher's
+  `Ident(_, _)` branch dispatches to the path walker regardless of
+  whether the ident is a valid path-start keyword (`self`, `Self`,
+  `super`, `crate`, the empty set otherwise). Reserved keywords like
+  `let`, `if`, `match`, `for`, `while` are accepted as path heads
+  and the resulting "trivial path" leaves an unexpected tail in the
+  suffix walk, which still bottoms out as non-trivial — so the lint
+  classification is correct by coincidence. Tighten `take_trivial_atom`
+  to reject reserved-keyword idents so the right door owns the
+  decision.
 
 The "What to lint" pipeline below applies to the implemented
 modes as written. The remainder of this file is the active spec

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -1,5 +1,30 @@
 # `macro_argument_binding`
 
+## Status
+
+Partially implemented. Modes 0-2 (`deny_only`, `blanket`,
+`allow_and_deny`) ship today, along with the `enabled`,
+`deny_extra`, `allow_extra`, and `ignore` knobs. The lint emits
+diagnostics with a `let`-binding hint (no autofix, by design — the
+binding name varies per site).
+
+Still pending:
+
+- **Mode 3 (`matcher_based`).** The mode value is not accepted by
+  the configuration parser yet; a `dylint.toml` that names it
+  fails to deserialise. The matcher-walking infrastructure is
+  shared with the equivalent eligibility check planned for
+  `macro-trailing-comma`; both will land together.
+- **Cast suffix beyond path-shaped types.** The trivial-expression
+  predicate currently recognises `expr as Path` (e.g., `x as u64`,
+  `x as my::Type`) but treats `expr as &Path`, `expr as *const T`,
+  and other non-path type forms as non-trivial. Expanding the
+  type recogniser is a small, additive change.
+
+The "What to lint" pipeline below applies to the implemented
+modes as written. The remainder of this file is the active spec
+for the unimplemented portion.
+
 **Source:** project convention. The motivating bug:
 
 ```rust

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -20,6 +20,13 @@ Still pending:
   `x as my::Type`) but treats `expr as &Path`, `expr as *const T`,
   and other non-path type forms as non-trivial. Expanding the
   type recogniser is a small, additive change.
+- **Turbofish in path arguments.** A path with explicit generics
+  (`Vec::<u32>::new`, `Some::<u32>`) is parsed as `path-segment` plus
+  `::<...>` plus more segments; the current path walker only consumes
+  `::ident` runs and so falls through to non-trivial on the turbofish.
+  These should be trivial per the spec's intent ("a path resolving to
+  a function name, or unit / tuple variant"); extend `take_path_tail`
+  to consume an optional `::<...>` token-tree per segment.
 
 The "What to lint" pipeline below applies to the implemented
 modes as written. The remainder of this file is the active spec

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use rustc_session::Session;
 
 dylint_linting::dylint_library!();
 
+mod macro_path;
 mod rules;
 
 #[unsafe(no_mangle)]
@@ -32,6 +33,7 @@ pub fn register_lints(session: &Session, lint_store: &mut LintStore) {
         arc_rc_clone
         derive_ordering
         flat_module_pattern
+        macro_argument_binding
         macro_trailing_comma
         non_exhaustive_error
         prefer_raw_string

--- a/src/macro_path.rs
+++ b/src/macro_path.rs
@@ -44,16 +44,16 @@ pub fn entry_matches(entry: &[String], invocation: &rustc_ast::Path) -> bool {
         return false;
     }
     if entry.len() == 1 {
-        segments
+        return segments
             .last()
-            .is_some_and(|segment| segment.ident.name.as_str() == entry[0])
-    } else if segments.len() < entry.len() {
-        false
-    } else {
-        let start = segments.len() - entry.len();
-        segments[start..]
-            .iter()
-            .zip(entry.iter())
-            .all(|(segment, entry_segment)| segment.ident.name.as_str() == entry_segment.as_str())
+            .is_some_and(|segment| segment.ident.name.as_str() == entry[0]);
     }
+    if segments.len() < entry.len() {
+        return false;
+    }
+    let start = segments.len() - entry.len();
+    segments[start..]
+        .iter()
+        .zip(entry.iter())
+        .all(|(segment, entry_segment)| segment.ident.name.as_str() == entry_segment.as_str())
 }

--- a/src/macro_path.rs
+++ b/src/macro_path.rs
@@ -1,0 +1,59 @@
+//! Shared helpers for matching macro-invocation paths against configured
+//! name lists. Used by every rule that classifies an `ast::MacCall`
+//! against a curated name set; see the rules in `src/rules/` that work
+//! with `EarlyLintPass::check_mac`.
+//!
+//! Match semantics:
+//!
+//! - A single-segment entry matches by the invocation path's final
+//!   segment, so `vec!`, `std::vec!`, and `::std::vec!` all match the
+//!   `"vec"` entry.
+//! - A multi-segment entry tail-matches the invocation path's segment
+//!   sequence, so the entry `"inner::their_macro"` matches both
+//!   `inner::their_macro!(...)` and `outer::inner::their_macro!(...)`.
+//! - Per-segment whitespace is trimmed and empty segments are dropped,
+//!   so `"  std::vec  "` is equivalent to `"std::vec"`.
+
+use std::collections::BTreeSet;
+
+/// Split a configured `"a::b::c"`-style path into its segments. Trims
+/// per-segment whitespace and drops empty segments — `"  std::vec  "`
+/// becomes `["std", "vec"]`. An empty or all-empty input returns an
+/// empty vector; callers should treat that as "no matchable path" and
+/// skip the entry.
+pub fn parse_path(raw: &str) -> Vec<String> {
+    raw.split("::")
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Returns `true` if any entry in `entries` matches the invocation path.
+pub fn matches_any(invocation: &rustc_ast::Path, entries: &BTreeSet<Vec<String>>) -> bool {
+    entries.iter().any(|entry| entry_matches(entry, invocation))
+}
+
+/// Match a configured entry against an invocation path without
+/// allocating a `Vec<String>` snapshot of the invocation. Single-segment
+/// entries match the path's final segment; multi-segment entries
+/// tail-match the path's segment sequence.
+pub fn entry_matches(entry: &[String], invocation: &rustc_ast::Path) -> bool {
+    let segments = &invocation.segments;
+    if entry.is_empty() || segments.is_empty() {
+        return false;
+    }
+    if entry.len() == 1 {
+        segments
+            .last()
+            .is_some_and(|segment| segment.ident.name.as_str() == entry[0])
+    } else if segments.len() < entry.len() {
+        false
+    } else {
+        let start = segments.len() - entry.len();
+        segments[start..]
+            .iter()
+            .zip(entry.iter())
+            .all(|(segment, entry_segment)| segment.ident.name.as_str() == entry_segment.as_str())
+    }
+}

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,6 +1,7 @@
 pub mod arc_rc_clone;
 pub mod derive_ordering;
 pub mod flat_module_pattern;
+pub mod macro_argument_binding;
 pub mod macro_trailing_comma;
 pub mod non_exhaustive_error;
 pub mod prefer_raw_string;

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -267,6 +267,9 @@ fn check_argument(argument: &[TokenTree]) {
     if argument.is_empty() {
         return;
     }
+    if !looks_like_expression(argument) {
+        return;
+    }
     if is_trivial_expression(argument) {
         return;
     }
@@ -274,6 +277,27 @@ fn check_argument(argument: &[TokenTree]) {
     let last = argument.last().expect("non-empty checked above");
     let span = first.span().to(last.span());
     queue(span);
+}
+
+/// Heuristic: does the argument plausibly parse as a single Rust
+/// expression? The rule docs say "skip arguments that don't parse as a
+/// single expression (`name: type`, `name = value`, etc. are syntactic
+/// positions the macro author chose)" and prescribe a `Parser::parse_expr`
+/// re-parse to make that call. We approximate without `rustc_parse` to
+/// avoid emitting parser-recovery diagnostics for arbitrary macro
+/// inputs: a top-level `=>` token is a match-arm separator (`matches!`,
+/// `impl_lint_pass!`-style `Type => [LINT_NAMES]` DSLs) and is never
+/// part of a single Rust expression. Other non-expression markers like
+/// `name: type` and `name = value` are not reliably distinguishable
+/// from valid expression syntax (`expr: type` ascription, assignment),
+/// and a future re-parse-based implementation will subsume this check.
+fn looks_like_expression(argument: &[TokenTree]) -> bool {
+    !argument.iter().any(|tree| {
+        matches!(
+            tree,
+            TokenTree::Token(token, _) if token.kind == TokenKind::FatArrow,
+        )
+    })
 }
 
 fn queue(span: Span) {

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -1,18 +1,40 @@
-use std::collections::BTreeSet;
+//! `perfectionist::macro_argument_binding` — flag non-trivial top-level
+//! arguments to function-like (`name!(...)`) and array-like (`name![...]`)
+//! macro invocations.
+//!
+//! Module layout:
+//!
+//! - [`config`] — user-facing configuration (`Mode`, `Config`,
+//!   `MacroArgumentBinding` state) and the curated built-in deny /
+//!   allow lists.
+//! - [`triviality`] — top-level argument splitter, the
+//!   `looks_like_expression` heuristic, and the trivial-expression
+//!   token-stream walker.
+//! - [`late`] — late pass that drains [`PENDING_VIOLATIONS`] and emits
+//!   each diagnostic at the deepest enclosing HIR node.
+//!
+//! The pre-expansion pass below threads the three together: split
+//! arguments, skip non-expression arguments, classify expressions,
+//! park violation spans for the late pass to emit.
+
 use std::sync::Mutex;
 
-use crate::macro_path::{matches_any, parse_path};
-use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_ast::MacCall;
-use rustc_ast::token::{Delimiter, IdentIsRaw, TokenKind};
-use rustc_ast::tokenstream::{TokenStream, TokenTree};
-use rustc_hir as hir;
-use rustc_hir::intravisit::{self, Visitor};
-use rustc_lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintStore};
-use rustc_middle::hir::nested_filter;
-use rustc_middle::ty::TyCtxt;
+use rustc_ast::token::Delimiter;
+use rustc_ast::tokenstream::TokenTree;
+use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::{Span, kw};
+use rustc_span::Span;
+
+use crate::macro_path::matches_any;
+
+mod config;
+mod late;
+mod triviality;
+
+use config::MacroArgumentBinding;
+use late::MacroArgumentBindingLate;
+use triviality::{is_trivial_expression, looks_like_expression, split_top_level_arguments};
 
 declare_tool_lint! {
     /// ### What it does
@@ -64,161 +86,6 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-const CONFIG_KEY: &str = "perfectionist::macro_argument_binding";
-
-/// Macros whose argument list is checked unconditionally because the
-/// expansion is known to evaluate captures conditionally on a `cfg`
-/// (`debug_assert*`) or to drop them entirely in release builds.
-const BUILTIN_DENY: &[&str] = &["debug_assert", "debug_assert_eq", "debug_assert_ne"];
-
-/// Macros known to evaluate every top-level argument exactly once. The
-/// list mirrors the curated set in `macro_trailing_comma`, with the
-/// conditional-evaluation families (`log::*`, `tracing::*`) removed
-/// because those *do* drop arguments below the configured filter level.
-const BUILTIN_ALLOW: &[&str] = &[
-    "format",
-    "format_args",
-    "print",
-    "println",
-    "eprint",
-    "eprintln",
-    "write",
-    "writeln",
-    "vec",
-    "panic",
-    "unimplemented",
-    "todo",
-    "unreachable",
-    "assert",
-    "assert_eq",
-    "assert_ne",
-    "matches",
-    "dbg",
-    "anyhow",
-];
-
-/// Eligibility mode. The default is `AllowAndDeny`. The matcher-based
-/// mode described in `planned-rules/macro-argument-binding.md` is not
-/// yet implemented and is therefore not exposed as a value here; a
-/// `dylint.toml` that names it will fail to deserialise with a
-/// useful error.
-#[derive(Debug, Clone, Copy, Default, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum Mode {
-    /// Flag only invocations of the curated deny list (`debug_assert*`
-    /// plus `deny_extra`). Every other macro is silently accepted.
-    DenyOnly,
-    /// Flag every function-like or array-like invocation that carries
-    /// a non-trivial top-level argument, regardless of any built-in
-    /// classification — unless the invocation matches an `allow_extra`
-    /// entry. The built-in allow list is deliberately ignored in this
-    /// mode; project exceptions go in `allow_extra`.
-    Blanket,
-    /// Curated deny list plus curated allow list, both extensible via
-    /// `deny_extra` / `allow_extra`. Macros on neither list are
-    /// flagged — flagging unrecognised macros is deliberate so the
-    /// rule remains useful in projects that depend on uncatalogued
-    /// proc macros.
-    #[default]
-    AllowAndDeny,
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
-struct Config {
-    /// Master on/off switch for the rule. Defaults to `true`. Set
-    /// to `false` to silence every diagnostic this lint would emit
-    /// without having to enumerate every macro under `ignore`.
-    enabled: bool,
-    /// Eligibility mode. See [`Mode`].
-    mode: Mode,
-    /// Macros added to the built-in deny list. Each entry is a
-    /// fully-qualified macro path (no trailing `!`) or a bare macro
-    /// name to match by final segment only.
-    deny_extra: Vec<String>,
-    /// Macros added to the built-in allow list. Same matching rules
-    /// as `deny_extra`. Only meaningful in `AllowAndDeny` and
-    /// `Blanket` modes; in `DenyOnly` the allow list is unused.
-    allow_extra: Vec<String>,
-    /// Macros to skip entirely, regardless of which list they would
-    /// otherwise hit. Same matching rules as `deny_extra`.
-    ignore: Vec<String>,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            mode: Mode::default(),
-            deny_extra: Vec::new(),
-            allow_extra: Vec::new(),
-            ignore: Vec::new(),
-        }
-    }
-}
-
-pub struct MacroArgumentBinding {
-    enabled: bool,
-    mode: Mode,
-    /// Built-in deny list plus `deny_extra`. Used in `DenyOnly` and
-    /// `AllowAndDeny`.
-    deny: BTreeSet<Vec<String>>,
-    /// Built-in allow list plus `allow_extra`. Used only in
-    /// `AllowAndDeny`; `Blanket` deliberately ignores the built-in
-    /// allow list and consults `allow_extra` alone.
-    allow: BTreeSet<Vec<String>>,
-    /// Only the user-supplied `allow_extra` entries. Used in
-    /// `Blanket` mode, which has no built-in allow list per the rule
-    /// docs (`planned-rules/macro-argument-binding.md`).
-    allow_extra: BTreeSet<Vec<String>>,
-    ignore: BTreeSet<Vec<String>>,
-}
-
-impl MacroArgumentBinding {
-    fn new() -> Self {
-        let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-        let extra_deny = parse_path_list(&config.deny_extra);
-        let extra_allow = parse_path_list(&config.allow_extra);
-        let deny = merge_with_builtins(BUILTIN_DENY, &extra_deny);
-        let allow = merge_with_builtins(BUILTIN_ALLOW, &extra_allow);
-        let ignore = parse_path_list(&config.ignore);
-        Self {
-            enabled: config.enabled,
-            mode: config.mode,
-            deny,
-            allow,
-            allow_extra: extra_allow,
-            ignore,
-        }
-    }
-
-    fn arguments_should_be_checked(&self, mac_call: &MacCall) -> bool {
-        let on_deny = matches_any(&mac_call.path, &self.deny);
-        match self.mode {
-            Mode::DenyOnly => on_deny,
-            Mode::Blanket => !matches_any(&mac_call.path, &self.allow_extra),
-            Mode::AllowAndDeny => on_deny || !matches_any(&mac_call.path, &self.allow),
-        }
-    }
-}
-
-fn parse_path_list(raw_entries: &[String]) -> BTreeSet<Vec<String>> {
-    raw_entries
-        .iter()
-        .map(|entry| parse_path(entry))
-        .filter(|parsed| !parsed.is_empty())
-        .collect()
-}
-
-fn merge_with_builtins(builtin: &[&str], extras: &BTreeSet<Vec<String>>) -> BTreeSet<Vec<String>> {
-    let mut set: BTreeSet<Vec<String>> = builtin
-        .iter()
-        .map(|name| vec![(*name).to_owned()])
-        .collect();
-    set.extend(extras.iter().cloned());
-    set
-}
-
 impl_lint_pass!(MacroArgumentBinding => [MACRO_ARGUMENT_BINDING]);
 impl_lint_pass!(MacroArgumentBindingLate => [MACRO_ARGUMENT_BINDING]);
 
@@ -235,9 +102,13 @@ pub fn register_pass(lint_store: &mut LintStore) {
     lint_store.register_late_pass(|_| Box::new(MacroArgumentBindingLate));
 }
 
-static PENDING_VIOLATIONS: Mutex<Vec<Span>> = Mutex::new(Vec::new());
-
-pub struct MacroArgumentBindingLate;
+/// Violation spans the pre-expansion pass has parked, waiting for the
+/// late pass to anchor each at the deepest enclosing HIR node and
+/// emit the diagnostic. `Span` is `Copy + Send + Sync` (a 32-bit id
+/// into a session-side table), so a process-wide static is safe; the
+/// `Mutex` just serialises the queue against parallel pre-expansion
+/// passes within one compilation.
+pub(crate) static PENDING_VIOLATIONS: Mutex<Vec<Span>> = Mutex::new(Vec::new());
 
 impl EarlyLintPass for MacroArgumentBinding {
     fn check_mac(&mut self, _lint_context: &EarlyContext<'_>, mac_call: &MacCall) {
@@ -280,315 +151,9 @@ fn check_argument(argument: &[TokenTree]) {
     queue(span);
 }
 
-/// Heuristic: does the argument plausibly parse as a single Rust
-/// expression? The rule docs say "skip arguments that don't parse as a
-/// single expression (`name: type`, `name = value`, etc. are syntactic
-/// positions the macro author chose)" and prescribe a `Parser::parse_expr`
-/// re-parse to make that call. We approximate without `rustc_parse` to
-/// avoid emitting parser-recovery diagnostics for arbitrary macro
-/// inputs: a top-level `=>` token is a match-arm separator (`matches!`,
-/// `impl_lint_pass!`-style `Type => [LINT_NAMES]` DSLs) and is never
-/// part of a single Rust expression. Other non-expression markers like
-/// `name: type` and `name = value` are not reliably distinguishable
-/// from valid expression syntax (`expr: type` ascription, assignment),
-/// and a future re-parse-based implementation will subsume this check.
-fn looks_like_expression(argument: &[TokenTree]) -> bool {
-    !argument.iter().any(|tree| {
-        matches!(
-            tree,
-            TokenTree::Token(token, _) if token.kind == TokenKind::FatArrow,
-        )
-    })
-}
-
 fn queue(span: Span) {
     let mut guard = PENDING_VIOLATIONS
         .lock()
         .unwrap_or_else(|err| err.into_inner());
     guard.push(span);
-}
-
-/// Split the top-level token stream of a macro invocation into one
-/// segment per comma-separated argument. Returns `None` if a top-level
-/// `;` is encountered (the repeat form, `vec![v; count]`), which
-/// signals that the invocation is not a comma-separated argument list
-/// and the rule skips the whole call.
-///
-/// `=>` is ordinary content here — match-arm syntax inside `matches!`
-/// shows up as a top-level fat arrow but is meaningful to the macro,
-/// not a separator. The walker passes it through unchanged so each
-/// argument's `looks_like_expression` check can skip it as a non-
-/// expression position the macro author chose.
-fn split_top_level_arguments(stream: &TokenStream) -> Option<Vec<Vec<TokenTree>>> {
-    let mut arguments: Vec<Vec<TokenTree>> = Vec::new();
-    let mut current: Vec<TokenTree> = Vec::new();
-    for tree in stream.iter() {
-        if let TokenTree::Token(token, _) = tree {
-            match token.kind {
-                TokenKind::Semi => return None,
-                TokenKind::Comma => {
-                    arguments.push(std::mem::take(&mut current));
-                    continue;
-                }
-                _ => {}
-            }
-        }
-        current.push(tree.clone());
-    }
-    if !current.is_empty() {
-        arguments.push(current);
-    }
-    Some(arguments)
-}
-
-/// Returns `true` if the entire token slice forms a "trivial"
-/// expression per the rule's grammar. Triviality is purely syntactic:
-/// the seven shapes the rule docs enumerate, recursive on operands.
-/// Anything outside that grammar is non-trivial — including `const fn`
-/// calls and other "morally pure" expressions.
-fn is_trivial_expression(tokens: &[TokenTree]) -> bool {
-    take_trivial_expression(tokens).is_some_and(<[_]>::is_empty)
-}
-
-fn take_trivial_expression(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
-    let after_atom = take_trivial_atom(tokens)?;
-    Some(take_trivial_suffixes(after_atom))
-}
-
-fn take_trivial_atom(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
-    let (head, rest) = tokens.split_first()?;
-    let TokenTree::Token(token, _) = head else {
-        return None;
-    };
-    match token.kind {
-        TokenKind::Literal(_) => Some(rest),
-        // `true` and `false` are keyword idents, not `Literal` tokens.
-        TokenKind::Ident(name, IdentIsRaw::No) if name == kw::True || name == kw::False => {
-            Some(rest)
-        }
-        // `&` expr or `&mut` expr.
-        TokenKind::And => take_reference_tail(rest),
-        // `&&` expr or `&& mut` expr (double reference).
-        TokenKind::AndAnd => take_reference_tail(rest),
-        // `*expr` (deref).
-        TokenKind::Star => take_trivial_expression(rest),
-        // Path: ident (`::` ident)*.
-        TokenKind::Ident(_, _) => Some(take_path_tail(rest)),
-        // Leading `::` — must be followed by an ident.
-        TokenKind::PathSep => take_path_after_sep(rest),
-        _ => None,
-    }
-}
-
-fn take_reference_tail(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
-    let after_mut = match tokens.split_first() {
-        Some((TokenTree::Token(token, _), rest)) if token.is_keyword(kw::Mut) => rest,
-        _ => tokens,
-    };
-    take_trivial_expression(after_mut)
-}
-
-fn take_path_tail(mut tokens: &[TokenTree]) -> &[TokenTree] {
-    while let Some((TokenTree::Token(sep, _), after_sep)) = tokens.split_first() {
-        if sep.kind != TokenKind::PathSep {
-            break;
-        }
-        let Some((TokenTree::Token(ident, _), after_ident)) = after_sep.split_first() else {
-            break;
-        };
-        if !matches!(ident.kind, TokenKind::Ident(_, _)) {
-            break;
-        }
-        tokens = after_ident;
-    }
-    tokens
-}
-
-fn take_path_after_sep(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
-    let (ident, rest) = tokens.split_first()?;
-    let TokenTree::Token(token, _) = ident else {
-        return None;
-    };
-    if !matches!(token.kind, TokenKind::Ident(_, _)) {
-        return None;
-    }
-    Some(take_path_tail(rest))
-}
-
-fn take_trivial_suffixes(mut tokens: &[TokenTree]) -> &[TokenTree] {
-    loop {
-        let Some((head, rest)) = tokens.split_first() else {
-            return tokens;
-        };
-        match head {
-            TokenTree::Token(token, _) => match token.kind {
-                // `.ident` (field access) or `.0` (tuple index).
-                TokenKind::Dot => {
-                    let Some((next, after)) = rest.split_first() else {
-                        return tokens;
-                    };
-                    let TokenTree::Token(next_token, _) = next else {
-                        return tokens;
-                    };
-                    match next_token.kind {
-                        TokenKind::Ident(_, _) | TokenKind::Literal(_) => tokens = after,
-                        _ => return tokens,
-                    }
-                }
-                // `as path` — type annotation. Only path-shaped types
-                // are recognised; references, slices, function pointers,
-                // etc. fall back to non-trivial.
-                TokenKind::Ident(name, IdentIsRaw::No) if name == kw::As => {
-                    let Some(after) = take_trivial_type(rest) else {
-                        return tokens;
-                    };
-                    tokens = after;
-                }
-                _ => return tokens,
-            },
-            // `[expr]` — index. Both base and index must be trivial;
-            // the recursion happens here for the index.
-            TokenTree::Delimited(_, _, Delimiter::Bracket, inner) => {
-                if !is_trivial_expression_stream(inner) {
-                    return tokens;
-                }
-                tokens = rest;
-            }
-            _ => return tokens,
-        }
-    }
-}
-
-fn take_trivial_type(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
-    let (head, rest) = tokens.split_first()?;
-    let TokenTree::Token(token, _) = head else {
-        return None;
-    };
-    match token.kind {
-        TokenKind::Ident(_, _) => Some(take_path_tail(rest)),
-        TokenKind::PathSep => take_path_after_sep(rest),
-        _ => None,
-    }
-}
-
-fn is_trivial_expression_stream(stream: &TokenStream) -> bool {
-    let trees: Vec<TokenTree> = stream.iter().cloned().collect();
-    is_trivial_expression(&trees)
-}
-
-impl<'tcx> LateLintPass<'tcx> for MacroArgumentBindingLate {
-    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
-        let pending: Vec<Span> = {
-            let mut guard = PENDING_VIOLATIONS
-                .lock()
-                .unwrap_or_else(|err| err.into_inner());
-            std::mem::take(&mut *guard)
-        };
-        if pending.is_empty() {
-            return;
-        }
-        let tcx = lint_context.tcx;
-        let mut best: Vec<hir::HirId> = vec![hir::CRATE_HIR_ID; pending.len()];
-        let mut finder = EnclosingHirFinder {
-            tcx,
-            pending: &pending,
-            best: &mut best,
-        };
-        tcx.hir_walk_toplevel_module(&mut finder);
-        for (&span, &hir_id) in pending.iter().zip(best.iter()) {
-            emit(lint_context, hir_id, span);
-        }
-    }
-}
-
-fn emit(lint_context: &LateContext<'_>, hir_id: hir::HirId, span: Span) {
-    span_lint_hir_and_then(
-        lint_context,
-        MACRO_ARGUMENT_BINDING,
-        hir_id,
-        span,
-        "non-trivial expression passed directly to a macro",
-        |diag| {
-            diag.help(
-                "bind the expression to a `let` immediately before the macro \
-                 call so it is evaluated exactly once, regardless of how the \
-                 macro expands",
-            );
-        },
-    );
-}
-
-/// Walk the HIR once and, for each pending violation span, record the
-/// deepest HIR node whose span contains it. Mirrors the equivalent
-/// finder in `macro_trailing_comma`; the two cannot share a single
-/// instance cheaply because each rule's pending list is a different
-/// type, but the walk shape is identical.
-struct EnclosingHirFinder<'a, 'tcx> {
-    tcx: TyCtxt<'tcx>,
-    pending: &'a [Span],
-    best: &'a mut [hir::HirId],
-}
-
-impl<'a, 'tcx> EnclosingHirFinder<'a, 'tcx> {
-    fn update(&mut self, hir_id: hir::HirId, span: Span) {
-        for (index, &target) in self.pending.iter().enumerate() {
-            if !span.contains(target) {
-                continue;
-            }
-            self.best[index] = hir_id;
-        }
-    }
-}
-
-impl<'tcx> Visitor<'tcx> for EnclosingHirFinder<'_, 'tcx> {
-    type NestedFilter = nested_filter::All;
-
-    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
-        self.tcx
-    }
-
-    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_item(self, item);
-    }
-
-    fn visit_trait_item(&mut self, item: &'tcx hir::TraitItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_trait_item(self, item);
-    }
-
-    fn visit_impl_item(&mut self, item: &'tcx hir::ImplItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_impl_item(self, item);
-    }
-
-    fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_foreign_item(self, item);
-    }
-
-    fn visit_block(&mut self, block: &'tcx hir::Block<'tcx>) {
-        self.update(block.hir_id, block.span);
-        intravisit::walk_block(self, block);
-    }
-
-    fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
-        self.update(stmt.hir_id, stmt.span);
-        intravisit::walk_stmt(self, stmt);
-    }
-
-    fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) {
-        self.update(local.hir_id, local.span);
-        intravisit::walk_local(self, local);
-    }
-
-    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
-        self.update(expr.hir_id, expr.span);
-        intravisit::walk_expr(self, expr);
-    }
-
-    fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
-        self.update(pat.hir_id, pat.span);
-        intravisit::walk_pat(self, pat);
-    }
 }

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -26,8 +26,6 @@ use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
 
-use crate::macro_path::matches_any;
-
 mod config;
 mod late;
 mod triviality;
@@ -112,21 +110,16 @@ pub(crate) static PENDING_VIOLATIONS: Mutex<Vec<Span>> = Mutex::new(Vec::new());
 
 impl EarlyLintPass for MacroArgumentBinding {
     fn check_mac(&mut self, _lint_context: &EarlyContext<'_>, mac_call: &MacCall) {
-        if !self.enabled {
+        // Curly-brace invocations are DSL bodies; skip them. The
+        // delimiter check is on AST shape, not path / config, so it
+        // lives here rather than behind `should_check_path`.
+        if mac_call.args.delim == Delimiter::Brace {
             return;
         }
-        let args = &mac_call.args;
-        // Curly-brace invocations are DSL bodies; skip them.
-        if args.delim == Delimiter::Brace {
+        if !self.should_check_path(mac_call) {
             return;
         }
-        if matches_any(&mac_call.path, &self.ignore) {
-            return;
-        }
-        if !self.arguments_should_be_checked(mac_call) {
-            return;
-        }
-        let Some(arguments) = split_top_level_arguments(&args.tokens) else {
+        let Some(arguments) = split_top_level_arguments(&mac_call.args.tokens) else {
             return;
         };
         for argument in arguments {

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -109,9 +109,10 @@ enum Mode {
     /// plus `deny_extra`). Every other macro is silently accepted.
     DenyOnly,
     /// Flag every function-like or array-like invocation that carries
-    /// a non-trivial top-level argument, regardless of macro. Project
-    /// exceptions go in `allow_extra`; there is no built-in allow list
-    /// in this mode.
+    /// a non-trivial top-level argument, regardless of any built-in
+    /// classification — unless the invocation matches an `allow_extra`
+    /// entry. The built-in allow list is deliberately ignored in this
+    /// mode; project exceptions go in `allow_extra`.
     Blanket,
     /// Curated deny list plus curated allow list, both extensible via
     /// `deny_extra` / `allow_extra`. Macros on neither list are
@@ -315,9 +316,9 @@ fn queue(span: Span) {
 ///
 /// `=>` is ordinary content here — match-arm syntax inside `matches!`
 /// shows up as a top-level fat arrow but is meaningful to the macro,
-/// not a separator. The walker passes it through unchanged so the
-/// per-argument re-parser can decide whether each argument is a single
-/// expression (and if not, the argument is skipped on parse failure).
+/// not a separator. The walker passes it through unchanged so each
+/// argument's `looks_like_expression` check can skip it as a non-
+/// expression position the macro author chose.
 fn split_top_level_arguments(stream: &TokenStream) -> Option<Vec<Vec<TokenTree>>> {
     let mut arguments: Vec<Vec<TokenTree>> = Vec::new();
     let mut current: Vec<TokenTree> = Vec::new();

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -1,0 +1,569 @@
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+
+use crate::macro_path::{matches_any, parse_path};
+use clippy_utils::diagnostics::span_lint_hir_and_then;
+use rustc_ast::MacCall;
+use rustc_ast::token::{Delimiter, IdentIsRaw, TokenKind};
+use rustc_ast::tokenstream::{TokenStream, TokenTree};
+use rustc_hir as hir;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintStore};
+use rustc_middle::hir::nested_filter;
+use rustc_middle::ty::TyCtxt;
+use rustc_session::{declare_tool_lint, impl_lint_pass};
+use rustc_span::{Span, kw};
+
+declare_tool_lint! {
+    /// ### What it does
+    /// Flags non-trivial expressions passed as top-level arguments to a
+    /// function-like (`name!(...)`) or array-like (`name![...]`) macro
+    /// invocation. The fix is to bind the expression to a `let` first
+    /// and pass the binding instead, guaranteeing exactly-once
+    /// evaluation.
+    ///
+    /// Curly-brace invocations (`name! { ... }`) are out of scope: by
+    /// convention they are DSL bodies (`thread_local! { ... }`,
+    /// `quote! { ... }`, `html! { ... }`) where the evaluation
+    /// contract is the macro's, not the call site's.
+    ///
+    /// ### Why is this bad?
+    /// A function-like or array-like macro may evaluate any top-level
+    /// argument zero, one, or many times depending on its matcher.
+    /// Functions guarantee exactly-once evaluation per argument; macros
+    /// do not, even when the call shape looks identical. The classic
+    /// case is `debug_assert_eq!`:
+    ///
+    /// ```rust,ignore
+    /// debug_assert_eq!(map.insert(key, value), None, "duplicate");
+    /// ```
+    ///
+    /// In debug builds the call runs and the assertion holds. In
+    /// release builds `debug_assertions` is off, the body folds to
+    /// `if false { ... }`, and the argument expressions are *not*
+    /// evaluated — `insert` never runs and the map ends the function
+    /// in a state the author did not intend. The bug only surfaces
+    /// under `--release`.
+    ///
+    /// The same trap covers any macro that expands its capture more
+    /// than once (`min!`/`max!`-style, retry loops): a side-effecting
+    /// expression repeated produces wrong results.
+    ///
+    /// ### Example
+    /// ```rust,ignore
+    /// debug_assert_eq!(map.insert(key, value), None, "duplicate");
+    /// ```
+    /// Use instead:
+    /// ```rust,ignore
+    /// let ejected = map.insert(key, value);
+    /// debug_assert_eq!(ejected, None, "duplicate");
+    /// ```
+    pub perfectionist::MACRO_ARGUMENT_BINDING,
+    Warn,
+    "macro invocation passes a non-trivial expression that should be bound to a `let` first",
+    report_in_external_macro: false
+}
+
+const CONFIG_KEY: &str = "perfectionist::macro_argument_binding";
+
+/// Macros whose argument list is checked unconditionally because the
+/// expansion is known to evaluate captures conditionally on a `cfg`
+/// (`debug_assert*`) or to drop them entirely in release builds.
+const BUILTIN_DENY: &[&str] = &["debug_assert", "debug_assert_eq", "debug_assert_ne"];
+
+/// Macros known to evaluate every top-level argument exactly once. The
+/// list mirrors the curated set in `macro_trailing_comma`, with the
+/// conditional-evaluation families (`log::*`, `tracing::*`) removed
+/// because those *do* drop arguments below the configured filter level.
+const BUILTIN_ALLOW: &[&str] = &[
+    "format",
+    "format_args",
+    "print",
+    "println",
+    "eprint",
+    "eprintln",
+    "write",
+    "writeln",
+    "vec",
+    "panic",
+    "unimplemented",
+    "todo",
+    "unreachable",
+    "assert",
+    "assert_eq",
+    "assert_ne",
+    "matches",
+    "dbg",
+    "anyhow",
+];
+
+/// Eligibility mode. The default is `AllowAndDeny`. The matcher-based
+/// mode described in `planned-rules/macro-argument-binding.md` is not
+/// yet implemented and is therefore not exposed as a value here; a
+/// `dylint.toml` that names it will fail to deserialise with a
+/// useful error.
+#[derive(Debug, Clone, Copy, Default, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Mode {
+    /// Flag only invocations of the curated deny list (`debug_assert*`
+    /// plus `deny_extra`). Every other macro is silently accepted.
+    DenyOnly,
+    /// Flag every function-like or array-like invocation that carries
+    /// a non-trivial top-level argument, regardless of macro. Project
+    /// exceptions go in `allow_extra`; there is no built-in allow list
+    /// in this mode.
+    Blanket,
+    /// Curated deny list plus curated allow list, both extensible via
+    /// `deny_extra` / `allow_extra`. Macros on neither list are
+    /// flagged — flagging unrecognised macros is deliberate so the
+    /// rule remains useful in projects that depend on uncatalogued
+    /// proc macros.
+    #[default]
+    AllowAndDeny,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(default, rename_all = "snake_case")]
+struct Config {
+    /// Master on/off switch for the rule. Defaults to `true`. Set
+    /// to `false` to silence every diagnostic this lint would emit
+    /// without having to enumerate every macro under `ignore`.
+    enabled: bool,
+    /// Eligibility mode. See [`Mode`].
+    mode: Mode,
+    /// Macros added to the built-in deny list. Each entry is a
+    /// fully-qualified macro path (no trailing `!`) or a bare macro
+    /// name to match by final segment only.
+    deny_extra: Vec<String>,
+    /// Macros added to the built-in allow list. Same matching rules
+    /// as `deny_extra`. Only meaningful in `AllowAndDeny` and
+    /// `Blanket` modes; in `DenyOnly` the allow list is unused.
+    allow_extra: Vec<String>,
+    /// Macros to skip entirely, regardless of which list they would
+    /// otherwise hit. Same matching rules as `deny_extra`.
+    ignore: Vec<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            mode: Mode::default(),
+            deny_extra: Vec::new(),
+            allow_extra: Vec::new(),
+            ignore: Vec::new(),
+        }
+    }
+}
+
+pub struct MacroArgumentBinding {
+    enabled: bool,
+    mode: Mode,
+    /// Built-in deny list plus `deny_extra`. Used in `DenyOnly` and
+    /// `AllowAndDeny`.
+    deny: BTreeSet<Vec<String>>,
+    /// Built-in allow list plus `allow_extra`. Used only in
+    /// `AllowAndDeny`; `Blanket` deliberately ignores the built-in
+    /// allow list and consults `allow_extra` alone.
+    allow: BTreeSet<Vec<String>>,
+    /// Only the user-supplied `allow_extra` entries. Used in
+    /// `Blanket` mode, which has no built-in allow list per the rule
+    /// docs (`planned-rules/macro-argument-binding.md`).
+    allow_extra: BTreeSet<Vec<String>>,
+    ignore: BTreeSet<Vec<String>>,
+}
+
+impl MacroArgumentBinding {
+    fn new() -> Self {
+        let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
+        let extra_deny = parse_path_list(&config.deny_extra);
+        let extra_allow = parse_path_list(&config.allow_extra);
+        let deny = merge_with_builtins(BUILTIN_DENY, &extra_deny);
+        let allow = merge_with_builtins(BUILTIN_ALLOW, &extra_allow);
+        let ignore = parse_path_list(&config.ignore);
+        Self {
+            enabled: config.enabled,
+            mode: config.mode,
+            deny,
+            allow,
+            allow_extra: extra_allow,
+            ignore,
+        }
+    }
+
+    fn arguments_should_be_checked(&self, mac_call: &MacCall) -> bool {
+        let on_deny = matches_any(&mac_call.path, &self.deny);
+        match self.mode {
+            Mode::DenyOnly => on_deny,
+            Mode::Blanket => !matches_any(&mac_call.path, &self.allow_extra),
+            Mode::AllowAndDeny => on_deny || !matches_any(&mac_call.path, &self.allow),
+        }
+    }
+}
+
+fn parse_path_list(raw_entries: &[String]) -> BTreeSet<Vec<String>> {
+    raw_entries
+        .iter()
+        .map(|entry| parse_path(entry))
+        .filter(|parsed| !parsed.is_empty())
+        .collect()
+}
+
+fn merge_with_builtins(builtin: &[&str], extras: &BTreeSet<Vec<String>>) -> BTreeSet<Vec<String>> {
+    let mut set: BTreeSet<Vec<String>> = builtin
+        .iter()
+        .map(|name| vec![(*name).to_owned()])
+        .collect();
+    set.extend(extras.iter().cloned());
+    set
+}
+
+impl_lint_pass!(MacroArgumentBinding => [MACRO_ARGUMENT_BINDING]);
+impl_lint_pass!(MacroArgumentBindingLate => [MACRO_ARGUMENT_BINDING]);
+
+pub fn register_lint(lint_store: &mut LintStore) {
+    lint_store.register_lints(&[MACRO_ARGUMENT_BINDING]);
+}
+
+pub fn register_pass(lint_store: &mut LintStore) {
+    // Same split as `macro_trailing_comma`: a pre-expansion pass parks
+    // violation spans, a late pass walks the HIR and emits each at the
+    // deepest enclosing node so `cfg_attr`-wrapped `#[expect]` and
+    // `#[allow]` attributes resolve correctly.
+    lint_store.register_pre_expansion_pass(|| Box::new(MacroArgumentBinding::new()));
+    lint_store.register_late_pass(|_| Box::new(MacroArgumentBindingLate));
+}
+
+static PENDING_VIOLATIONS: Mutex<Vec<Span>> = Mutex::new(Vec::new());
+
+pub struct MacroArgumentBindingLate;
+
+impl EarlyLintPass for MacroArgumentBinding {
+    fn check_mac(&mut self, _lint_context: &EarlyContext<'_>, mac_call: &MacCall) {
+        if !self.enabled {
+            return;
+        }
+        let args = &mac_call.args;
+        // Curly-brace invocations are DSL bodies; skip them.
+        if args.delim == Delimiter::Brace {
+            return;
+        }
+        if matches_any(&mac_call.path, &self.ignore) {
+            return;
+        }
+        if !self.arguments_should_be_checked(mac_call) {
+            return;
+        }
+        let Some(arguments) = split_top_level_arguments(&args.tokens) else {
+            return;
+        };
+        for argument in arguments {
+            check_argument(&argument);
+        }
+    }
+}
+
+fn check_argument(argument: &[TokenTree]) {
+    if argument.is_empty() {
+        return;
+    }
+    if is_trivial_expression(argument) {
+        return;
+    }
+    let first = argument.first().expect("non-empty checked above");
+    let last = argument.last().expect("non-empty checked above");
+    let span = first.span().to(last.span());
+    queue(span);
+}
+
+fn queue(span: Span) {
+    let mut guard = PENDING_VIOLATIONS
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    guard.push(span);
+}
+
+/// Split the top-level token stream of a macro invocation into one
+/// segment per comma-separated argument. Returns `None` if a top-level
+/// `;` is encountered (the repeat form, `vec![v; count]`), which
+/// signals that the invocation is not a comma-separated argument list
+/// and the rule skips the whole call.
+///
+/// `=>` is ordinary content here — match-arm syntax inside `matches!`
+/// shows up as a top-level fat arrow but is meaningful to the macro,
+/// not a separator. The walker passes it through unchanged so the
+/// per-argument re-parser can decide whether each argument is a single
+/// expression (and if not, the argument is skipped on parse failure).
+fn split_top_level_arguments(stream: &TokenStream) -> Option<Vec<Vec<TokenTree>>> {
+    let mut arguments: Vec<Vec<TokenTree>> = Vec::new();
+    let mut current: Vec<TokenTree> = Vec::new();
+    for tree in stream.iter() {
+        if let TokenTree::Token(token, _) = tree {
+            match token.kind {
+                TokenKind::Semi => return None,
+                TokenKind::Comma => {
+                    arguments.push(std::mem::take(&mut current));
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        current.push(tree.clone());
+    }
+    if !current.is_empty() {
+        arguments.push(current);
+    }
+    Some(arguments)
+}
+
+/// Returns `true` if the entire token slice forms a "trivial"
+/// expression per the rule's grammar. Triviality is purely syntactic:
+/// the seven shapes the rule docs enumerate, recursive on operands.
+/// Anything outside that grammar is non-trivial — including `const fn`
+/// calls and other "morally pure" expressions.
+fn is_trivial_expression(tokens: &[TokenTree]) -> bool {
+    take_trivial_expression(tokens).is_some_and(<[_]>::is_empty)
+}
+
+fn take_trivial_expression(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+    let after_atom = take_trivial_atom(tokens)?;
+    Some(take_trivial_suffixes(after_atom))
+}
+
+fn take_trivial_atom(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+    let (head, rest) = tokens.split_first()?;
+    let TokenTree::Token(token, _) = head else {
+        return None;
+    };
+    match token.kind {
+        TokenKind::Literal(_) => Some(rest),
+        // `true` and `false` are keyword idents, not `Literal` tokens.
+        TokenKind::Ident(name, IdentIsRaw::No) if name == kw::True || name == kw::False => {
+            Some(rest)
+        }
+        // `&` expr or `&mut` expr.
+        TokenKind::And => take_reference_tail(rest),
+        // `&&` expr or `&& mut` expr (double reference).
+        TokenKind::AndAnd => take_reference_tail(rest),
+        // `*expr` (deref).
+        TokenKind::Star => take_trivial_expression(rest),
+        // Path: ident (`::` ident)*.
+        TokenKind::Ident(_, _) => Some(take_path_tail(rest)),
+        // Leading `::` — must be followed by an ident.
+        TokenKind::PathSep => take_path_after_sep(rest),
+        _ => None,
+    }
+}
+
+fn take_reference_tail(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+    let after_mut = match tokens.split_first() {
+        Some((TokenTree::Token(token, _), rest)) if token.is_keyword(kw::Mut) => rest,
+        _ => tokens,
+    };
+    take_trivial_expression(after_mut)
+}
+
+fn take_path_tail(mut tokens: &[TokenTree]) -> &[TokenTree] {
+    while let Some((TokenTree::Token(sep, _), after_sep)) = tokens.split_first() {
+        if sep.kind != TokenKind::PathSep {
+            break;
+        }
+        let Some((TokenTree::Token(ident, _), after_ident)) = after_sep.split_first() else {
+            break;
+        };
+        if !matches!(ident.kind, TokenKind::Ident(_, _)) {
+            break;
+        }
+        tokens = after_ident;
+    }
+    tokens
+}
+
+fn take_path_after_sep(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+    let (ident, rest) = tokens.split_first()?;
+    let TokenTree::Token(token, _) = ident else {
+        return None;
+    };
+    if !matches!(token.kind, TokenKind::Ident(_, _)) {
+        return None;
+    }
+    Some(take_path_tail(rest))
+}
+
+fn take_trivial_suffixes(mut tokens: &[TokenTree]) -> &[TokenTree] {
+    loop {
+        let Some((head, rest)) = tokens.split_first() else {
+            return tokens;
+        };
+        match head {
+            TokenTree::Token(token, _) => match token.kind {
+                // `.ident` (field access) or `.0` (tuple index).
+                TokenKind::Dot => {
+                    let Some((next, after)) = rest.split_first() else {
+                        return tokens;
+                    };
+                    let TokenTree::Token(next_token, _) = next else {
+                        return tokens;
+                    };
+                    match next_token.kind {
+                        TokenKind::Ident(_, _) | TokenKind::Literal(_) => tokens = after,
+                        _ => return tokens,
+                    }
+                }
+                // `as path` — type annotation. Only path-shaped types
+                // are recognised; references, slices, function pointers,
+                // etc. fall back to non-trivial.
+                TokenKind::Ident(name, IdentIsRaw::No) if name == kw::As => {
+                    let Some(after) = take_trivial_type(rest) else {
+                        return tokens;
+                    };
+                    tokens = after;
+                }
+                _ => return tokens,
+            },
+            // `[expr]` — index. Both base and index must be trivial;
+            // the recursion happens here for the index.
+            TokenTree::Delimited(_, _, Delimiter::Bracket, inner) => {
+                if !is_trivial_expression_stream(inner) {
+                    return tokens;
+                }
+                tokens = rest;
+            }
+            _ => return tokens,
+        }
+    }
+}
+
+fn take_trivial_type(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+    let (head, rest) = tokens.split_first()?;
+    let TokenTree::Token(token, _) = head else {
+        return None;
+    };
+    match token.kind {
+        TokenKind::Ident(_, _) => Some(take_path_tail(rest)),
+        TokenKind::PathSep => take_path_after_sep(rest),
+        _ => None,
+    }
+}
+
+fn is_trivial_expression_stream(stream: &TokenStream) -> bool {
+    let trees: Vec<TokenTree> = stream.iter().cloned().collect();
+    is_trivial_expression(&trees)
+}
+
+impl<'tcx> LateLintPass<'tcx> for MacroArgumentBindingLate {
+    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
+        let pending: Vec<Span> = {
+            let mut guard = PENDING_VIOLATIONS
+                .lock()
+                .unwrap_or_else(|err| err.into_inner());
+            std::mem::take(&mut *guard)
+        };
+        if pending.is_empty() {
+            return;
+        }
+        let tcx = lint_context.tcx;
+        let mut best: Vec<hir::HirId> = vec![hir::CRATE_HIR_ID; pending.len()];
+        let mut finder = EnclosingHirFinder {
+            tcx,
+            pending: &pending,
+            best: &mut best,
+        };
+        tcx.hir_walk_toplevel_module(&mut finder);
+        for (&span, &hir_id) in pending.iter().zip(best.iter()) {
+            emit(lint_context, hir_id, span);
+        }
+    }
+}
+
+fn emit(lint_context: &LateContext<'_>, hir_id: hir::HirId, span: Span) {
+    span_lint_hir_and_then(
+        lint_context,
+        MACRO_ARGUMENT_BINDING,
+        hir_id,
+        span,
+        "non-trivial expression passed directly to a macro",
+        |diag| {
+            diag.help(
+                "bind the expression to a `let` immediately before the macro \
+                 call so it is evaluated exactly once, regardless of how the \
+                 macro expands",
+            );
+        },
+    );
+}
+
+/// Walk the HIR once and, for each pending violation span, record the
+/// deepest HIR node whose span contains it. Mirrors the equivalent
+/// finder in `macro_trailing_comma`; the two cannot share a single
+/// instance cheaply because each rule's pending list is a different
+/// type, but the walk shape is identical.
+struct EnclosingHirFinder<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    pending: &'a [Span],
+    best: &'a mut [hir::HirId],
+}
+
+impl<'a, 'tcx> EnclosingHirFinder<'a, 'tcx> {
+    fn update(&mut self, hir_id: hir::HirId, span: Span) {
+        for (index, &target) in self.pending.iter().enumerate() {
+            if !span.contains(target) {
+                continue;
+            }
+            self.best[index] = hir_id;
+        }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for EnclosingHirFinder<'_, 'tcx> {
+    type NestedFilter = nested_filter::All;
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.tcx
+    }
+
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_item(self, item);
+    }
+
+    fn visit_trait_item(&mut self, item: &'tcx hir::TraitItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_trait_item(self, item);
+    }
+
+    fn visit_impl_item(&mut self, item: &'tcx hir::ImplItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_impl_item(self, item);
+    }
+
+    fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_foreign_item(self, item);
+    }
+
+    fn visit_block(&mut self, block: &'tcx hir::Block<'tcx>) {
+        self.update(block.hir_id, block.span);
+        intravisit::walk_block(self, block);
+    }
+
+    fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
+        self.update(stmt.hir_id, stmt.span);
+        intravisit::walk_stmt(self, stmt);
+    }
+
+    fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) {
+        self.update(local.hir_id, local.span);
+        intravisit::walk_local(self, local);
+    }
+
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+        self.update(expr.hir_id, expr.span);
+        intravisit::walk_expr(self, expr);
+    }
+
+    fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
+        self.update(pat.hir_id, pat.span);
+        intravisit::walk_pat(self, pat);
+    }
+}

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -119,7 +119,7 @@ impl EarlyLintPass for MacroArgumentBinding {
         if mac_call.args.delim == Delimiter::Brace {
             return;
         }
-        if !self.should_check_path(mac_call) {
+        if !self.should_check_path(&mac_call.path) {
             return;
         }
         let Some(arguments) = split_top_level_arguments(&mac_call.args.tokens) else {

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -106,7 +106,10 @@ pub fn register_pass(lint_store: &mut LintStore) {
 /// into a session-side table), so a process-wide static is safe; the
 /// `Mutex` just serialises the queue against parallel pre-expansion
 /// passes within one compilation.
-pub(crate) static PENDING_VIOLATIONS: Mutex<Vec<Span>> = Mutex::new(Vec::new());
+///
+/// The static is private — child modules (`late`) read it through
+/// Rust's standard descendant-reachability rule for non-`pub` items.
+static PENDING_VIOLATIONS: Mutex<Vec<Span>> = Mutex::new(Vec::new());
 
 impl EarlyLintPass for MacroArgumentBinding {
     fn check_mac(&mut self, _lint_context: &EarlyContext<'_>, mac_call: &MacCall) {

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -106,7 +106,7 @@ impl Default for Config {
     }
 }
 
-pub struct MacroArgumentBinding {
+pub(super) struct MacroArgumentBinding {
     enabled: bool,
     mode: Mode,
     /// Built-in deny list plus `deny_extra`. Used in `DenyOnly` and

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -1,0 +1,168 @@
+//! Configuration for `macro_argument_binding`. Owns the `Mode` enum,
+//! the user-facing `Config` shape, the curated built-in deny / allow
+//! lists, and the in-memory `MacroArgumentBinding` state the early
+//! pass holds.
+//!
+//! Path-set construction goes through the helpers at the bottom of
+//! this file so each list (`deny`, `allow`, `allow_extra`, `ignore`)
+//! is built consistently.
+
+use std::collections::BTreeSet;
+
+use rustc_ast::MacCall;
+
+use crate::macro_path::{matches_any, parse_path};
+
+pub(super) const CONFIG_KEY: &str = "perfectionist::macro_argument_binding";
+
+/// Macros whose argument list is checked unconditionally because the
+/// expansion is known to evaluate captures conditionally on a `cfg`
+/// (`debug_assert*`) or to drop them entirely in release builds.
+const BUILTIN_DENY: &[&str] = &["debug_assert", "debug_assert_eq", "debug_assert_ne"];
+
+/// Macros known to evaluate every top-level argument exactly once. The
+/// list mirrors the curated set in `macro_trailing_comma`, with the
+/// conditional-evaluation families (`log::*`, `tracing::*`) removed
+/// because those *do* drop arguments below the configured filter level.
+const BUILTIN_ALLOW: &[&str] = &[
+    "format",
+    "format_args",
+    "print",
+    "println",
+    "eprint",
+    "eprintln",
+    "write",
+    "writeln",
+    "vec",
+    "panic",
+    "unimplemented",
+    "todo",
+    "unreachable",
+    "assert",
+    "assert_eq",
+    "assert_ne",
+    "matches",
+    "dbg",
+    "anyhow",
+];
+
+/// Eligibility mode. The default is `AllowAndDeny`. The matcher-based
+/// mode described in `planned-rules/macro-argument-binding.md` is not
+/// yet implemented and is therefore not exposed as a value here; a
+/// `dylint.toml` that names it will fail to deserialise with a
+/// useful error.
+#[derive(Debug, Clone, Copy, Default, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum Mode {
+    /// Flag only invocations of the curated deny list (`debug_assert*`
+    /// plus `deny_extra`). Every other macro is silently accepted.
+    DenyOnly,
+    /// Flag every function-like or array-like invocation that carries
+    /// a non-trivial top-level argument, regardless of any built-in
+    /// classification — unless the invocation matches an `allow_extra`
+    /// entry. The built-in allow list is deliberately ignored in this
+    /// mode; project exceptions go in `allow_extra`.
+    Blanket,
+    /// Curated deny list plus curated allow list, both extensible via
+    /// `deny_extra` / `allow_extra`. Macros on neither list are
+    /// flagged — flagging unrecognised macros is deliberate so the
+    /// rule remains useful in projects that depend on uncatalogued
+    /// proc macros.
+    #[default]
+    AllowAndDeny,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(default, rename_all = "snake_case")]
+pub(super) struct Config {
+    /// Master on/off switch for the rule. Defaults to `true`. Set
+    /// to `false` to silence every diagnostic this lint would emit
+    /// without having to enumerate every macro under `ignore`.
+    pub enabled: bool,
+    /// Eligibility mode. See [`Mode`].
+    pub mode: Mode,
+    /// Macros added to the built-in deny list. Each entry is a
+    /// fully-qualified macro path (no trailing `!`) or a bare macro
+    /// name to match by final segment only.
+    pub deny_extra: Vec<String>,
+    /// Macros added to the built-in allow list. Same matching rules
+    /// as `deny_extra`. Only meaningful in `AllowAndDeny` and
+    /// `Blanket` modes; in `DenyOnly` the allow list is unused.
+    pub allow_extra: Vec<String>,
+    /// Macros to skip entirely, regardless of which list they would
+    /// otherwise hit. Same matching rules as `deny_extra`.
+    pub ignore: Vec<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            mode: Mode::default(),
+            deny_extra: Vec::new(),
+            allow_extra: Vec::new(),
+            ignore: Vec::new(),
+        }
+    }
+}
+
+pub struct MacroArgumentBinding {
+    pub(super) enabled: bool,
+    mode: Mode,
+    /// Built-in deny list plus `deny_extra`. Used in `DenyOnly` and
+    /// `AllowAndDeny`.
+    deny: BTreeSet<Vec<String>>,
+    /// Built-in allow list plus `allow_extra`. Used only in
+    /// `AllowAndDeny`; `Blanket` deliberately ignores the built-in
+    /// allow list and consults `allow_extra` alone.
+    allow: BTreeSet<Vec<String>>,
+    /// Only the user-supplied `allow_extra` entries. Used in
+    /// `Blanket` mode, which has no built-in allow list per the rule
+    /// docs (`planned-rules/macro-argument-binding.md`).
+    allow_extra: BTreeSet<Vec<String>>,
+    pub(super) ignore: BTreeSet<Vec<String>>,
+}
+
+impl MacroArgumentBinding {
+    pub(super) fn new() -> Self {
+        let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
+        let extra_deny = parse_path_list(&config.deny_extra);
+        let extra_allow = parse_path_list(&config.allow_extra);
+        let deny = merge_with_builtins(BUILTIN_DENY, &extra_deny);
+        let allow = merge_with_builtins(BUILTIN_ALLOW, &extra_allow);
+        let ignore = parse_path_list(&config.ignore);
+        Self {
+            enabled: config.enabled,
+            mode: config.mode,
+            deny,
+            allow,
+            allow_extra: extra_allow,
+            ignore,
+        }
+    }
+
+    pub(super) fn arguments_should_be_checked(&self, mac_call: &MacCall) -> bool {
+        let on_deny = matches_any(&mac_call.path, &self.deny);
+        match self.mode {
+            Mode::DenyOnly => on_deny,
+            Mode::Blanket => !matches_any(&mac_call.path, &self.allow_extra),
+            Mode::AllowAndDeny => on_deny || !matches_any(&mac_call.path, &self.allow),
+        }
+    }
+}
+
+fn parse_path_list(raw_entries: &[String]) -> BTreeSet<Vec<String>> {
+    raw_entries
+        .iter()
+        .map(|entry| parse_path(entry))
+        .filter(|parsed| !parsed.is_empty())
+        .collect()
+}
+
+fn merge_with_builtins(builtin: &[&str], extras: &BTreeSet<Vec<String>>) -> BTreeSet<Vec<String>> {
+    builtin
+        .iter()
+        .map(|name| vec![(*name).to_owned()])
+        .chain(extras.iter().cloned())
+        .collect()
+}

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -146,9 +146,7 @@ impl MacroArgumentBinding {
     /// *not* consider the call's delimiter or argument shape — those
     /// stay in the early-pass driver, where token-tree concerns live.
     pub(super) fn should_check_path(&self, path: &Path) -> bool {
-        self.enabled
-            && !matches_any(path, &self.ignore)
-            && self.arguments_should_be_checked(path)
+        self.enabled && !matches_any(path, &self.ignore) && self.arguments_should_be_checked(path)
     }
 
     fn arguments_should_be_checked(&self, path: &Path) -> bool {

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -13,7 +13,7 @@ use rustc_ast::MacCall;
 
 use crate::macro_path::{matches_any, parse_path};
 
-pub(super) const CONFIG_KEY: &str = "perfectionist::macro_argument_binding";
+const CONFIG_KEY: &str = "perfectionist::macro_argument_binding";
 
 /// Macros whose argument list is checked unconditionally because the
 /// expansion is known to evaluate captures conditionally on a `cfg`
@@ -107,7 +107,7 @@ impl Default for Config {
 }
 
 pub struct MacroArgumentBinding {
-    pub(super) enabled: bool,
+    enabled: bool,
     mode: Mode,
     /// Built-in deny list plus `deny_extra`. Used in `DenyOnly` and
     /// `AllowAndDeny`.
@@ -120,7 +120,7 @@ pub struct MacroArgumentBinding {
     /// `Blanket` mode, which has no built-in allow list per the rule
     /// docs (`planned-rules/macro-argument-binding.md`).
     allow_extra: BTreeSet<Vec<String>>,
-    pub(super) ignore: BTreeSet<Vec<String>>,
+    ignore: BTreeSet<Vec<String>>,
 }
 
 impl MacroArgumentBinding {
@@ -141,7 +141,17 @@ impl MacroArgumentBinding {
         }
     }
 
-    pub(super) fn arguments_should_be_checked(&self, mac_call: &MacCall) -> bool {
+    /// Path-side eligibility: combines the `enabled` switch, the
+    /// `ignore` list, and the mode-based deny / allow lookup. Does
+    /// *not* consider the call's delimiter or argument shape — those
+    /// stay in the early-pass driver, where token-tree concerns live.
+    pub(super) fn should_check_path(&self, mac_call: &MacCall) -> bool {
+        self.enabled
+            && !matches_any(&mac_call.path, &self.ignore)
+            && self.arguments_should_be_checked(mac_call)
+    }
+
+    fn arguments_should_be_checked(&self, mac_call: &MacCall) -> bool {
         let on_deny = matches_any(&mac_call.path, &self.deny);
         match self.mode {
             Mode::DenyOnly => on_deny,

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -9,7 +9,7 @@
 
 use std::collections::BTreeSet;
 
-use rustc_ast::MacCall;
+use rustc_ast::Path;
 
 use crate::macro_path::{matches_any, parse_path};
 
@@ -145,18 +145,18 @@ impl MacroArgumentBinding {
     /// `ignore` list, and the mode-based deny / allow lookup. Does
     /// *not* consider the call's delimiter or argument shape — those
     /// stay in the early-pass driver, where token-tree concerns live.
-    pub(super) fn should_check_path(&self, mac_call: &MacCall) -> bool {
+    pub(super) fn should_check_path(&self, path: &Path) -> bool {
         self.enabled
-            && !matches_any(&mac_call.path, &self.ignore)
-            && self.arguments_should_be_checked(mac_call)
+            && !matches_any(path, &self.ignore)
+            && self.arguments_should_be_checked(path)
     }
 
-    fn arguments_should_be_checked(&self, mac_call: &MacCall) -> bool {
-        let on_deny = matches_any(&mac_call.path, &self.deny);
+    fn arguments_should_be_checked(&self, path: &Path) -> bool {
+        let on_deny = matches_any(path, &self.deny);
         match self.mode {
             Mode::DenyOnly => on_deny,
-            Mode::Blanket => !matches_any(&mac_call.path, &self.allow_extra),
-            Mode::AllowAndDeny => on_deny || !matches_any(&mac_call.path, &self.allow),
+            Mode::Blanket => !matches_any(path, &self.allow_extra),
+            Mode::AllowAndDeny => on_deny || !matches_any(path, &self.allow),
         }
     }
 }

--- a/src/rules/macro_argument_binding/late.rs
+++ b/src/rules/macro_argument_binding/late.rs
@@ -1,0 +1,137 @@
+//! Late-pass machinery: drains the pre-expansion pass's
+//! [`PENDING_VIOLATIONS`] queue and emits each diagnostic at the
+//! deepest enclosing HIR node so `cfg_attr`-wrapped `#[expect]` /
+//! `#[allow]` attributes resolve correctly.
+//!
+//! Mirrors the equivalent late pass in `macro_trailing_comma`; the
+//! two cannot share a single `EnclosingHirFinder` instance cheaply
+//! because each rule's pending list is a different type, but the walk
+//! shape is identical and a future refactor can extract a generic
+//! helper.
+
+use clippy_utils::diagnostics::span_lint_hir_and_then;
+use rustc_hir as hir;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::hir::nested_filter;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+use super::{MACRO_ARGUMENT_BINDING, PENDING_VIOLATIONS};
+
+pub struct MacroArgumentBindingLate;
+
+impl<'tcx> LateLintPass<'tcx> for MacroArgumentBindingLate {
+    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
+        let pending: Vec<Span> = {
+            let mut guard = PENDING_VIOLATIONS
+                .lock()
+                .unwrap_or_else(|err| err.into_inner());
+            std::mem::take(&mut *guard)
+        };
+        if pending.is_empty() {
+            return;
+        }
+        let tcx = lint_context.tcx;
+        let mut best: Vec<hir::HirId> = vec![hir::CRATE_HIR_ID; pending.len()];
+        let mut finder = EnclosingHirFinder {
+            tcx,
+            pending: &pending,
+            best: &mut best,
+        };
+        tcx.hir_walk_toplevel_module(&mut finder);
+        for (&span, &hir_id) in pending.iter().zip(best.iter()) {
+            emit(lint_context, hir_id, span);
+        }
+    }
+}
+
+fn emit(lint_context: &LateContext<'_>, hir_id: hir::HirId, span: Span) {
+    span_lint_hir_and_then(
+        lint_context,
+        MACRO_ARGUMENT_BINDING,
+        hir_id,
+        span,
+        "non-trivial expression passed directly to a macro",
+        |diag| {
+            diag.help(
+                "bind the expression to a `let` immediately before the macro \
+                 call so it is evaluated exactly once, regardless of how the \
+                 macro expands",
+            );
+        },
+    );
+}
+
+/// Walk the HIR once and, for each pending violation span, record the
+/// deepest HIR node whose span contains it. Mirrors the equivalent
+/// finder in `macro_trailing_comma`.
+struct EnclosingHirFinder<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    pending: &'a [Span],
+    best: &'a mut [hir::HirId],
+}
+
+impl<'a, 'tcx> EnclosingHirFinder<'a, 'tcx> {
+    fn update(&mut self, hir_id: hir::HirId, span: Span) {
+        for (index, &target) in self.pending.iter().enumerate() {
+            if !span.contains(target) {
+                continue;
+            }
+            self.best[index] = hir_id;
+        }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for EnclosingHirFinder<'_, 'tcx> {
+    type NestedFilter = nested_filter::All;
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.tcx
+    }
+
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_item(self, item);
+    }
+
+    fn visit_trait_item(&mut self, item: &'tcx hir::TraitItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_trait_item(self, item);
+    }
+
+    fn visit_impl_item(&mut self, item: &'tcx hir::ImplItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_impl_item(self, item);
+    }
+
+    fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_foreign_item(self, item);
+    }
+
+    fn visit_block(&mut self, block: &'tcx hir::Block<'tcx>) {
+        self.update(block.hir_id, block.span);
+        intravisit::walk_block(self, block);
+    }
+
+    fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
+        self.update(stmt.hir_id, stmt.span);
+        intravisit::walk_stmt(self, stmt);
+    }
+
+    fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) {
+        self.update(local.hir_id, local.span);
+        intravisit::walk_local(self, local);
+    }
+
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+        self.update(expr.hir_id, expr.span);
+        intravisit::walk_expr(self, expr);
+    }
+
+    fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
+        self.update(pat.hir_id, pat.span);
+        intravisit::walk_pat(self, pat);
+    }
+}

--- a/src/rules/macro_argument_binding/late.rs
+++ b/src/rules/macro_argument_binding/late.rs
@@ -19,7 +19,7 @@ use rustc_span::Span;
 
 use super::{MACRO_ARGUMENT_BINDING, PENDING_VIOLATIONS};
 
-pub struct MacroArgumentBindingLate;
+pub(super) struct MacroArgumentBindingLate;
 
 impl<'tcx> LateLintPass<'tcx> for MacroArgumentBindingLate {
     fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {

--- a/src/rules/macro_argument_binding/triviality.rs
+++ b/src/rules/macro_argument_binding/triviality.rs
@@ -1,0 +1,206 @@
+//! Argument splitting and the trivial-expression predicate.
+//!
+//! [`split_top_level_arguments`] turns the macro invocation's
+//! token stream into one segment per comma-separated argument.
+//! [`looks_like_expression`] rules out non-expression positions the
+//! macro author chose (`Type => [...]` and friends).
+//! [`is_trivial_expression`] decides whether the surviving expression
+//! falls in the spec's seven trivial shapes.
+//!
+//! The predicate is a hand-rolled token-stream walker — see the
+//! rationale in `planned-rules/macro-argument-binding.md`'s
+//! "Implementation notes" section. The walker is `take_*`-style per
+//! `planned-rules/IMPLEMENTATION_CONVENTIONS.md`.
+
+use rustc_ast::token::{Delimiter, IdentIsRaw, TokenKind};
+use rustc_ast::tokenstream::{TokenStream, TokenTree};
+use rustc_span::kw;
+
+/// Split the top-level token stream of a macro invocation into one
+/// segment per comma-separated argument. Returns `None` if a top-level
+/// `;` is encountered (the repeat form, `vec![v; count]`), which
+/// signals that the invocation is not a comma-separated argument list
+/// and the rule skips the whole call.
+///
+/// `=>` is ordinary content here — match-arm syntax inside `matches!`
+/// shows up as a top-level fat arrow but is meaningful to the macro,
+/// not a separator. The walker passes it through unchanged so each
+/// argument's `looks_like_expression` check can skip it as a non-
+/// expression position the macro author chose.
+pub(super) fn split_top_level_arguments(stream: &TokenStream) -> Option<Vec<Vec<TokenTree>>> {
+    let mut arguments: Vec<Vec<TokenTree>> = Vec::new();
+    let mut current: Vec<TokenTree> = Vec::new();
+    for tree in stream.iter() {
+        if let TokenTree::Token(token, _) = tree {
+            match token.kind {
+                TokenKind::Semi => return None,
+                TokenKind::Comma => {
+                    arguments.push(std::mem::take(&mut current));
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        current.push(tree.clone());
+    }
+    if !current.is_empty() {
+        arguments.push(current);
+    }
+    Some(arguments)
+}
+
+/// Heuristic: does the argument plausibly parse as a single Rust
+/// expression? The rule docs say "skip arguments that don't parse as a
+/// single expression (`name: type`, `name = value`, etc. are syntactic
+/// positions the macro author chose)" and prescribe a `Parser::parse_expr`
+/// re-parse to make that call. We approximate without `rustc_parse` to
+/// avoid emitting parser-recovery diagnostics for arbitrary macro
+/// inputs: a top-level `=>` token is a match-arm separator (`matches!`,
+/// `impl_lint_pass!`-style `Type => [LINT_NAMES]` DSLs) and is never
+/// part of a single Rust expression. Other non-expression markers like
+/// `name: type` and `name = value` are not reliably distinguishable
+/// from valid expression syntax (`expr: type` ascription, assignment),
+/// and a future re-parse-based implementation will subsume this check.
+pub(super) fn looks_like_expression(argument: &[TokenTree]) -> bool {
+    !argument.iter().any(|tree| {
+        matches!(
+            tree,
+            TokenTree::Token(token, _) if token.kind == TokenKind::FatArrow,
+        )
+    })
+}
+
+/// Returns `true` if the entire token slice forms a "trivial"
+/// expression per the rule's grammar. Triviality is purely syntactic:
+/// the seven shapes the rule docs enumerate, recursive on operands.
+/// Anything outside that grammar is non-trivial — including `const fn`
+/// calls and other "morally pure" expressions.
+pub(super) fn is_trivial_expression(tokens: &[TokenTree]) -> bool {
+    take_trivial_expression(tokens).is_some_and(<[_]>::is_empty)
+}
+
+fn take_trivial_expression(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+    let after_atom = take_trivial_atom(tokens)?;
+    Some(take_trivial_suffixes(after_atom))
+}
+
+fn take_trivial_atom(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+    let (head, rest) = tokens.split_first()?;
+    let TokenTree::Token(token, _) = head else {
+        return None;
+    };
+    match token.kind {
+        TokenKind::Literal(_) => Some(rest),
+        // `true` and `false` are keyword idents, not `Literal` tokens.
+        TokenKind::Ident(name, IdentIsRaw::No) if name == kw::True || name == kw::False => {
+            Some(rest)
+        }
+        // `&` expr or `&mut` expr.
+        TokenKind::And => take_reference_tail(rest),
+        // `&&` expr or `&& mut` expr (double reference).
+        TokenKind::AndAnd => take_reference_tail(rest),
+        // `*expr` (deref).
+        TokenKind::Star => take_trivial_expression(rest),
+        // Path: ident (`::` ident)*.
+        TokenKind::Ident(_, _) => Some(take_path_tail(rest)),
+        // Leading `::` — must be followed by an ident.
+        TokenKind::PathSep => take_path_after_sep(rest),
+        _ => None,
+    }
+}
+
+fn take_reference_tail(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+    let after_mut = match tokens.split_first() {
+        Some((TokenTree::Token(token, _), rest)) if token.is_keyword(kw::Mut) => rest,
+        _ => tokens,
+    };
+    take_trivial_expression(after_mut)
+}
+
+fn take_path_tail(mut tokens: &[TokenTree]) -> &[TokenTree] {
+    while let Some((TokenTree::Token(sep, _), after_sep)) = tokens.split_first() {
+        if sep.kind != TokenKind::PathSep {
+            break;
+        }
+        let Some((TokenTree::Token(ident, _), after_ident)) = after_sep.split_first() else {
+            break;
+        };
+        if !matches!(ident.kind, TokenKind::Ident(_, _)) {
+            break;
+        }
+        tokens = after_ident;
+    }
+    tokens
+}
+
+fn take_path_after_sep(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+    let (ident, rest) = tokens.split_first()?;
+    let TokenTree::Token(token, _) = ident else {
+        return None;
+    };
+    if !matches!(token.kind, TokenKind::Ident(_, _)) {
+        return None;
+    }
+    Some(take_path_tail(rest))
+}
+
+fn take_trivial_suffixes(mut tokens: &[TokenTree]) -> &[TokenTree] {
+    loop {
+        let Some((head, rest)) = tokens.split_first() else {
+            return tokens;
+        };
+        match head {
+            TokenTree::Token(token, _) => match token.kind {
+                // `.ident` (field access) or `.0` (tuple index).
+                TokenKind::Dot => {
+                    let Some((next, after)) = rest.split_first() else {
+                        return tokens;
+                    };
+                    let TokenTree::Token(next_token, _) = next else {
+                        return tokens;
+                    };
+                    match next_token.kind {
+                        TokenKind::Ident(_, _) | TokenKind::Literal(_) => tokens = after,
+                        _ => return tokens,
+                    }
+                }
+                // `as path` — type annotation. Only path-shaped types
+                // are recognised; references, slices, function pointers,
+                // etc. fall back to non-trivial.
+                TokenKind::Ident(name, IdentIsRaw::No) if name == kw::As => {
+                    let Some(after) = take_trivial_type(rest) else {
+                        return tokens;
+                    };
+                    tokens = after;
+                }
+                _ => return tokens,
+            },
+            // `[expr]` — index. Both base and index must be trivial;
+            // the recursion happens here for the index.
+            TokenTree::Delimited(_, _, Delimiter::Bracket, inner) => {
+                if !is_trivial_expression_stream(inner) {
+                    return tokens;
+                }
+                tokens = rest;
+            }
+            _ => return tokens,
+        }
+    }
+}
+
+fn take_trivial_type(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+    let (head, rest) = tokens.split_first()?;
+    let TokenTree::Token(token, _) = head else {
+        return None;
+    };
+    match token.kind {
+        TokenKind::Ident(_, _) => Some(take_path_tail(rest)),
+        TokenKind::PathSep => take_path_after_sep(rest),
+        _ => None,
+    }
+}
+
+fn is_trivial_expression_stream(stream: &TokenStream) -> bool {
+    let trees: Vec<TokenTree> = stream.iter().cloned().collect();
+    is_trivial_expression(&trees)
+}

--- a/src/rules/macro_argument_binding/triviality.rs
+++ b/src/rules/macro_argument_binding/triviality.rs
@@ -152,6 +152,12 @@ fn take_trivial_suffixes(mut tokens: &[TokenTree]) -> &[TokenTree] {
         match head {
             TokenTree::Token(token, _) => match token.kind {
                 // `.ident` (field access) or `.0` (tuple index).
+                // Postfix `.await` is *not* a field access — it's
+                // `ExprKind::Await`, which the rule docs list as
+                // non-trivial. Reject the `await` keyword explicitly so
+                // `future.await` correctly falls out as non-trivial.
+                // (`r#await` as a raw ident remains a literal field
+                // access and stays accepted via the catch-all arm.)
                 TokenKind::Dot => {
                     let Some((next, after)) = rest.split_first() else {
                         return tokens;
@@ -160,6 +166,9 @@ fn take_trivial_suffixes(mut tokens: &[TokenTree]) -> &[TokenTree] {
                         return tokens;
                     };
                     match next_token.kind {
+                        TokenKind::Ident(name, IdentIsRaw::No) if name == kw::Await => {
+                            return tokens;
+                        }
                         TokenKind::Ident(_, _) | TokenKind::Literal(_) => tokens = after,
                         _ => return tokens,
                     }

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::sync::Mutex;
 
+use crate::macro_path::{matches_any, parse_path};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_ast::MacCall;
 use rustc_ast::token::TokenKind;
@@ -331,46 +332,6 @@ fn queue(violation: PendingViolation) {
         .lock()
         .unwrap_or_else(|err| err.into_inner());
     guard.push(violation);
-}
-
-fn parse_path(raw: &str) -> Vec<String> {
-    raw.split("::")
-        .map(str::trim)
-        .filter(|segment| !segment.is_empty())
-        .map(str::to_owned)
-        .collect()
-}
-
-fn matches_any(invocation: &rustc_ast::Path, entries: &BTreeSet<Vec<String>>) -> bool {
-    entries.iter().any(|entry| entry_matches(entry, invocation))
-}
-
-/// Match a configured entry against an invocation path without
-/// allocating a `Vec<String>` snapshot of the invocation. Single-
-/// segment entries match the path's final segment; multi-segment
-/// entries tail-match the path's segments.
-fn entry_matches(entry: &[String], invocation: &rustc_ast::Path) -> bool {
-    let segments = &invocation.segments;
-    if entry.is_empty() || segments.is_empty() {
-        return false;
-    }
-    if entry.len() == 1 {
-        // Single-segment entry: match by the final segment of the path,
-        // so `vec!`, `std::vec!`, and `::std::vec!` all qualify.
-        segments
-            .last()
-            .is_some_and(|segment| segment.ident.name.as_str() == entry[0])
-    } else if segments.len() < entry.len() {
-        false
-    } else {
-        // Multi-segment entry: tail-match against the invocation path,
-        // accommodating optional leading crate prefixes.
-        let start = segments.len() - entry.len();
-        segments[start..]
-            .iter()
-            .zip(entry.iter())
-            .all(|(segment, entry_segment)| segment.ident.name.as_str() == entry_segment.as_str())
-    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for MacroTrailingCommaLate {

--- a/tests/macro_argument_binding.rs
+++ b/tests/macro_argument_binding.rs
@@ -1,0 +1,136 @@
+//! UI tests for `macro_argument_binding`'s configuration knobs. The
+//! default-config sweep lives in `ui/macro_argument_binding.rs` and is
+//! picked up by `tests/ui.rs`; these tests each point at their own
+//! one-fixture directory under `ui-toml/macro_argument_binding/` and
+//! pass a per-rule `dylint.toml` to [`dylint_testing::ui::Test`].
+//!
+//! Mirrors the structure of `tests/macro_trailing_comma.rs` — same
+//! shared-`Mutex` serialisation, same `dylint.toml` synthesis, same
+//! one-fixture-per-knob layout.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+const LINT_NAME: &str = "perfectionist::macro_argument_binding";
+
+static SERIAL: Mutex<()> = Mutex::new(());
+
+#[derive(Default, serde::Serialize)]
+struct RuleConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mode: Option<&'static str>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    deny_extra: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    allow_extra: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    ignore: Vec<String>,
+}
+
+fn dylint_toml(config: RuleConfig) -> String {
+    let table: BTreeMap<&str, RuleConfig> = [(LINT_NAME, config)].into_iter().collect();
+    toml::to_string(&table).expect("serialise rule config as dylint.toml")
+}
+
+fn run(src_base: &str, config: RuleConfig) {
+    let _serial = SERIAL.lock().unwrap_or_else(|err| err.into_inner());
+    dylint_testing::ui::Test::src_base(env!("CARGO_PKG_NAME"), src_base)
+        .dylint_toml(dylint_toml(config))
+        .run();
+}
+
+#[test]
+fn enabled_false_suppresses_the_entire_rule() {
+    run(
+        "ui-toml/macro_argument_binding/disabled",
+        RuleConfig {
+            enabled: Some(false),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn deny_only_silently_accepts_uncatalogued_macros() {
+    run(
+        "ui-toml/macro_argument_binding/mode_deny_only",
+        RuleConfig {
+            mode: Some("deny_only"),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn blanket_flags_allow_listed_macros_too() {
+    run(
+        "ui-toml/macro_argument_binding/mode_blanket",
+        RuleConfig {
+            mode: Some("blanket"),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn deny_extra_adds_a_qualified_macro_to_the_deny_list() {
+    run(
+        "ui-toml/macro_argument_binding/deny_extra",
+        RuleConfig {
+            deny_extra: vec!["inner::their_macro".into()],
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn allow_extra_silences_an_uncatalogued_macro() {
+    run(
+        "ui-toml/macro_argument_binding/allow_extra",
+        RuleConfig {
+            allow_extra: vec!["my_macro".into()],
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn ignore_suppresses_a_built_in_deny_listed_macro() {
+    run(
+        "ui-toml/macro_argument_binding/ignore",
+        RuleConfig {
+            ignore: vec!["debug_assert_eq".into()],
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn ignore_wins_over_deny_extra_for_the_same_macro() {
+    run(
+        "ui-toml/macro_argument_binding/ignore_overrides_deny_extra",
+        RuleConfig {
+            deny_extra: vec!["my_macro".into()],
+            ignore: vec!["my_macro".into()],
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn fn_level_expect_fulfils_against_a_violation() {
+    run(
+        "ui-toml/macro_argument_binding/expect_at_fn_scope",
+        RuleConfig::default(),
+    );
+}
+
+#[test]
+fn crate_level_expect_fulfils_against_a_violation() {
+    run(
+        "ui-toml/macro_argument_binding/expect_at_crate_root",
+        RuleConfig::default(),
+    );
+}

--- a/ui-toml/macro_argument_binding/allow_extra/fixture.rs
+++ b/ui-toml/macro_argument_binding/allow_extra/fixture.rs
@@ -1,0 +1,19 @@
+// Skipped: `my_macro!` is uncatalogued and would normally be flagged
+// under the default `AllowAndDeny` mode, but the fixture's
+// `dylint.toml` adds `my_macro` to `allow_extra`, opting the macro
+// into the trusted set. Even a non-trivial argument is now accepted.
+
+macro_rules! my_macro {
+    ($item:expr) => {{
+        let _ = $item;
+        0
+    }};
+}
+
+fn main() {
+    let _ = my_macro!(value());
+}
+
+fn value() -> u32 {
+    0
+}

--- a/ui-toml/macro_argument_binding/deny_extra/fixture.rs
+++ b/ui-toml/macro_argument_binding/deny_extra/fixture.rs
@@ -1,0 +1,26 @@
+// `deny_extra` adds a project-specific macro to the deny list. The
+// `inner::their_macro!` invocation here matches the multi-segment
+// entry `inner::their_macro` — multi-segment entries tail-match the
+// invocation path, so it covers both `their_macro!` reached through
+// the `inner` module here and a third-party macro reached as
+// `somecrate::their_macro!`.
+
+#[macro_export]
+macro_rules! their_macro {
+    ($item:expr) => {{
+        let _ = $item;
+        0
+    }};
+}
+
+mod inner {
+    pub(crate) use crate::their_macro;
+}
+
+fn main() {
+    let _ = inner::their_macro!(value());
+}
+
+fn value() -> u32 {
+    0
+}

--- a/ui-toml/macro_argument_binding/deny_extra/fixture.rs
+++ b/ui-toml/macro_argument_binding/deny_extra/fixture.rs
@@ -4,6 +4,16 @@
 // invocation path, so it covers both `their_macro!` reached through
 // the `inner` module here and a third-party macro reached as
 // `somecrate::their_macro!`.
+//
+// Note: `#[macro_export]` here is a fixture-only workaround, not a
+// representation of how a downstream crate would expose its macro.
+// `macro_rules!` macros are not at crate-root scope by default, so
+// `pub(crate) use crate::their_macro` would otherwise fail to
+// resolve; `#[macro_export]` hoists the macro into the root namespace
+// for the duration of this self-contained test. A real third-party
+// macro is already exported through its defining crate's module
+// structure, so users adding a qualified entry to `deny_extra` do
+// not need the attribute.
 
 #[macro_export]
 macro_rules! their_macro {

--- a/ui-toml/macro_argument_binding/deny_extra/fixture.stderr
+++ b/ui-toml/macro_argument_binding/deny_extra/fixture.stderr
@@ -1,0 +1,11 @@
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/fixture.rs:21:33
+   |
+LL |     let _ = inner::their_macro!(value());
+   |                                 ^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+   = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
+
+warning: 1 warning emitted
+

--- a/ui-toml/macro_argument_binding/deny_extra/fixture.stderr
+++ b/ui-toml/macro_argument_binding/deny_extra/fixture.stderr
@@ -1,5 +1,5 @@
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/fixture.rs:21:33
+  --> $DIR/fixture.rs:31:33
    |
 LL |     let _ = inner::their_macro!(value());
    |                                 ^^^^^^^

--- a/ui-toml/macro_argument_binding/disabled/fixture.rs
+++ b/ui-toml/macro_argument_binding/disabled/fixture.rs
@@ -1,0 +1,14 @@
+// Skipped: `debug_assert_eq!` is on the built-in deny list and the
+// first argument is a non-trivial method call, but the fixture's
+// `dylint.toml` sets `enabled = false`, so the rule must NOT fire.
+
+fn main() {
+    let mut value: u32 = 0;
+    debug_assert_eq!(replace(&mut value, 1), 0);
+}
+
+fn replace(slot: &mut u32, new: u32) -> u32 {
+    let old = *slot;
+    *slot = new;
+    old
+}

--- a/ui-toml/macro_argument_binding/expect_at_crate_root/fixture.rs
+++ b/ui-toml/macro_argument_binding/expect_at_crate_root/fixture.rs
@@ -1,0 +1,21 @@
+// Crate-level `#[expect]` must mark the expectation fulfilled when
+// a violation exists in the crate. Mirrors the equivalent fixture in
+// `macro_trailing_comma`'s test suite.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+#![cfg_attr(
+    dylint_lib = "perfectionist",
+    expect(
+        perfectionist::macro_argument_binding,
+        reason = "crate-root expect must fulfil"
+    )
+)]
+
+fn main() {
+    debug_assert!(value().is_some());
+}
+
+fn value() -> Option<u32> {
+    None
+}

--- a/ui-toml/macro_argument_binding/expect_at_fn_scope/fixture.rs
+++ b/ui-toml/macro_argument_binding/expect_at_fn_scope/fixture.rs
@@ -1,0 +1,27 @@
+// A function-scope `#[expect]` should fulfil — the late pass finds
+// the deepest enclosing HIR node for each violation and emits the
+// diagnostic there, so a per-function suppression behaves correctly.
+// The crate-level case is exercised by the `expect_at_crate_root`
+// fixture.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+
+#[cfg_attr(
+    dylint_lib = "perfectionist",
+    expect(
+        perfectionist::macro_argument_binding,
+        reason = "function-scope expect must still fulfil"
+    )
+)]
+fn suppressed() {
+    debug_assert!(value().is_some());
+}
+
+fn main() {
+    suppressed();
+}
+
+fn value() -> Option<u32> {
+    None
+}

--- a/ui-toml/macro_argument_binding/ignore/fixture.rs
+++ b/ui-toml/macro_argument_binding/ignore/fixture.rs
@@ -1,0 +1,15 @@
+// Skipped: `debug_assert_eq!` is on the built-in deny list and the
+// first argument is a non-trivial method call, but the fixture's
+// `dylint.toml` adds `debug_assert_eq` to `ignore`, which always
+// wins over the deny / allow lists. The rule emits no diagnostic.
+
+fn main() {
+    let mut value: u32 = 0;
+    debug_assert_eq!(replace(&mut value, 1), 0);
+}
+
+fn replace(slot: &mut u32, new: u32) -> u32 {
+    let old = *slot;
+    *slot = new;
+    old
+}

--- a/ui-toml/macro_argument_binding/ignore_overrides_deny_extra/fixture.rs
+++ b/ui-toml/macro_argument_binding/ignore_overrides_deny_extra/fixture.rs
@@ -1,0 +1,19 @@
+// Skipped: `my_macro!` is added to both `deny_extra` and `ignore`.
+// `ignore` is checked first and always wins, so the rule emits no
+// diagnostic even though the deny-list entry would otherwise fire on
+// the non-trivial argument.
+
+macro_rules! my_macro {
+    ($item:expr) => {{
+        let _ = $item;
+        0
+    }};
+}
+
+fn main() {
+    let _ = my_macro!(value());
+}
+
+fn value() -> u32 {
+    0
+}

--- a/ui-toml/macro_argument_binding/mode_blanket/fixture.rs
+++ b/ui-toml/macro_argument_binding/mode_blanket/fixture.rs
@@ -1,0 +1,17 @@
+// `mode = "blanket"` flags every function-like or array-like
+// invocation that carries a non-trivial argument, regardless of what
+// list (if any) the macro would otherwise hit. `format!` is on the
+// default allow list but blanket mode disregards the built-in allow
+// list, so the non-trivial format argument gets flagged. `vec!` of
+// trivial elements is still accepted because the elements themselves
+// are trivial.
+
+fn main() {
+    let count: u32 = 0;
+    let _ = format!("count = {}", value());
+    let _ = vec![count, count, count];
+}
+
+fn value() -> u32 {
+    0
+}

--- a/ui-toml/macro_argument_binding/mode_blanket/fixture.stderr
+++ b/ui-toml/macro_argument_binding/mode_blanket/fixture.stderr
@@ -1,0 +1,11 @@
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/fixture.rs:11:35
+   |
+LL |     let _ = format!("count = {}", value());
+   |                                   ^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+   = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
+
+warning: 1 warning emitted
+

--- a/ui-toml/macro_argument_binding/mode_deny_only/fixture.rs
+++ b/ui-toml/macro_argument_binding/mode_deny_only/fixture.rs
@@ -1,0 +1,20 @@
+// `mode = "deny_only"` flags only invocations of the curated deny
+// list (`debug_assert*`). Every other macro is silently accepted —
+// the uncatalogued `my_macro!` here gets a free pass even though its
+// argument is a non-trivial function call.
+
+macro_rules! my_macro {
+    ($item:expr) => {{
+        let _ = $item;
+        0
+    }};
+}
+
+fn main() {
+    let _ = my_macro!(value());
+    debug_assert!(value().is_some());
+}
+
+fn value() -> Option<u32> {
+    None
+}

--- a/ui-toml/macro_argument_binding/mode_deny_only/fixture.stderr
+++ b/ui-toml/macro_argument_binding/mode_deny_only/fixture.stderr
@@ -1,0 +1,11 @@
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/fixture.rs:15:19
+   |
+LL |     debug_assert!(value().is_some());
+   |                   ^^^^^^^^^^^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+   = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
+
+warning: 1 warning emitted
+

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -112,7 +112,6 @@ fn _single_argument_deny() {
 // the test harness's default edition (no real `async fn` needed).
 fn _await_suffix_flagged() {
     let future = ();
-    let _ = future;
     let _ = await_macro!(future.await);
 }
 

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -9,6 +9,10 @@ macro_rules! arrow_macro {
     }};
 }
 
+macro_rules! await_macro {
+    ($($tokens:tt)*) => {{ 0 }};
+}
+
 // `debug_assert_eq!` is on the built-in deny list. The first argument
 // is a non-trivial method call; in release builds the macro folds to
 // `if false { ... }` and the call never runs, leaving the map in a
@@ -96,6 +100,20 @@ fn _all_trivial_shapes_accepted() {
 // Single-argument deny-listed call with a non-trivial expression.
 fn _single_argument_deny() {
     debug_assert!(value().is_some());
+}
+
+// `.await` is `ExprKind::Await`, not a field access — non-trivial
+// per the spec. Without the explicit `await`-keyword rejection in
+// the dot-suffix branch, the walker would consume `.await` as a
+// "trivial field access" and silently accept the whole expression.
+// `await_macro!` is uncatalogued so default-mode flags non-trivial
+// args — that's what we verify here. The macro swallows the tokens
+// rather than emitting an `expr` so the fixture stays valid under
+// the test harness's default edition (no real `async fn` needed).
+fn _await_suffix_flagged() {
+    let future = ();
+    let _ = future;
+    let _ = await_macro!(future.await);
 }
 
 // Empty top-level argument list — nothing to check, no false positive.

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -2,6 +2,13 @@ macro_rules! my_macro {
     ($($item:expr),* $(,)?) => {{ $(let _ = $item;)* 0 }};
 }
 
+macro_rules! arrow_macro {
+    ($name:ident => $value:expr) => {{
+        let _ = $value;
+        0
+    }};
+}
+
 // `debug_assert_eq!` is on the built-in deny list. The first argument
 // is a non-trivial method call; in release builds the macro folds to
 // `if false { ... }` and the call never runs, leaving the map in a
@@ -104,13 +111,6 @@ fn _empty_argument_list() {
 // argument is skipped rather than parsed as an expression.
 fn _fat_arrow_skips_argument() {
     let _ = arrow_macro!(NameType => value());
-}
-
-macro_rules! arrow_macro {
-    ($name:ident => $value:expr) => {{
-        let _ = $value;
-        0
-    }};
 }
 
 #[allow(dead_code)]

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -96,6 +96,26 @@ fn _empty_argument_list() {
     let _: Vec<u32> = vec![];
 }
 
+// Skipped: a top-level `=>` signals the argument is a syntactic
+// position the macro author chose (`Type => [LINT_NAMES]` is the
+// canonical example, courtesy of `impl_lint_pass!`), not a Rust
+// expression. The rule does not flag these — `value()` here is
+// non-trivial but lives on the right-hand side of `=>`, so the whole
+// argument is skipped rather than parsed as an expression.
+fn _fat_arrow_skips_argument() {
+    let _ = arrow_macro!(NameType => value());
+}
+
+macro_rules! arrow_macro {
+    ($name:ident => $value:expr) => {{
+        let _ = $value;
+        0
+    }};
+}
+
+#[allow(dead_code)]
+struct NameType;
+
 struct Map;
 impl Map {
     fn insert(&mut self, _: u32, _: u32) -> Option<u32> {

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -1,0 +1,113 @@
+macro_rules! my_macro {
+    ($($item:expr),* $(,)?) => {{ $(let _ = $item;)* 0 }};
+}
+
+// `debug_assert_eq!` is on the built-in deny list. The first argument
+// is a non-trivial method call; in release builds the macro folds to
+// `if false { ... }` and the call never runs, leaving the map in a
+// state the author did not intend. The literal `None` and the string
+// literal panic message are trivial and accepted.
+fn _motivating_bug(map: &mut Map) {
+    debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
+}
+
+// Bare `debug_assert!` likewise: the condition is a method call, the
+// argument is non-trivial, the rule flags it.
+fn _debug_assert_method_call() {
+    debug_assert!(value().is_some());
+}
+
+// `debug_assert_ne!` flagged on both arguments. `value()` is a
+// function call; `Some(0)` is a tuple-variant *call*, not a bare
+// path. Only the bare-path form (e.g., `Some` as a function pointer)
+// is trivial, so the constructor invocation is flagged separately.
+fn _debug_assert_ne_call() {
+    debug_assert_ne!(value(), Some(0));
+}
+
+// An uncatalogued macro under the default `AllowAndDeny` mode is
+// neither denied nor allowed: the rule defaults to flagging non-
+// trivial arguments. `value()` is non-trivial; `count` (a path) is
+// trivial and accepted.
+fn _unknown_macro_default_flags(count: u32) {
+    let _ = my_macro!(value(), count);
+}
+
+// Allow-listed `format!` evaluates each argument exactly once. Even a
+// non-trivial expression in a format-args slot is accepted.
+fn _format_allow_listed() {
+    let mut count: u32 = 0;
+    let _ = format!("retrying {} times", {
+        count += 1;
+        count
+    });
+}
+
+// Allow-listed `vec!`. Comma-form is the array-like shape the rule
+// targets, but `vec!` is on the allow list, so non-trivial elements
+// are accepted under the default config.
+fn _vec_allow_listed() {
+    let _ = vec![value(), value(), value()];
+}
+
+// Repeat-form `vec![v; count]` uses a top-level `;`, which signals
+// that the invocation is not a comma-separated argument list. The
+// rule skips the whole call.
+fn _vec_repeat_form_skipped() {
+    let _ = vec![value(); 4];
+}
+
+// Curly-brace invocation is out of scope: by convention the body is
+// the macro's DSL, not a comma-separated argument list. Skipped even
+// for a deny-listed macro name. `debug_assert!` accepts the brace
+// form via the surrounding `macro_rules!` dispatch.
+fn _brace_delimiter_skipped() {
+    debug_assert! { value().is_some() }
+}
+
+// All seven trivial argument shapes — accepted under every mode. The
+// outer `debug_assert_eq!` is on the deny list, so any non-trivial
+// argument here would otherwise be flagged.
+fn _all_trivial_shapes_accepted() {
+    let pair: (u32, u32) = (0, 0);
+    let buffer: [u32; 4] = [0; 4];
+    let pointer: &u32 = &MAX;
+    let owned: u32 = 0;
+    let mut left: u32 = 0;
+    let mut right: u32 = 0;
+    debug_assert_eq!(0u32, MAX, "literal vs path");
+    debug_assert_eq!(true, false, "bool keywords");
+    debug_assert_eq!(&owned, &MAX, "references");
+    debug_assert_ne!(&mut left, &mut right, "mut reference");
+    debug_assert_eq!(pair.0, pair.1, "tuple index");
+    debug_assert_eq!(buffer[0], buffer[INDEX], "indexing trivial bases");
+    debug_assert_eq!(*pointer, *pointer, "deref of a path");
+    debug_assert_eq!(0u32 as u64, MAX as u64, "trivial cast");
+    debug_assert_eq!(::std::u32::MAX, std::u32::MAX, "rooted path");
+}
+
+// Single-argument deny-listed call with a non-trivial expression.
+fn _single_argument_deny() {
+    debug_assert!(value().is_some());
+}
+
+// Empty top-level argument list — nothing to check, no false positive.
+fn _empty_argument_list() {
+    let _: Vec<u32> = vec![];
+}
+
+struct Map;
+impl Map {
+    fn insert(&mut self, _: u32, _: u32) -> Option<u32> {
+        None
+    }
+}
+
+const MAX: u32 = 0;
+const INDEX: usize = 0;
+
+fn value() -> Option<u32> {
+    None
+}
+
+fn main() {}

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -1,5 +1,5 @@
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:18:22
+  --> $DIR/macro_argument_binding.rs:22:22
    |
 LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
    |                      ^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
    = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:24:19
+  --> $DIR/macro_argument_binding.rs:28:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:32:22
+  --> $DIR/macro_argument_binding.rs:36:22
    |
 LL |     debug_assert_ne!(value(), Some(0));
    |                      ^^^^^^^
@@ -24,7 +24,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:32:31
+  --> $DIR/macro_argument_binding.rs:36:31
    |
 LL |     debug_assert_ne!(value(), Some(0));
    |                               ^^^^^^^
@@ -32,7 +32,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:40:23
+  --> $DIR/macro_argument_binding.rs:44:23
    |
 LL |     let _ = my_macro!(value(), count);
    |                       ^^^^^^^
@@ -40,12 +40,20 @@ LL |     let _ = my_macro!(value(), count);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:98:19
+  --> $DIR/macro_argument_binding.rs:102:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: 6 warnings emitted
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:116:26
+   |
+LL |     let _ = await_macro!(future.await);
+   |                          ^^^^^^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: 7 warnings emitted
 

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -1,0 +1,51 @@
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:11:22
+   |
+LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
+   |                      ^^^^^^^^^^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+   = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
+
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:17:19
+   |
+LL |     debug_assert!(value().is_some());
+   |                   ^^^^^^^^^^^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:25:22
+   |
+LL |     debug_assert_ne!(value(), Some(0));
+   |                      ^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:25:31
+   |
+LL |     debug_assert_ne!(value(), Some(0));
+   |                               ^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:33:23
+   |
+LL |     let _ = my_macro!(value(), count);
+   |                       ^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:91:19
+   |
+LL |     debug_assert!(value().is_some());
+   |                   ^^^^^^^^^^^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: 6 warnings emitted
+

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -1,51 +1,14 @@
-warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:11:22
+error: cannot find macro `arrow_macro` in this scope
+  --> $DIR/macro_argument_binding.rs:106:13
    |
-LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
-   |                      ^^^^^^^^^^^^^^^^
+LL |     let _ = arrow_macro!(NameType => value());
+   |             ^^^^^^^^^^^ consider moving the definition of `arrow_macro` before this call
    |
-   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
-   = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
+note: a macro with the same name exists, but it appears later
+  --> $DIR/macro_argument_binding.rs:109:14
+   |
+LL | macro_rules! arrow_macro {
+   |              ^^^^^^^^^^^
 
-warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:17:19
-   |
-LL |     debug_assert!(value().is_some());
-   |                   ^^^^^^^^^^^^^^^^^
-   |
-   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
-
-warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:25:22
-   |
-LL |     debug_assert_ne!(value(), Some(0));
-   |                      ^^^^^^^
-   |
-   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
-
-warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:25:31
-   |
-LL |     debug_assert_ne!(value(), Some(0));
-   |                               ^^^^^^^
-   |
-   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
-
-warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:33:23
-   |
-LL |     let _ = my_macro!(value(), count);
-   |                       ^^^^^^^
-   |
-   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
-
-warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:91:19
-   |
-LL |     debug_assert!(value().is_some());
-   |                   ^^^^^^^^^^^^^^^^^
-   |
-   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
-
-warning: 6 warnings emitted
+error: aborting due to 1 previous error
 

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -48,7 +48,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:116:26
+  --> $DIR/macro_argument_binding.rs:115:26
    |
 LL |     let _ = await_macro!(future.await);
    |                          ^^^^^^^^^^^^

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -1,14 +1,51 @@
-error: cannot find macro `arrow_macro` in this scope
-  --> $DIR/macro_argument_binding.rs:106:13
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:18:22
    |
-LL |     let _ = arrow_macro!(NameType => value());
-   |             ^^^^^^^^^^^ consider moving the definition of `arrow_macro` before this call
+LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
+   |                      ^^^^^^^^^^^^^^^^
    |
-note: a macro with the same name exists, but it appears later
-  --> $DIR/macro_argument_binding.rs:109:14
-   |
-LL | macro_rules! arrow_macro {
-   |              ^^^^^^^^^^^
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+   = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
 
-error: aborting due to 1 previous error
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:24:19
+   |
+LL |     debug_assert!(value().is_some());
+   |                   ^^^^^^^^^^^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:32:22
+   |
+LL |     debug_assert_ne!(value(), Some(0));
+   |                      ^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:32:31
+   |
+LL |     debug_assert_ne!(value(), Some(0));
+   |                               ^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:40:23
+   |
+LL |     let _ = my_macro!(value(), count);
+   |                       ^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:98:19
+   |
+LL |     debug_assert!(value().is_some());
+   |                   ^^^^^^^^^^^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: 6 warnings emitted
 


### PR DESCRIPTION
Implements the easy half of [`macro_argument_binding`](https://github.com/KSXGitHub/perfectionist/blob/master/planned-rules/macro-argument-binding.md): flag non-trivial top-level arguments to `name!(...)` / `name![...]` invocations.

## Eligibility modes

| Mode | What it flags |
| --- | --- |
| `deny_only` | curated `debug_assert*` deny list + `deny_extra` |
| `blanket` | every invocation except `allow_extra` (built-in allow list ignored) |
| `allow_and_deny` (default) | deny list + everything not on the allow list |

`enabled`, `deny_extra`, `allow_extra`, `ignore` work as documented. `matcher_based` mode is left for a follow-up so it can share infrastructure with `macro_trailing_comma`'s equivalent check.

## Implementation notes

- The trivial-expression predicate is a hand-rolled token-stream walker (literal / path / `&`/`*` / `.field` / `[index]` / `as path`) rather than a `rustc_parse` round-trip, to avoid emitting parser-recovery diagnostics for arbitrary macro inputs.
- Pre-expansion + late-pass split mirrors `macro_trailing_comma`'s `cfg_attr`-aware `#[expect]` handling.
- `parse_path` / `matches_any` / `entry_matches` move to `crate::macro_path` so both rules share one implementation.

## Test plan

- [x] `ui/macro_argument_binding.rs` covers the seven trivial shapes, the deny / allow / unknown verdicts, brace-delimited skip, and `vec![v; count]` skip.
- [x] 9 ui-toml fixtures exercise every config knob and `#[expect]` fulfillment at fn / crate scope.
- [x] `cargo test --test ui --test macro_argument_binding --test macro_trailing_comma`.