### PR TITLE
ci: preview web pages

### DIFF
--- a/.github/workflows/pages-preview.yaml
+++ b/.github/workflows/pages-preview.yaml
@@ -1,0 +1,80 @@
+name: Pages preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+# One in-flight preview build per PR. Newer pushes supersede older
+# ones; the deploy itself is fast enough that overlap is rare, but
+# cancelling avoids racing two `wrangler pages deploy` calls.
+concurrency:
+  group: pages-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    name: Build and deploy preview
+    runs-on: ubuntu-latest
+
+    # Scopes CLOUDFLARE_API_TOKEN to this job. The deployment also
+    # shows up under the repo's Environments tab so each preview is
+    # tracked alongside production.
+    environment:
+      name: cloudflare-preview
+      url: ${{ steps.deploy.outputs.deployment-url }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache
+        uses: actions/cache@v5
+        timeout-minutes: 1
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ github.job }}-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ github.job }}-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
+
+      - name: Install Rust
+        shell: bash
+        run: |
+          installer=$(mktemp -d)/install-rustup
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > $installer
+          bash $installer --default-toolchain none -y
+          source "$HOME/.cargo/env"
+          rustup show active-toolchain || rustup show
+
+      - name: Install dylint-link
+        uses: taiki-e/install-action@v2
+        with:
+          tool: dylint-link
+
+      - name: Render site
+        shell: bash
+        run: cargo run --package _gen_docs --bin gen-docs -- "$(pwd)" gh-pages
+
+      # Wrangler's `--branch` flag drives the alias subdomain
+      # Cloudflare assigns to the deployment
+      # (<branch-slug>.perfectionist-preview.pages.dev). Using the
+      # PR's head ref keeps that URL stable across pushes to the
+      # same PR; the per-commit hash URL stays unique per deploy.
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy gh-pages --project-name=perfectionist-preview --branch=${{ github.head_ref }} --commit-hash=${{ github.event.pull_request.head.sha }}
+
+      - name: Clean workspace artifacts before cache
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: cargo clean --workspace

--- a/.github/workflows/pages-preview.yaml
+++ b/.github/workflows/pages-preview.yaml
@@ -27,7 +27,13 @@ jobs:
       url: ${{ steps.deploy.outputs.deployment-url }}
 
     steps:
+      # Check out the PR head commit (not the auto-generated merge
+      # ref) so the rendered docs reflect exactly the code under
+      # review and the "Source:" permalinks resolve to a SHA that
+      # exists on GitHub.
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Cache
         uses: actions/cache@v5
@@ -56,9 +62,13 @@ jobs:
         with:
           tool: dylint-link
 
+      # Pass the PR head SHA as `--git-ref` so the rendered
+      # "Source:" links permalink the exact commit being previewed
+      # rather than `master` (which `gen-docs` defaults to but
+      # which isn't checked out here).
       - name: Render site
         shell: bash
-        run: cargo run --package _gen_docs --bin gen-docs -- "$(pwd)" gh-pages
+        run: cargo run --package _gen_docs --bin gen-docs -- "$(pwd)" gh-pages --git-ref="${{ github.event.pull_request.head.sha }}"
 
       # Wrangler's `--branch` flag drives the alias subdomain
       # Cloudflare assigns to the deployment


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pages-preview.yaml`, which builds the lint-catalogue docs site on every `pull_request` push and deploys it to a separate Cloudflare Pages project (`perfectionist-preview`). The preview URL appears under the PR's Deployments section.

The existing production deploy via `pages.yaml` to `ksxgithub.github.io/perfectionist` is untouched — this workflow only triggers on `pull_request` and only writes to the preview project.

## Mechanics

- Build mirrors `pages.yaml` (same cache key prefix, rustup install, `cargo run -p _gen_docs`).
- Checkout is pinned to the PR head SHA; the same SHA is passed to `gen-docs --git-ref` so rendered "Source:" links permalink the reviewed commit.
- Deploy uses `cloudflare/wrangler-action@v3` with `--branch=<head-ref>` for stable per-PR alias URLs (`<branch-slug>.perfectionist-preview.pages.dev`).
- Job is gated on `environment: cloudflare-preview`, scoping `CLOUDFLARE_API_TOKEN` to this workflow and surfacing each preview in the repo's Environments tab.
- Concurrency keyed per PR with `cancel-in-progress: true` so a fresh push supersedes an in-flight build.

## Known limitations

- **Fork PRs won't deploy.** GitHub withholds secrets from fork workflows by design; those PRs build successfully and fail only at the deploy step. Can be addressed later with a two-workflow `workflow_run` pattern if a fork PR ever needs a preview.
- **Old previews aren't auto-cleaned on PR close.** Cloudflare retains them indefinitely at no cost; a cleanup workflow can be added if the list grows noisy.