### PR TITLE
refactor(rules): split the long rule files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,46 @@ has two consequences for the implementer:
    crate-internal module rather than co-housing the rules in one
    file.
 
+3. **When a rule grows past one screenful, split it into a
+   directory module beside the flat `.rs` entry.** The crate's own
+   `perfectionist::flat_module_pattern` lint forbids the `mod.rs`
+   form, so the layout is `src/rules/<rule>.rs` next to
+   `src/rules/<rule>/<concern>.rs`. The flat `.rs` entry keeps the
+   `declare_tool_lint!` block, the `register_lint` / `register_pass`
+   functions, the `EarlyLintPass` / `LateLintPass` driver, and any
+   process-wide state (`static PENDING_VIOLATIONS`, etc.). Common
+   submodule names that have emerged:
+   - `config` — `Config` struct, default lists, in-memory rule state.
+   - `early` / `late` — the corresponding pass implementation when
+     it doesn't fit alongside the driver.
+   - `emit` — diagnostic-emission helpers, one per violation shape.
+   - `queue` — the `PendingViolation` payload for rules that split
+     across pre-expansion and late passes.
+   - `scan` / `parser` — source-text walkers and parser combinators.
+   - `ordering` / `triviality` — rule-specific algorithms.
+
+   The `macro_argument_binding/`, `macro_trailing_comma/`,
+   `prefer_raw_string/`, `derive_ordering/`,
+   `unicode_ellipsis_in_panic_messages/`, and
+   `single_letter_closure_param/` directories illustrate the
+   pattern.
+
+4. **Cross-rule helpers are `pub(crate)`, not `pub`.** The crate is
+   a dylint `cdylib` with no public API surface, so `pub` over-
+   advertises. Items in `src/common.rs`, `src/macro_path.rs`,
+   `src/enclosing_hir.rs`, and `src/literal_scan.rs` should all be
+   `pub(crate)` (or tighter). Use `pub(super)` for items that are
+   only meant to leak one module level up — e.g. a rule's `Config`
+   struct that's read by the rule's flat `.rs` driver but nowhere
+   else.
+
+   When deciding between `src/common.rs` and a dedicated module:
+   `common.rs` is for short, self-contained, single-concept
+   helpers (`is_single_ascii_letter`, `binding_ident`). Anything
+   that has its own invariants worth documenting in a module
+   docstring — a generic HIR walker, a per-character emit loop, a
+   path-set parser — earns its own file.
+
 ## When the implementation is complete
 
 If a PR fully implements a rule — every sub-check, every

--- a/src/common.rs
+++ b/src/common.rs
@@ -25,3 +25,14 @@ pub(crate) fn binding_ident<'hir>(pat: &'hir hir::Pat<'hir>) -> Option<rustc_spa
         _ => None,
     }
 }
+
+/// Sibling of [`binding_ident`] that returns the binding's `HirId`
+/// instead of its `Ident`. Used by the closure-parameter rule to test
+/// whether a particular expression refers to one of the closure's
+/// parameters.
+pub(crate) fn binding_hir_id<'hir>(pat: &'hir hir::Pat<'hir>) -> Option<hir::HirId> {
+    match pat.kind {
+        hir::PatKind::Binding(_, hir_id, _, None) => Some(hir_id),
+        _ => None,
+    }
+}

--- a/src/enclosing_hir.rs
+++ b/src/enclosing_hir.rs
@@ -24,8 +24,9 @@ use rustc_span::Span;
 /// Walk the HIR once and, for each input span, return the deepest HIR
 /// node whose own span contains it. The returned vector has the same
 /// length and order as `target_spans`. A span not contained by any
-/// visited node — e.g. one that lies outside the crate's local HIR —
-/// maps to [`hir::CRATE_HIR_ID`].
+/// visited node — e.g. one inside a synthesised macro expansion whose
+/// enclosing item's span does not cover the call site — maps to
+/// [`hir::CRATE_HIR_ID`].
 pub(crate) fn find_enclosing_hir_ids(tcx: TyCtxt<'_>, target_spans: &[Span]) -> Vec<hir::HirId> {
     let mut best: Vec<hir::HirId> = vec![hir::CRATE_HIR_ID; target_spans.len()];
     let mut finder = EnclosingHirFinder {

--- a/src/enclosing_hir.rs
+++ b/src/enclosing_hir.rs
@@ -1,0 +1,111 @@
+//! Shared helper for the pre-expansion → late-pass split that
+//! `macro_trailing_comma` and `macro_argument_binding` both use.
+//!
+//! Both rules emit their diagnostics from a late pass, after parking
+//! violation spans during a pre-expansion pass. The late pass then
+//! anchors each pending span at the deepest enclosing HIR node so
+//! `cfg_attr`-wrapped `#[expect]` / `#[allow]` attributes resolve
+//! correctly. The walk shape is identical between the two rules; this
+//! module provides the generic walker.
+//!
+//! Callers feed in the spans they care about and get back, for each
+//! one, the deepest HIR node whose span contains it (or
+//! [`hir::CRATE_HIR_ID`] if nothing did). Pre-expansion-pass payloads
+//! that carry more than a span (e.g. `macro_trailing_comma`'s
+//! `Insert` / `Remove` discriminator) project to `Span` at the call
+//! site before invoking [`find_enclosing_hir_ids`].
+
+use rustc_hir as hir;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_middle::hir::nested_filter;
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+/// Walk the HIR once and, for each input span, return the deepest HIR
+/// node whose own span contains it. The returned vector has the same
+/// length and order as `target_spans`. A span not contained by any
+/// visited node — e.g. one that lies outside the crate's local HIR —
+/// maps to [`hir::CRATE_HIR_ID`].
+pub fn find_enclosing_hir_ids(tcx: TyCtxt<'_>, target_spans: &[Span]) -> Vec<hir::HirId> {
+    let mut best: Vec<hir::HirId> = vec![hir::CRATE_HIR_ID; target_spans.len()];
+    let mut finder = EnclosingHirFinder {
+        tcx,
+        targets: target_spans,
+        best: &mut best,
+    };
+    tcx.hir_walk_toplevel_module(&mut finder);
+    best
+}
+
+struct EnclosingHirFinder<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    targets: &'a [Span],
+    best: &'a mut [hir::HirId],
+}
+
+impl<'a, 'tcx> EnclosingHirFinder<'a, 'tcx> {
+    fn update(&mut self, hir_id: hir::HirId, span: Span) {
+        for (index, &target) in self.targets.iter().enumerate() {
+            if !span.contains(target) {
+                continue;
+            }
+            // The walk is depth-first: a parent is visited before its
+            // children, so each successful containment update lands on
+            // the deepest node seen so far.
+            self.best[index] = hir_id;
+        }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for EnclosingHirFinder<'_, 'tcx> {
+    type NestedFilter = nested_filter::All;
+
+    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
+        self.tcx
+    }
+
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_item(self, item);
+    }
+
+    fn visit_trait_item(&mut self, item: &'tcx hir::TraitItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_trait_item(self, item);
+    }
+
+    fn visit_impl_item(&mut self, item: &'tcx hir::ImplItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_impl_item(self, item);
+    }
+
+    fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) {
+        self.update(item.hir_id(), item.span);
+        intravisit::walk_foreign_item(self, item);
+    }
+
+    fn visit_block(&mut self, block: &'tcx hir::Block<'tcx>) {
+        self.update(block.hir_id, block.span);
+        intravisit::walk_block(self, block);
+    }
+
+    fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
+        self.update(stmt.hir_id, stmt.span);
+        intravisit::walk_stmt(self, stmt);
+    }
+
+    fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) {
+        self.update(local.hir_id, local.span);
+        intravisit::walk_local(self, local);
+    }
+
+    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
+        self.update(expr.hir_id, expr.span);
+        intravisit::walk_expr(self, expr);
+    }
+
+    fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
+        self.update(pat.hir_id, pat.span);
+        intravisit::walk_pat(self, pat);
+    }
+}

--- a/src/enclosing_hir.rs
+++ b/src/enclosing_hir.rs
@@ -26,7 +26,7 @@ use rustc_span::Span;
 /// length and order as `target_spans`. A span not contained by any
 /// visited node — e.g. one that lies outside the crate's local HIR —
 /// maps to [`hir::CRATE_HIR_ID`].
-pub fn find_enclosing_hir_ids(tcx: TyCtxt<'_>, target_spans: &[Span]) -> Vec<hir::HirId> {
+pub(crate) fn find_enclosing_hir_ids(tcx: TyCtxt<'_>, target_spans: &[Span]) -> Vec<hir::HirId> {
     let mut best: Vec<hir::HirId> = vec![hir::CRATE_HIR_ID; target_spans.len()];
     let mut finder = EnclosingHirFinder {
         tcx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ use rustc_session::Session;
 dylint_linting::dylint_library!();
 
 mod common;
+mod enclosing_hir;
+mod literal_scan;
 mod macro_path;
 mod rules;
 

--- a/src/literal_scan.rs
+++ b/src/literal_scan.rs
@@ -1,0 +1,107 @@
+//! Helpers shared by the Unicode-ellipsis rules.
+//!
+//! Both `unicode_ellipsis_in_comments` and
+//! `unicode_ellipsis_in_panic_messages` walk a stretch of source text,
+//! emit a diagnostic for each flagged character, and offer the same
+//! `...` autofix. The per-character logic is identical; the only
+//! per-rule pieces are the lint name, a context label, and how to
+//! turn a byte offset within the text into a [`Span`]. This module
+//! captures that shared shape so the two rules emit identically.
+
+use clippy_utils::diagnostics::span_lint_and_sugg;
+use rustc_errors::Applicability;
+use rustc_lint::{Lint, LintContext};
+use rustc_span::Span;
+
+/// For each character in `text` that appears in `flagged`, emit a
+/// diagnostic against `lint` with the suggested `...` replacement.
+///
+/// `context_label` is the trailing phrase in the message, e.g.
+/// `"comment"` or `` "`panic!` message" ``. `span_for` maps a
+/// `(byte_offset_within_text, character_utf8_length)` pair into the
+/// [`Span`] of the offending character in source — different callers
+/// resolve this differently (a source-file-relative position for the
+/// comment scanner, a `BytePos`-arithmetic offset from a literal span
+/// for the panic-message scanner).
+///
+/// Applicability is [`MachineApplicable`] for U+2026 (the rule's
+/// primary target, which always maps cleanly to `...`) and
+/// [`MaybeIncorrect`] for any user-configured `also_flag` characters
+/// (whose visual equivalence to `...` is up to the project to assert).
+///
+/// [`MachineApplicable`]: Applicability::MachineApplicable
+/// [`MaybeIncorrect`]: Applicability::MaybeIncorrect
+pub fn emit_flagged_chars<Cx>(
+    lint_context: &Cx,
+    lint: &'static Lint,
+    text: &str,
+    flagged: &[char],
+    context_label: &str,
+    mut span_for: impl FnMut(usize, u32) -> Span,
+) where
+    Cx: LintContext,
+{
+    for (byte_offset, character) in text.char_indices() {
+        if !flagged.contains(&character) {
+            continue;
+        }
+        let character_length = character.len_utf8() as u32;
+        let span = span_for(byte_offset, character_length);
+        let applicability = if character == '\u{2026}' {
+            Applicability::MachineApplicable
+        } else {
+            Applicability::MaybeIncorrect
+        };
+        span_lint_and_sugg(
+            lint_context,
+            lint,
+            span,
+            format!(
+                "Unicode `{character}` (U+{:04X}) in {context_label}",
+                character as u32,
+            ),
+            "use ASCII `...` instead",
+            "...".to_owned(),
+            applicability,
+        );
+    }
+}
+
+/// Return `(prefix_length, suffix_length)` covering the opening and
+/// closing delimiters of a Rust string-literal snippet, or `None` if
+/// the snippet does not look like a string literal whose body we can
+/// scan as plain text.
+///
+/// Recognises plain (`"..."`) and raw (`r"..."`, `r#"..."#`, …)
+/// strings. Byte / C-string forms are excluded — the helper is for
+/// rules that operate on display strings.
+pub fn string_literal_quote_lengths(snippet: &str) -> Option<(usize, usize)> {
+    let bytes = snippet.as_bytes();
+    let mut index = 0;
+    let mut hash_count = 0;
+    if index < bytes.len() && bytes[index] == b'r' {
+        index += 1;
+        while index < bytes.len() && bytes[index] == b'#' {
+            hash_count += 1;
+            index += 1;
+        }
+    }
+    if index >= bytes.len() || bytes[index] != b'"' {
+        return None;
+    }
+    let prefix_length = index + 1;
+    let expected_suffix_length = hash_count + 1;
+    if bytes.len() < prefix_length + expected_suffix_length {
+        return None;
+    }
+    let suffix_start = bytes.len() - expected_suffix_length;
+    if bytes[suffix_start] != b'"' {
+        return None;
+    }
+    for trailing_hash_index in 0..hash_count {
+        if bytes[suffix_start + 1 + trailing_hash_index] != b'#' {
+            return None;
+        }
+    }
+    Some((prefix_length, expected_suffix_length))
+}

--- a/src/literal_scan.rs
+++ b/src/literal_scan.rs
@@ -31,7 +31,7 @@ use rustc_span::Span;
 ///
 /// [`MachineApplicable`]: Applicability::MachineApplicable
 /// [`MaybeIncorrect`]: Applicability::MaybeIncorrect
-pub fn emit_flagged_chars<Cx>(
+pub(crate) fn emit_flagged_chars<Cx>(
     lint_context: &Cx,
     lint: &'static Lint,
     text: &str,
@@ -75,7 +75,7 @@ pub fn emit_flagged_chars<Cx>(
 /// Recognises plain (`"..."`) and raw (`r"..."`, `r#"..."#`, …)
 /// strings. Byte / C-string forms are excluded — the helper is for
 /// rules that operate on display strings.
-pub fn string_literal_quote_lengths(snippet: &str) -> Option<(usize, usize)> {
+pub(crate) fn string_literal_quote_lengths(snippet: &str) -> Option<(usize, usize)> {
     let bytes = snippet.as_bytes();
     let mut index = 0;
     let mut hash_count = 0;

--- a/src/literal_scan.rs
+++ b/src/literal_scan.rs
@@ -1,12 +1,20 @@
-//! Helpers shared by the Unicode-ellipsis rules.
+//! Helpers shared by rules that scan string-literal / comment text.
 //!
-//! Both `unicode_ellipsis_in_comments` and
-//! `unicode_ellipsis_in_panic_messages` walk a stretch of source text,
-//! emit a diagnostic for each flagged character, and offer the same
-//! `...` autofix. The per-character logic is identical; the only
+//! [`emit_flagged_chars`] is used by both Unicode-ellipsis rules
+//! (`unicode_ellipsis_in_comments` and
+//! `unicode_ellipsis_in_panic_messages`): walk a stretch of source
+//! text, emit a diagnostic for each flagged character, and offer the
+//! same `...` autofix. The per-character logic is identical; the only
 //! per-rule pieces are the lint name, a context label, and how to
-//! turn a byte offset within the text into a [`Span`]. This module
-//! captures that shared shape so the two rules emit identically.
+//! turn a byte offset within the text into a [`Span`].
+//!
+//! [`string_literal_quote_lengths`] is the companion parser for any
+//! rule that needs to scan a string-literal body without its opening
+//! and closing delimiters. Currently used only by
+//! `unicode_ellipsis_in_panic_messages`'s literal scanner, but it
+//! sits here rather than inside that rule because the shape it
+//! recognises (plain and raw display strings) is a generic property
+//! of Rust string literals, not specific to ellipsis detection.
 
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use rustc_errors::Applicability;

--- a/src/macro_path.rs
+++ b/src/macro_path.rs
@@ -29,6 +29,33 @@ pub fn parse_path(raw: &str) -> Vec<String> {
         .collect()
 }
 
+/// Parse a list of `"a::b::c"`-style entries from configuration into a
+/// deduplicated set of segment sequences. Empty / whitespace-only
+/// entries are silently dropped, mirroring the contract of
+/// [`parse_path`].
+pub fn parse_path_list<S: AsRef<str>>(raw_entries: &[S]) -> BTreeSet<Vec<String>> {
+    raw_entries
+        .iter()
+        .map(|entry| parse_path(entry.as_ref()))
+        .filter(|parsed| !parsed.is_empty())
+        .collect()
+}
+
+/// Combine a curated built-in name list (single segments) with a set of
+/// user-supplied multi-segment entries into a single matchable set.
+/// The built-in side is treated as single-segment entries, which match
+/// by the invocation path's final segment.
+pub fn merge_with_builtins(
+    builtin: &[&str],
+    extras: &BTreeSet<Vec<String>>,
+) -> BTreeSet<Vec<String>> {
+    builtin
+        .iter()
+        .map(|name| vec![(*name).to_owned()])
+        .chain(extras.iter().cloned())
+        .collect()
+}
+
 /// Returns `true` if any entry in `entries` matches the invocation path.
 pub fn matches_any(invocation: &rustc_ast::Path, entries: &BTreeSet<Vec<String>>) -> bool {
     entries.iter().any(|entry| entry_matches(entry, invocation))

--- a/src/macro_path.rs
+++ b/src/macro_path.rs
@@ -33,10 +33,10 @@ pub fn parse_path(raw: &str) -> Vec<String> {
 /// deduplicated set of segment sequences. Empty / whitespace-only
 /// entries are silently dropped, mirroring the contract of
 /// [`parse_path`].
-pub fn parse_path_list<S: AsRef<str>>(raw_entries: &[S]) -> BTreeSet<Vec<String>> {
+pub fn parse_path_list(raw_entries: &[String]) -> BTreeSet<Vec<String>> {
     raw_entries
         .iter()
-        .map(|entry| parse_path(entry.as_ref()))
+        .map(|entry| parse_path(entry))
         .filter(|parsed| !parsed.is_empty())
         .collect()
 }

--- a/src/macro_path.rs
+++ b/src/macro_path.rs
@@ -33,7 +33,7 @@ pub fn parse_path(raw: &str) -> Vec<String> {
 /// deduplicated set of segment sequences. Empty / whitespace-only
 /// entries are silently dropped, mirroring the contract of
 /// [`parse_path`].
-pub fn parse_path_list(raw_entries: &[String]) -> BTreeSet<Vec<String>> {
+pub(crate) fn parse_path_list(raw_entries: &[String]) -> BTreeSet<Vec<String>> {
     raw_entries
         .iter()
         .map(|entry| parse_path(entry))
@@ -45,7 +45,7 @@ pub fn parse_path_list(raw_entries: &[String]) -> BTreeSet<Vec<String>> {
 /// user-supplied multi-segment entries into a single matchable set.
 /// The built-in side is treated as single-segment entries, which match
 /// by the invocation path's final segment.
-pub fn merge_with_builtins(
+pub(crate) fn merge_with_builtins(
     builtin: &[&str],
     extras: &BTreeSet<Vec<String>>,
 ) -> BTreeSet<Vec<String>> {

--- a/src/macro_path.rs
+++ b/src/macro_path.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeSet;
 /// becomes `["std", "vec"]`. An empty or all-empty input returns an
 /// empty vector; callers should treat that as "no matchable path" and
 /// skip the entry.
-pub fn parse_path(raw: &str) -> Vec<String> {
+pub(crate) fn parse_path(raw: &str) -> Vec<String> {
     raw.split("::")
         .map(str::trim)
         .filter(|segment| !segment.is_empty())
@@ -57,7 +57,7 @@ pub(crate) fn merge_with_builtins(
 }
 
 /// Returns `true` if any entry in `entries` matches the invocation path.
-pub fn matches_any(invocation: &rustc_ast::Path, entries: &BTreeSet<Vec<String>>) -> bool {
+pub(crate) fn matches_any(invocation: &rustc_ast::Path, entries: &BTreeSet<Vec<String>>) -> bool {
     entries.iter().any(|entry| entry_matches(entry, invocation))
 }
 
@@ -65,7 +65,7 @@ pub fn matches_any(invocation: &rustc_ast::Path, entries: &BTreeSet<Vec<String>>
 /// allocating a `Vec<String>` snapshot of the invocation. Single-segment
 /// entries match the path's final segment; multi-segment entries
 /// tail-match the path's segment sequence.
-pub fn entry_matches(entry: &[String], invocation: &rustc_ast::Path) -> bool {
+pub(crate) fn entry_matches(entry: &[String], invocation: &rustc_ast::Path) -> bool {
     let segments = &invocation.segments;
     if entry.is_empty() || segments.is_empty() {
         return false;

--- a/src/rules/derive_ordering.rs
+++ b/src/rules/derive_ordering.rs
@@ -1,11 +1,20 @@
-use std::cmp::Ordering;
+//! `perfectionist::derive_ordering` — enforce a project-wide ordering
+//! of trait names inside a single `#[derive(...)]` list.
+//!
+//! The ordering algorithm itself lives in [`ordering`]; this file
+//! owns the lint declaration, the configuration, and the early
+//! pre-expansion pass that runs it.
 
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Attribute, MetaItemInner};
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::{Span, sym};
+use rustc_span::sym;
+
+mod ordering;
+
+use ordering::{DeriveEntry, Style, desired_order, is_identity};
 
 declare_tool_lint! {
     /// ### What it does
@@ -70,21 +79,6 @@ const DEFAULT_PREFIX: &[&str] = &[
     "Ord",
     "Hash",
 ];
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum Style {
-    /// No-op. The lint emits nothing.
-    #[default]
-    Preserve,
-    /// Every trait name must appear in ASCII-case-insensitive
-    /// alphabetical order.
-    Alphabetical,
-    /// Traits listed in the configured `prefix` come first, in the
-    /// listed order; remaining traits are sorted alphabetically
-    /// after.
-    PrefixThenAlphabetical,
-}
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(default, rename_all = "snake_case")]
@@ -185,7 +179,7 @@ impl DeriveOrdering {
                 span: entry.span(),
             });
         }
-        let desired = self.desired_order(&parsed);
+        let desired = desired_order(self.style, &self.prefix, &parsed);
         if is_identity(&desired) {
             return;
         }
@@ -253,75 +247,4 @@ impl DeriveOrdering {
             },
         );
     }
-
-    /// Return a permutation of `0..entries.len()` describing the
-    /// desired source order under the configured `style`. A return
-    /// value equal to the identity permutation means the entries
-    /// are already in order.
-    fn desired_order(&self, entries: &[DeriveEntry]) -> Vec<usize> {
-        match self.style {
-            Style::Preserve => (0..entries.len()).collect(),
-            Style::Alphabetical => {
-                let mut indices: Vec<usize> = (0..entries.len()).collect();
-                // `slice::sort_by` is stable, so equal-key entries
-                // retain their original relative order.
-                indices.sort_by(|left, right| {
-                    ascii_ci_cmp(&entries[*left].final_name, &entries[*right].final_name)
-                });
-                indices
-            }
-            Style::PrefixThenAlphabetical => {
-                let mut used = vec![false; entries.len()];
-                let mut order: Vec<usize> = Vec::with_capacity(entries.len());
-                // Walk the configured prefix in order; for each
-                // prefix name, find the first not-yet-used entry
-                // that matches and append it. An entry that appears
-                // in the prefix list but not in the user's derive
-                // is silently skipped — the prefix is "preferred
-                // ordering", not "required to be present".
-                for prefix_name in &self.prefix {
-                    for (index, entry) in entries.iter().enumerate() {
-                        if !used[index] && entry.final_name == *prefix_name {
-                            order.push(index);
-                            used[index] = true;
-                            break;
-                        }
-                    }
-                }
-                let mut rest: Vec<usize> =
-                    (0..entries.len()).filter(|index| !used[*index]).collect();
-                rest.sort_by(|left, right| {
-                    ascii_ci_cmp(&entries[*left].final_name, &entries[*right].final_name)
-                });
-                order.extend(rest);
-                order
-            }
-        }
-    }
-}
-
-struct DeriveEntry {
-    /// Final segment of the entry's path. `serde::Deserialize` is
-    /// represented as `"Deserialize"`. Used for ordering decisions;
-    /// the full path is recovered from `span` via the source map
-    /// when emitting the suggestion.
-    final_name: String,
-    /// Source span of the entry, covering its full path text.
-    span: Span,
-}
-
-/// `Ordering::Less` if `left` precedes `right` in ASCII-case-
-/// insensitive alphabetical order. Lowercases byte-by-byte during
-/// the comparison rather than allocating a normalised form.
-fn ascii_ci_cmp(left: &str, right: &str) -> Ordering {
-    left.bytes()
-        .map(|byte| byte.to_ascii_lowercase())
-        .cmp(right.bytes().map(|byte| byte.to_ascii_lowercase()))
-}
-
-fn is_identity(permutation: &[usize]) -> bool {
-    permutation
-        .iter()
-        .enumerate()
-        .all(|(position, &index)| position == index)
 }

--- a/src/rules/derive_ordering/ordering.rs
+++ b/src/rules/derive_ordering/ordering.rs
@@ -1,0 +1,97 @@
+//! The permutation algorithm used by `derive_ordering`.
+//!
+//! [`desired_order`] returns a permutation of `0..entries.len()`
+//! describing the target source order under a chosen [`Style`]. The
+//! identity permutation means the entries are already in order.
+
+use std::cmp::Ordering;
+
+use rustc_span::Span;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum Style {
+    /// No-op. The lint emits nothing.
+    #[default]
+    Preserve,
+    /// Every trait name must appear in ASCII-case-insensitive
+    /// alphabetical order.
+    Alphabetical,
+    /// Traits listed in the configured `prefix` come first, in the
+    /// listed order; remaining traits are sorted alphabetically
+    /// after.
+    PrefixThenAlphabetical,
+}
+
+pub(super) struct DeriveEntry {
+    /// Final segment of the entry's path. `serde::Deserialize` is
+    /// represented as `"Deserialize"`. Used for ordering decisions;
+    /// the full path is recovered from `span` via the source map
+    /// when emitting the suggestion.
+    pub(super) final_name: String,
+    /// Source span of the entry, covering its full path text.
+    pub(super) span: Span,
+}
+
+/// Return a permutation of `0..entries.len()` describing the desired
+/// source order under `style`. A return value equal to the identity
+/// permutation means the entries are already in order.
+pub(super) fn desired_order(
+    style: Style,
+    prefix: &[String],
+    entries: &[DeriveEntry],
+) -> Vec<usize> {
+    match style {
+        Style::Preserve => (0..entries.len()).collect(),
+        Style::Alphabetical => {
+            let mut indices: Vec<usize> = (0..entries.len()).collect();
+            // `slice::sort_by` is stable, so equal-key entries
+            // retain their original relative order.
+            indices.sort_by(|left, right| {
+                ascii_ci_cmp(&entries[*left].final_name, &entries[*right].final_name)
+            });
+            indices
+        }
+        Style::PrefixThenAlphabetical => {
+            let mut used = vec![false; entries.len()];
+            let mut order: Vec<usize> = Vec::with_capacity(entries.len());
+            // Walk the configured prefix in order; for each
+            // prefix name, find the first not-yet-used entry
+            // that matches and append it. An entry that appears
+            // in the prefix list but not in the user's derive
+            // is silently skipped — the prefix is "preferred
+            // ordering", not "required to be present".
+            for prefix_name in prefix {
+                for (index, entry) in entries.iter().enumerate() {
+                    if !used[index] && entry.final_name == *prefix_name {
+                        order.push(index);
+                        used[index] = true;
+                        break;
+                    }
+                }
+            }
+            let mut rest: Vec<usize> = (0..entries.len()).filter(|index| !used[*index]).collect();
+            rest.sort_by(|left, right| {
+                ascii_ci_cmp(&entries[*left].final_name, &entries[*right].final_name)
+            });
+            order.extend(rest);
+            order
+        }
+    }
+}
+
+pub(super) fn is_identity(permutation: &[usize]) -> bool {
+    permutation
+        .iter()
+        .enumerate()
+        .all(|(position, &index)| position == index)
+}
+
+/// `Ordering::Less` if `left` precedes `right` in ASCII-case-
+/// insensitive alphabetical order. Lowercases byte-by-byte during
+/// the comparison rather than allocating a normalised form.
+fn ascii_ci_cmp(left: &str, right: &str) -> Ordering {
+    left.bytes()
+        .map(|byte| byte.to_ascii_lowercase())
+        .cmp(right.bytes().map(|byte| byte.to_ascii_lowercase()))
+}

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeSet;
 
 use rustc_ast::Path;
 
-use crate::macro_path::{matches_any, parse_path};
+use crate::macro_path::{matches_any, merge_with_builtins, parse_path_list};
 
 const CONFIG_KEY: &str = "perfectionist::macro_argument_binding";
 
@@ -159,18 +159,3 @@ impl MacroArgumentBinding {
     }
 }
 
-fn parse_path_list(raw_entries: &[String]) -> BTreeSet<Vec<String>> {
-    raw_entries
-        .iter()
-        .map(|entry| parse_path(entry))
-        .filter(|parsed| !parsed.is_empty())
-        .collect()
-}
-
-fn merge_with_builtins(builtin: &[&str], extras: &BTreeSet<Vec<String>>) -> BTreeSet<Vec<String>> {
-    builtin
-        .iter()
-        .map(|name| vec![(*name).to_owned()])
-        .chain(extras.iter().cloned())
-        .collect()
-}

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -158,4 +158,3 @@ impl MacroArgumentBinding {
         }
     }
 }
-

--- a/src/rules/macro_argument_binding/late.rs
+++ b/src/rules/macro_argument_binding/late.rs
@@ -1,21 +1,16 @@
 //! Late-pass machinery: drains the pre-expansion pass's
-//! [`PENDING_VIOLATIONS`] queue and emits each diagnostic at the
-//! deepest enclosing HIR node so `cfg_attr`-wrapped `#[expect]` /
-//! `#[allow]` attributes resolve correctly.
-//!
-//! Mirrors the equivalent late pass in `macro_trailing_comma`; the
-//! two cannot share a single `EnclosingHirFinder` instance cheaply
-//! because each rule's pending list is a different type, but the walk
-//! shape is identical and a future refactor can extract a generic
-//! helper.
+//! [`PENDING_VIOLATIONS`] queue and emits
+//! each diagnostic at the deepest enclosing HIR node so
+//! `cfg_attr`-wrapped `#[expect]` / `#[allow]` attributes resolve
+//! correctly. The walk itself is provided by
+//! [`crate::enclosing_hir::find_enclosing_hir_ids`].
 
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_hir as hir;
-use rustc_hir::intravisit::{self, Visitor};
 use rustc_lint::{LateContext, LateLintPass};
-use rustc_middle::hir::nested_filter;
-use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
+
+use crate::enclosing_hir::find_enclosing_hir_ids;
 
 use super::{MACRO_ARGUMENT_BINDING, PENDING_VIOLATIONS};
 
@@ -32,14 +27,7 @@ impl<'tcx> LateLintPass<'tcx> for MacroArgumentBindingLate {
         if pending.is_empty() {
             return;
         }
-        let tcx = lint_context.tcx;
-        let mut best: Vec<hir::HirId> = vec![hir::CRATE_HIR_ID; pending.len()];
-        let mut finder = EnclosingHirFinder {
-            tcx,
-            pending: &pending,
-            best: &mut best,
-        };
-        tcx.hir_walk_toplevel_module(&mut finder);
+        let best = find_enclosing_hir_ids(lint_context.tcx, &pending);
         for (&span, &hir_id) in pending.iter().zip(best.iter()) {
             emit(lint_context, hir_id, span);
         }
@@ -61,77 +49,4 @@ fn emit(lint_context: &LateContext<'_>, hir_id: hir::HirId, span: Span) {
             );
         },
     );
-}
-
-/// Walk the HIR once and, for each pending violation span, record the
-/// deepest HIR node whose span contains it. Mirrors the equivalent
-/// finder in `macro_trailing_comma`.
-struct EnclosingHirFinder<'a, 'tcx> {
-    tcx: TyCtxt<'tcx>,
-    pending: &'a [Span],
-    best: &'a mut [hir::HirId],
-}
-
-impl<'a, 'tcx> EnclosingHirFinder<'a, 'tcx> {
-    fn update(&mut self, hir_id: hir::HirId, span: Span) {
-        for (index, &target) in self.pending.iter().enumerate() {
-            if !span.contains(target) {
-                continue;
-            }
-            self.best[index] = hir_id;
-        }
-    }
-}
-
-impl<'tcx> Visitor<'tcx> for EnclosingHirFinder<'_, 'tcx> {
-    type NestedFilter = nested_filter::All;
-
-    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
-        self.tcx
-    }
-
-    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_item(self, item);
-    }
-
-    fn visit_trait_item(&mut self, item: &'tcx hir::TraitItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_trait_item(self, item);
-    }
-
-    fn visit_impl_item(&mut self, item: &'tcx hir::ImplItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_impl_item(self, item);
-    }
-
-    fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_foreign_item(self, item);
-    }
-
-    fn visit_block(&mut self, block: &'tcx hir::Block<'tcx>) {
-        self.update(block.hir_id, block.span);
-        intravisit::walk_block(self, block);
-    }
-
-    fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
-        self.update(stmt.hir_id, stmt.span);
-        intravisit::walk_stmt(self, stmt);
-    }
-
-    fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) {
-        self.update(local.hir_id, local.span);
-        intravisit::walk_local(self, local);
-    }
-
-    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
-        self.update(expr.hir_id, expr.span);
-        intravisit::walk_expr(self, expr);
-    }
-
-    fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
-        self.update(pat.hir_id, pat.span);
-        intravisit::walk_pat(self, pat);
-    }
 }

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -1,19 +1,40 @@
-use std::collections::BTreeSet;
+//! `perfectionist::macro_trailing_comma` — enforce rustfmt's
+//! `trailing_comma = "Vertical"` policy on the curated set of macros
+//! whose top-level argument list is comma-separated.
+//!
+//! Module layout:
+//!
+//! - [`config`] — user-facing configuration (`Config`,
+//!   `MacroTrailingComma` state) and the curated built-in name list.
+//! - [`mod@queue`] — the [`PendingViolation`] payload parked by the
+//!   pre-expansion pass for the late pass to emit.
+//! - [`late`] — late pass that drains [`PENDING_VIOLATIONS`] and emits
+//!   each diagnostic at the deepest enclosing HIR node via the shared
+//!   [`crate::enclosing_hir`] walker.
+//! - [`emit`] — diagnostic-emission helpers, one per violation shape.
+//!
+//! The pre-expansion pass below threads the early-side pieces
+//! together: gate on path eligibility, walk the top-level token stream
+//! exactly once to find the first / last trees and detect repeat
+//! (`v; n`) form, and park the resulting violation span for the late
+//! pass to emit.
+
 use std::sync::Mutex;
 
-use crate::macro_path::{matches_any, parse_path};
-use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_ast::MacCall;
 use rustc_ast::token::TokenKind;
 use rustc_ast::tokenstream::TokenTree;
-use rustc_errors::Applicability;
-use rustc_hir as hir;
-use rustc_hir::intravisit::{self, Visitor};
-use rustc_lint::{EarlyContext, EarlyLintPass, LateContext, LateLintPass, LintContext, LintStore};
-use rustc_middle::hir::nested_filter;
-use rustc_middle::ty::TyCtxt;
+use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::Span;
+
+mod config;
+mod emit;
+mod late;
+mod queue;
+
+use config::MacroTrailingComma;
+use late::MacroTrailingCommaLate;
+use queue::PendingViolation;
 
 declare_tool_lint! {
     /// ### What it does
@@ -72,147 +93,6 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-const CONFIG_KEY: &str = "perfectionist::macro_trailing_comma";
-
-/// Curated macros whose top-level argument list is comma-separated with
-/// a syntactically optional trailing comma. See the rule docs in
-/// `planned-rules/macro-trailing-comma.md` for the inclusion criterion.
-///
-/// Each entry is a single segment; matching is by the final segment of
-/// the invocation's path, so `vec!`, `std::vec!`, and `::std::vec!` all
-/// match the `"vec"` entry.
-const BUILTIN_NAME_BASED: &[&str] = &[
-    // `core` / `std`
-    "vec",
-    "format",
-    "format_args",
-    "print",
-    "println",
-    "eprint",
-    "eprintln",
-    "write",
-    "writeln",
-    "panic",
-    "unimplemented",
-    "todo",
-    "unreachable",
-    "assert",
-    "assert_eq",
-    "assert_ne",
-    "debug_assert",
-    "debug_assert_eq",
-    "debug_assert_ne",
-    "matches",
-    "dbg",
-    "concat",
-    "env",
-    "option_env",
-    // `pretty_assertions` (its `assert_eq` / `assert_ne` final segments
-    // already match the `core` entries; `assert_str_eq` is unique to it).
-    "assert_str_eq",
-    // `maplit`
-    "hashmap",
-    "btreemap",
-    "hashset",
-    "btreeset",
-    "convert_args",
-    // `log` (its `error` / `warn` / `info` / `debug` / `trace` final
-    // segments also cover `tracing`'s same-named macros).
-    "log",
-    "error",
-    "warn",
-    "info",
-    "debug",
-    "trace",
-    // `tracing`
-    "event",
-    "span",
-    // `anyhow`
-    "anyhow",
-    "bail",
-    "ensure",
-];
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
-struct Config {
-    /// Master on/off switch for the rule. Defaults to `true`. Set
-    /// to `false` to silence every diagnostic this lint would emit
-    /// without having to enumerate every macro under `ignore`.
-    enabled: bool,
-    /// Accepted for forward compatibility with the matcher-based half of
-    /// the rule. Currently a no-op — only name-based eligibility is
-    /// implemented; see `planned-rules/macro-trailing-comma.md` for the
-    /// status breakdown.
-    matcher_based: bool,
-    /// Additional macro paths to treat as name-based eligible, on top
-    /// of the curated built-in list. Each entry is matched by its
-    /// final path segment, so `"my_crate::vec_like"` and `"vec_like"`
-    /// both target invocations whose last segment is `vec_like`.
-    /// Empty by default. Only add macros whose trailing comma is
-    /// syntactically optional at the top level; macros that treat
-    /// the comma as a fully optional separator throughout (rather
-    /// than only at the tail) should not be listed here.
-    extra_name_based: Vec<String>,
-    /// Macro paths to opt out of the rule, even if they would
-    /// otherwise be eligible via the built-in list or
-    /// `extra_name_based`. Matched by final path segment, like
-    /// `extra_name_based`. Checked first, so this knob always wins
-    /// over eligibility. Empty by default.
-    ignore: Vec<String>,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            matcher_based: true,
-            extra_name_based: Vec::new(),
-            ignore: Vec::new(),
-        }
-    }
-}
-
-pub struct MacroTrailingComma {
-    enabled: bool,
-    // TODO(matcher_based): the lookup is currently linear
-    // (`entries.iter().any(...)`), so the `BTreeSet` ordering is unused
-    // — it only deduplicates identical config entries. When the
-    // matcher-based half grows these lists, bucket by entry length: a
-    // `BTreeSet<String>` for single-segment entries (O(log N) on the
-    // invocation's final segment) plus a `Vec<Vec<String>>` for
-    // multi-segment entries.
-    name_based: BTreeSet<Vec<String>>,
-    ignore: BTreeSet<Vec<String>>,
-}
-
-impl MacroTrailingComma {
-    fn new() -> Self {
-        let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-        let mut name_based: BTreeSet<Vec<String>> = BUILTIN_NAME_BASED
-            .iter()
-            .map(|name| vec![(*name).to_owned()])
-            .collect();
-        for entry in &config.extra_name_based {
-            let parsed = parse_path(entry);
-            if !parsed.is_empty() {
-                name_based.insert(parsed);
-            }
-        }
-        let ignore = config
-            .ignore
-            .iter()
-            .map(|entry| parse_path(entry))
-            .filter(|parsed| !parsed.is_empty())
-            .collect();
-        Self {
-            enabled: config.enabled,
-            name_based,
-            ignore,
-        }
-    }
-}
-
 impl_lint_pass!(MacroTrailingComma => [MACRO_TRAILING_COMMA]);
 impl_lint_pass!(MacroTrailingCommaLate => [MACRO_TRAILING_COMMA]);
 
@@ -239,91 +119,63 @@ pub fn register_pass(lint_store: &mut LintStore) {
 /// stashing them in a process-wide static is safe.
 static PENDING_VIOLATIONS: Mutex<Vec<PendingViolation>> = Mutex::new(Vec::new());
 
-#[derive(Debug, Clone, Copy)]
-enum PendingViolation {
-    /// Multi-line macro invocation, missing a trailing comma after the
-    /// last argument. The span is the insertion point.
-    Insert(Span),
-    /// Single-line macro invocation, with a gratuitous trailing comma
-    /// after the last argument. The span covers the comma to remove.
-    Remove(Span),
-}
-
-impl PendingViolation {
-    fn span(self) -> Span {
-        match self {
-            PendingViolation::Insert(span) | PendingViolation::Remove(span) => span,
-        }
-    }
-}
-
-pub struct MacroTrailingCommaLate;
-
 impl EarlyLintPass for MacroTrailingComma {
     fn check_mac(&mut self, lint_context: &EarlyContext<'_>, mac_call: &MacCall) {
-        if !self.enabled {
+        if !self.should_check_path(&mac_call.path) {
             return;
         }
-        if matches_any(&mac_call.path, &self.ignore) {
-            return;
-        }
-        if !matches_any(&mac_call.path, &self.name_based) {
-            return;
-        }
-        self.check_invocation(lint_context, mac_call);
+        check_invocation(lint_context, mac_call);
     }
 }
 
-impl MacroTrailingComma {
-    fn check_invocation(&self, lint_context: &EarlyContext<'_>, mac_call: &MacCall) {
-        let args = &mac_call.args;
-        // Single-pass walk over the top-level token stream: track the
-        // first and last trees and bail on a top-level `;`. Avoids
-        // allocating a `Vec` per `check_mac` call.
-        let mut first_tree: Option<&TokenTree> = None;
-        let mut last_tree: Option<&TokenTree> = None;
-        for tree in args.tokens.iter() {
-            if let TokenTree::Token(token, _) = tree
-                && token.kind == TokenKind::Semi
-            {
-                return;
-            }
-            if first_tree.is_none() {
-                first_tree = Some(tree);
-            }
-            last_tree = Some(tree);
-        }
-        let Some(last_tree) = last_tree else {
+fn check_invocation(lint_context: &EarlyContext<'_>, mac_call: &MacCall) {
+    let args = &mac_call.args;
+    // Single-pass walk over the top-level token stream: track the
+    // first and last trees and bail on a top-level `;`. Avoids
+    // allocating a `Vec` per `check_mac` call.
+    let mut first_tree: Option<&TokenTree> = None;
+    let mut last_tree: Option<&TokenTree> = None;
+    for tree in args.tokens.iter() {
+        if let TokenTree::Token(token, _) = tree
+            && token.kind == TokenKind::Semi
+        {
             return;
-        };
-        let source_map = lint_context.sess().source_map();
-        let is_multi_line = source_map.is_multiline(args.dspan.entire());
-        let last_is_comma = matches!(
-            last_tree,
-            TokenTree::Token(token, _) if token.kind == TokenKind::Comma,
-        );
-        // rustfmt's `trailing_comma = "Vertical"` only applies in block-
-        // indent style -- i.e., when the first top-level item starts on
-        // a line of its own, separate from the opening delimiter. If
-        // the first item shares its starting line with the opening
-        // delimiter (the compact / visual-indent layout that rustfmt
-        // produces for a single multi-line element such as
-        // `vec![Inner { ... }]` or `vec![bar(\n    ...,\n)]`), rustfmt
-        // leaves the trailing comma off and actively strips any that
-        // gets added. Skip the multi-line "insert comma" branch in that
-        // case so the two tools agree.
-        let suppress_insert = is_multi_line
-            && first_tree.is_some_and(|first_tree| {
-                let between = args.dspan.open.between(first_tree.span());
-                !source_map.is_multiline(between)
-            });
-        match (is_multi_line, last_is_comma) {
-            (true, false) if !suppress_insert => {
-                queue(PendingViolation::Insert(last_tree.span().shrink_to_hi()));
-            }
-            (false, true) => queue(PendingViolation::Remove(last_tree.span())),
-            _ => {}
         }
+        if first_tree.is_none() {
+            first_tree = Some(tree);
+        }
+        last_tree = Some(tree);
+    }
+    let Some(last_tree) = last_tree else {
+        return;
+    };
+    let source_map = lint_context.sess().source_map();
+    let is_multi_line = source_map.is_multiline(args.dspan.entire());
+    let last_is_comma = matches!(
+        last_tree,
+        TokenTree::Token(token, _) if token.kind == TokenKind::Comma,
+    );
+    // rustfmt's `trailing_comma = "Vertical"` only applies in block-
+    // indent style -- i.e., when the first top-level item starts on
+    // a line of its own, separate from the opening delimiter. If
+    // the first item shares its starting line with the opening
+    // delimiter (the compact / visual-indent layout that rustfmt
+    // produces for a single multi-line element such as
+    // `vec![Inner { ... }]` or `vec![bar(\n    ...,\n)]`), rustfmt
+    // leaves the trailing comma off and actively strips any that
+    // gets added. Skip the multi-line "insert comma" branch in that
+    // case so the two tools agree.
+    let suppress_insert = is_multi_line
+        && first_tree.is_some_and(|first_tree| {
+            let between = args.dspan.open.between(first_tree.span());
+            !source_map.is_multiline(between)
+        });
+    match (is_multi_line, last_is_comma) {
+        (true, false) if !suppress_insert => {
+            queue(PendingViolation::Insert(last_tree.span().shrink_to_hi()));
+        }
+        (false, true) => queue(PendingViolation::Remove(last_tree.span())),
+        _ => {}
     }
 }
 
@@ -332,147 +184,4 @@ fn queue(violation: PendingViolation) {
         .lock()
         .unwrap_or_else(|err| err.into_inner());
     guard.push(violation);
-}
-
-impl<'tcx> LateLintPass<'tcx> for MacroTrailingCommaLate {
-    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
-        let pending: Vec<PendingViolation> = {
-            let mut guard = PENDING_VIOLATIONS
-                .lock()
-                .unwrap_or_else(|err| err.into_inner());
-            std::mem::take(&mut *guard)
-        };
-        if pending.is_empty() {
-            return;
-        }
-        let tcx = lint_context.tcx;
-        let mut best: Vec<hir::HirId> = vec![hir::CRATE_HIR_ID; pending.len()];
-        let mut finder = EnclosingHirFinder {
-            tcx,
-            pending: &pending,
-            best: &mut best,
-        };
-        tcx.hir_walk_toplevel_module(&mut finder);
-        for (violation, &hir_id) in pending.iter().zip(best.iter()) {
-            match *violation {
-                PendingViolation::Insert(span) => emit_insert(lint_context, hir_id, span),
-                PendingViolation::Remove(span) => emit_remove(lint_context, hir_id, span),
-            }
-        }
-    }
-}
-
-/// Walk the HIR once and, for each pending violation span, record the
-/// deepest HIR node whose span contains it. Emitting at that node ties
-/// the diagnostic to the user's lint-level attributes — both on the
-/// containing item and any ancestor — so `#[allow]` / `#[expect]` at
-/// any scope behave correctly.
-struct EnclosingHirFinder<'a, 'tcx> {
-    tcx: TyCtxt<'tcx>,
-    pending: &'a [PendingViolation],
-    best: &'a mut [hir::HirId],
-}
-
-impl<'a, 'tcx> EnclosingHirFinder<'a, 'tcx> {
-    fn update(&mut self, hir_id: hir::HirId, span: Span) {
-        for (index, violation) in self.pending.iter().enumerate() {
-            let target = violation.span();
-            if !span.contains(target) {
-                continue;
-            }
-            // The walk is depth-first: a parent is visited before its
-            // children, so each successful containment update lands on
-            // the deepest node seen so far.
-            self.best[index] = hir_id;
-        }
-    }
-}
-
-impl<'tcx> Visitor<'tcx> for EnclosingHirFinder<'_, 'tcx> {
-    type NestedFilter = nested_filter::All;
-
-    fn maybe_tcx(&mut self) -> Self::MaybeTyCtxt {
-        self.tcx
-    }
-
-    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_item(self, item);
-    }
-
-    fn visit_trait_item(&mut self, item: &'tcx hir::TraitItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_trait_item(self, item);
-    }
-
-    fn visit_impl_item(&mut self, item: &'tcx hir::ImplItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_impl_item(self, item);
-    }
-
-    fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
-        intravisit::walk_foreign_item(self, item);
-    }
-
-    fn visit_block(&mut self, block: &'tcx hir::Block<'tcx>) {
-        self.update(block.hir_id, block.span);
-        intravisit::walk_block(self, block);
-    }
-
-    fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
-        self.update(stmt.hir_id, stmt.span);
-        intravisit::walk_stmt(self, stmt);
-    }
-
-    fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) {
-        self.update(local.hir_id, local.span);
-        intravisit::walk_local(self, local);
-    }
-
-    fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
-        self.update(expr.hir_id, expr.span);
-        intravisit::walk_expr(self, expr);
-    }
-
-    fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
-        self.update(pat.hir_id, pat.span);
-        intravisit::walk_pat(self, pat);
-    }
-}
-
-fn emit_insert(lint_context: &LateContext<'_>, hir_id: hir::HirId, insert_at: Span) {
-    span_lint_hir_and_then(
-        lint_context,
-        MACRO_TRAILING_COMMA,
-        hir_id,
-        insert_at,
-        "multi-line macro invocation should end with a trailing comma",
-        |diag| {
-            diag.span_suggestion(
-                insert_at,
-                "add a trailing comma",
-                ",",
-                Applicability::MachineApplicable,
-            );
-        },
-    );
-}
-
-fn emit_remove(lint_context: &LateContext<'_>, hir_id: hir::HirId, comma_span: Span) {
-    span_lint_hir_and_then(
-        lint_context,
-        MACRO_TRAILING_COMMA,
-        hir_id,
-        comma_span,
-        "single-line macro invocation should not end with a trailing comma",
-        |diag| {
-            diag.span_suggestion(
-                comma_span,
-                "remove the trailing comma",
-                "",
-                Applicability::MachineApplicable,
-            );
-        },
-    );
 }

--- a/src/rules/macro_trailing_comma/config.rs
+++ b/src/rules/macro_trailing_comma/config.rs
@@ -1,0 +1,147 @@
+//! Configuration for `macro_trailing_comma`. Owns the user-facing
+//! `Config` shape, the curated built-in name list, and the in-memory
+//! `MacroTrailingComma` state the early pass holds.
+
+use std::collections::BTreeSet;
+
+use crate::macro_path::{matches_any, merge_with_builtins, parse_path, parse_path_list};
+
+const CONFIG_KEY: &str = "perfectionist::macro_trailing_comma";
+
+/// Curated macros whose top-level argument list is comma-separated with
+/// a syntactically optional trailing comma. See the rule docs in
+/// `planned-rules/macro-trailing-comma.md` for the inclusion criterion.
+///
+/// Each entry is a single segment; matching is by the final segment of
+/// the invocation's path, so `vec!`, `std::vec!`, and `::std::vec!` all
+/// match the `"vec"` entry.
+const BUILTIN_NAME_BASED: &[&str] = &[
+    // `core` / `std`
+    "vec",
+    "format",
+    "format_args",
+    "print",
+    "println",
+    "eprint",
+    "eprintln",
+    "write",
+    "writeln",
+    "panic",
+    "unimplemented",
+    "todo",
+    "unreachable",
+    "assert",
+    "assert_eq",
+    "assert_ne",
+    "debug_assert",
+    "debug_assert_eq",
+    "debug_assert_ne",
+    "matches",
+    "dbg",
+    "concat",
+    "env",
+    "option_env",
+    // `pretty_assertions` (its `assert_eq` / `assert_ne` final segments
+    // already match the `core` entries; `assert_str_eq` is unique to it).
+    "assert_str_eq",
+    // `maplit`
+    "hashmap",
+    "btreemap",
+    "hashset",
+    "btreeset",
+    "convert_args",
+    // `log` (its `error` / `warn` / `info` / `debug` / `trace` final
+    // segments also cover `tracing`'s same-named macros).
+    "log",
+    "error",
+    "warn",
+    "info",
+    "debug",
+    "trace",
+    // `tracing`
+    "event",
+    "span",
+    // `anyhow`
+    "anyhow",
+    "bail",
+    "ensure",
+];
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(default, rename_all = "snake_case")]
+struct Config {
+    /// Master on/off switch for the rule. Defaults to `true`. Set
+    /// to `false` to silence every diagnostic this lint would emit
+    /// without having to enumerate every macro under `ignore`.
+    enabled: bool,
+    /// Accepted for forward compatibility with the matcher-based half of
+    /// the rule. Currently a no-op — only name-based eligibility is
+    /// implemented; see `planned-rules/macro-trailing-comma.md` for the
+    /// status breakdown.
+    matcher_based: bool,
+    /// Additional macro paths to treat as name-based eligible, on top
+    /// of the curated built-in list. Each entry is matched by its
+    /// final path segment, so `"my_crate::vec_like"` and `"vec_like"`
+    /// both target invocations whose last segment is `vec_like`.
+    /// Empty by default. Only add macros whose trailing comma is
+    /// syntactically optional at the top level; macros that treat
+    /// the comma as a fully optional separator throughout (rather
+    /// than only at the tail) should not be listed here.
+    extra_name_based: Vec<String>,
+    /// Macro paths to opt out of the rule, even if they would
+    /// otherwise be eligible via the built-in list or
+    /// `extra_name_based`. Matched by final path segment, like
+    /// `extra_name_based`. Checked first, so this knob always wins
+    /// over eligibility. Empty by default.
+    ignore: Vec<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            matcher_based: true,
+            extra_name_based: Vec::new(),
+            ignore: Vec::new(),
+        }
+    }
+}
+
+pub(super) struct MacroTrailingComma {
+    enabled: bool,
+    // TODO(matcher_based): the lookup is currently linear
+    // (`entries.iter().any(...)`), so the `BTreeSet` ordering is unused
+    // — it only deduplicates identical config entries. When the
+    // matcher-based half grows these lists, bucket by entry length: a
+    // `BTreeSet<String>` for single-segment entries (O(log N) on the
+    // invocation's final segment) plus a `Vec<Vec<String>>` for
+    // multi-segment entries.
+    name_based: BTreeSet<Vec<String>>,
+    ignore: BTreeSet<Vec<String>>,
+}
+
+impl MacroTrailingComma {
+    pub(super) fn new() -> Self {
+        let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
+        let extra_name_based: BTreeSet<Vec<String>> = config
+            .extra_name_based
+            .iter()
+            .map(|entry| parse_path(entry))
+            .filter(|parsed| !parsed.is_empty())
+            .collect();
+        let name_based = merge_with_builtins(BUILTIN_NAME_BASED, &extra_name_based);
+        let ignore = parse_path_list(&config.ignore);
+        Self {
+            enabled: config.enabled,
+            name_based,
+            ignore,
+        }
+    }
+
+    /// Path-side eligibility: combines the `enabled` switch with the
+    /// `ignore` / built-in `name_based` lookup. Does *not* consider the
+    /// invocation's argument shape — that stays in the early pass.
+    pub(super) fn should_check_path(&self, path: &rustc_ast::Path) -> bool {
+        self.enabled && !matches_any(path, &self.ignore) && matches_any(path, &self.name_based)
+    }
+}

--- a/src/rules/macro_trailing_comma/emit.rs
+++ b/src/rules/macro_trailing_comma/emit.rs
@@ -1,0 +1,45 @@
+//! Diagnostic emission for the two violation shapes.
+
+use clippy_utils::diagnostics::span_lint_hir_and_then;
+use rustc_errors::Applicability;
+use rustc_hir as hir;
+use rustc_lint::LateContext;
+use rustc_span::Span;
+
+use super::MACRO_TRAILING_COMMA;
+
+pub(super) fn emit_insert(lint_context: &LateContext<'_>, hir_id: hir::HirId, insert_at: Span) {
+    span_lint_hir_and_then(
+        lint_context,
+        MACRO_TRAILING_COMMA,
+        hir_id,
+        insert_at,
+        "multi-line macro invocation should end with a trailing comma",
+        |diag| {
+            diag.span_suggestion(
+                insert_at,
+                "add a trailing comma",
+                ",",
+                Applicability::MachineApplicable,
+            );
+        },
+    );
+}
+
+pub(super) fn emit_remove(lint_context: &LateContext<'_>, hir_id: hir::HirId, comma_span: Span) {
+    span_lint_hir_and_then(
+        lint_context,
+        MACRO_TRAILING_COMMA,
+        hir_id,
+        comma_span,
+        "single-line macro invocation should not end with a trailing comma",
+        |diag| {
+            diag.span_suggestion(
+                comma_span,
+                "remove the trailing comma",
+                "",
+                Applicability::MachineApplicable,
+            );
+        },
+    );
+}

--- a/src/rules/macro_trailing_comma/late.rs
+++ b/src/rules/macro_trailing_comma/late.rs
@@ -1,0 +1,38 @@
+//! Late-pass machinery: drains the pre-expansion pass's
+//! [`PENDING_VIOLATIONS`] queue and emits
+//! each diagnostic at the deepest enclosing HIR node so
+//! `cfg_attr`-wrapped `#[expect]` / `#[allow]` attributes resolve
+//! correctly. The walk itself is provided by
+//! [`crate::enclosing_hir::find_enclosing_hir_ids`].
+
+use rustc_lint::{LateContext, LateLintPass};
+
+use crate::enclosing_hir::find_enclosing_hir_ids;
+
+use super::PENDING_VIOLATIONS;
+use super::emit::{emit_insert, emit_remove};
+use super::queue::PendingViolation;
+
+pub(super) struct MacroTrailingCommaLate;
+
+impl<'tcx> LateLintPass<'tcx> for MacroTrailingCommaLate {
+    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
+        let pending: Vec<PendingViolation> = {
+            let mut guard = PENDING_VIOLATIONS
+                .lock()
+                .unwrap_or_else(|err| err.into_inner());
+            std::mem::take(&mut *guard)
+        };
+        if pending.is_empty() {
+            return;
+        }
+        let target_spans: Vec<_> = pending.iter().map(|violation| violation.span()).collect();
+        let best = find_enclosing_hir_ids(lint_context.tcx, &target_spans);
+        for (violation, &hir_id) in pending.iter().zip(best.iter()) {
+            match *violation {
+                PendingViolation::Insert(span) => emit_insert(lint_context, hir_id, span),
+                PendingViolation::Remove(span) => emit_remove(lint_context, hir_id, span),
+            }
+        }
+    }
+}

--- a/src/rules/macro_trailing_comma/queue.rs
+++ b/src/rules/macro_trailing_comma/queue.rs
@@ -1,0 +1,24 @@
+//! The pre-expansion pass parks violation spans here for the late pass
+//! to anchor in the HIR. The two variants distinguish the two shapes
+//! of fix this rule offers: insert a missing trailing comma, or remove
+//! a gratuitous one.
+
+use rustc_span::Span;
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum PendingViolation {
+    /// Multi-line macro invocation, missing a trailing comma after the
+    /// last argument. The span is the insertion point.
+    Insert(Span),
+    /// Single-line macro invocation, with a gratuitous trailing comma
+    /// after the last argument. The span covers the comma to remove.
+    Remove(Span),
+}
+
+impl PendingViolation {
+    pub(super) fn span(self) -> Span {
+        match self {
+            PendingViolation::Insert(span) | PendingViolation::Remove(span) => span,
+        }
+    }
+}

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -1,9 +1,22 @@
+//! `perfectionist::prefer_raw_string` — flag cooked string literals
+//! whose only escapes are ones a raw string would express verbatim.
+//!
+//! The hand-rolled parser-combinator scanner lives in [`parser`]; this
+//! file owns the lint declaration, the configuration, and the late
+//! pass that drives it.
+
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use rustc_ast::{LitKind, StrStyle};
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
+
+mod parser;
+
+use parser::{
+    DEFAULT_ESCAPES_ELIGIBLE, is_supported_eligible_entry, minimal_hash_count, scan_body,
+};
 
 declare_tool_lint! {
     /// ### What it does
@@ -63,10 +76,6 @@ declare_tool_lint! {
 
 const CONFIG_KEY: &str = "perfectionist::prefer_raw_string";
 
-/// Default eligible escape sequences: the three escapes that a raw
-/// string can express verbatim with no escape at all.
-const DEFAULT_ESCAPES_ELIGIBLE: &[&str] = &[r#"\""#, r"\\", r"\'"];
-
 #[derive(Debug, serde::Deserialize)]
 #[serde(default, rename_all = "snake_case")]
 struct Config {
@@ -116,11 +125,10 @@ impl PreferRawString {
         // Drop entries that aren't one of the three self-decoding
         // escapes (`\"`, `\\`, `\'`). Anything else — `\n`, `\t`,
         // `\xNN`, `\u{...}`, ill-formed shapes — would break
-        // `eliminable_decoded`'s "second char is the decoded form"
-        // contract and let the `MachineApplicable` autofix silently
-        // corrupt user code. Filter rather than reject so a stray
-        // entry in the config table doesn't take the whole rule
-        // offline.
+        // the parser's "second char is the decoded form" contract
+        // and let the `MachineApplicable` autofix silently corrupt
+        // user code. Filter rather than reject so a stray entry in
+        // the config table doesn't take the whole rule offline.
         let escapes_eligible = config
             .escapes_eligible
             .into_iter()
@@ -198,159 +206,4 @@ impl<'tcx> LateLintPass<'tcx> for PreferRawString {
             Applicability::MachineApplicable,
         );
     }
-}
-
-struct ScanResult {
-    eliminable_count: usize,
-    decoded: String,
-}
-
-/// Walk the body of a cooked string literal (everything between the
-/// surrounding quotes) and classify each escape. Returns `None` if
-/// the body contains any non-raw escape — `\n`, `\t`, `\r`, `\0`,
-/// `\xNN`, `\u{...}`, line continuations, or any other backslash
-/// sequence that is not listed in the configured `escapes_eligible`.
-fn scan_body(body: &str, eligible: &[String]) -> Option<ScanResult> {
-    let mut rest = body;
-    let mut eliminable_count: usize = 0;
-    let mut decoded = String::with_capacity(body.len());
-    while !rest.is_empty() {
-        if let Some((escape, remainder)) = take_escape_eliminable(rest, eligible) {
-            decoded.push_str(eliminable_decoded(escape));
-            eliminable_count = eliminable_count.saturating_add(1);
-            rest = remainder;
-            continue;
-        }
-        if take_escape_non_raw(rest).is_some() {
-            return None;
-        }
-        let (literal, remainder) = take_literal_char(rest)?;
-        decoded.push_str(literal);
-        rest = remainder;
-    }
-    Some(ScanResult {
-        eliminable_count,
-        decoded,
-    })
-}
-
-/// Take a prefix of `input` that matches one of the configured
-/// eligible escape sequences. Each entry is matched literally
-/// against the input — no decoding, no normalisation. Entries
-/// reach this function only after [`is_supported_eligible_entry`]
-/// has accepted them, so they are non-empty by construction.
-fn take_escape_eliminable<'a>(input: &'a str, eligible: &[String]) -> Option<(&'a str, &'a str)> {
-    for entry in eligible {
-        if input.starts_with(entry.as_str()) {
-            return Some(input.split_at(entry.len()));
-        }
-    }
-    None
-}
-
-/// Decode an eligible escape into the verbatim text it represents
-/// in a raw string. Eligible entries are constrained to the three
-/// self-decoding escapes by [`is_supported_eligible_entry`], so the
-/// decoded form is exactly the entry with its leading backslash
-/// removed.
-fn eliminable_decoded(escape: &str) -> &str {
-    &escape['\\'.len_utf8()..]
-}
-
-/// Take any backslash escape from the front of `input`. Recognises
-/// `\xNN` (4 bytes), `\u{...}` (variable length), and any
-/// single-character escape (`\n`, `\t`, `\r`, `\0`, `\"`, `\\`,
-/// `\'`, line continuation, …). Returns `None` if `input` does not
-/// start with `\` or the escape is malformed (incomplete `\u{...}`
-/// without a closing brace, dangling backslash at the end of input,
-/// truncated `\xNN`).
-fn take_escape_non_raw(input: &str) -> Option<(&str, &str)> {
-    let bytes = input.as_bytes();
-    if bytes.first() != Some(&b'\\') {
-        return None;
-    }
-    let second_byte = *bytes.get(1)?;
-    let escape_len = match second_byte {
-        b'x' => 4,
-        b'u' => {
-            // `\u{...}`: scan to the closing `}`. The bytes between
-            // `{` and `}` are constrained to ASCII hex by the rustc
-            // lexer, so a byte-level scan is sufficient.
-            let mut length: usize = 2;
-            let mut closing_found = false;
-            for &byte in &bytes[2..] {
-                length = length.saturating_add(1);
-                if byte == b'}' {
-                    closing_found = true;
-                    break;
-                }
-            }
-            if !closing_found {
-                return None;
-            }
-            length
-        }
-        _ => {
-            // `\` + a single UTF-8 character (e.g. `\n`, `\"`,
-            // or the line-continuation `\<newline>`).
-            let second_char = input['\\'.len_utf8()..].chars().next()?;
-            '\\'.len_utf8() + second_char.len_utf8()
-        }
-    };
-    if escape_len > input.len() {
-        return None;
-    }
-    Some(input.split_at(escape_len))
-}
-
-/// Take a single non-backslash UTF-8 character from the front of
-/// `input`. Returns `None` only when `input` is empty or starts with
-/// `\`, in which case the caller should run one of the escape
-/// combinators first.
-fn take_literal_char(input: &str) -> Option<(&str, &str)> {
-    let first = input.chars().next()?;
-    if first == '\\' {
-        return None;
-    }
-    Some(input.split_at(first.len_utf8()))
-}
-
-/// Smallest number of `#` characters needed so that the closing
-/// `"<n #s>` sequence does not appear inside `decoded`.
-///
-/// In practice this is 0 for paths and 1 for JSON / HTML snippets;
-/// longer runs only matter when the literal itself embeds raw-
-/// string source text.
-fn minimal_hash_count(decoded: &str) -> usize {
-    let mut hashes = String::new();
-    let mut count: usize = 0;
-    loop {
-        let mut pattern = String::with_capacity('"'.len_utf8() + hashes.len());
-        pattern.push('"');
-        pattern.push_str(&hashes);
-        if !decoded.contains(&pattern) {
-            return count;
-        }
-        hashes.push('#');
-        count = count.saturating_add(1);
-    }
-}
-
-/// A supported `escapes_eligible` entry is one of the three Rust
-/// escapes that self-decode — that is, whose decoded character is
-/// exactly the byte that follows the backslash: `\"`, `\\`, `\'`.
-/// `eliminable_decoded`'s contract is "strip the leading backslash",
-/// which only holds for these three. Every other valid Rust escape
-/// (`\n`, `\t`, `\r`, `\0`, `\xNN`, `\u{...}`) decodes to a
-/// different character, so accepting it here would let the autofix
-/// silently corrupt strings — e.g. `escapes_eligible = ["\\n"]`
-/// would rewrite a newline-containing literal to one containing the
-/// letter `n`.
-///
-/// The supported set is the same one named by
-/// [`DEFAULT_ESCAPES_ELIGIBLE`]; matching against that constant
-/// keeps the two definitions from drifting apart if a future
-/// extension to `eliminable_decoded` ever adds a fourth entry.
-fn is_supported_eligible_entry(entry: &str) -> bool {
-    DEFAULT_ESCAPES_ELIGIBLE.contains(&entry)
 }

--- a/src/rules/prefer_raw_string/parser.rs
+++ b/src/rules/prefer_raw_string/parser.rs
@@ -1,0 +1,171 @@
+//! Parser-combinator-style scanner for a cooked Rust string literal's
+//! body. Each `take_*` function follows the convention in
+//! `planned-rules/IMPLEMENTATION_CONVENTIONS.md`: consume a recognised
+//! prefix from the input and return the rest, or `None` if the input
+//! doesn't start with that shape.
+//!
+//! The walk decides whether a literal contains *only* escapes that a
+//! raw string would express verbatim (`\"`, `\\`, `\'`). A single
+//! escape outside that set — `\n`, `\t`, `\xNN`, `\u{...}`, line
+//! continuations — makes the whole literal ineligible.
+
+/// Default eligible escape sequences: the three escapes that a raw
+/// string can express verbatim with no escape at all. Also used as
+/// the closed set against which user-supplied `escapes_eligible`
+/// entries are validated.
+pub(super) const DEFAULT_ESCAPES_ELIGIBLE: &[&str] = &[r#"\""#, r"\\", r"\'"];
+
+pub(super) struct ScanResult {
+    pub(super) eliminable_count: usize,
+    pub(super) decoded: String,
+}
+
+/// Walk the body of a cooked string literal (everything between the
+/// surrounding quotes) and classify each escape. Returns `None` if
+/// the body contains any non-raw escape — `\n`, `\t`, `\r`, `\0`,
+/// `\xNN`, `\u{...}`, line continuations, or any other backslash
+/// sequence that is not listed in the configured `escapes_eligible`.
+pub(super) fn scan_body(body: &str, eligible: &[String]) -> Option<ScanResult> {
+    let mut rest = body;
+    let mut eliminable_count: usize = 0;
+    let mut decoded = String::with_capacity(body.len());
+    while !rest.is_empty() {
+        if let Some((escape, remainder)) = take_escape_eliminable(rest, eligible) {
+            decoded.push_str(eliminable_decoded(escape));
+            eliminable_count = eliminable_count.saturating_add(1);
+            rest = remainder;
+            continue;
+        }
+        if take_escape_non_raw(rest).is_some() {
+            return None;
+        }
+        let (literal, remainder) = take_literal_char(rest)?;
+        decoded.push_str(literal);
+        rest = remainder;
+    }
+    Some(ScanResult {
+        eliminable_count,
+        decoded,
+    })
+}
+
+/// Take a prefix of `input` that matches one of the configured
+/// eligible escape sequences. Each entry is matched literally
+/// against the input — no decoding, no normalisation. Entries
+/// reach this function only after [`is_supported_eligible_entry`]
+/// has accepted them, so they are non-empty by construction.
+fn take_escape_eliminable<'a>(input: &'a str, eligible: &[String]) -> Option<(&'a str, &'a str)> {
+    for entry in eligible {
+        if input.starts_with(entry.as_str()) {
+            return Some(input.split_at(entry.len()));
+        }
+    }
+    None
+}
+
+/// Decode an eligible escape into the verbatim text it represents
+/// in a raw string. Eligible entries are constrained to the three
+/// self-decoding escapes by [`is_supported_eligible_entry`], so the
+/// decoded form is exactly the entry with its leading backslash
+/// removed.
+fn eliminable_decoded(escape: &str) -> &str {
+    &escape['\\'.len_utf8()..]
+}
+
+/// Take any backslash escape from the front of `input`. Recognises
+/// `\xNN` (4 bytes), `\u{...}` (variable length), and any
+/// single-character escape (`\n`, `\t`, `\r`, `\0`, `\"`, `\\`,
+/// `\'`, line continuation, …). Returns `None` if `input` does not
+/// start with `\` or the escape is malformed (incomplete `\u{...}`
+/// without a closing brace, dangling backslash at the end of input,
+/// truncated `\xNN`).
+fn take_escape_non_raw(input: &str) -> Option<(&str, &str)> {
+    let bytes = input.as_bytes();
+    if bytes.first() != Some(&b'\\') {
+        return None;
+    }
+    let second_byte = *bytes.get(1)?;
+    let escape_len = match second_byte {
+        b'x' => 4,
+        b'u' => {
+            // `\u{...}`: scan to the closing `}`. The bytes between
+            // `{` and `}` are constrained to ASCII hex by the rustc
+            // lexer, so a byte-level scan is sufficient.
+            let mut length: usize = 2;
+            let mut closing_found = false;
+            for &byte in &bytes[2..] {
+                length = length.saturating_add(1);
+                if byte == b'}' {
+                    closing_found = true;
+                    break;
+                }
+            }
+            if !closing_found {
+                return None;
+            }
+            length
+        }
+        _ => {
+            // `\` + a single UTF-8 character (e.g. `\n`, `\"`,
+            // or the line-continuation `\<newline>`).
+            let second_char = input['\\'.len_utf8()..].chars().next()?;
+            '\\'.len_utf8() + second_char.len_utf8()
+        }
+    };
+    if escape_len > input.len() {
+        return None;
+    }
+    Some(input.split_at(escape_len))
+}
+
+/// Take a single non-backslash UTF-8 character from the front of
+/// `input`. Returns `None` only when `input` is empty or starts with
+/// `\`, in which case the caller should run one of the escape
+/// combinators first.
+fn take_literal_char(input: &str) -> Option<(&str, &str)> {
+    let first = input.chars().next()?;
+    if first == '\\' {
+        return None;
+    }
+    Some(input.split_at(first.len_utf8()))
+}
+
+/// Smallest number of `#` characters needed so that the closing
+/// `"<n #s>` sequence does not appear inside `decoded`.
+///
+/// In practice this is 0 for paths and 1 for JSON / HTML snippets;
+/// longer runs only matter when the literal itself embeds raw-
+/// string source text.
+pub(super) fn minimal_hash_count(decoded: &str) -> usize {
+    let mut hashes = String::new();
+    let mut count: usize = 0;
+    loop {
+        let mut pattern = String::with_capacity('"'.len_utf8() + hashes.len());
+        pattern.push('"');
+        pattern.push_str(&hashes);
+        if !decoded.contains(&pattern) {
+            return count;
+        }
+        hashes.push('#');
+        count = count.saturating_add(1);
+    }
+}
+
+/// A supported `escapes_eligible` entry is one of the three Rust
+/// escapes that self-decode — that is, whose decoded character is
+/// exactly the byte that follows the backslash: `\"`, `\\`, `\'`.
+/// [`eliminable_decoded`]'s contract is "strip the leading backslash",
+/// which only holds for these three. Every other valid Rust escape
+/// (`\n`, `\t`, `\r`, `\0`, `\xNN`, `\u{...}`) decodes to a
+/// different character, so accepting it here would let the autofix
+/// silently corrupt strings — e.g. `escapes_eligible = ["\\n"]`
+/// would rewrite a newline-containing literal to one containing the
+/// letter `n`.
+///
+/// The supported set is the same one named by
+/// [`DEFAULT_ESCAPES_ELIGIBLE`]; matching against that constant
+/// keeps the two definitions from drifting apart if a future
+/// extension to [`eliminable_decoded`] ever adds a fourth entry.
+pub(super) fn is_supported_eligible_entry(entry: &str) -> bool {
+    DEFAULT_ESCAPES_ELIGIBLE.contains(&entry)
+}

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -1,13 +1,23 @@
+//! `perfectionist::single_letter_closure_param` — flag closure
+//! parameters whose identifier is one ASCII letter, unless the
+//! closure is a trivial single-expression callback.
+//!
+//! The trivial-callback predicate lives in [`triviality`]; this file
+//! owns the lint declaration, the configuration, and the late pass
+//! that drives them.
+
 use std::collections::BTreeSet;
 
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
-use rustc_hir::def::Res;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::Symbol;
 
 use crate::common::{binding_ident, is_single_ascii_letter};
+
+mod triviality;
+
+use triviality::{is_trivial_wrapper, parent_call_callee_name, single_expression_body};
 
 declare_tool_lint! {
     /// ### What it does
@@ -190,93 +200,9 @@ impl SingleLetterClosureParam {
         lint_context: &LateContext<'tcx>,
         closure_expr: &'tcx hir::Expr<'tcx>,
     ) -> bool {
-        let parent = lint_context.tcx.parent_hir_node(closure_expr.hir_id);
-        let hir::Node::Expr(parent_expr) = parent else {
-            return false;
-        };
-        let callee_name = match parent_expr.kind {
-            hir::ExprKind::MethodCall(segment, _, _, _) => Some(segment.ident.name),
-            hir::ExprKind::Call(callee, _) => path_final_segment(callee),
-            _ => None,
-        };
-        let Some(name) = callee_name else {
+        let Some(name) = parent_call_callee_name(lint_context, closure_expr) else {
             return false;
         };
         self.comparison_methods.contains(name.as_str())
-    }
-}
-
-fn binding_hir_id<'hir>(pat: &'hir hir::Pat<'hir>) -> Option<hir::HirId> {
-    match pat.kind {
-        hir::PatKind::Binding(_, hir_id, _, None) => Some(hir_id),
-        _ => None,
-    }
-}
-
-/// If `body.value` is a single expression — either directly or
-/// wrapped in a block with no statements — return that
-/// expression. Otherwise return `None`.
-fn single_expression_body<'hir>(body: &'hir hir::Body<'hir>) -> Option<&'hir hir::Expr<'hir>> {
-    let value = body.value;
-    if let hir::ExprKind::Block(block, _) = value.kind {
-        if !block.stmts.is_empty() {
-            return None;
-        }
-        block.expr
-    } else {
-        Some(value)
-    }
-}
-
-fn path_final_segment<'hir>(expr: &'hir hir::Expr<'hir>) -> Option<Symbol> {
-    let hir::ExprKind::Path(qpath) = &expr.kind else {
-        return None;
-    };
-    let segment = match qpath {
-        hir::QPath::Resolved(_, path) => path.segments.last()?,
-        hir::QPath::TypeRelative(_, segment) => *segment,
-    };
-    Some(segment.ident.name)
-}
-
-/// Returns whether `expr` is a "trivial wrapper" around one of
-/// the closure's parameters:
-/// - a field access `param.field`,
-/// - a method call `param.foo(args)`,
-/// - a one-argument call `f(param)`,
-/// - a reference `&param`.
-///
-/// In every shape, `*` / `&` operators around the reference to
-/// the parameter are peeled by `is_param_ref` before matching,
-/// so `|s| (*s).foo()` and `|s| f(&*s)` both qualify.
-fn is_trivial_wrapper<'hir>(expr: &'hir hir::Expr<'hir>, params: &'hir [hir::Param<'hir>]) -> bool {
-    /// "Refers to a parameter, possibly through one or more `*` /
-    /// `&` operators." Peeling through these keeps `|s| (*s).foo()`
-    /// classified as a trivial wrapper, since the deref is a
-    /// purely-structural step the reader does not need help with.
-    fn is_param_ref(expr: &hir::Expr<'_>, params: &[hir::Param<'_>]) -> bool {
-        let mut expr = expr;
-        loop {
-            match &expr.kind {
-                hir::ExprKind::Unary(hir::UnOp::Deref, inner)
-                | hir::ExprKind::AddrOf(_, _, inner) => expr = inner,
-                hir::ExprKind::Path(hir::QPath::Resolved(None, path)) => {
-                    let Res::Local(local_hir_id) = path.res else {
-                        return false;
-                    };
-                    return params
-                        .iter()
-                        .any(|param| binding_hir_id(param.pat) == Some(local_hir_id));
-                }
-                _ => return false,
-            }
-        }
-    }
-    match expr.kind {
-        hir::ExprKind::Field(receiver, _) => is_param_ref(receiver, params),
-        hir::ExprKind::MethodCall(_, receiver, _, _) => is_param_ref(receiver, params),
-        hir::ExprKind::Call(_, args) => args.len() == 1 && is_param_ref(&args[0], params),
-        hir::ExprKind::AddrOf(_, _, inner) => is_param_ref(inner, params),
-        _ => false,
     }
 }

--- a/src/rules/single_letter_closure_param/triviality.rs
+++ b/src/rules/single_letter_closure_param/triviality.rs
@@ -96,8 +96,9 @@ fn is_param_ref(expr: &hir::Expr<'_>, params: &[hir::Param<'_>]) -> bool {
     let mut expr = expr;
     loop {
         match &expr.kind {
-            hir::ExprKind::Unary(hir::UnOp::Deref, inner)
-            | hir::ExprKind::AddrOf(_, _, inner) => expr = inner,
+            hir::ExprKind::Unary(hir::UnOp::Deref, inner) | hir::ExprKind::AddrOf(_, _, inner) => {
+                expr = inner
+            }
             hir::ExprKind::Path(hir::QPath::Resolved(None, path)) => {
                 let Res::Local(local_hir_id) = path.res else {
                     return false;

--- a/src/rules/single_letter_closure_param/triviality.rs
+++ b/src/rules/single_letter_closure_param/triviality.rs
@@ -1,0 +1,112 @@
+//! Classifiers for the "trivial single-expression callback"
+//! exemption.
+//!
+//! A closure is exempted if either:
+//! - its body is a single expression and the enclosing call is one of
+//!   the configured comparison / fold callees, or
+//! - its body is a single expression that is a trivial wrapper around
+//!   one of the closure's parameters (field access, method call, one-
+//!   argument call, reference).
+//!
+//! The helpers here decide each predicate. The driver in
+//! [`super`] composes them.
+
+use rustc_hir as hir;
+use rustc_hir::def::Res;
+use rustc_lint::LateContext;
+use rustc_span::Symbol;
+
+use crate::common::binding_hir_id;
+
+/// If `body.value` is a single expression — either directly or
+/// wrapped in a block with no statements — return that
+/// expression. Otherwise return `None`.
+pub(super) fn single_expression_body<'hir>(
+    body: &'hir hir::Body<'hir>,
+) -> Option<&'hir hir::Expr<'hir>> {
+    let value = body.value;
+    if let hir::ExprKind::Block(block, _) = value.kind {
+        if !block.stmts.is_empty() {
+            return None;
+        }
+        block.expr
+    } else {
+        Some(value)
+    }
+}
+
+/// Return the callee name of the parent call expression of
+/// `closure_expr`, if any. `MethodCall` returns the method's final
+/// segment; `Call` returns the final segment of the callee path.
+/// Anything else (`if`, indexing, …) returns `None`.
+pub(super) fn parent_call_callee_name<'tcx>(
+    lint_context: &LateContext<'tcx>,
+    closure_expr: &'tcx hir::Expr<'tcx>,
+) -> Option<Symbol> {
+    let parent = lint_context.tcx.parent_hir_node(closure_expr.hir_id);
+    let hir::Node::Expr(parent_expr) = parent else {
+        return None;
+    };
+    match parent_expr.kind {
+        hir::ExprKind::MethodCall(segment, _, _, _) => Some(segment.ident.name),
+        hir::ExprKind::Call(callee, _) => path_final_segment(callee),
+        _ => None,
+    }
+}
+
+fn path_final_segment<'hir>(expr: &'hir hir::Expr<'hir>) -> Option<Symbol> {
+    let hir::ExprKind::Path(qpath) = &expr.kind else {
+        return None;
+    };
+    let segment = match qpath {
+        hir::QPath::Resolved(_, path) => path.segments.last()?,
+        hir::QPath::TypeRelative(_, segment) => *segment,
+    };
+    Some(segment.ident.name)
+}
+
+/// Returns whether `expr` is a "trivial wrapper" around one of
+/// the closure's parameters:
+/// - a field access `param.field`,
+/// - a method call `param.foo(args)`,
+/// - a one-argument call `f(param)`,
+/// - a reference `&param`.
+///
+/// In every shape, `*` / `&` operators around the reference to
+/// the parameter are peeled by `is_param_ref` before matching,
+/// so `|s| (*s).foo()` and `|s| f(&*s)` both qualify.
+pub(super) fn is_trivial_wrapper<'hir>(
+    expr: &'hir hir::Expr<'hir>,
+    params: &'hir [hir::Param<'hir>],
+) -> bool {
+    match expr.kind {
+        hir::ExprKind::Field(receiver, _) => is_param_ref(receiver, params),
+        hir::ExprKind::MethodCall(_, receiver, _, _) => is_param_ref(receiver, params),
+        hir::ExprKind::Call(_, args) => args.len() == 1 && is_param_ref(&args[0], params),
+        hir::ExprKind::AddrOf(_, _, inner) => is_param_ref(inner, params),
+        _ => false,
+    }
+}
+
+/// "Refers to a parameter, possibly through one or more `*` /
+/// `&` operators." Peeling through these keeps `|s| (*s).foo()`
+/// classified as a trivial wrapper, since the deref is a
+/// purely-structural step the reader does not need help with.
+fn is_param_ref(expr: &hir::Expr<'_>, params: &[hir::Param<'_>]) -> bool {
+    let mut expr = expr;
+    loop {
+        match &expr.kind {
+            hir::ExprKind::Unary(hir::UnOp::Deref, inner)
+            | hir::ExprKind::AddrOf(_, _, inner) => expr = inner,
+            hir::ExprKind::Path(hir::QPath::Resolved(None, path)) => {
+                let Res::Local(local_hir_id) = path.res else {
+                    return false;
+                };
+                return params
+                    .iter()
+                    .any(|param| binding_hir_id(param.pat) == Some(local_hir_id));
+            }
+            _ => return false,
+        }
+    }
+}

--- a/src/rules/single_letter_closure_param/triviality.rs
+++ b/src/rules/single_letter_closure_param/triviality.rs
@@ -1,15 +1,19 @@
 //! Classifiers for the "trivial single-expression callback"
 //! exemption.
 //!
-//! A closure is exempted if either:
-//! - its body is a single expression and the enclosing call is one of
-//!   the configured comparison / fold callees, or
-//! - its body is a single expression that is a trivial wrapper around
-//!   one of the closure's parameters (field access, method call, one-
-//!   argument call, reference).
+//! The exemption has a shared precondition and two acceptance
+//! branches. A closure qualifies when [`single_expression_body`]
+//! returns `Some` *and* either of the following holds:
 //!
-//! The helpers here decide each predicate. The driver in
-//! [`super`] composes them.
+//! - the enclosing call's callee — recovered via
+//!   [`parent_call_callee_name`] — is on the rule's configured
+//!   comparison / fold allowlist, or
+//! - the body is a trivial wrapper around one of the closure's
+//!   parameters (field access, method call, one-argument call,
+//!   reference), as decided by [`is_trivial_wrapper`].
+//!
+//! The driver in [`super`] composes these helpers; this module
+//! holds the predicates themselves.
 
 use rustc_hir as hir;
 use rustc_hir::def::Res;

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -1,14 +1,14 @@
 use std::collections::BTreeSet;
 
-use clippy_utils::diagnostics::span_lint_and_sugg;
 use rustc_ast::Crate;
-use rustc_errors::Applicability;
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::{
     BytePos, Pos, RelativeBytePos, SourceFile, Span, SyntaxContext, def_id::LOCAL_CRATE,
 };
+
+use crate::literal_scan::emit_flagged_chars;
 
 declare_tool_lint! {
     /// ### What it does
@@ -152,33 +152,19 @@ impl UnicodeEllipsisInComments {
         comment_offset: u32,
         comment: &str,
     ) {
-        for (byte_index, character) in comment.char_indices() {
-            if !self.flagged_chars.contains(&character) {
-                continue;
-            }
-            let char_len = character.len_utf8() as u32;
-            let span_start = source_file.absolute_position(RelativeBytePos::from_u32(
-                comment_offset + byte_index as u32,
-            ));
-            let span_end = BytePos::from_u32(span_start.0 + char_len);
-            let span = Span::new(span_start, span_end, SyntaxContext::root(), None);
-            let applicability = if character == '\u{2026}' {
-                Applicability::MachineApplicable
-            } else {
-                Applicability::MaybeIncorrect
-            };
-            span_lint_and_sugg(
-                lint_context,
-                UNICODE_ELLIPSIS_IN_COMMENTS,
-                span,
-                format!(
-                    "Unicode `{character}` (U+{:04X}) in comment",
-                    character as u32,
-                ),
-                "use ASCII `...` instead",
-                "...".to_owned(),
-                applicability,
-            );
-        }
+        emit_flagged_chars(
+            lint_context,
+            UNICODE_ELLIPSIS_IN_COMMENTS,
+            comment,
+            &self.flagged_chars,
+            "comment",
+            |byte_index, char_len| {
+                let span_start = source_file.absolute_position(RelativeBytePos::from_u32(
+                    comment_offset + byte_index as u32,
+                ));
+                let span_end = BytePos::from_u32(span_start.0 + char_len);
+                Span::new(span_start, span_end, SyntaxContext::root(), None)
+            },
+        );
     }
 }

--- a/src/rules/unicode_ellipsis_in_panic_messages.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages.rs
@@ -1,13 +1,32 @@
-use clippy_utils::diagnostics::span_lint_and_sugg;
+//! `perfectionist::unicode_ellipsis_in_panic_messages` — flag U+2026
+//! HORIZONTAL ELLIPSIS (`…`) in panic / assertion / `expect` messages.
+//!
+//! Module layout:
+//!
+//! - [`config`] — user-facing configuration and the curated default
+//!   macro / method lists.
+//! - [`scan`] — the two source-text scans the rule performs: a
+//!   tokenizer walk over a macro call's snippet, and a per-literal
+//!   body scan for `expect` / `expect_err`. Both forward to the
+//!   shared [`crate::literal_scan`] helpers for per-character
+//!   emission.
+//!
+//! The late pass below threads them together: every `Expr` is
+//! checked once as a possible root macro call, and once as a possible
+//! `expect` / `expect_err` method call.
+
 use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::res::MaybeDef;
 use rustc_ast::LitKind;
-use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind};
-use rustc_lexer::{FrontmatterAllowed, LiteralKind, TokenKind, tokenize};
 use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::{BytePos, Pos, Span, Symbol, sym};
+use rustc_span::sym;
+
+mod config;
+mod scan;
+
+use config::UnicodeEllipsisInPanicMessages;
 
 declare_tool_lint! {
     /// ### What it does
@@ -55,89 +74,6 @@ declare_tool_lint! {
     report_in_external_macro: true
 }
 
-const CONFIG_KEY: &str = "perfectionist::unicode_ellipsis_in_panic_messages";
-
-const DEFAULT_MACROS: &[&str] = &[
-    "panic",
-    "unimplemented",
-    "todo",
-    "unreachable",
-    "debug_unreachable",
-    "assert",
-    "assert_eq",
-    "assert_ne",
-    "debug_assert",
-    "debug_assert_eq",
-    "debug_assert_ne",
-];
-
-const DEFAULT_METHODS: &[&str] = &["expect", "expect_err"];
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
-struct Config {
-    /// Macros whose call site should be scanned for the flagged
-    /// characters. Defaults to the standard panic and assertion
-    /// macros (`panic`, `unimplemented`, `todo`, `unreachable`,
-    /// `debug_unreachable`, and the `assert*` family). Override to
-    /// add project-specific assertion-shaped macros, or to narrow
-    /// the set when a project deliberately uses `…` in one of them.
-    macros: Vec<String>,
-    /// Method names on `Option` / `Result` whose first argument is
-    /// the panic message. Defaults to `expect` and `expect_err`.
-    methods: Vec<String>,
-    /// Extra characters to flag alongside U+2026, in the same spirit
-    /// as `unicode_ellipsis_in_comments.also_flag`. Empty by default.
-    also_flag: Vec<char>,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            macros: DEFAULT_MACROS
-                .iter()
-                .map(|name| (*name).to_owned())
-                .collect(),
-            methods: DEFAULT_METHODS
-                .iter()
-                .map(|name| (*name).to_owned())
-                .collect(),
-            also_flag: Vec::new(),
-        }
-    }
-}
-
-pub struct UnicodeEllipsisInPanicMessages {
-    flagged_chars: Vec<char>,
-    macros: Vec<Symbol>,
-    methods: Vec<Symbol>,
-}
-
-impl UnicodeEllipsisInPanicMessages {
-    fn new() -> Self {
-        let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-        let mut flagged_chars = vec!['\u{2026}'];
-        for character in config.also_flag {
-            if !flagged_chars.contains(&character) {
-                flagged_chars.push(character);
-            }
-        }
-        Self {
-            flagged_chars,
-            macros: config
-                .macros
-                .iter()
-                .map(|name| Symbol::intern(name))
-                .collect(),
-            methods: config
-                .methods
-                .iter()
-                .map(|name| Symbol::intern(name))
-                .collect(),
-        }
-    }
-}
-
 impl_lint_pass!(UnicodeEllipsisInPanicMessages => [UNICODE_ELLIPSIS_IN_PANIC_MESSAGES]);
 
 pub fn register_lint(lint_store: &mut LintStore) {
@@ -157,7 +93,12 @@ impl<'tcx> LateLintPass<'tcx> for UnicodeEllipsisInPanicMessages {
         if let Some(macro_call) = root_macro_call_first_node(lint_context, expr) {
             let macro_name = lint_context.tcx.item_name(macro_call.def_id);
             if self.macros.contains(&macro_name) {
-                self.scan_macro_call_source(lint_context, macro_call.span, macro_name);
+                scan::scan_macro_call_source(
+                    lint_context,
+                    &self.flagged_chars,
+                    macro_call.span,
+                    macro_name,
+                );
             }
         }
         // `expect` / `expect_err` on `Option` / `Result`.
@@ -174,7 +115,13 @@ impl<'tcx> LateLintPass<'tcx> for UnicodeEllipsisInPanicMessages {
                 .source_map()
                 .span_to_snippet(literal.span)
             {
-                self.scan_literal(lint_context, literal.span, &snippet, &context);
+                scan::scan_literal(
+                    lint_context,
+                    &self.flagged_chars,
+                    literal.span,
+                    &snippet,
+                    &context,
+                );
             }
         }
     }
@@ -187,178 +134,4 @@ fn receiver_is_option_or_result<'tcx>(
     let receiver_type = lint_context.typeck_results().expr_ty(receiver).peel_refs();
     receiver_type.is_diag_item(lint_context, sym::Option)
         || receiver_type.is_diag_item(lint_context, sym::Result)
-}
-
-impl UnicodeEllipsisInPanicMessages {
-    fn scan_macro_call_source(
-        &self,
-        lint_context: &LateContext<'_>,
-        call_span: Span,
-        macro_name: Symbol,
-    ) {
-        let Ok(snippet) = lint_context.sess().source_map().span_to_snippet(call_span) else {
-            return;
-        };
-        let context = format!("`{macro_name}!` message");
-        // Track delimiter nesting so we only scan literals at the
-        // macro's own argument level. The snippet starts with
-        // `macro_name!(`/`[`/`{`, which opens depth 1; literals
-        // belonging to the panic message live at exactly depth 1.
-        // Anything deeper is an argument of a nested call (e.g.,
-        // `format!("...")` or `include_str!("path")`) whose literal
-        // is not the panic message.
-        //
-        // Within depth 1 we also count commas to skip the non-message
-        // arguments of `assert!`-family macros: `assert!(cond, msg)`
-        // skips one comma-separated argument before the message,
-        // `assert_eq!(a, b, msg)` and `assert_ne!`/`debug_assert_eq!`/
-        // `debug_assert_ne!` skip two. Scanning value-position
-        // literals would otherwise rewrite comparison operands.
-        let skip_arguments = arguments_before_message(macro_name);
-        let mut byte_offset: u32 = 0;
-        let mut depth: u32 = 0;
-        let mut top_level_comma_count: u32 = 0;
-        for token in tokenize(&snippet, FrontmatterAllowed::No) {
-            let token_length = token.len;
-            match token.kind {
-                TokenKind::OpenParen | TokenKind::OpenBracket | TokenKind::OpenBrace => {
-                    depth = depth.saturating_add(1);
-                }
-                TokenKind::CloseParen | TokenKind::CloseBracket | TokenKind::CloseBrace => {
-                    depth = depth.saturating_sub(1);
-                }
-                TokenKind::Comma if depth == 1 => {
-                    top_level_comma_count = top_level_comma_count.saturating_add(1);
-                }
-                TokenKind::Literal { kind, .. }
-                    if depth == 1
-                        && top_level_comma_count >= skip_arguments
-                        && is_display_string_literal(kind) =>
-                {
-                    let token_start = byte_offset as usize;
-                    let token_end = token_start + token_length as usize;
-                    let literal_snippet = &snippet[token_start..token_end];
-                    let token_lo = call_span.lo() + BytePos::from_u32(byte_offset);
-                    let token_hi = token_lo + BytePos::from_u32(token_length);
-                    let token_span =
-                        Span::new(token_lo, token_hi, call_span.ctxt(), call_span.parent());
-                    self.scan_literal(lint_context, token_span, literal_snippet, &context);
-                }
-                _ => {}
-            }
-            byte_offset = byte_offset
-                .checked_add(token_length)
-                .expect("snippet offset overflowed u32");
-        }
-    }
-
-    fn scan_literal(
-        &self,
-        lint_context: &LateContext<'_>,
-        literal_span: Span,
-        literal_snippet: &str,
-        context: &str,
-    ) {
-        let Some((prefix_length, suffix_length)) = string_literal_quote_lengths(literal_snippet)
-        else {
-            return;
-        };
-        let body = &literal_snippet[prefix_length..literal_snippet.len() - suffix_length];
-        for (byte_offset, character) in body.char_indices() {
-            if !self.flagged_chars.contains(&character) {
-                continue;
-            }
-            let character_length = character.len_utf8() as u32;
-            let span_start =
-                literal_span.lo() + BytePos::from_u32((prefix_length + byte_offset) as u32);
-            let span_end = span_start + BytePos::from_u32(character_length);
-            let span = Span::new(
-                span_start,
-                span_end,
-                literal_span.ctxt(),
-                literal_span.parent(),
-            );
-            let applicability = if character == '\u{2026}' {
-                Applicability::MachineApplicable
-            } else {
-                Applicability::MaybeIncorrect
-            };
-            span_lint_and_sugg(
-                lint_context,
-                UNICODE_ELLIPSIS_IN_PANIC_MESSAGES,
-                span,
-                format!(
-                    "Unicode `{character}` (U+{:04X}) in {context}",
-                    character as u32,
-                ),
-                "use ASCII `...` instead",
-                "...".to_owned(),
-                applicability,
-            );
-        }
-    }
-}
-
-fn is_display_string_literal(kind: LiteralKind) -> bool {
-    matches!(kind, LiteralKind::Str { .. } | LiteralKind::RawStr { .. })
-}
-
-/// How many comma-separated top-level arguments precede the message
-/// argument for a given macro. `0` for macros whose first argument is
-/// itself the message (`panic!`, `todo!`, …); `1` for `assert!` /
-/// `debug_assert!` (the condition comes first); `2` for `assert_eq!`
-/// / `assert_ne!` / `debug_assert_eq!` / `debug_assert_ne!` (the two
-/// values come first).
-///
-/// Unknown macros — including any added through the configuration's
-/// `macros` knob — default to `0`. A project that adds an
-/// assertion-shaped custom macro through configuration accepts the
-/// false positive in that case; correctly handling it would require
-/// a per-macro skip-count configuration knob that the planning file
-/// did not call for.
-fn arguments_before_message(macro_name: Symbol) -> u32 {
-    match macro_name.as_str() {
-        "assert" | "debug_assert" => 1,
-        "assert_eq" | "assert_ne" | "debug_assert_eq" | "debug_assert_ne" => 2,
-        _ => 0,
-    }
-}
-
-/// Return `(prefix_length, suffix_length)` covering the opening and
-/// closing delimiters of a Rust string-literal snippet, or `None` if
-/// the snippet does not look like a string literal whose body we can
-/// scan as plain text.
-///
-/// Recognises plain (`"..."`) and raw (`r"..."`, `r#"..."#`, …)
-/// strings. Byte / C-string forms are excluded — the lint operates on
-/// display strings.
-fn string_literal_quote_lengths(snippet: &str) -> Option<(usize, usize)> {
-    let bytes = snippet.as_bytes();
-    let mut index = 0;
-    let mut hash_count = 0;
-    if index < bytes.len() && bytes[index] == b'r' {
-        index += 1;
-        while index < bytes.len() && bytes[index] == b'#' {
-            hash_count += 1;
-            index += 1;
-        }
-    }
-    if index >= bytes.len() || bytes[index] != b'"' {
-        return None;
-    }
-    let prefix_length = index + 1;
-    let expected_suffix_length = hash_count + 1;
-    if bytes.len() < prefix_length + expected_suffix_length {
-        return None;
-    }
-    let suffix_start = bytes.len() - expected_suffix_length;
-    if bytes[suffix_start] != b'"' {
-        return None;
-    }
-    for trailing_hash_index in 0..hash_count {
-        if bytes[suffix_start + 1 + trailing_hash_index] != b'#' {
-            return None;
-        }
-    }
-    Some((prefix_length, expected_suffix_length))
 }

--- a/src/rules/unicode_ellipsis_in_panic_messages/config.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages/config.rs
@@ -1,0 +1,89 @@
+//! Configuration for `unicode_ellipsis_in_panic_messages`. Owns the
+//! user-facing `Config` shape, the curated default macro / method
+//! lists, and the in-memory `UnicodeEllipsisInPanicMessages` state the
+//! late pass holds.
+
+use rustc_span::Symbol;
+
+const CONFIG_KEY: &str = "perfectionist::unicode_ellipsis_in_panic_messages";
+
+const DEFAULT_MACROS: &[&str] = &[
+    "panic",
+    "unimplemented",
+    "todo",
+    "unreachable",
+    "debug_unreachable",
+    "assert",
+    "assert_eq",
+    "assert_ne",
+    "debug_assert",
+    "debug_assert_eq",
+    "debug_assert_ne",
+];
+
+const DEFAULT_METHODS: &[&str] = &["expect", "expect_err"];
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(default, rename_all = "snake_case")]
+struct Config {
+    /// Macros whose call site should be scanned for the flagged
+    /// characters. Defaults to the standard panic and assertion
+    /// macros (`panic`, `unimplemented`, `todo`, `unreachable`,
+    /// `debug_unreachable`, and the `assert*` family). Override to
+    /// add project-specific assertion-shaped macros, or to narrow
+    /// the set when a project deliberately uses `…` in one of them.
+    macros: Vec<String>,
+    /// Method names on `Option` / `Result` whose first argument is
+    /// the panic message. Defaults to `expect` and `expect_err`.
+    methods: Vec<String>,
+    /// Extra characters to flag alongside U+2026, in the same spirit
+    /// as `unicode_ellipsis_in_comments.also_flag`. Empty by default.
+    also_flag: Vec<char>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            macros: DEFAULT_MACROS
+                .iter()
+                .map(|name| (*name).to_owned())
+                .collect(),
+            methods: DEFAULT_METHODS
+                .iter()
+                .map(|name| (*name).to_owned())
+                .collect(),
+            also_flag: Vec::new(),
+        }
+    }
+}
+
+pub(super) struct UnicodeEllipsisInPanicMessages {
+    pub(super) flagged_chars: Vec<char>,
+    pub(super) macros: Vec<Symbol>,
+    pub(super) methods: Vec<Symbol>,
+}
+
+impl UnicodeEllipsisInPanicMessages {
+    pub(super) fn new() -> Self {
+        let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
+        let mut flagged_chars = vec!['\u{2026}'];
+        for character in config.also_flag {
+            if !flagged_chars.contains(&character) {
+                flagged_chars.push(character);
+            }
+        }
+        Self {
+            flagged_chars,
+            macros: config
+                .macros
+                .iter()
+                .map(|name| Symbol::intern(name))
+                .collect(),
+            methods: config
+                .methods
+                .iter()
+                .map(|name| Symbol::intern(name))
+                .collect(),
+        }
+    }
+}

--- a/src/rules/unicode_ellipsis_in_panic_messages/scan.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages/scan.rs
@@ -68,7 +68,8 @@ pub(super) fn scan_macro_call_source(
                 let literal_snippet = &snippet[token_start..token_end];
                 let token_lo = call_span.lo() + BytePos::from_u32(byte_offset);
                 let token_hi = token_lo + BytePos::from_u32(token_length);
-                let token_span = Span::new(token_lo, token_hi, call_span.ctxt(), call_span.parent());
+                let token_span =
+                    Span::new(token_lo, token_hi, call_span.ctxt(), call_span.parent());
                 scan_literal(
                     lint_context,
                     flagged_chars,
@@ -106,7 +107,12 @@ pub(super) fn scan_literal(
             let span_start =
                 literal_span.lo() + BytePos::from_u32((prefix_length + byte_offset) as u32);
             let span_end = span_start + BytePos::from_u32(character_length);
-            Span::new(span_start, span_end, literal_span.ctxt(), literal_span.parent())
+            Span::new(
+                span_start,
+                span_end,
+                literal_span.ctxt(),
+                literal_span.parent(),
+            )
         },
     );
 }

--- a/src/rules/unicode_ellipsis_in_panic_messages/scan.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages/scan.rs
@@ -1,0 +1,137 @@
+//! The two source-text scans the rule performs.
+//!
+//! [`scan_macro_call_source`] walks the rendered text of a panic /
+//! assertion macro invocation with `rustc_lexer::tokenize`, tracks
+//! delimiter nesting so only depth-1 literals reach the per-character
+//! scan, and skips over the leading non-message arguments of
+//! `assert!`-family macros.
+//!
+//! [`scan_literal`] is the simpler entry point used directly by
+//! `expect` / `expect_err`: take a string-literal snippet, locate its
+//! body, and forward to [`crate::literal_scan::emit_flagged_chars`].
+
+use rustc_lexer::{FrontmatterAllowed, LiteralKind, TokenKind, tokenize};
+use rustc_lint::{LateContext, LintContext};
+use rustc_span::{BytePos, Pos, Span, Symbol};
+
+use crate::literal_scan::{emit_flagged_chars, string_literal_quote_lengths};
+
+use super::UNICODE_ELLIPSIS_IN_PANIC_MESSAGES;
+
+pub(super) fn scan_macro_call_source(
+    lint_context: &LateContext<'_>,
+    flagged_chars: &[char],
+    call_span: Span,
+    macro_name: Symbol,
+) {
+    let Ok(snippet) = lint_context.sess().source_map().span_to_snippet(call_span) else {
+        return;
+    };
+    let context = format!("`{macro_name}!` message");
+    // Track delimiter nesting so we only scan literals at the
+    // macro's own argument level. The snippet starts with
+    // `macro_name!(`/`[`/`{`, which opens depth 1; literals
+    // belonging to the panic message live at exactly depth 1.
+    // Anything deeper is an argument of a nested call (e.g.,
+    // `format!("...")` or `include_str!("path")`) whose literal
+    // is not the panic message.
+    //
+    // Within depth 1 we also count commas to skip the non-message
+    // arguments of `assert!`-family macros: `assert!(cond, msg)`
+    // skips one comma-separated argument before the message,
+    // `assert_eq!(a, b, msg)` and `assert_ne!`/`debug_assert_eq!`/
+    // `debug_assert_ne!` skip two. Scanning value-position
+    // literals would otherwise rewrite comparison operands.
+    let skip_arguments = arguments_before_message(macro_name);
+    let mut byte_offset: u32 = 0;
+    let mut depth: u32 = 0;
+    let mut top_level_comma_count: u32 = 0;
+    for token in tokenize(&snippet, FrontmatterAllowed::No) {
+        let token_length = token.len;
+        match token.kind {
+            TokenKind::OpenParen | TokenKind::OpenBracket | TokenKind::OpenBrace => {
+                depth = depth.saturating_add(1);
+            }
+            TokenKind::CloseParen | TokenKind::CloseBracket | TokenKind::CloseBrace => {
+                depth = depth.saturating_sub(1);
+            }
+            TokenKind::Comma if depth == 1 => {
+                top_level_comma_count = top_level_comma_count.saturating_add(1);
+            }
+            TokenKind::Literal { kind, .. }
+                if depth == 1
+                    && top_level_comma_count >= skip_arguments
+                    && is_display_string_literal(kind) =>
+            {
+                let token_start = byte_offset as usize;
+                let token_end = token_start + token_length as usize;
+                let literal_snippet = &snippet[token_start..token_end];
+                let token_lo = call_span.lo() + BytePos::from_u32(byte_offset);
+                let token_hi = token_lo + BytePos::from_u32(token_length);
+                let token_span = Span::new(token_lo, token_hi, call_span.ctxt(), call_span.parent());
+                scan_literal(
+                    lint_context,
+                    flagged_chars,
+                    token_span,
+                    literal_snippet,
+                    &context,
+                );
+            }
+            _ => {}
+        }
+        byte_offset = byte_offset
+            .checked_add(token_length)
+            .expect("snippet offset overflowed u32");
+    }
+}
+
+pub(super) fn scan_literal(
+    lint_context: &LateContext<'_>,
+    flagged_chars: &[char],
+    literal_span: Span,
+    literal_snippet: &str,
+    context: &str,
+) {
+    let Some((prefix_length, suffix_length)) = string_literal_quote_lengths(literal_snippet) else {
+        return;
+    };
+    let body = &literal_snippet[prefix_length..literal_snippet.len() - suffix_length];
+    emit_flagged_chars(
+        lint_context,
+        UNICODE_ELLIPSIS_IN_PANIC_MESSAGES,
+        body,
+        flagged_chars,
+        context,
+        |byte_offset, character_length| {
+            let span_start =
+                literal_span.lo() + BytePos::from_u32((prefix_length + byte_offset) as u32);
+            let span_end = span_start + BytePos::from_u32(character_length);
+            Span::new(span_start, span_end, literal_span.ctxt(), literal_span.parent())
+        },
+    );
+}
+
+fn is_display_string_literal(kind: LiteralKind) -> bool {
+    matches!(kind, LiteralKind::Str { .. } | LiteralKind::RawStr { .. })
+}
+
+/// How many comma-separated top-level arguments precede the message
+/// argument for a given macro. `0` for macros whose first argument is
+/// itself the message (`panic!`, `todo!`, …); `1` for `assert!` /
+/// `debug_assert!` (the condition comes first); `2` for `assert_eq!`
+/// / `assert_ne!` / `debug_assert_eq!` / `debug_assert_ne!` (the two
+/// values come first).
+///
+/// Unknown macros — including any added through the configuration's
+/// `macros` knob — default to `0`. A project that adds an
+/// assertion-shaped custom macro through configuration accepts the
+/// false positive in that case; correctly handling it would require
+/// a per-macro skip-count configuration knob that the planning file
+/// did not call for.
+fn arguments_before_message(macro_name: Symbol) -> u32 {
+    match macro_name.as_str() {
+        "assert" | "debug_assert" => 1,
+        "assert_eq" | "assert_ne" | "debug_assert_eq" | "debug_assert_ne" => 2,
+        _ => 0,
+    }
+}


### PR DESCRIPTION
## Summary

Split the five rule files past 250 lines into directory modules beside their flat `<rule>.rs` entry (`macro_trailing_comma`, `unicode_ellipsis_in_panic_messages`, `prefer_raw_string`, `derive_ordering`, `single_letter_closure_param`). Layout mirrors the existing `macro_argument_binding` — required by this crate's own `flat_module_pattern` lint.

Factored two helpers that were duplicated across rules (both already flagged in code comments) into dedicated crate-internal modules:

- `src/enclosing_hir.rs` — the deepest-enclosing-HIR-node walker shared by `macro_trailing_comma` and `macro_argument_binding`.
- `src/literal_scan.rs` — the flagged-character emit loop and `string_literal_quote_lengths` parser shared by the two Unicode-ellipsis rules.

Trivial cross-rule helpers land in the existing flat modules:
- `parse_path_list`, `merge_with_builtins` → `macro_path`
- `binding_hir_id` → `common`

No lint behaviour changes; diffs are purely structural.

## Test plan

- [x] `cargo build --workspace --all-targets`
- [x] `RUSTFLAGS='-D warnings' cargo doc --lib --no-deps --document-private-items`
- [x] `cargo fmt`
- [ ] Integration UI tests (need `dylint-link`; run in CI)
