### PR TITLE
docs: rewrap hyphenated compounds broken across lines

### DIFF
--- a/src/rules/derive_ordering.rs
+++ b/src/rules/derive_ordering.rs
@@ -310,9 +310,9 @@ struct DeriveEntry {
     span: Span,
 }
 
-/// `Ordering::Less` if `left` precedes `right` in ASCII-case-
-/// insensitive alphabetical order. Lowercases byte-by-byte during
-/// the comparison rather than allocating a normalised form.
+/// `Ordering::Less` if `left` precedes `right` in
+/// ASCII-case-insensitive alphabetical order. Lowercases byte-by-byte
+/// during the comparison rather than allocating a normalised form.
 fn ascii_ci_cmp(left: &str, right: &str) -> Ordering {
     left.bytes()
         .map(|byte| byte.to_ascii_lowercase())

--- a/src/rules/macro_argument_binding/triviality.rs
+++ b/src/rules/macro_argument_binding/triviality.rs
@@ -25,8 +25,8 @@ use rustc_span::kw;
 /// `=>` is ordinary content here — match-arm syntax inside `matches!`
 /// shows up as a top-level fat arrow but is meaningful to the macro,
 /// not a separator. The walker passes it through unchanged so each
-/// argument's `looks_like_expression` check can skip it as a non-
-/// expression position the macro author chose.
+/// argument's `looks_like_expression` check can skip it as a
+/// non-expression position the macro author chose.
 pub(super) fn split_top_level_arguments(stream: &TokenStream) -> Option<Vec<Vec<TokenTree>>> {
     let mut arguments: Vec<Vec<TokenTree>> = Vec::new();
     let mut current: Vec<TokenTree> = Vec::new();

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -319,8 +319,8 @@ fn take_literal_char(input: &str) -> Option<(&str, &str)> {
 /// `"<n #s>` sequence does not appear inside `decoded`.
 ///
 /// In practice this is 0 for paths and 1 for JSON / HTML snippets;
-/// longer runs only matter when the literal itself embeds raw-
-/// string source text.
+/// longer runs only matter when the literal itself embeds
+/// raw-string source text.
 fn minimal_hash_count(decoded: &str) -> usize {
     let mut hashes = String::new();
     let mut count: usize = 0;

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -31,8 +31,8 @@ declare_tool_lint! {
     /// This is a stylistic preference, not a correctness issue.
     /// A multi-line closure body whose parameter is a single
     /// letter forces the reader to scroll back to the closure
-    /// header for context on every reference. The trivial-
-    /// callback exception covers `sort_by(|a, b| ...)` and
+    /// header for context on every reference. The
+    /// trivial-callback exception covers `sort_by(|a, b| ...)` and
     /// `.map(|x| x.field)` shapes that are short enough that the
     /// parameter's role is unambiguous from the call site.
     ///


### PR DESCRIPTION
Markdown collapses an in-paragraph newline into a space, so a trailing hyphen at end-of-line renders as a stray dash with a space (e.g. "trivial- callback exception"). Pull each hyphenated compound onto a single line.