### PR TITLE
fix(pages): adblock filter on back-to-top aria-label

### DIFF
--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -113,7 +113,7 @@ fn rule_article(rule: &Rule, context: &RenderContext<'_>) -> Markup {
                     span.lint-prefix { (NAMESPACE) }
                     span.lint-name { (unnamespaced(&rule.namespaced)) }
                 }
-                a.rule-jump-link href="#catalogue" aria-label="Back to top" { "↑ top" }
+                a.rule-jump-link href="#catalogue" aria-label="Back to catalogue" { "↑ top" }
             }
             p {
                 (level_badge(rule.level))


### PR DESCRIPTION
Fanboy's Annoyances filter list (default-enabled in uBlock Origin and AdBlock Plus annoyances) contains a generic cosmetic rule `##[aria-label="Back to top"]` that hides every element on every page with that exact aria-label, including the per-rule jump links in the catalogue. The filter uses exact-equality matching, so a small reword sidesteps it; "Back to catalogue" is also more accurate, since the link anchors to `#catalogue`, not the document top.