### PR TITLE
feat(config)!: deny unknown fields

### DIFF
--- a/src/rules/arc_rc_clone.rs
+++ b/src/rules/arc_rc_clone.rs
@@ -75,7 +75,7 @@ const CONFIG_KEY: &str = "perfectionist::arc_rc_clone";
 /// `[perfectionist::arc_rc_clone]` table in `dylint.toml`
 /// deserialises rather than producing a confusing parse error.
 #[derive(Debug, Default, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {}
 
 pub struct ArcRcClone;

--- a/src/rules/derive_ordering.rs
+++ b/src/rules/derive_ordering.rs
@@ -81,7 +81,7 @@ const DEFAULT_PREFIX: &[&str] = &[
 ];
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Ordering policy. Defaults to `preserve`, which is a no-op;
     /// a project opts in by setting `alphabetical` or

--- a/src/rules/flat_module_pattern.rs
+++ b/src/rules/flat_module_pattern.rs
@@ -42,7 +42,7 @@ const CONFIG_KEY: &str = "perfectionist::flat_module_pattern";
 /// `[perfectionist::flat_module_pattern]` table in `dylint.toml`
 /// deserialises rather than producing a confusing parse error.
 #[derive(Debug, Default, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {}
 
 pub struct FlatModulePattern;

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -73,7 +73,7 @@ pub(super) enum Mode {
 }
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 pub(super) struct Config {
     /// Master on/off switch for the rule. Defaults to `true`. Set
     /// to `false` to silence every diagnostic this lint would emit

--- a/src/rules/macro_trailing_comma/config.rs
+++ b/src/rules/macro_trailing_comma/config.rs
@@ -68,7 +68,7 @@ const BUILTIN_NAME_BASED: &[&str] = &[
 ];
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Master on/off switch for the rule. Defaults to `true`. Set
     /// to `false` to silence every diagnostic this lint would emit

--- a/src/rules/non_exhaustive_error.rs
+++ b/src/rules/non_exhaustive_error.rs
@@ -84,7 +84,7 @@ enum RequireFor {
 }
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Visibility threshold for the rule.
     require_for: RequireFor,

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -77,7 +77,7 @@ declare_tool_lint! {
 const CONFIG_KEY: &str = "perfectionist::prefer_raw_string";
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Master on/off switch for the rule. Set to `false` to silence
     /// every diagnostic without enumerating individual literals.

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -135,7 +135,7 @@ const DEFAULT_COMPARISON_METHODS: &[&str] = &[
 ];
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Method / function names whose closure argument may carry
     /// single-letter parameters when the body is a single

--- a/src/rules/single_letter_function_param.rs
+++ b/src/rules/single_letter_function_param.rs
@@ -46,7 +46,7 @@ const CONFIG_KEY: &str = "perfectionist::single_letter_function_param";
 const DEFAULT_FN_PARAM_ALLOWLIST: &[&str] = &["n", "f", "i", "j", "k"];
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Identifiers that are always allowed as function or method
     /// parameter names. Defaults to `["n", "f", "i", "j", "k"]`.

--- a/src/rules/single_letter_generic.rs
+++ b/src/rules/single_letter_generic.rs
@@ -46,7 +46,7 @@ declare_tool_lint! {
 const CONFIG_KEY: &str = "perfectionist::single_letter_generic";
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Maximum number of source lines an `impl Trait for Type`
     /// block may span and still permit single-letter generic

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -45,7 +45,7 @@ const CONFIG_KEY: &str = "perfectionist::single_letter_let_binding";
 const DEFAULT_LET_ALLOWLIST: &[&str] = &["n"];
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Identifiers that are always allowed as `let` binding
     /// names, even outside `#[cfg(test)]` code. Defaults to

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -40,7 +40,7 @@ declare_tool_lint! {
 const CONFIG_KEY: &str = "perfectionist::unicode_ellipsis_in_comments";
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Extra characters to flag alongside U+2026. Useful for catching
     /// near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)

--- a/src/rules/unicode_ellipsis_in_panic_messages/config.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages/config.rs
@@ -24,7 +24,7 @@ const DEFAULT_MACROS: &[&str] = &[
 const DEFAULT_METHODS: &[&str] = &["expect", "expect_err"];
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Macros whose call site should be scanned for the flagged
     /// characters. Defaults to the standard panic and assertion

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -38,7 +38,7 @@ const CONFIG_KEY: &str = "perfectionist::unknown_perfectionist_lints";
 const TOOL_NAME: &str = "perfectionist";
 
 #[derive(Debug, serde::Deserialize)]
-#[serde(default, rename_all = "snake_case")]
+#[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Maximum Levenshtein edit distance between an unknown
     /// `perfectionist::*` name and a registered lint for the lint to


### PR DESCRIPTION
Reject typos and stray keys in dylint.toml rule tables instead of silently ignoring them.