### PR TITLE
fix(gen-docs): submodule config

### DIFF
--- a/rules/derive_ordering.md
+++ b/rules/derive_ordering.md
@@ -62,3 +62,22 @@ Trait names that must appear first under the
 appear. Ignored under other styles. Matched by the final
 path segment, so a configured `"Debug"` matches both
 `Debug` and `std::fmt::Debug` written in the source.
+
+### Types
+
+#### `Style` (enum)
+
+##### `"preserve"` (Rust: `Preserve`)
+
+No-op. The lint emits nothing.
+
+##### `"alphabetical"` (Rust: `Alphabetical`)
+
+Every trait name must appear in ASCII-case-insensitive
+alphabetical order.
+
+##### `"prefix_then_alphabetical"` (Rust: `PrefixThenAlphabetical`)
+
+Traits listed in the configured `prefix` come first, in the
+listed order; remaining traits are sorted alphabetically
+after.

--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -53,4 +53,62 @@ debug_assert_eq!(ejected, None, "duplicate");
 
 ## Configuration
 
-None.
+Configure via `dylint.toml` under `["perfectionist::macro_argument_binding"]`. Every field is optional; the per-field prose below states the default.
+
+### `enabled`: `boolean` (optional)
+
+Master on/off switch for the rule. Defaults to `true`. Set
+to `false` to silence every diagnostic this lint would emit
+without having to enumerate every macro under `ignore`.
+
+### `mode`: `Mode` (optional)
+
+Eligibility mode. See [`Mode`].
+
+### `deny_extra`: `[string]` (optional)
+
+Macros added to the built-in deny list. Each entry is a
+fully-qualified macro path (no trailing `!`) or a bare macro
+name to match by final segment only.
+
+### `allow_extra`: `[string]` (optional)
+
+Macros added to the built-in allow list. Same matching rules
+as `deny_extra`. Only meaningful in `AllowAndDeny` and
+`Blanket` modes; in `DenyOnly` the allow list is unused.
+
+### `ignore`: `[string]` (optional)
+
+Macros to skip entirely, regardless of which list they would
+otherwise hit. Same matching rules as `deny_extra`.
+
+### Types
+
+#### `Mode` (enum)
+
+Eligibility mode. The default is `AllowAndDeny`. The matcher-based
+mode described in `planned-rules/macro-argument-binding.md` is not
+yet implemented and is therefore not exposed as a value here; a
+`dylint.toml` that names it will fail to deserialise with a
+useful error.
+
+##### `"deny_only"` (Rust: `DenyOnly`)
+
+Flag only invocations of the curated deny list (`debug_assert*`
+plus `deny_extra`). Every other macro is silently accepted.
+
+##### `"blanket"` (Rust: `Blanket`)
+
+Flag every function-like or array-like invocation that carries
+a non-trivial top-level argument, regardless of any built-in
+classification — unless the invocation matches an `allow_extra`
+entry. The built-in allow list is deliberately ignored in this
+mode; project exceptions go in `allow_extra`.
+
+##### `"allow_and_deny"` (Rust: `AllowAndDeny`)
+
+Curated deny list plus curated allow list, both extensible via
+`deny_extra` / `allow_extra`. Macros on neither list are
+flagged — flagging unrecognised macros is deliberate so the
+rule remains useful in projects that depend on uncatalogued
+proc macros.

--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -63,7 +63,7 @@ without having to enumerate every macro under `ignore`.
 
 ### `mode`: `Mode` (optional)
 
-Eligibility mode. See [`Mode`].
+Eligibility mode.
 
 ### `deny_extra`: `[string]` (optional)
 

--- a/rules/macro_trailing_comma.md
+++ b/rules/macro_trailing_comma.md
@@ -60,4 +60,36 @@ let ys = vec![1, 2, 3];
 
 ## Configuration
 
-None.
+Configure via `dylint.toml` under `["perfectionist::macro_trailing_comma"]`. Every field is optional; the per-field prose below states the default.
+
+### `enabled`: `boolean` (optional)
+
+Master on/off switch for the rule. Defaults to `true`. Set
+to `false` to silence every diagnostic this lint would emit
+without having to enumerate every macro under `ignore`.
+
+### `matcher_based`: `boolean` (optional)
+
+Accepted for forward compatibility with the matcher-based half of
+the rule. Currently a no-op — only name-based eligibility is
+implemented; see `planned-rules/macro-trailing-comma.md` for the
+status breakdown.
+
+### `extra_name_based`: `[string]` (optional)
+
+Additional macro paths to treat as name-based eligible, on top
+of the curated built-in list. Each entry is matched by its
+final path segment, so `"my_crate::vec_like"` and `"vec_like"`
+both target invocations whose last segment is `vec_like`.
+Empty by default. Only add macros whose trailing comma is
+syntactically optional at the top level; macros that treat
+the comma as a fully optional separator throughout (rather
+than only at the tail) should not be listed here.
+
+### `ignore`: `[string]` (optional)
+
+Macro paths to opt out of the rule, even if they would
+otherwise be eligible via the built-in list or
+`extra_name_based`. Matched by final path segment, like
+`extra_name_based`. Checked first, so this knob always wins
+over eligibility. Empty by default.

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -44,4 +44,23 @@ schema and is out of scope for the initial rule.
 
 ## Configuration
 
-None.
+Configure via `dylint.toml` under `["perfectionist::unicode_ellipsis_in_panic_messages"]`. Every field is optional; the per-field prose below states the default.
+
+### `macros`: `[string]` (optional)
+
+Macros whose call site should be scanned for the flagged
+characters. Defaults to the standard panic and assertion
+macros (`panic`, `unimplemented`, `todo`, `unreachable`,
+`debug_unreachable`, and the `assert*` family). Override to
+add project-specific assertion-shaped macros, or to narrow
+the set when a project deliberately uses `…` in one of them.
+
+### `methods`: `[string]` (optional)
+
+Method names on `Option` / `Result` whose first argument is
+the panic message. Defaults to `expect` and `expect_err`.
+
+### `also_flag`: `[string]` (optional)
+
+Extra characters to flag alongside U+2026, in the same spirit
+as `unicode_ellipsis_in_comments.also_flag`. Empty by default.

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -79,7 +79,7 @@ pub(super) struct Config {
     /// to `false` to silence every diagnostic this lint would emit
     /// without having to enumerate every macro under `ignore`.
     pub enabled: bool,
-    /// Eligibility mode. See [`Mode`].
+    /// Eligibility mode.
     pub mode: Mode,
     /// Macros added to the built-in deny list. Each entry is a
     /// fully-qualified macro path (no trailing `!`) or a bare macro

--- a/tools/gen-docs/src/extract.rs
+++ b/tools/gen-docs/src/extract.rs
@@ -11,7 +11,7 @@ pub(crate) mod serde_attrs;
 pub(crate) mod ty;
 
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use pipe_trait::Pipe;
 use proc_macro2::TokenStream;
@@ -186,7 +186,7 @@ fn merge_submodule_items(source_path: &Path, parent: syn::File) -> syn::File {
             return parent;
         }
     };
-    let mut submodule_paths: Vec<std::path::PathBuf> = entries
+    let mut submodule_paths: Vec<PathBuf> = entries
         .filter_map(Result::ok)
         .map(|entry| entry.path())
         .filter(|path| path.extension().is_some_and(|extension| extension == "rs"))

--- a/tools/gen-docs/src/extract.rs
+++ b/tools/gen-docs/src/extract.rs
@@ -13,6 +13,7 @@ pub(crate) mod ty;
 use std::fs;
 use std::path::Path;
 
+use pipe_trait::Pipe;
 use proc_macro2::TokenStream;
 use syn::{
     Attribute, Ident, Item, LitStr, Token,
@@ -61,7 +62,7 @@ fn extract_rules(source_path: &Path) -> Vec<Rule> {
                     .last()
                     .is_some_and(|segment| segment.ident == "declare_tool_lint") =>
             {
-                Some(item_macro.mac.tokens.clone())
+                item_macro.mac.tokens.clone().pipe(Some)
             }
             _ => None,
         })
@@ -247,7 +248,27 @@ impl Parse for DeclareToolLint {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
+
+    /// Allocate a fresh temp directory unique across both processes
+    /// (cargo's test harness forks per binary) and across tests in
+    /// the same binary (the atomic counter handles concurrent runs
+    /// and any label collision). Mirrors the helper in
+    /// `check_md.rs`'s test module; kept local so the two test
+    /// modules stay self-contained.
+    fn tempdir(label: &str) -> PathBuf {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let base = std::env::temp_dir().join(format!(
+            "perfectionist-gen-docs-extract-{label}-{}-{seq}",
+            std::process::id(),
+        ));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        base
+    }
 
     /// Directory-module rules keep `CONFIG_KEY` and `Config` in
     /// `<rule>/config.rs`. Merging the submodule items into the
@@ -257,12 +278,7 @@ mod tests {
     /// can't silently come back.
     #[test]
     fn collect_rules_finds_config_in_submodule_file() {
-        let base = std::env::temp_dir().join(format!(
-            "perfectionist-merge-submodule-test-{}",
-            std::process::id(),
-        ));
-        let _ = fs::remove_dir_all(&base);
-        fs::create_dir_all(&base).unwrap();
+        let base = tempdir("merge-submodule");
         let parent_path = base.join("demo_rule.rs");
         fs::write(
             &parent_path,

--- a/tools/gen-docs/src/extract.rs
+++ b/tools/gen-docs/src/extract.rs
@@ -42,7 +42,14 @@ fn extract_rules(source_path: &Path) -> Vec<Rule> {
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", source_path.display()));
     let file = syn::parse_file(&source)
         .unwrap_or_else(|error| panic!("failed to parse {}: {error}", source_path.display()));
-    let macro_items: Vec<&TokenStream> = file
+    // `declare_tool_lint!` always lives in the parent file by
+    // convention. Collect the macro bodies into owned `TokenStream`s
+    // here so the merged-file step below (which consumes `file`) can't
+    // invalidate the references — and so an accidental
+    // `declare_tool_lint!` in a submodule wouldn't silently double-
+    // register the rule. `TokenStream` clones are cheap; the bodies
+    // are reparsed downstream anyway.
+    let macro_items: Vec<TokenStream> = file
         .items
         .iter()
         .filter_map(|item| match item {
@@ -54,11 +61,20 @@ fn extract_rules(source_path: &Path) -> Vec<Rule> {
                     .last()
                     .is_some_and(|segment| segment.ident == "declare_tool_lint") =>
             {
-                Some(&item_macro.mac.tokens)
+                Some(item_macro.mac.tokens.clone())
             }
             _ => None,
         })
         .collect();
+    // Rules that have outgrown a flat `.rs` keep `CONFIG_KEY` and the
+    // `Config` struct in a sibling `<rule>/config.rs` (see CLAUDE.md's
+    // "When a rule grows past one screenful" section). The extractor
+    // used to only see the parent file's items, so those rules'
+    // configurations rendered as "Configuration: none." in the docs.
+    // Merging submodule items into a single `syn::File` lets the
+    // existing item walks in `extract_config` and `find_type_doc`
+    // discover them without further plumbing.
+    let merged_file = merge_submodule_items(source_path, file);
     if macro_items.is_empty() {
         // Silent skip for legitimate helper files. But if the
         // file *looks* rule-shaped — has a `CONFIG_KEY` const
@@ -66,7 +82,7 @@ fn extract_rules(source_path: &Path) -> Vec<Rule> {
         // certainly a typo (`declare_tool_lin!`, etc.) that
         // would otherwise drop the rule from the docs without
         // any signal.
-        let looks_rule_shaped = file.items.iter().any(|item| match item {
+        let looks_rule_shaped = merged_file.items.iter().any(|item| match item {
             Item::Const(item_const) => item_const.ident == "CONFIG_KEY",
             Item::Struct(item_struct) => item_struct.ident == "Config",
             _ => false,
@@ -87,7 +103,7 @@ fn extract_rules(source_path: &Path) -> Vec<Rule> {
     // code below still handles a multi-lint file defensively —
     // every emitted rule receives the same `config` value — but
     // no rule in the catalogue uses that shape today.
-    let config = extract_config(source_path, &file);
+    let config = extract_config(source_path, &merged_file);
     let relative_source: std::path::PathBuf = source_path
         .components()
         .rev()
@@ -101,7 +117,7 @@ fn extract_rules(source_path: &Path) -> Vec<Rule> {
         .iter()
         .map(|tokens| {
             let declaration =
-                syn::parse2::<DeclareToolLint>((*tokens).clone()).unwrap_or_else(|error| {
+                syn::parse2::<DeclareToolLint>(tokens.clone()).unwrap_or_else(|error| {
                     panic!(
                         "failed to parse declare_tool_lint! body in {}: {error}",
                         source_path.display()
@@ -129,6 +145,72 @@ fn extract_rules(source_path: &Path) -> Vec<Rule> {
             }
         })
         .collect()
+}
+
+/// Return a `syn::File` containing `parent`'s items followed by every
+/// item declared in any `.rs` file of the sibling `<rule>/` directory,
+/// when one exists. This collapses the directory-module rule layout
+/// (parent `<rule>.rs` + `<rule>/<concern>.rs` siblings, see CLAUDE.md)
+/// into a single flat item list so the downstream `Config` /
+/// `CONFIG_KEY` lookup doesn't have to know which file declared what.
+///
+/// The walk is one level deep on purpose: every directory-module rule
+/// in this repo keeps `config.rs` directly under `<rule>/`, never
+/// nested further. Recursing would also pick up unrelated items from
+/// helper sub-trees if any rule ever grew them.
+///
+/// File reads or `syn::parse_file` failures on submodule files emit a
+/// warning and skip the file rather than panicking. The parent file
+/// is the rule's source of truth; a malformed helper shouldn't take
+/// the whole catalogue offline. Submodule entries are sorted by file
+/// name so the merged item order is deterministic across platforms.
+fn merge_submodule_items(source_path: &Path, parent: syn::File) -> syn::File {
+    let Some(stem) = source_path.file_stem() else {
+        return parent;
+    };
+    let Some(parent_dir) = source_path.parent() else {
+        return parent;
+    };
+    let submodule_dir = parent_dir.join(stem);
+    if !submodule_dir.is_dir() {
+        return parent;
+    }
+    let entries = match fs::read_dir(&submodule_dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            eprintln!(
+                "warning: failed to read {}: {error}",
+                submodule_dir.display(),
+            );
+            return parent;
+        }
+    };
+    let mut submodule_paths: Vec<std::path::PathBuf> = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|extension| extension == "rs"))
+        .collect();
+    submodule_paths.sort();
+
+    let mut merged = parent;
+    for path in submodule_paths {
+        let source = match fs::read_to_string(&path) {
+            Ok(source) => source,
+            Err(error) => {
+                eprintln!("warning: failed to read {}: {error}", path.display());
+                continue;
+            }
+        };
+        let submodule = match syn::parse_file(&source) {
+            Ok(file) => file,
+            Err(error) => {
+                eprintln!("warning: failed to parse {}: {error}", path.display());
+                continue;
+            }
+        };
+        merged.items.extend(submodule.items);
+    }
+    merged
 }
 
 /// Minimal grammar of `declare_tool_lint!`'s body. The macro itself
@@ -160,5 +242,72 @@ impl Parse for DeclareToolLint {
             level,
             desc,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Directory-module rules keep `CONFIG_KEY` and `Config` in
+    /// `<rule>/config.rs`. Merging the submodule items into the
+    /// parent file is what lets `extract_config` find them; this
+    /// pins the behaviour so the bug that sent
+    /// `unicode_ellipsis_in_panic_messages` to "Configuration: none."
+    /// can't silently come back.
+    #[test]
+    fn collect_rules_finds_config_in_submodule_file() {
+        let base = std::env::temp_dir().join(format!(
+            "perfectionist-merge-submodule-test-{}",
+            std::process::id(),
+        ));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base).unwrap();
+        let parent_path = base.join("demo_rule.rs");
+        fs::write(
+            &parent_path,
+            r#"
+                use rustc_session::declare_tool_lint;
+
+                mod config;
+
+                declare_tool_lint! {
+                    /// ### What it does
+                    /// Demo.
+                    pub perfectionist::DEMO_RULE,
+                    Warn,
+                    "demo description"
+                }
+            "#,
+        )
+        .unwrap();
+        let submodule_dir = base.join("demo_rule");
+        fs::create_dir_all(&submodule_dir).unwrap();
+        fs::write(
+            submodule_dir.join("config.rs"),
+            r#"
+                const CONFIG_KEY: &str = "perfectionist::demo_rule";
+
+                #[derive(serde::Deserialize)]
+                #[serde(default, rename_all = "snake_case")]
+                struct Config {
+                    /// Demo knob.
+                    knob: bool,
+                }
+            "#,
+        )
+        .unwrap();
+
+        let rules = collect_rules(&base);
+        assert_eq!(rules.len(), 1, "exactly one rule should be discovered");
+        let config = rules[0]
+            .config
+            .as_ref()
+            .expect("config in submodule should be merged into the rule's ConfigDoc");
+        assert_eq!(config.key, "perfectionist::demo_rule");
+        let names: Vec<&str> = config.fields.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(names, vec!["knob"]);
+
+        let _ = fs::remove_dir_all(&base);
     }
 }


### PR DESCRIPTION
## Summary

The gen-docs extractor only inspected the entry `<rule>.rs` for `CONFIG_KEY` and `Config`, so rules using the directory-module layout (`<rule>/config.rs`, per CLAUDE.md's "When a rule grows past one screenful" section) silently rendered as **"Configuration: none."** in the catalogue.

Fix: merge sibling `<rule>/*.rs` items into the parsed `syn::File` before extracting the config. Downstream walks (`extract_config`, `find_type_doc`) work unchanged on the merged item list.

## Affected rule docs

- `unicode_ellipsis_in_panic_messages` — now lists `macros`, `methods`, `also_flag`.
- `macro_argument_binding` — now lists 5 fields plus the `Mode` enum and its variants.
- `macro_trailing_comma` — now lists 4 fields.
- `derive_ordering` — `Config` was already in the parent file, but the `Style` enum lives in `ordering.rs`, so its variants were missing from the rendered Types section. Now included.

## Test plan

- [x] New unit test (`collect_rules_finds_config_in_submodule_file`) builds a synthetic parent + submodule layout and asserts the merged `ConfigDoc` reaches the rule.
- [x] `cargo test -p _gen_docs` passes.
- [x] `gen-docs check-md rules` reports clean after regenerating with `gen-docs write-md`.