### PR TITLE
fix(single-letter-let-binding): skip proc-macro-synthesised bindings

### DIFF
--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -5,7 +5,6 @@ use clippy_utils::is_in_test;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-
 use rustc_span::Symbol;
 
 use crate::common::{binding_ident, is_single_ascii_letter, merge_symbol_allowlist};

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::is_in_test;
 use rustc_hir as hir;
-use rustc_lint::{LateContext, LateLintPass, LintStore};
+use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 
 use crate::common::{binding_ident, is_single_ascii_letter};
@@ -92,6 +92,20 @@ impl<'tcx> LateLintPass<'tcx> for SingleLetterLetBinding {
         if !matches!(local.source, hir::LocalSource::Normal) {
             // `for` / `while let` desugarings synthesise `LetStmt`
             // nodes with names the user did not write.
+            return;
+        }
+        if local
+            .span
+            .in_external_macro(lint_context.sess().source_map())
+        {
+            // Proc-macros such as `clap_derive`'s `default_value_t`
+            // synthesise `let <one-letter> = ...;` bindings while
+            // attaching a user-source span to the identifier. The
+            // tool-lint's `report_in_external_macro: false` flag
+            // inspects the diagnostic span (the identifier), which
+            // looks like user code; the surrounding statement span
+            // still carries the external expansion context, so the
+            // explicit check is needed to suppress the lint.
             return;
         }
         let Some(ident) = binding_ident(local.pat) else {

--- a/ui/auxiliary/proc_macro_synth_binding.rs
+++ b/ui/auxiliary/proc_macro_synth_binding.rs
@@ -1,0 +1,83 @@
+// force-host
+// no-prefer-dynamic
+//
+// A miniature stand-in for `clap_derive`'s `default_value_t` expansion.
+// The derive emits `const _: () = { let <one-letter> = <expr>; };`
+// where the synthesised `let` binding identifier carries a *user*
+// span (the span of the attribute identifier) rather than a call-site
+// span. That span pattern is what makes `clap_derive`'s expansion
+// slip past rustc's built-in `report_in_external_macro: false` check
+// in `perfectionist::single_letter_let_binding`.
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
+
+#[proc_macro_derive(SynthBinding, attributes(synth_default))]
+pub fn synth_binding(input: TokenStream) -> TokenStream {
+    let tokens: Vec<TokenTree> = input.into_iter().collect();
+    // Locate the first `#[synth_default = ...]` attribute and remember
+    // the `synth_default` identifier's span. That span is the
+    // user-source position the synthesised binding will inherit.
+    let attr_span = find_attr_span(&tokens)
+        .expect("`#[derive(SynthBinding)]` requires a `#[synth_default = ..]`");
+
+    // `s` carries the user-source span of the `synth_default` attribute
+    // identifier — the same span shape `clap_derive` attaches to its
+    // own synthesised `let` binding when expanding `default_value_t`.
+    let s_ident = Ident::new("s", attr_span);
+    let call_site = Span::call_site();
+
+    let mut body = TokenStream::new();
+    body.extend([
+        TokenTree::Ident(Ident::new("let", call_site)),
+        TokenTree::Ident(s_ident.clone()),
+        TokenTree::Punct(Punct::new('=', Spacing::Alone)),
+        TokenTree::Literal(Literal::u32_unsuffixed(1)),
+        TokenTree::Punct(Punct::new(';', Spacing::Alone)),
+        TokenTree::Ident(Ident::new("let", call_site)),
+        TokenTree::Ident(Ident::new("_", call_site)),
+        TokenTree::Punct(Punct::new('=', Spacing::Alone)),
+        TokenTree::Ident(s_ident),
+        TokenTree::Punct(Punct::new(';', Spacing::Alone)),
+    ]);
+
+    let mut out = TokenStream::new();
+    out.extend([
+        TokenTree::Ident(Ident::new("const", call_site)),
+        TokenTree::Ident(Ident::new("_", call_site)),
+        TokenTree::Punct(Punct::new(':', Spacing::Alone)),
+        TokenTree::Group(Group::new(Delimiter::Parenthesis, TokenStream::new())),
+        TokenTree::Punct(Punct::new('=', Spacing::Alone)),
+        TokenTree::Group(Group::new(Delimiter::Brace, body)),
+        TokenTree::Punct(Punct::new(';', Spacing::Alone)),
+    ]);
+    out
+}
+
+fn find_attr_span(tokens: &[TokenTree]) -> Option<Span> {
+    for window in tokens.windows(2) {
+        let (hash, group) = (&window[0], &window[1]);
+        let is_hash = match hash {
+            TokenTree::Punct(p) => p.as_char() == '#',
+            _ => false,
+        };
+        if !is_hash {
+            continue;
+        }
+        let group = match group {
+            TokenTree::Group(g) if g.delimiter() == Delimiter::Bracket => g,
+            _ => continue,
+        };
+        for inner in group.stream() {
+            if let TokenTree::Ident(ident) = inner {
+                if ident.to_string() == "synth_default" {
+                    return Some(ident.span());
+                }
+            }
+        }
+    }
+    None
+}

--- a/ui/single_letter_let_binding_proc_macro.rs
+++ b/ui/single_letter_let_binding_proc_macro.rs
@@ -1,0 +1,25 @@
+// aux-build:proc_macro_synth_binding.rs
+
+// Regression test for issue #410 (parallel-disk-usage):
+// `single_letter_let_binding` must not fire on bindings synthesised
+// by a proc-macro derive whose expansion attaches a user-source span
+// to the binding identifier. `clap_derive` does this when expanding
+// `#[clap(default_value_t = ...)]` into a `ToString`-based fallback;
+// the `SynthBinding` derive imported below mirrors the same span
+// shape on a minimal `#[synth_default]` attribute.
+
+#![allow(dead_code, unused_variables)]
+
+extern crate proc_macro_synth_binding;
+
+use proc_macro_synth_binding::SynthBinding;
+
+// The derive emits `const _: () = { let s = 1; let _ = s; };` with the
+// `s` identifier carrying the span of `synth_default`. Without the
+// proc-macro-expansion check, `perfectionist::single_letter_let_binding`
+// would flag this `s` at the `synth_default` attribute.
+#[derive(SynthBinding)]
+#[synth_default = 1]
+struct UsesSynthDefault;
+
+fn main() {}


### PR DESCRIPTION
Fixes <https://github.com/KSXGitHub/parallel-disk-usage/issues/410>.

`clap_derive` expands `#[clap(default_value_t = …)]` into a `let s = …;` binding whose identifier carries the *user-source* span of the attribute identifier rather than a call-site span. rustc's `report_in_external_macro: false` check inspects the diagnostic's primary span (the identifier), so the binding looked like user code and the lint fired at the `default_value_t` attribute.

The fix adds an explicit `Span::in_external_macro` check on `local.span` (the whole `let` statement, which still carries the proc-macro's expansion context). Local `macro_rules!` authored by the user are unaffected.

A minimal proc-macro derive under `ui/auxiliary/proc_macro_synth_binding.rs` reproduces the same span shape on a `#[synth_default]` attribute and locks in the regression test.