### PR TITLE
fix(single-letter-closure-param): accept macro-call bodies as trivial wrappers

### DIFF
--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -22,10 +22,13 @@ callback. Two shapes qualify as trivial:
 - the body is a trivial wrapper around the parameter —
   a field access (`|x| x.field`), a method call
   (`|x| x.foo()`), a one-argument call where the
-  parameter is the sole argument (`|x| vec![x]`), or a
-  reference (`|x| &x`). Surrounding `*` / `&` operators
-  around the parameter inside any of these shapes are
-  peeled before the match, so `|s| (*s).foo()` qualifies.
+  parameter is the sole argument (`|x| f(x)`), a
+  reference (`|x| &x`), or a macro call
+  (`|x| vec![x]`, `|x| dbg!(x)`,
+  `|x| format!("{x}")`). Surrounding `*` / `&`
+  operators around the parameter inside any of the
+  non-macro shapes are peeled before the match, so
+  `|s| (*s).foo()` qualifies.
 
 ## Why restrict this?
 This is a stylistic preference, not a correctness issue.

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -35,10 +35,13 @@ declare_tool_lint! {
     /// - the body is a trivial wrapper around the parameter —
     ///   a field access (`|x| x.field`), a method call
     ///   (`|x| x.foo()`), a one-argument call where the
-    ///   parameter is the sole argument (`|x| vec![x]`), or a
-    ///   reference (`|x| &x`). Surrounding `*` / `&` operators
-    ///   around the parameter inside any of these shapes are
-    ///   peeled before the match, so `|s| (*s).foo()` qualifies.
+    ///   parameter is the sole argument (`|x| f(x)`), a
+    ///   reference (`|x| &x`), or a macro call
+    ///   (`|x| vec![x]`, `|x| dbg!(x)`,
+    ///   `|x| format!("{x}")`). Surrounding `*` / `&`
+    ///   operators around the parameter inside any of the
+    ///   non-macro shapes are peeled before the match, so
+    ///   `|s| (*s).foo()` qualifies.
     ///
     /// ### Why restrict this?
     /// This is a stylistic preference, not a correctness issue.

--- a/src/rules/single_letter_closure_param/triviality.rs
+++ b/src/rules/single_letter_closure_param/triviality.rs
@@ -10,7 +10,8 @@
 //!   trivial-callback allowlist, or
 //! - the body is a trivial wrapper around one of the closure's
 //!   parameters (field access, method call, one-argument call,
-//!   reference), as decided by [`is_trivial_wrapper`].
+//!   reference, or a macro call), as decided by
+//!   [`is_trivial_wrapper`].
 //!
 //! The driver in [`super`] composes these helpers; this module
 //! holds the predicates themselves.
@@ -74,15 +75,32 @@ fn path_final_segment<'hir>(expr: &'hir hir::Expr<'hir>) -> Option<Symbol> {
 /// - a field access `param.field`,
 /// - a method call `param.foo(args)`,
 /// - a one-argument call `f(param)`,
-/// - a reference `&param`.
+/// - a reference `&param`,
+/// - a macro call (`vec![param]`, `dbg!(param)`,
+///   `format!("{param}")`, …).
 ///
-/// In every shape, `*` / `&` operators around the reference to
-/// the parameter are peeled by `is_param_ref` before matching,
-/// so `|s| (*s).foo()` and `|s| f(&*s)` both qualify.
+/// In every non-macro shape, `*` / `&` operators around the
+/// reference to the parameter are peeled by `is_param_ref`
+/// before matching, so `|s| (*s).foo()` and `|s| f(&*s)` both
+/// qualify.
+///
+/// Macro calls are accepted unconditionally on the basis that
+/// the body's expression span lies entirely inside a single
+/// macro invocation written by the user — the source text is a
+/// one-liner whose role is unambiguous from the call site, in
+/// the same spirit as the other shapes. The post-expansion HIR
+/// of `vec![param]`, `dbg!(param)`, `format!("{param}")`, etc.
+/// does not pattern-match any of the arms above (e.g. `vec!`
+/// expands to `<[_]>::into_vec(Box::new([param]))`), so without
+/// this branch the rule would false-positive on every macro
+/// callback body.
 pub(super) fn is_trivial_wrapper<'hir>(
     expr: &'hir hir::Expr<'hir>,
     params: &'hir [hir::Param<'hir>],
 ) -> bool {
+    if expr.span.from_expansion() {
+        return true;
+    }
     match expr.kind {
         hir::ExprKind::Field(receiver, _) => is_param_ref(receiver, params),
         hir::ExprKind::MethodCall(_, receiver, _, _) => is_param_ref(receiver, params),

--- a/ui/single_letter_names.rs
+++ b/ui/single_letter_names.rs
@@ -88,6 +88,13 @@ fn run() {
     let names = ["one", "two"];
     let _owned: Vec<String> = names.iter().map(|s| (*s).to_owned()).collect();
 
+    // OK: macro-call body. `vec![x]` expands to
+    // `<[_]>::into_vec(Box::new([x]))`, which doesn't pattern-match
+    // any of the HIR-level trivial-wrapper arms, so the rule relies
+    // on the body's expansion-origin span to recognise it.
+    let _nested: Vec<Vec<i32>> = sorted.iter().copied().map(|x| vec![x]).collect();
+    let _shouted: Vec<String> = sorted.iter().map(|n| format!("{n}!")).collect();
+
     // Bad: multi-statement closure body, single-letter parameter.
     let _formatted: Vec<String> = sorted
         .iter()

--- a/ui/single_letter_names.stderr
+++ b/ui/single_letter_names.stderr
@@ -57,7 +57,7 @@ LL |     let m = 5_u32;
    = note: `#[warn(perfectionist::single_letter_let_binding)]` on by default
 
 warning: closure parameter `t` has a single-letter name
-  --> $DIR/single_letter_names.rs:94:15
+  --> $DIR/single_letter_names.rs:101:15
    |
 LL |         .map(|t| {
    |               ^
@@ -66,7 +66,7 @@ LL |         .map(|t| {
    = note: `#[warn(perfectionist::single_letter_closure_param)]` on by default
 
 warning: function parameter `w` has a single-letter name
-  --> $DIR/single_letter_names.rs:109:16
+  --> $DIR/single_letter_names.rs:116:16
    |
 LL | fn write_label(w: &mut String, t: &str) {
    |                ^
@@ -75,7 +75,7 @@ LL | fn write_label(w: &mut String, t: &str) {
    = note: `#[warn(perfectionist::single_letter_function_param)]` on by default
 
 warning: function parameter `t` has a single-letter name
-  --> $DIR/single_letter_names.rs:109:32
+  --> $DIR/single_letter_names.rs:116:32
    |
 LL | fn write_label(w: &mut String, t: &str) {
    |                                ^


### PR DESCRIPTION
Fixes <https://github.com/KSXGitHub/parallel-disk-usage/issues/411>.

`single_letter_closure_param`'s trivial-wrapper classifier ran on
post-expansion HIR and only matched `Field`, `MethodCall`,
one-argument `Call`, and `AddrOf`. Macro-call bodies expand to
shapes the classifier never sees — `vec![x]` becomes
`<[_]>::into_vec(Box::new([x]))` — so `|x| vec![x]`, `|x| dbg!(x)`,
`|x| format!("{x}")`, etc. all false-positived. The rule's own
rustdoc even cited `|x| vec![x]` as an example of the
"one-argument call" arm, so the documented coverage and the
actual coverage had diverged.

## Changes

- `triviality::is_trivial_wrapper` now short-circuits to `true`
  when the body expression's span comes from a macro expansion.
  This is the HIR-level analogue of the AST-level `MacCall` arm
  the issue suggested. External-macro bodies are already filtered
  by `report_in_external_macro: false`, so the relaxation only
  picks up macros the user wrote in-crate.
- Rustdoc on the lint declaration now lists the macro-call shape
  as its own bullet, with `|x| f(x)` taking over as the
  one-argument-call example.
- UI test `ui/single_letter_names.rs` gains `.map(|x| vec![x])`
  and `.map(|n| format!("{n}!"))` as accepted cases.
- `rules/single_letter_closure_param.md` regenerated.