### PR TITLE
fix(macro-argument-binding): skip `->` and `in` DSL separators

### DIFF
--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -297,10 +297,12 @@ For every macro invocation:
    expression — including positional operator markers
    (`debug_assert_op_expr!(a, ==, b)`), assignment-shaped
    matchers (`make_const!(NAME = 'x')`, `bump!(counter += 1)`),
-   `name: type` ascription-shaped matchers, and `Type => body`
-   match-arm DSLs. All are syntactic positions the macro author
-   chose, and the let-bind rewrite the rule would propose is
-   meaningless for the macro's matcher arm.
+   `name: type` ascription-shaped matchers, `Type => body`
+   match-arm DSLs, `arg -> arg` arrow-paired matchers
+   (`link!("src" -> "dst")`), and `pat in iter`-style matchers.
+   All are syntactic positions the macro author chose, and the
+   let-bind rewrite the rule would propose is meaningless for
+   the macro's matcher arm.
 7. Classify the expression with the trivial / non-trivial split.
    If trivial, accept; if non-trivial, emit a diagnostic
    suggesting a `let` binding immediately before the macro

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -298,8 +298,9 @@ For every macro invocation:
    (`debug_assert_op_expr!(a, ==, b)`), assignment-shaped
    matchers (`make_const!(NAME = 'x')`, `bump!(counter += 1)`),
    `name: type` ascription-shaped matchers, `Type => body`
-   match-arm DSLs, `arg -> arg` arrow-paired matchers
-   (`link!("src" -> "dst")`), and `pat in iter`-style matchers.
+   match-arm DSLs, `lhs -> rhs` arrow-paired matchers
+   (`link!("src" -> "dst")`), and `name in name`-style separators
+   (`for_each!(x in iter, ...)`).
    All are syntactic positions the macro author chose, and the
    let-bind rewrite the rule would propose is meaningless for
    the macro's matcher arm.

--- a/src/rules/macro_argument_binding/triviality.rs
+++ b/src/rules/macro_argument_binding/triviality.rs
@@ -4,7 +4,7 @@
 //! token stream into one segment per comma-separated argument.
 //! [`looks_like_expression`] rules out non-expression positions the
 //! macro author chose (`Type => [...]`, `name = value`, `name += value`,
-//! bare operators like `==`, and friends).
+//! `pat -> body`, `pat in iter`, bare operators like `==`, and friends).
 //! [`is_trivial_expression`] decides whether the surviving expression
 //! falls in the spec's trivial shapes (literals, paths, references,
 //! field accesses, indexing, dereferences, casts, parenthesised /
@@ -19,7 +19,7 @@
 
 use std::collections::BTreeSet;
 
-use rustc_ast::token::{Delimiter, IdentIsRaw, TokenKind};
+use rustc_ast::token::{Delimiter, IdentIsRaw, Token, TokenKind};
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
 use rustc_span::kw;
 
@@ -74,12 +74,20 @@ pub(super) fn split_top_level_arguments(stream: &TokenStream) -> Option<Vec<Vec<
 ///    `Type => [LINT_NAMES]` DSLs); `=`, `+=`, `-=`, ... (assignment-
 ///    shaped matchers like `make_const!(NAME = '█')` or
 ///    `bump!(items += 1)`); a top-level `:` (`name: type` ascription-
-///    shaped matchers) — fails the check. `name = value` is technically
-///    a valid Rust assignment expression of unit type, but in macro-
+///    shaped matchers); `->` (`link!("src" -> "dst")`-style arrow
+///    matchers); the `in` keyword (`for_each!(x in iter, ...)`-style
+///    matchers) — fails the check. `name = value` is technically a
+///    valid Rust assignment expression of unit type, but in macro-
 ///    argument position the macro author overwhelmingly chose the `=`
 ///    as a structural marker; the let-bind rewrite the rule would
-///    propose is meaningless for the macro's matcher arm. A future
-///    re-parse-based implementation will subsume this check.
+///    propose is meaningless for the macro's matcher arm. The same
+///    reasoning extends to `->`, `in`, and the compound-assignment
+///    family — none of these tokens form a single Rust expression
+///    standalone in the shapes the rule observes. `==`, by contrast,
+///    is a real Rust binary operator (`debug_assert!(a == b)` is the
+///    motivating trivial shape) and is intentionally absent from this
+///    list. A future re-parse-based implementation will subsume the
+///    whole heuristic.
 pub(super) fn looks_like_expression(argument: &[TokenTree]) -> bool {
     if let Some(TokenTree::Token(token, _)) = argument.first()
         && !token.can_begin_expr()
@@ -87,15 +95,19 @@ pub(super) fn looks_like_expression(argument: &[TokenTree]) -> bool {
         return false;
     }
     !argument.iter().any(|tree| match tree {
-        TokenTree::Token(token, _) => is_dsl_marker(token.kind),
+        TokenTree::Token(token, _) => is_dsl_marker(token),
         _ => false,
     })
 }
 
-fn is_dsl_marker(kind: TokenKind) -> bool {
+fn is_dsl_marker(token: &Token) -> bool {
+    if token.is_keyword(kw::In) {
+        return true;
+    }
     matches!(
-        kind,
+        token.kind,
         TokenKind::FatArrow
+            | TokenKind::RArrow
             | TokenKind::Colon
             | TokenKind::Eq
             | TokenKind::PlusEq

--- a/src/rules/macro_argument_binding/triviality.rs
+++ b/src/rules/macro_argument_binding/triviality.rs
@@ -4,7 +4,8 @@
 //! token stream into one segment per comma-separated argument.
 //! [`looks_like_expression`] rules out non-expression positions the
 //! macro author chose (`Type => [...]`, `name = value`, `name += value`,
-//! `pat -> body`, `pat in iter`, bare operators like `==`, and friends).
+//! `lhs -> rhs` arrow-paired matchers, `name in name`-style separators,
+//! bare operators like `==`, and friends).
 //! [`is_trivial_expression`] decides whether the surviving expression
 //! falls in the spec's trivial shapes (literals, paths, references,
 //! field accesses, indexing, dereferences, casts, parenthesised /
@@ -82,12 +83,23 @@ pub(super) fn split_top_level_arguments(stream: &TokenStream) -> Option<Vec<Vec<
 ///    as a structural marker; the let-bind rewrite the rule would
 ///    propose is meaningless for the macro's matcher arm. The same
 ///    reasoning extends to `->`, `in`, and the compound-assignment
-///    family — none of these tokens form a single Rust expression
-///    standalone in the shapes the rule observes. `==`, by contrast,
+///    family — in the shapes the rule observes, none of these tokens
+///    form a single Rust expression standalone. `==`, by contrast,
 ///    is a real Rust binary operator (`debug_assert!(a == b)` is the
 ///    motivating trivial shape) and is intentionally absent from this
-///    list. A future re-parse-based implementation will subsume the
-///    whole heuristic.
+///    list.
+///
+///    The trade-off is asymmetric. `->` and `in` *can* legitimately
+///    appear inside a real Rust expression — `->` in a closure return
+///    type (`|x: u32| -> u32 { x + 1 }`), `in` in a `for`-loop
+///    expression (`for x in iter { ... }`). Both are non-trivial
+///    expressions the rule would otherwise flag; with the markers in
+///    place the rule now silently *skips* them (false negative)
+///    rather than emit a confusing `let`-bind hint inside a DSL
+///    matcher (false positive). The latter has been reported in the
+///    wild; the former has not. A future re-parse-based
+///    implementation (see issue #64) will subsume the whole
+///    heuristic and resolve the trade-off properly.
 pub(super) fn looks_like_expression(argument: &[TokenTree]) -> bool {
     if let Some(TokenTree::Token(token, _)) = argument.first()
         && !token.can_begin_expr()

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -21,6 +21,14 @@ macro_rules! op_separator_macro {
     ($($tokens:tt)*) => {{ 0 }};
 }
 
+macro_rules! arrow_separator_macro {
+    ($($tokens:tt)*) => {{ 0 }};
+}
+
+macro_rules! in_separator_macro {
+    ($($tokens:tt)*) => {{ 0 }};
+}
+
 // `debug_assert_eq!` is on the built-in deny list. The first argument
 // is a non-trivial method call; in release builds the macro folds to
 // `if false { ... }` and the call never runs, leaving the map in a
@@ -158,6 +166,36 @@ fn _assignment_dsl_skipped(items: &mut u32, slot: &mut u32) {
 fn _bare_operator_skipped(left: u32, right: u32) {
     let _ = op_separator_macro!(left, ==, right);
     let _ = op_separator_macro!(left, >, right);
+}
+
+// Skipped: a top-level `->` is a structural matcher token, not a Rust
+// operator. Macros like `link!("src" -> "dst")` use it to pair two
+// arguments; reparse-as-expression would fail and the let-bind hint is
+// nonsense. Same skip applies to definition-shape DSLs that mix `->`
+// with other separators (`test_case!(name -> value in System == "x")`).
+fn _arrow_separator_skipped(left: u32, right: u32) {
+    let _ = arrow_separator_macro!("src" -> "dst");
+    let _ = arrow_separator_macro!(left -> right);
+}
+
+// Skipped: a top-level `in` keyword is a DSL separator (`for_each!(x
+// in iter, ...)`-style matchers), not a Rust expression operator —
+// `in` only appears inside `for` loop heads, which the macro's
+// argument position cannot be. Without the skip the walker would
+// consume the LHS path, leave `in iter` as residue, and emit a
+// let-bind hint that does not parse.
+fn _in_keyword_separator_skipped() {
+    let _ = in_separator_macro!(item in container);
+}
+
+// Skipped: a definition-shape DSL that mixes `->`, `in`, and `==` as
+// separator-position tokens. None of these positions form a single
+// Rust expression standalone, and any `let` binding the rule could
+// suggest would break the matcher's structural pattern. The `->`
+// alone is enough to disqualify the argument; `==` stays a real Rust
+// binary operator so that `debug_assert!(a == b)` keeps being trivial.
+fn _mixed_definition_dsl_skipped() {
+    let _ = arrow_separator_macro!(plain_number -> 65_535 in PlainNumber == "65535");
 }
 
 // `()` is the canonical trivial value: the empty-tuple / unit literal.

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -178,12 +178,13 @@ fn _arrow_separator_skipped(left: u32, right: u32) {
     let _ = arrow_separator_macro!(left -> right);
 }
 
-// Skipped: a top-level `in` keyword is a DSL separator (`for_each!(x
-// in iter, ...)`-style matchers), not a Rust expression operator —
-// `in` only appears inside `for` loop heads, which the macro's
-// argument position cannot be. Without the skip the walker would
-// consume the LHS path, leave `in iter` as residue, and emit a
-// let-bind hint that does not parse.
+// Skipped: a top-level `in` keyword usually indicates a DSL separator
+// (`for_each!(x in iter, ...)`-style matchers) rather than a Rust
+// expression. A bare `for x in iter { ... }` macro argument is also a
+// real Rust expression containing a top-level `in`, and the heuristic
+// will skip that too; the trade-off favours the DSL-matcher case,
+// which has been reported in the wild, over the `for`-expression case,
+// which has not. The principled fix (#64) is a parser-based reparse.
 fn _in_keyword_separator_skipped() {
     let _ = in_separator_macro!(item in container);
 }

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -56,7 +56,7 @@ LL |     let _ = await_macro!(future.await);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:207:27
+  --> $DIR/macro_argument_binding.rs:208:27
    |
 LL |     let _ = my_macro!((), value());
    |                           ^^^^^^^
@@ -64,7 +64,7 @@ LL |     let _ = my_macro!((), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:208:30
+  --> $DIR/macro_argument_binding.rs:209:30
    |
 LL |     let _ = my_macro!((MAX), value());
    |                              ^^^^^^^
@@ -72,7 +72,7 @@ LL |     let _ = my_macro!((MAX), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:209:43
+  --> $DIR/macro_argument_binding.rs:210:43
    |
 LL |     let _ = my_macro!((point.0, point.1), value());
    |                                           ^^^^^^^
@@ -80,7 +80,7 @@ LL |     let _ = my_macro!((point.0, point.1), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:210:31
+  --> $DIR/macro_argument_binding.rs:211:31
    |
 LL |     let _ = my_macro!((MAX,), value());
    |                               ^^^^^^^
@@ -88,7 +88,7 @@ LL |     let _ = my_macro!((MAX,), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:253:19
+  --> $DIR/macro_argument_binding.rs:254:19
    |
 LL |     debug_assert!(slice.clear() == ());
    |                   ^^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL |     debug_assert!(slice.clear() == ());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:263:19
+  --> $DIR/macro_argument_binding.rs:264:19
    |
 LL |     debug_assert!(text.parse::<u32>().is_ok());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -1,5 +1,5 @@
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:30:22
+  --> $DIR/macro_argument_binding.rs:38:22
    |
 LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
    |                      ^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
    = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:36:19
+  --> $DIR/macro_argument_binding.rs:44:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:44:22
+  --> $DIR/macro_argument_binding.rs:52:22
    |
 LL |     debug_assert_ne!(value(), Some(0));
    |                      ^^^^^^^
@@ -24,7 +24,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:44:31
+  --> $DIR/macro_argument_binding.rs:52:31
    |
 LL |     debug_assert_ne!(value(), Some(0));
    |                               ^^^^^^^
@@ -32,7 +32,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:52:23
+  --> $DIR/macro_argument_binding.rs:60:23
    |
 LL |     let _ = my_macro!(value(), count);
    |                       ^^^^^^^
@@ -40,7 +40,7 @@ LL |     let _ = my_macro!(value(), count);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:110:19
+  --> $DIR/macro_argument_binding.rs:118:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:123:26
+  --> $DIR/macro_argument_binding.rs:131:26
    |
 LL |     let _ = await_macro!(future.await);
    |                          ^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     let _ = await_macro!(future.await);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:169:27
+  --> $DIR/macro_argument_binding.rs:207:27
    |
 LL |     let _ = my_macro!((), value());
    |                           ^^^^^^^
@@ -64,7 +64,7 @@ LL |     let _ = my_macro!((), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:170:30
+  --> $DIR/macro_argument_binding.rs:208:30
    |
 LL |     let _ = my_macro!((MAX), value());
    |                              ^^^^^^^
@@ -72,7 +72,7 @@ LL |     let _ = my_macro!((MAX), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:171:43
+  --> $DIR/macro_argument_binding.rs:209:43
    |
 LL |     let _ = my_macro!((point.0, point.1), value());
    |                                           ^^^^^^^
@@ -80,7 +80,7 @@ LL |     let _ = my_macro!((point.0, point.1), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:172:31
+  --> $DIR/macro_argument_binding.rs:210:31
    |
 LL |     let _ = my_macro!((MAX,), value());
    |                               ^^^^^^^
@@ -88,7 +88,7 @@ LL |     let _ = my_macro!((MAX,), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:215:19
+  --> $DIR/macro_argument_binding.rs:253:19
    |
 LL |     debug_assert!(slice.clear() == ());
    |                   ^^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL |     debug_assert!(slice.clear() == ());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:225:19
+  --> $DIR/macro_argument_binding.rs:263:19
    |
 LL |     debug_assert!(text.parse::<u32>().is_ok());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Two more DSL-separator shapes were surfacing as `macro_argument_binding`
false positives — `link!("src" -> "dst")` (arrow-paired matcher) and
`for_each!(x in iter, ...)` (`in`-keyword matcher) — surfaced in
[KSXGitHub/parallel-disk-usage#416 (comment)](https://github.com/KSXGitHub/parallel-disk-usage/issues/416#issuecomment-4429675144).

`looks_like_expression` only blocklisted `=>`, `=`, and the
compound-assignment family, so the new shapes slipped through, got
partially consumed by `is_trivial_expression`, and produced let-bind
hints that don't parse.

## Changes

- `src/rules/macro_argument_binding/triviality.rs` — `is_dsl_marker`
  now also matches `TokenKind::RArrow` and the `in` keyword. Signature
  changed to `&Token` so `is_keyword(kw::In)` works.
- `ui/macro_argument_binding.rs` — three new fixtures: bare `->`
  separator, bare `in` separator, and the mixed `->`/`in`/`==`
  definition-shape DSL from the comment.
- `planned-rules/macro-argument-binding.md` — pipeline step 6 lists
  the new skip cases.

## Why not `==`

`==` is a real Rust binary operator and `debug_assert!(a == b)` is the
rule's motivating trivial shape. Adding it to the marker set would
re-introduce false negatives on the rule's primary use case. The
mixed-DSL fixture (`name -> value in System == "x"`) is fully covered
by `->` alone — `==` doesn't need to be a marker for it to work.

## Follow-up

The blocklist approach has now grown five times. #64 tracks replacing
it with a `Parser::parse_expr` reparse, which is the long-term plan
the rule's docstring and planning file already commit to.

## Test plan

- [x] `cargo test --test macro_argument_binding` (12/12 pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`