### PR TITLE
docs(plan): three rules for lint-attribute reasons

### DIFF
--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -215,12 +215,14 @@ pattern that several rules call out by reference — live in
   deterministically, so a future fix that removes the underlying
   issue surfaces an `unfulfilled_lint_expectations` warning rather
   than silently leaving a stale suppression.
+- [`lint-silence-reason.md`](./lint-silence-reason.md) —
+  require a `reason = "..."` on every `#[allow]` and `#[expect]`
+  attribute. Local check; no ancestry walk.
 - [`lint-downgrade-reason.md`](./lint-downgrade-reason.md) —
-  require a `reason = "..."` on any lint-level attribute that
-  relaxes a lint: `#[allow]` / `#[expect]` unconditionally
-  (`silenced_without_reason`), and any `#[warn]` /
-  `#[allow]` / `#[expect]` that lowers the lint's inherited level
-  (`downgraded_without_reason`).
+  require a `reason = "..."` on any `#[warn]` / `#[allow]` /
+  `#[expect]` that lowers the lint's inherited level
+  (`deny → warn`, `warn → allow`, etc.). Ancestry-aware
+  counterpart to `lint-silence-reason`.
 
 ### Clap derive help
 - [`clap-help-no-markdown.md`](./clap-help-no-markdown.md) — forbid

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -204,6 +204,24 @@ pattern that several rules call out by reference — live in
   permissive (any length passes); a project tightens the window to
   pin a fixed length such as 12 or 40.
 
+### Lint-level attributes
+- [`lint-reason-from-comment.md`](./lint-reason-from-comment.md) — when
+  a lint-level attribute (`#[allow]`, `#[expect]`, `#[warn]`,
+  `#[deny]`, `#[forbid]`) carries an adjacent comment that
+  documents *why*, lift the comment into the attribute's
+  `reason = "..."` field.
+- [`prefer-expect-over-allow.md`](./prefer-expect-over-allow.md) —
+  rewrite `#[allow(...)]` to `#[expect(...)]` for lints that fire
+  deterministically, so a future fix that removes the underlying
+  issue surfaces an `unfulfilled_lint_expectations` warning rather
+  than silently leaving a stale suppression.
+- [`lint-downgrade-reason.md`](./lint-downgrade-reason.md) —
+  require a `reason = "..."` on any lint-level attribute that
+  relaxes a lint: `#[allow]` / `#[expect]` unconditionally
+  (`silenced_without_reason`), and any `#[warn]` /
+  `#[allow]` / `#[expect]` that lowers the lint's inherited level
+  (`downgraded_without_reason`).
+
 ### Clap derive help
 - [`clap-help-no-markdown.md`](./clap-help-no-markdown.md) — forbid
   markdown constructs (HTML, links, intra-doc links, code blocks, code

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -216,13 +216,15 @@ pattern that several rules call out by reference — live in
   issue surfaces an `unfulfilled_lint_expectations` warning rather
   than silently leaving a stale suppression.
 - [`lint-silence-reason.md`](./lint-silence-reason.md) —
-  require a `reason = "..."` on every `#[allow]` and `#[expect]`
+  require a `reason = "..."` of at least `min_reason_length`
+  characters (default 3) on every `#[allow]` and `#[expect]`
   attribute. Local check; no ancestry walk.
 - [`lint-downgrade-reason.md`](./lint-downgrade-reason.md) —
-  require a `reason = "..."` on any `#[warn]` / `#[allow]` /
-  `#[expect]` that lowers the lint's inherited level
-  (`deny → warn`, `warn → allow`, etc.). Ancestry-aware
-  counterpart to `lint-silence-reason`.
+  same presence-and-length requirement as
+  `lint-silence-reason`, extended to any `#[warn]` /
+  `#[allow]` / `#[expect]` that lowers the lint's inherited
+  level (`deny → warn`, `warn → allow`, etc.). Ancestry-aware
+  counterpart.
 
 ### Clap derive help
 - [`clap-help-no-markdown.md`](./clap-help-no-markdown.md) — forbid

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -21,8 +21,8 @@ to the surrounding scope.
 This is a stylistic preference, not a correctness issue.
 
 - A relative downgrade is a *local exception* to a *project
-  policy*. The policy tends to live in `dylint.toml` /
-  `Cargo.toml`'s `[lints]` table / a crate-root `#![deny(...)]`;
+  policy*. The policy tends to live in `Cargo.toml`'s `[lints]`
+  table / a crate-root `#![deny(...)]` / `RUSTFLAGS=-D <lint>`;
   the exception lives at the site that needs it. The rationale
   for the exception is itself local information and belongs
   with the exception.
@@ -40,15 +40,18 @@ This is a stylistic preference, not a correctness issue.
 ## What to lint
 
 For every `#[warn(<lints>)]`, `#[allow(<lints>)]`, or
-`#[expect(<lints>)]` attribute, compute the effective level of
-each named lint at the *enclosing* scope. The level comes from
-the cargo-level sources — the workspace / package `[lints]`
-table in `Cargo.toml` (Rust 1.74+), `RUSTFLAGS`'s `-D` / `-W` /
-`-A` / `-F` flags, and inherited source attributes
-(`#![deny(...)]` at the crate root, `#[warn(...)]` on a parent
-module, etc.). `dylint.toml` is *not* a level source — it
-carries per-lint configuration tables (e.g. `[perfectionist::<lint>]`),
-not lint levels.
+`#[expect(<lints>)]` attribute, first filter against
+`exempt_lints`: if every lint named in the attribute is on the
+configured exempt list, the attribute is not flagged.
+Otherwise, compute the effective level of each named lint at
+the *enclosing* scope. The level comes from the cargo-level
+sources — the workspace / package `[lints]` table in
+`Cargo.toml` (Rust 1.74+), `RUSTFLAGS`'s `-D` / `-W` / `-A` /
+`-F` flags, and inherited source attributes (`#![deny(...)]` at
+the crate root, `#[warn(...)]` on a parent module, etc.).
+`dylint.toml` is *not* a level source — it carries per-lint
+configuration tables (e.g. `[perfectionist::<lint>]`), not lint
+levels.
 
 If the attribute's level is strictly lower than the resolved
 enclosing level (`deny → warn`, `deny → allow`,
@@ -131,14 +134,17 @@ fn build(/* ... */) {}
 
 ## Autofix
 
-Insert `, reason = ""` immediately before the closing `)` of the
-attribute's argument list. `Applicability::HasPlaceholders` —
-the empty string is a placeholder the author fills in. Layout
-and the `cfg_attr` / inner-attribute scope handling are the
-same as for
+For the missing-reason case: insert `, reason = ""` immediately
+before the closing `)` of the attribute's argument list.
+`Applicability::HasPlaceholders` — the empty string is a
+placeholder the author fills in. Layout and the `cfg_attr` /
+inner-attribute scope handling are the same as for
 [`lint-silence-reason`](./lint-silence-reason.md): the
 insertion point is the inner `warn(...)` / `allow(...)` /
 `expect(...)` argument list, not any wrapping `cfg_attr`.
+
+The too-short case has no autofix; the diagnostic points at the
+`reason` literal's span and the author rewrites it.
 
 ## Configuration
 

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -186,7 +186,11 @@ min_reason_length = 3
   `src/enclosing_hir.rs`.
 - Compare the attribute's level against the inherited level
   using the `Forbid > Deny > Warn > Expect ≈ Allow` ordering.
-  Emit only when strictly lower.
+  If not strictly lower, accept. If strictly lower, run the
+  presence / length check from
+  [`lint-silence-reason`](./lint-silence-reason.md) and emit
+  the corresponding "missing reason" or "reason too short"
+  diagnostic.
 - The `reason`-presence check is shared with
   [`lint-reason-from-comment`](./lint-reason-from-comment.md)
   and

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -4,52 +4,40 @@
 
 ## Statement
 
-A lint-level attribute that *relaxes* a lint — silences it
-(`#[allow]`, `#[expect]`) or downgrades it from a stricter
-inherited level (e.g., `#[warn]` placed under a crate-level
-`#![deny]`) — must carry an explanatory `reason = "..."` field.
-The strict forms (`#[deny]`, `#[forbid]`, or a `#[warn]` that
-does not relax anything) are not flagged.
+A lint-level attribute that lowers a lint's level *relative to
+the inherited level* — `#[warn]` placed under a crate-level
+`#![deny]`, `#[allow]` overriding an outer `#[warn]`, and so on —
+must carry an explanatory `reason = "..."` field. Attributes that
+tighten, or that match the inherited level, are not flagged.
+
+The local case — every `#[allow]` / `#[expect]` regardless of
+inherited level — is covered by the sibling
+[`lint-silence-reason`](./lint-silence-reason.md). This rule
+covers the ancestry-aware case: any explicit step down relative
+to the surrounding scope.
 
 ## Why restrict this?
 
 This is a stylistic preference, not a correctness issue.
 
-- Suppressions outlive the conditions that justify them. A bare
-  `#[allow(clippy::too_many_arguments)]` told the original author
-  to ignore a complaint; six months later, no one knows whether
-  the rationale was "matches upstream signature", "intentional
-  over-engineering", or "we'll fix it in the next refactor". The
-  `reason` field records intent at the moment of suppression.
-- Diagnostics render the `reason` in the lint message when the
-  suppression is queried — e.g., the
-  `unfulfilled_lint_expectations` note on a stale `#[expect]`
-  shows the original rationale alongside the "no longer
-  applies" message.
+- A relative downgrade is a *local exception* to a *project
+  policy*. The policy tends to live in `dylint.toml` /
+  `Cargo.toml`'s `[lints]` table / a crate-root `#![deny(...)]`;
+  the exception lives at the site that needs it. The rationale
+  for the exception is itself local information and belongs
+  with the exception.
 - The asymmetry — strict levels do not need a reason, relaxed
-  levels do — matches the asymmetry of risk. Tightening a lint
-  is routine project policy and its rationale tends to live in
-  the project config alongside other policy. Relaxing it is a
-  local exception, and the rationale belongs with the exception.
+  levels do — matches the asymmetry of risk. Tightening is
+  routine policy and its rationale lives in the config file.
+  Relaxing the project policy at a specific site is the kind of
+  change a reviewer wants context for.
+- A grep for `#[warn(<lint>)]` is the easiest way to find
+  partial migrations away from a project-wide `#[deny(<lint>)]`
+  policy. Embedding the reason makes those greps
+  self-documenting ("stub during the parser-rewrite migration;
+  tighten back to deny in #1234").
 
-## Sub-lints
-
-Two related triggers. Both register under the namespace
-`perfectionist::lint_downgrade_reason::*`.
-
-### `lint_downgrade_reason::silenced_without_reason`
-
-For every `#[allow(<lints>)]` or `#[expect(<lints>)]` attribute
-that does *not* contain a `reason = "..."` field, flag the
-attribute.
-
-`#[allow]` and `#[expect]` are the lowest two lint levels and
-unconditionally silence output. They always count as a
-relaxation regardless of the lint's default level — the author
-has chosen "don't tell me about this", and the project's record
-of suppressions needs to record why.
-
-### `lint_downgrade_reason::downgraded_without_reason`
+## What to lint
 
 For every `#[warn(<lints>)]`, `#[allow(<lints>)]`, or
 `#[expect(<lints>)]` attribute, compute the effective level of
@@ -61,37 +49,39 @@ the new level is strictly lower than the enclosing level
 `warn → expect`) and the attribute does not contain
 `reason = "..."`, flag it.
 
-This sub-lint subsumes `silenced_without_reason` when the lint's
-inherited level is `warn` or `deny`. The two are kept separate so
-that a project that finds the inherited-level analysis too noisy
-or too expensive can enable `silenced_without_reason` alone (which
-is purely local) and skip `downgraded_without_reason`.
+`#[deny]` and `#[forbid]` are never flagged — they tighten, not
+loosen. `#[warn]` at a site whose inherited level is already
+`warn` is not flagged either: the attribute is a no-op relative
+to ambient policy and does not relax anything.
+
+The lint-level ordering used for "strictly lower" is
+`Forbid > Deny > Warn > Expect ≈ Allow`. `Expect` and `Allow`
+are treated equally — both fully silence output.
+
+## Relationship to `lint-silence-reason`
+
+The two rules overlap when the inherited level is `warn` or
+`deny`:
+
+- [`lint-silence-reason`](./lint-silence-reason.md) fires on
+  every `#[allow]` / `#[expect]` regardless of inherited level.
+- `lint_downgrade_reason` fires on every level lower than
+  ambient, which includes `#[allow]` / `#[expect]` whose
+  inherited level is `warn` or `deny` — and additionally
+  catches `#[warn]` over `#[deny]`, which the sibling rule
+  cannot see.
+
+A project that enables both rules gets one diagnostic per
+attribute either way (the rules deduplicate via a shared
+attribute-already-flagged guard). A project that enables only
+`lint_silence_reason` skips the ancestry walk entirely and still
+catches the high-value cases — most silencing in practice is of
+clippy lints whose default level is `warn`. A project that
+enables only `lint_downgrade_reason` accepts `#[allow]` on
+default-`allow` lints (rare) but catches every relative
+downgrade including `#[warn]` over `#[deny]`.
 
 ## Examples
-
-### `silenced_without_reason`
-
-```rust
-// Bad
-#[allow(clippy::too_many_arguments)]
-fn build_fetcher(/* ... */) {}
-
-// Good
-#[allow(clippy::too_many_arguments, reason = "matches pnpm's signature")]
-fn build_fetcher(/* ... */) {}
-```
-
-```rust
-// Bad — `expect` without reason
-#[expect(clippy::too_many_arguments)]
-fn build_fetcher(/* ... */) {}
-
-// Good
-#[expect(clippy::too_many_arguments, reason = "matches pnpm's signature")]
-fn build_fetcher(/* ... */) {}
-```
-
-### `downgraded_without_reason`
 
 ```rust
 #![deny(clippy::missing_errors_doc)]
@@ -109,85 +99,65 @@ pub fn parse(input: &str) -> Result<Manifest, ParseError> { /* ... */ }
 ```
 
 ```rust
-// `#[deny]` and `#[forbid]` are never flagged by this rule — they
-// tighten, not loosen.
+// `#[deny]` and `#[forbid]` are never flagged — they tighten,
+// not loosen.
 #[deny(clippy::too_many_arguments)]
 mod hot_path {}
 ```
 
+```rust
+// Not flagged — `#[warn]` does not lower the lint below its
+// inherited `warn`, so the attribute is a no-op relative to
+// ambient policy.
+#[warn(clippy::too_many_arguments)]
+fn build(/* ... */) {}
+```
+
 ## Autofix
 
-Both sub-lints suggest inserting `, reason = ""` immediately
-before the closing `)` of the argument list.
-`Applicability::HasPlaceholders` — the empty string is a
-placeholder the author fills in.
-
-If the attribute uses bare zero-argument form
-(`#[allow(my_lint)]` with no trailing comma), the suggestion
-adds the comma. If the attribute is laid out across multiple
-lines, the suggestion keeps the `reason` entry on its own line
-matching the existing indentation.
+Insert `, reason = ""` immediately before the closing `)` of the
+argument list. `Applicability::HasPlaceholders` — the empty
+string is a placeholder the author fills in. Layout is preserved
+the same way as for
+[`lint-silence-reason`](./lint-silence-reason.md).
 
 ## Configuration
 
 ```toml
 [lint_downgrade_reason]
-# Enable each sub-lint independently.
-silenced_without_reason = "warn"   # or "allow", "deny", "forbid"
-downgraded_without_reason = "warn"
-
-# Lints excluded from the requirement. Useful for project-wide
-# suppressions whose rationale lives in the project README rather
-# than per-site.
+# Lints excluded from the requirement.
 exempt_lints = [
     # "clippy::module_name_repetitions",
 ]
 
 # Minimum length of the `reason` value. A one-word reason
-# ("legacy", "TODO") satisfies the literal requirement but conveys
-# little; this knob enforces a useful floor. Set to 0 to disable.
+# ("legacy", "TODO") satisfies the literal requirement but
+# conveys little; this knob enforces a useful floor. Set to 0
+# to disable.
 min_reason_length = 3
 ```
 
 ## Implementation notes
 
-- `silenced_without_reason`:
-  `EarlyLintPass::check_attribute`. Match `attr.path` against
-  `sym::allow` and `sym::expect`. Iterate
-  `attr.meta_item_list()` and check whether any item has the
-  shape `reason = "<str>"`. If absent, emit at the attribute's
-  span.
-- `downgraded_without_reason`: requires the effective ambient
-  lint level at the attribute's site. Use the late pass: hook
-  `LateLintPass::check_attribute` with `TyCtxt` available, and
-  query `tcx.lint_level_at_node(lint, hir_id)` against the
-  attribute's enclosing item's `HirId`. The returned level
-  reflects the level *that would apply if this attribute did not
-  exist*; if the attribute's level is strictly lower, the rule
-  fires.
-- The "strictly lower" comparison uses the standard lint-level
-  ordering: `Forbid > Deny > Warn > Expect ≈ Allow`. `Expect`
-  and `Allow` are treated as equal for this comparison — both
-  fully silence output.
-- Per-named-lint reasoning: an attribute that names multiple
-  lints (`#[allow(a, b)]`) is treated as a separate
-  relaxation per name. Configuration entries in `exempt_lints`
-  remove names from the per-attribute set; if every named lint
-  is exempt, the attribute is not flagged.
-- The `reason`-field-presence check is shared with the
-  `silenced_without_reason` sub-lint and lives in
-  `src/common.rs::attr_has_reason`.
+- `LateLintPass::check_attribute` with `TyCtxt` available. Match
+  `attr.path` against `sym::warn`, `sym::allow`, `sym::expect`.
+- For each named lint, resolve its inherited level using
+  `tcx.lint_level_at_node(lint, parent_hir_id)` where
+  `parent_hir_id` is the HIR node *above* the attribute's owner
+  — equivalent to "what level would apply if this attribute did
+  not exist". The manual walk also handles `cfg_attr`-wrapped
+  lint attributes uniformly, per the pattern in
+  `src/enclosing_hir.rs`.
+- Compare the attribute's level against the inherited level
+  using the `Forbid > Deny > Warn > Expect ≈ Allow` ordering.
+  Emit only when strictly lower.
+- The `reason`-presence check is shared with
+  [`lint-silence-reason`](./lint-silence-reason.md) — both
+  consume `src/common.rs::attr_has_reason`.
 
 ### Difficulty
 
-**Sub-lint `silenced_without_reason`: easy.** A single attribute
-walk that looks for `#[allow(...)]` / `#[expect(...)]` and checks
-whether any nested meta item matches the `reason = "<str>"`
-shape. The autofix span is the closing `)` of the attribute
-list, plus the inserted bytes `, reason = ""`.
-
-**Sub-lint `downgraded_without_reason`: hard.** The inherited-
-level analysis is the cost driver:
+**Hard.** The inherited-level analysis is the cost driver:
 
 - Lint-level resolution at an arbitrary HIR node is not stable
   across rustc nightlies. `tcx.lint_level_at_node` works today
@@ -197,22 +167,22 @@ level analysis is the cost driver:
 - The ambient level must reflect *both* attribute-driven levels
   (`#![deny(...)]` on the crate, `#[warn(...)]` on a parent
   module) *and* configuration-driven levels (`dylint.toml`'s
-  `[clippy_lints]` table, the workspace `Cargo.toml`'s `[lints]`
-  table introduced in Rust 1.74, and the `RUSTFLAGS=-D <lint>`
-  environment variable). Most of these are aggregated by
-  `lint_level_at_node` before it returns, but the test matrix
-  for the rule expands accordingly.
+  `[clippy_lints]` table, the workspace `Cargo.toml`'s
+  `[lints]` table introduced in Rust 1.74, and the
+  `RUSTFLAGS=-D <lint>` environment variable). Most of these
+  are aggregated by `lint_level_at_node` before it returns, but
+  the test matrix for the rule expands accordingly.
 - Determining "the level that would apply if this attribute did
   not exist" requires temporarily removing the attribute from
   consideration. Either re-query the lint-level map against the
-  attribute's parent `HirId`, or — equivalent and cheaper — walk
-  the ancestry manually, skipping the attribute under inspection.
-  The manual walk also handles `cfg_attr`-wrapped lint
-  attributes uniformly, per the pattern in
-  `src/enclosing_hir.rs`.
+  attribute's parent `HirId`, or — equivalent and cheaper —
+  walk the ancestry manually, skipping the attribute under
+  inspection.
 
-Ship `silenced_without_reason` first; `downgraded_without_reason`
-in a follow-up once the lint-level query interface is pinned.
+Ship [`lint-silence-reason`](./lint-silence-reason.md) first
+(easy, `EarlyLintPass`, no ancestry); this rule in a follow-up
+once the lint-level query interface is pinned for the target
+nightly.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
   for cross-cutting conventions that apply to every rule in this
@@ -225,12 +195,16 @@ Warn.
 
 ## Interaction with sibling rules
 
-- [`lint-reason-from-comment`](./lint-reason-from-comment.md) lifts
-  an adjacent comment into the attribute's `reason` field. When
-  the author has already written the rationale as a comment,
-  that rule fires first and satisfies this one preemptively.
+- [`lint-silence-reason`](./lint-silence-reason.md) covers the
+  local case (every `#[allow]` / `#[expect]` regardless of
+  inherited level). See "Relationship to `lint-silence-reason`"
+  above.
+- [`lint-reason-from-comment`](./lint-reason-from-comment.md)
+  lifts an adjacent comment into the attribute's `reason` field
+  and so satisfies this rule preemptively when the rationale is
+  already present in source.
 - [`prefer-expect-over-allow`](./prefer-expect-over-allow.md)
-  rewrites `#[allow]` to `#[expect]`. The
-  `silenced_without_reason` trigger applies equally to both
-  forms, so the two rewrites compose: the canonical end state
-  is `#[expect(<lint>, reason = "...")]`.
+  rewrites `#[allow]` to `#[expect]`. The level under analysis
+  here is the relaxation level, so the rewrite does not affect
+  whether this rule fires — `allow` and `expect` rank equally
+  in the ordering above.

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -118,6 +118,15 @@ pub fn parse(input: &str) -> Result<Manifest, ParseError> { /* ... */ }
 ```
 
 ```rust
+#![deny(clippy::missing_errors_doc)]
+
+// Bad — relaxed below the crate-level `deny`, but the `reason`
+// is shorter than `min_reason_length`
+#[warn(clippy::missing_errors_doc, reason = "x")]
+pub fn parse(input: &str) -> Result<Manifest, ParseError> { /* ... */ }
+```
+
+```rust
 // `#[deny]` and `#[forbid]` are never flagged — they tighten,
 // not loosen.
 #[deny(clippy::too_many_arguments)]

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -1,0 +1,236 @@
+# `lint_downgrade_reason`
+
+**Source:** project convention.
+
+## Statement
+
+A lint-level attribute that *relaxes* a lint — silences it
+(`#[allow]`, `#[expect]`) or downgrades it from a stricter
+inherited level (e.g., `#[warn]` placed under a crate-level
+`#![deny]`) — must carry an explanatory `reason = "..."` field.
+The strict forms (`#[deny]`, `#[forbid]`, or a `#[warn]` that
+does not relax anything) are not flagged.
+
+## Why restrict this?
+
+This is a stylistic preference, not a correctness issue.
+
+- Suppressions outlive the conditions that justify them. A bare
+  `#[allow(clippy::too_many_arguments)]` told the original author
+  to ignore a complaint; six months later, no one knows whether
+  the rationale was "matches upstream signature", "intentional
+  over-engineering", or "we'll fix it in the next refactor". The
+  `reason` field records intent at the moment of suppression.
+- Diagnostics render the `reason` in the lint message when the
+  suppression is queried — e.g., the
+  `unfulfilled_lint_expectations` note on a stale `#[expect]`
+  shows the original rationale alongside the "no longer
+  applies" message.
+- The asymmetry — strict levels do not need a reason, relaxed
+  levels do — matches the asymmetry of risk. Tightening a lint
+  is routine project policy and its rationale tends to live in
+  the project config alongside other policy. Relaxing it is a
+  local exception, and the rationale belongs with the exception.
+
+## Sub-lints
+
+Two related triggers. Both register under the namespace
+`perfectionist::lint_downgrade_reason::*`.
+
+### `lint_downgrade_reason::silenced_without_reason`
+
+For every `#[allow(<lints>)]` or `#[expect(<lints>)]` attribute
+that does *not* contain a `reason = "..."` field, flag the
+attribute.
+
+`#[allow]` and `#[expect]` are the lowest two lint levels and
+unconditionally silence output. They always count as a
+relaxation regardless of the lint's default level — the author
+has chosen "don't tell me about this", and the project's record
+of suppressions needs to record why.
+
+### `lint_downgrade_reason::downgraded_without_reason`
+
+For every `#[warn(<lints>)]`, `#[allow(<lints>)]`, or
+`#[expect(<lints>)]` attribute, compute the effective level of
+each named lint at the *enclosing* scope (the project's
+`dylint.toml` / `Cargo.toml` `[lints]` table, the crate-root
+`#![deny(...)]`, the next outer item's `#[warn(...)]`, etc.). If
+the new level is strictly lower than the enclosing level
+(`deny → warn`, `deny → allow`, `deny → expect`, `warn → allow`,
+`warn → expect`) and the attribute does not contain
+`reason = "..."`, flag it.
+
+This sub-lint subsumes `silenced_without_reason` when the lint's
+inherited level is `warn` or `deny`. The two are kept separate so
+that a project that finds the inherited-level analysis too noisy
+or too expensive can enable `silenced_without_reason` alone (which
+is purely local) and skip `downgraded_without_reason`.
+
+## Examples
+
+### `silenced_without_reason`
+
+```rust
+// Bad
+#[allow(clippy::too_many_arguments)]
+fn build_fetcher(/* ... */) {}
+
+// Good
+#[allow(clippy::too_many_arguments, reason = "matches pnpm's signature")]
+fn build_fetcher(/* ... */) {}
+```
+
+```rust
+// Bad — `expect` without reason
+#[expect(clippy::too_many_arguments)]
+fn build_fetcher(/* ... */) {}
+
+// Good
+#[expect(clippy::too_many_arguments, reason = "matches pnpm's signature")]
+fn build_fetcher(/* ... */) {}
+```
+
+### `downgraded_without_reason`
+
+```rust
+#![deny(clippy::missing_errors_doc)]
+
+// Bad — downgrades from the crate-level `deny` without a reason
+#[warn(clippy::missing_errors_doc)]
+pub fn parse(input: &str) -> Result<Manifest, ParseError> { /* ... */ }
+
+// Good
+#[warn(
+    clippy::missing_errors_doc,
+    reason = "stub during the parser-rewrite migration; tighten back to deny in #1234",
+)]
+pub fn parse(input: &str) -> Result<Manifest, ParseError> { /* ... */ }
+```
+
+```rust
+// `#[deny]` and `#[forbid]` are never flagged by this rule — they
+// tighten, not loosen.
+#[deny(clippy::too_many_arguments)]
+mod hot_path {}
+```
+
+## Autofix
+
+Both sub-lints suggest inserting `, reason = ""` immediately
+before the closing `)` of the argument list.
+`Applicability::HasPlaceholders` — the empty string is a
+placeholder the author fills in.
+
+If the attribute uses bare zero-argument form
+(`#[allow(my_lint)]` with no trailing comma), the suggestion
+adds the comma. If the attribute is laid out across multiple
+lines, the suggestion keeps the `reason` entry on its own line
+matching the existing indentation.
+
+## Configuration
+
+```toml
+[lint_downgrade_reason]
+# Enable each sub-lint independently.
+silenced_without_reason = "warn"   # or "allow", "deny", "forbid"
+downgraded_without_reason = "warn"
+
+# Lints excluded from the requirement. Useful for project-wide
+# suppressions whose rationale lives in the project README rather
+# than per-site.
+exempt_lints = [
+    # "clippy::module_name_repetitions",
+]
+
+# Minimum length of the `reason` value. A one-word reason
+# ("legacy", "TODO") satisfies the literal requirement but conveys
+# little; this knob enforces a useful floor. Set to 0 to disable.
+min_reason_length = 3
+```
+
+## Implementation notes
+
+- `silenced_without_reason`:
+  `EarlyLintPass::check_attribute`. Match `attr.path` against
+  `sym::allow` and `sym::expect`. Iterate
+  `attr.meta_item_list()` and check whether any item has the
+  shape `reason = "<str>"`. If absent, emit at the attribute's
+  span.
+- `downgraded_without_reason`: requires the effective ambient
+  lint level at the attribute's site. Use the late pass: hook
+  `LateLintPass::check_attribute` with `TyCtxt` available, and
+  query `tcx.lint_level_at_node(lint, hir_id)` against the
+  attribute's enclosing item's `HirId`. The returned level
+  reflects the level *that would apply if this attribute did not
+  exist*; if the attribute's level is strictly lower, the rule
+  fires.
+- The "strictly lower" comparison uses the standard lint-level
+  ordering: `Forbid > Deny > Warn > Expect ≈ Allow`. `Expect`
+  and `Allow` are treated as equal for this comparison — both
+  fully silence output.
+- Per-named-lint reasoning: an attribute that names multiple
+  lints (`#[allow(a, b)]`) is treated as a separate
+  relaxation per name. Configuration entries in `exempt_lints`
+  remove names from the per-attribute set; if every named lint
+  is exempt, the attribute is not flagged.
+- The `reason`-field-presence check is shared with the
+  `silenced_without_reason` sub-lint and lives in
+  `src/common.rs::attr_has_reason`.
+
+### Difficulty
+
+**Sub-lint `silenced_without_reason`: easy.** A single attribute
+walk that looks for `#[allow(...)]` / `#[expect(...)]` and checks
+whether any nested meta item matches the `reason = "<str>"`
+shape. The autofix span is the closing `)` of the attribute
+list, plus the inserted bytes `, reason = ""`.
+
+**Sub-lint `downgraded_without_reason`: hard.** The inherited-
+level analysis is the cost driver:
+
+- Lint-level resolution at an arbitrary HIR node is not stable
+  across rustc nightlies. `tcx.lint_level_at_node` works today
+  but has shifted signature across versions, so the rule has to
+  pin to a compatible nightly or guard the call with a
+  version-conditional shim.
+- The ambient level must reflect *both* attribute-driven levels
+  (`#![deny(...)]` on the crate, `#[warn(...)]` on a parent
+  module) *and* configuration-driven levels (`dylint.toml`'s
+  `[clippy_lints]` table, the workspace `Cargo.toml`'s `[lints]`
+  table introduced in Rust 1.74, and the `RUSTFLAGS=-D <lint>`
+  environment variable). Most of these are aggregated by
+  `lint_level_at_node` before it returns, but the test matrix
+  for the rule expands accordingly.
+- Determining "the level that would apply if this attribute did
+  not exist" requires temporarily removing the attribute from
+  consideration. Either re-query the lint-level map against the
+  attribute's parent `HirId`, or — equivalent and cheaper — walk
+  the ancestry manually, skipping the attribute under inspection.
+  The manual walk also handles `cfg_attr`-wrapped lint
+  attributes uniformly, per the pattern in
+  `src/enclosing_hir.rs`.
+
+Ship `silenced_without_reason` first; `downgraded_without_reason`
+in a follow-up once the lint-level query interface is pinned.
+
+- See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  for cross-cutting conventions that apply to every rule in this
+  catalogue, in particular the lint-name namespacing
+  (`perfectionist::*`) that every registered lint follows.
+
+## Severity
+
+Warn.
+
+## Interaction with sibling rules
+
+- [`lint-reason-from-comment`](./lint-reason-from-comment.md) lifts
+  an adjacent comment into the attribute's `reason` field. When
+  the author has already written the rationale as a comment,
+  that rule fires first and satisfies this one preemptively.
+- [`prefer-expect-over-allow`](./prefer-expect-over-allow.md)
+  rewrites `#[allow]` to `#[expect]`. The
+  `silenced_without_reason` trigger applies equally to both
+  forms, so the two rewrites compose: the canonical end state
+  is `#[expect(<lint>, reason = "...")]`.

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -78,8 +78,9 @@ attribute-already-flagged guard). A project that enables only
 catches the high-value cases — most silencing in practice is of
 clippy lints whose default level is `warn`. A project that
 enables only `lint_downgrade_reason` accepts `#[allow]` on
-default-`allow` lints (rare) but catches every relative
-downgrade including `#[warn]` over `#[deny]`.
+default-`allow` lints (a large share of the pedantic / nursery /
+restriction clippy groups) but catches every relative downgrade
+including `#[warn]` over `#[deny]`.
 
 ## Examples
 

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -41,13 +41,28 @@ This is a stylistic preference, not a correctness issue.
 
 For every `#[warn(<lints>)]`, `#[allow(<lints>)]`, or
 `#[expect(<lints>)]` attribute, compute the effective level of
-each named lint at the *enclosing* scope (the project's
-`dylint.toml` / `Cargo.toml` `[lints]` table, the crate-root
-`#![deny(...)]`, the next outer item's `#[warn(...)]`, etc.). If
-the new level is strictly lower than the enclosing level
-(`deny → warn`, `deny → allow`, `deny → expect`, `warn → allow`,
-`warn → expect`) and the attribute does not contain
-`reason = "..."`, flag it.
+each named lint at the *enclosing* scope. The level comes from
+the cargo-level sources — the workspace / package `[lints]`
+table in `Cargo.toml` (Rust 1.74+), `RUSTFLAGS`'s `-D` / `-W` /
+`-A` / `-F` flags, and inherited source attributes
+(`#![deny(...)]` at the crate root, `#[warn(...)]` on a parent
+module, etc.). `dylint.toml` is *not* a level source — it
+carries per-lint configuration tables (e.g. `[perfectionist::<lint>]`),
+not lint levels.
+
+If the attribute's level is strictly lower than the resolved
+enclosing level (`deny → warn`, `deny → allow`,
+`deny → expect`, `warn → allow`, `warn → expect`), apply the
+same presence / length check as
+[`lint-silence-reason`](./lint-silence-reason.md):
+
+- **`reason` absent.** Emit a "missing reason" diagnostic at
+  the attribute's span.
+- **`reason` present but shorter than `min_reason_length`
+  (default 3).** Emit a "reason too short" diagnostic at the
+  literal's span. Set `min_reason_length = 0` to disable the
+  length branch (presence still enforced).
+- **`reason` present and long enough.** Accept.
 
 `#[deny]` and `#[forbid]` are never flagged — they tighten, not
 loosen. `#[warn]` at a site whose inherited level is already
@@ -117,10 +132,13 @@ fn build(/* ... */) {}
 ## Autofix
 
 Insert `, reason = ""` immediately before the closing `)` of the
-argument list. `Applicability::HasPlaceholders` — the empty
-string is a placeholder the author fills in. Layout is preserved
-the same way as for
-[`lint-silence-reason`](./lint-silence-reason.md).
+attribute's argument list. `Applicability::HasPlaceholders` —
+the empty string is a placeholder the author fills in. Layout
+and the `cfg_attr` / inner-attribute scope handling are the
+same as for
+[`lint-silence-reason`](./lint-silence-reason.md): the
+insertion point is the inner `warn(...)` / `allow(...)` /
+`expect(...)` argument list, not any wrapping `cfg_attr`.
 
 ## Configuration
 
@@ -153,7 +171,9 @@ min_reason_length = 3
   using the `Forbid > Deny > Warn > Expect ≈ Allow` ordering.
   Emit only when strictly lower.
 - The `reason`-presence check is shared with
-  [`lint-silence-reason`](./lint-silence-reason.md) — both
+  [`lint-reason-from-comment`](./lint-reason-from-comment.md)
+  and
+  [`lint-silence-reason`](./lint-silence-reason.md). All three
   consume `src/common.rs::attr_has_reason`.
 
 ### Difficulty
@@ -167,12 +187,14 @@ min_reason_length = 3
   version-conditional shim.
 - The ambient level must reflect *both* attribute-driven levels
   (`#![deny(...)]` on the crate, `#[warn(...)]` on a parent
-  module) *and* configuration-driven levels (`dylint.toml`'s
-  `[clippy_lints]` table, the workspace `Cargo.toml`'s
-  `[lints]` table introduced in Rust 1.74, and the
-  `RUSTFLAGS=-D <lint>` environment variable). Most of these
-  are aggregated by `lint_level_at_node` before it returns, but
-  the test matrix for the rule expands accordingly.
+  module) *and* cargo-level sources (the workspace / package
+  `[lints]` table in `Cargo.toml` introduced in Rust 1.74, and
+  the `RUSTFLAGS=-D <lint>` / `-W` / `-A` / `-F` environment
+  variable). Most of these are aggregated by
+  `lint_level_at_node` before it returns, but the test matrix
+  for the rule expands accordingly. `dylint.toml` is *not* a
+  source of lint levels — it carries per-lint configuration
+  tables only — so the query path does not consult it.
 - Determining "the level that would apply if this attribute did
   not exist" requires temporarily removing the attribute from
   consideration. Either re-query the lint-level map against the

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -155,10 +155,12 @@ exempt_lints = [
     # "clippy::module_name_repetitions",
 ]
 
-# Minimum length of the `reason` value. A one-word reason
-# ("legacy", "TODO") satisfies the literal requirement but
-# conveys little; this knob enforces a useful floor. Set to 0
-# to disable.
+# Minimum length of the `reason` value. A one- or two-character
+# reason ("x", "ok") satisfies the literal presence requirement
+# but conveys nothing; the default floor of 3 excludes those
+# cases. Projects that want a higher bar (e.g. require a full
+# sentence) can raise it. Set to 0 to disable the length branch
+# entirely.
 min_reason_length = 3
 ```
 

--- a/planned-rules/lint-reason-from-comment.md
+++ b/planned-rules/lint-reason-from-comment.md
@@ -138,11 +138,11 @@ include_tool_namespaces = true
   `src/rules/unicode_ellipsis_in_comments.rs`) for locating
   comments by source range.
 - The Rust-string-literal escape helper used to render the
-  lifted comment as a `"..."` string belongs in
-  `src/common.rs::escape_rust_string_literal`; it has no other
-  consumers yet (the sibling reason-related rules insert an
-  empty string and so do not escape anything) but the helper is
-  general enough to live in the shared module from the start.
+  lifted comment as a `"..."` string is single-use today — the
+  sibling reason-related rules insert an empty string and need
+  no escape. Per the catalogue's convention (single-rule helpers
+  live in the rule's own file, not `src/common.rs`), keep it
+  private to this rule's module until a second consumer arrives.
 
 ### Difficulty
 

--- a/planned-rules/lint-reason-from-comment.md
+++ b/planned-rules/lint-reason-from-comment.md
@@ -1,0 +1,173 @@
+# `lint_reason_from_comment`
+
+**Source:** project convention.
+
+## Statement
+
+When a lint-level attribute (`#[allow]`, `#[expect]`, `#[warn]`,
+`#[deny]`, `#[forbid]`) carries an adjacent comment that documents
+*why* the level was chosen, the comment belongs inside the
+attribute itself as a `reason = "..."` field. Lift the prose into
+the attribute and delete the comment.
+
+## Why restrict this?
+
+This is a stylistic preference, not a correctness issue.
+
+- `reason = "..."` is part of the attribute and travels with it
+  through every refactor: a `cargo expand`, a copy-paste, an
+  attribute that moves to a different item. A free-floating
+  comment can be separated from its attribute by an unrelated
+  edit without warning.
+- Compiler diagnostics render the `reason` field in the lint's
+  message (`note: rationale: ...`), so the explanation reaches
+  the reader at the moment of confusion. An adjacent comment is
+  visible only in the source.
+- One canonical location for the rationale removes the question
+  "is this comment for the attribute, or for the next item?"
+- The `reason` field was stabilised in Rust 1.81 for this exact
+  purpose. Comments-as-reasons predate the field; the catalogue
+  is prescribing the modern form.
+
+## What to lint
+
+For every lint-level attribute (`allow`, `expect`, `warn`, `deny`,
+`forbid`) without an existing `reason = "..."` field, look for an
+adjacent comment:
+
+- **Trailing comment** on the same source line as the attribute's
+  closing `]`. The canonical placement and the highest-confidence
+  case.
+- **Leading comment** on the previous source line, with no blank
+  line between the comment and the attribute and no other
+  attribute in between. Lower confidence — the comment may also
+  be documentation for the next item.
+
+If the attribute already contains `reason = "..."`, skip — there
+is nothing to lift.
+
+The rule is intentionally narrow about which comment forms count.
+Doc comments (`///`, `//!`) are *not* in scope; those document
+the attached item, not the attribute. Block comments (`/* ... */`)
+embedded mid-attribute are skipped — the placement is too unusual
+to mechanically rewrite.
+
+## Examples
+
+```rust
+// Bad — trailing comment as reason
+#[allow(clippy::too_many_arguments)] // arg count is set by upstream pnpm's fetcher signature
+fn build_fetcher(/* ... */) {}
+
+// Good
+#[allow(
+    clippy::too_many_arguments,
+    reason = "arg count is set by upstream pnpm's fetcher signature",
+)]
+fn build_fetcher(/* ... */) {}
+```
+
+```rust
+// Bad — leading comment as reason
+// pnpm's wire format is JSON-stringly typed
+#[allow(clippy::struct_excessive_bools)]
+pub struct Manifest { /* ... */ }
+
+// Good
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "pnpm's wire format is JSON-stringly typed",
+)]
+pub struct Manifest { /* ... */ }
+```
+
+```rust
+// Not flagged — the doc comment documents the function, not the
+// attribute.
+/// Builds a fetcher for the configured registry.
+#[allow(clippy::too_many_arguments, reason = "matches pnpm signature")]
+fn build_fetcher(/* ... */) {}
+```
+
+## Autofix
+
+Lift the comment text into `reason = "..."`, then delete the
+comment:
+
+- Strip the comment marker (`//`) and trim surrounding whitespace.
+  The result is the reason string.
+- Escape `\\`, `"`, and control characters per Rust string-literal
+  rules.
+- Insert `, reason = "<escaped text>"` immediately before the
+  closing `)` of the attribute's argument list.
+- Delete the comment span. If the comment was on its own line and
+  removing it leaves the line blank, delete the whole line.
+
+`Applicability::MachineApplicable` for trailing comments — the
+attachment is unambiguous. `Applicability::MaybeIncorrect` for
+leading comments — the comment might really belong to the next
+item; the author confirms.
+
+## Configuration
+
+```toml
+[lint_reason_from_comment]
+# Comment placements considered candidates. Subset of these two.
+sites = ["trailing", "leading"]
+
+# When false, only the `clippy::*` and built-in `unused_*`-style
+# lints are considered. When true, the rule also applies to tool-
+# namespaced lints (e.g. `perfectionist::*`).
+include_tool_namespaces = true
+```
+
+## Implementation notes
+
+- `EarlyLintPass::check_attribute`. The attribute parser exposes
+  `attr.meta_item_list()`; iterate it and check whether any
+  nested item has the shape `reason = "..."`.
+- For trailing-comment detection: read the attribute's span, walk
+  the source map forward over horizontal whitespace, and check
+  whether the next token on the same line is a line comment.
+- For leading-comment detection: walk backward from the
+  attribute's start over horizontal whitespace, then look for the
+  end of a line comment terminated by a newline with no blank line
+  separating the two.
+- Reuse the regular-comment retokenizer from the implemented
+  `perfectionist::unicode_ellipsis_in_comments` lint (see
+  `src/rules/unicode_ellipsis_in_comments.rs`) for locating
+  comments by source range.
+- The Rust-string-literal escape helper is shared with
+  [`lint-downgrade-reason`](./lint-downgrade-reason.md)'s autofix
+  hint. Factor it into `src/common.rs::escape_rust_string_literal`
+  the first time either rule lands.
+
+### Difficulty
+
+**Easy.** Two single-pass source-map searches around each lint
+attribute (one for the trailing comment, one for the leading
+comment) plus a `MetaItem` lookup to check for an existing
+`reason` field. The Rust-string-literal escape used by the
+autofix is the only piece of non-trivial logic, and the
+`std::ascii::escape_default`-equivalent shape is around twenty
+lines.
+
+- See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  for cross-cutting conventions that apply to every rule in this
+  catalogue, in particular the lint-name namespacing
+  (`perfectionist::*`) that every registered lint follows.
+
+## Severity
+
+Warn.
+
+## Interaction with sibling rules
+
+- [`prefer-expect-over-allow`](./prefer-expect-over-allow.md) acts
+  on the same attributes but does not touch the `reason` field.
+  The two rewrites compose in either order.
+- [`lint-downgrade-reason`](./lint-downgrade-reason.md) requires
+  that `#[allow]` / `#[expect]` carry a `reason` field. When the
+  rationale is currently written as a comment, this rule fires
+  first and lifts the comment; `lint-downgrade-reason` then sees
+  the `reason` field and stays silent.

--- a/planned-rules/lint-reason-from-comment.md
+++ b/planned-rules/lint-reason-from-comment.md
@@ -92,16 +92,39 @@ fn build_fetcher(/* ... */) {}
 ## Autofix
 
 Lift the comment text into `reason = "..."`, then delete the
-comment:
+comment.
 
-- Strip the comment marker (`//`) and trim surrounding whitespace.
-  The result is the reason string.
+Recognised comment shapes: a single `//` line-comment
+immediately adjacent to the attribute, in either the trailing or
+leading position defined in "What to lint". Doc comments
+(`///`, `//!`) are filtered out at the trigger stage (see "What
+to lint"). Multi-line trailing comments (a `// ...` followed by
+another `// ...` on the next line) are *not* in scope — only the
+single comment immediately adjacent to the attribute is lifted;
+the second line is left alone.
+
+Text normalisation:
+
+- Strip the leading `//` marker.
+- Trim surrounding ASCII whitespace.
+- Strip a single leading run of one or more `-`, `=`, or `*`
+  decoration characters followed by whitespace
+  (`//-- foo` / `//== foo` / `//* foo` → `foo`). Other decoration
+  styles pass through unchanged; the author can clean them up
+  after the autofix.
 - Escape `\\`, `"`, and control characters per Rust string-literal
-  rules.
-- Insert `, reason = "<escaped text>"` immediately before the
-  closing `)` of the attribute's argument list.
-- Delete the comment span. If the comment was on its own line and
-  removing it leaves the line blank, delete the whole line.
+  rules. The escape helper is described under "Implementation
+  notes".
+
+Splice into the attribute:
+
+- Insert `, reason = "<normalised, escaped text>"` immediately
+  before the closing `)` of the attribute's argument list (for a
+  `cfg_attr`-wrapped attribute, the *inner* lint attribute's
+  closing `)`, not the outer `cfg_attr`'s).
+- Delete the original comment span. If the comment was on its
+  own line and removing it leaves the line blank, delete the
+  whole line.
 
 `Applicability::MachineApplicable` for trailing comments — the
 attachment is unambiguous. `Applicability::MaybeIncorrect` for
@@ -114,18 +137,16 @@ item; the author confirms.
 [lint_reason_from_comment]
 # Comment placements considered candidates. Subset of these two.
 sites = ["trailing", "leading"]
-
-# When false, only the `clippy::*` and built-in `unused_*`-style
-# lints are considered. When true, the rule also applies to tool-
-# namespaced lints (e.g. `perfectionist::*`).
-include_tool_namespaces = true
 ```
 
 ## Implementation notes
 
-- `EarlyLintPass::check_attribute`. The attribute parser exposes
-  `attr.meta_item_list()`; iterate it and check whether any
-  nested item has the shape `reason = "..."`.
+- `EarlyLintPass::check_attribute`. Use
+  `src/common.rs::attr_has_reason` to check whether the
+  attribute already has a `reason` field (shared with
+  [`lint-silence-reason`](./lint-silence-reason.md) and
+  [`lint-downgrade-reason`](./lint-downgrade-reason.md)); if
+  present, skip.
 - For trailing-comment detection: read the attribute's span, walk
   the source map forward over horizontal whitespace, and check
   whether the next token on the same line is a line comment.

--- a/planned-rules/lint-reason-from-comment.md
+++ b/planned-rules/lint-reason-from-comment.md
@@ -137,10 +137,12 @@ include_tool_namespaces = true
   `perfectionist::unicode_ellipsis_in_comments` lint (see
   `src/rules/unicode_ellipsis_in_comments.rs`) for locating
   comments by source range.
-- The Rust-string-literal escape helper is shared with
-  [`lint-downgrade-reason`](./lint-downgrade-reason.md)'s autofix
-  hint. Factor it into `src/common.rs::escape_rust_string_literal`
-  the first time either rule lands.
+- The Rust-string-literal escape helper used to render the
+  lifted comment as a `"..."` string belongs in
+  `src/common.rs::escape_rust_string_literal`; it has no other
+  consumers yet (the sibling reason-related rules insert an
+  empty string and so do not escape anything) but the helper is
+  general enough to live in the shared module from the start.
 
 ### Difficulty
 
@@ -166,8 +168,11 @@ Warn.
 - [`prefer-expect-over-allow`](./prefer-expect-over-allow.md) acts
   on the same attributes but does not touch the `reason` field.
   The two rewrites compose in either order.
-- [`lint-downgrade-reason`](./lint-downgrade-reason.md) requires
-  that `#[allow]` / `#[expect]` carry a `reason` field. When the
-  rationale is currently written as a comment, this rule fires
-  first and lifts the comment; `lint-downgrade-reason` then sees
-  the `reason` field and stays silent.
+- [`lint-silence-reason`](./lint-silence-reason.md) requires
+  that every `#[allow]` / `#[expect]` carry a `reason` field;
+  [`lint-downgrade-reason`](./lint-downgrade-reason.md) extends
+  the same requirement to `#[warn]` / `#[allow]` / `#[expect]`
+  that lower an inherited level. When the rationale is
+  currently written as a comment, this rule fires first and
+  lifts the comment; the sibling rules then see the `reason`
+  field and stay silent.

--- a/planned-rules/lint-reason-from-comment.md
+++ b/planned-rules/lint-reason-from-comment.md
@@ -116,15 +116,27 @@ Text normalisation:
   rules. The escape helper is described under "Implementation
   notes".
 
-Splice into the attribute:
+Splice into the attribute. The insertion site and surrounding
+punctuation depend on the attribute's existing layout — the
+three cases match
+[`lint-silence-reason`](./lint-silence-reason.md)'s autofix:
 
-- Insert `, reason = "<normalised, escaped text>"` immediately
-  before the closing `)` of the attribute's argument list (for a
-  `cfg_attr`-wrapped attribute, the *inner* lint attribute's
-  closing `)`, not the outer `cfg_attr`'s).
-- Delete the original comment span. If the comment was on its
-  own line and removing it leaves the line blank, delete the
-  whole line.
+- **Single line, no trailing comma**: insert
+  `, reason = "<text>"` before the closing `)`.
+- **Single line, trailing comma**: insert
+  ` reason = "<text>",` before the closing `)`.
+- **Multi-line**: insert a new line `reason = "<text>",`
+  immediately before the line carrying the closing `)`,
+  matching the indentation of the preceding argument. If the
+  last argument on its own line lacks a trailing comma, add
+  one when inserting.
+
+For a `cfg_attr`-wrapped attribute, the target is the *inner*
+lint attribute's closing `)`, not the outer `cfg_attr`'s.
+
+Then delete the original comment span. If the comment was on
+its own line and removing it leaves the line blank, delete the
+whole line.
 
 `Applicability::MachineApplicable` for trailing comments — the
 attachment is unambiguous. `Applicability::MaybeIncorrect` for

--- a/planned-rules/lint-silence-reason.md
+++ b/planned-rules/lint-silence-reason.md
@@ -86,6 +86,16 @@ fn build_fetcher(/* ... */) {}
 ```
 
 ```rust
+// Bad — `reason` present but shorter than `min_reason_length`
+#[allow(clippy::too_many_arguments, reason = "x")]
+fn build_fetcher(/* ... */) {}
+
+// Good
+#[allow(clippy::too_many_arguments, reason = "matches pnpm's signature")]
+fn build_fetcher(/* ... */) {}
+```
+
+```rust
 // Not flagged by this rule — `#[warn]` is out of scope here.
 // `lint-downgrade-reason` decides whether the `warn` is a
 // relaxation relative to ambient policy.
@@ -149,9 +159,11 @@ min_reason_length = 3
   attributes, walk into the `cfg_attr` argument list and apply
   the same match to each inner attribute — `src/enclosing_hir.rs`
   carries the established walker shape; reuse it here.
-- Use `src/common.rs::attr_has_reason` to check whether the
-  attribute already carries a `reason = "<str>"` field; if
-  absent, emit at the attribute's span.
+- Use `src/common.rs::attr_has_reason` to retrieve the `reason`
+  field. If absent, emit the "missing reason" diagnostic at the
+  attribute's span. If present, compare the literal's length
+  against `min_reason_length`; if shorter, emit the "reason too
+  short" diagnostic at the literal's span.
 - Per-named-lint handling: an attribute that names multiple
   lints (`#[allow(a, b)]`) is treated as a single relaxation
   for diagnostic purposes — one missing `reason` triggers one

--- a/planned-rules/lint-silence-reason.md
+++ b/planned-rules/lint-silence-reason.md
@@ -133,10 +133,12 @@ exempt_lints = [
     # "clippy::module_name_repetitions",
 ]
 
-# Minimum length of the `reason` value. A one-word reason
-# ("legacy", "TODO") satisfies the literal requirement but
-# conveys little; this knob enforces a useful floor. Set to 0 to
-# disable.
+# Minimum length of the `reason` value. A one- or two-character
+# reason ("x", "ok") satisfies the literal presence requirement
+# but conveys nothing; the default floor of 3 excludes those
+# cases. Projects that want a higher bar (e.g. require a full
+# sentence) can raise it. Set to 0 to disable the length branch
+# entirely.
 min_reason_length = 3
 ```
 
@@ -167,8 +169,10 @@ min_reason_length = 3
 ### Difficulty
 
 **Easy.** A single attribute walk that reads the meta-item list
-for `reason = "<str>"`. The autofix span is the closing `)` of
-the attribute list, plus the inserted bytes `, reason = ""`.
+for `reason = "<str>"`. The autofix anchors at the closing `)`
+of the attribute list; the three layout cases in "Autofix"
+(single-line bare, single-line with trailing comma, multi-line)
+are all simple textual splices.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
   for cross-cutting conventions that apply to every rule in this

--- a/planned-rules/lint-silence-reason.md
+++ b/planned-rules/lint-silence-reason.md
@@ -95,20 +95,28 @@ pub fn parse(/* ... */) {}
 
 ## Autofix
 
-For the missing-reason case: insert `, reason = ""` immediately
-before the closing `)` of the attribute's argument list.
-`Applicability::HasPlaceholders` — the empty string is a
-placeholder the author fills in.
+For the missing-reason case, insert a new `reason = ""` entry
+into the attribute's argument list. `Applicability::HasPlaceholders`
+— the empty string is a placeholder the author fills in. The
+insertion site and surrounding punctuation depend on the
+attribute's existing layout:
+
+- **Single line, no trailing comma**
+  (`#[allow(foo)]`): insert `, reason = ""` before the closing
+  `)`, producing `#[allow(foo, reason = "")]`.
+- **Single line, trailing comma**
+  (`#[allow(foo,)]`): insert ` reason = "",` before the closing
+  `)`, producing `#[allow(foo, reason = "",)]`.
+- **Multi-line**: insert a new line `reason = "",` immediately
+  before the line carrying the closing `)`, matching the
+  indentation of the preceding argument. If the last argument
+  on its own line lacks a trailing comma, add one when inserting.
 
 For a `cfg_attr`-wrapped lint attribute
-(`#[cfg_attr(<cfg>, allow(...))]`), the closing `)` targeted is
-the *inner* `allow(...)` / `expect(...)` argument list, not the
-outer `cfg_attr` one. The inner-attribute form `#![allow(...)]`
-uses the same insertion point as the outer form.
-
-If the attribute is laid out across multiple lines, the
-suggestion keeps the `reason` entry on its own line matching the
-existing indentation.
+(`#[cfg_attr(<cfg>, allow(...))]`), the *inner* `allow(...)` /
+`expect(...)` argument list is the target, not the outer
+`cfg_attr` one. The inner-attribute form `#![allow(...)]` uses
+the same insertion mechanic as the outer form.
 
 The too-short case has no autofix: the lint cannot synthesise a
 longer rationale on the author's behalf. The diagnostic points
@@ -139,10 +147,9 @@ min_reason_length = 3
   attributes, walk into the `cfg_attr` argument list and apply
   the same match to each inner attribute — `src/enclosing_hir.rs`
   carries the established walker shape; reuse it here.
-- Iterate `attr.meta_item_list()` (or the equivalent inner
-  meta-item list for `cfg_attr`-wrapped attributes) and check
-  whether any item has the shape `reason = "<str>"`. If absent,
-  emit at the attribute's span.
+- Use `src/common.rs::attr_has_reason` to check whether the
+  attribute already carries a `reason = "<str>"` field; if
+  absent, emit at the attribute's span.
 - Per-named-lint handling: an attribute that names multiple
   lints (`#[allow(a, b)]`) is treated as a single relaxation
   for diagnostic purposes — one missing `reason` triggers one

--- a/planned-rules/lint-silence-reason.md
+++ b/planned-rules/lint-silence-reason.md
@@ -42,8 +42,10 @@ This is a stylistic preference, not a correctness issue.
 ## What to lint
 
 For every `#[allow(<lints>, ...)]` or `#[expect(<lints>, ...)]`
-attribute, check whether any nested meta item has the shape
-`reason = "<str>"`:
+attribute, first filter against `exempt_lints`: if every lint
+named in the attribute is on the configured exempt list, the
+attribute is not flagged. Otherwise, check whether any nested
+meta item has the shape `reason = "<str>"`:
 
 - **Absent.** Emit a "missing reason" diagnostic at the
   attribute's span.
@@ -93,9 +95,10 @@ pub fn parse(/* ... */) {}
 
 ## Autofix
 
-Insert `, reason = ""` immediately before the closing `)` of the
-attribute's argument list. `Applicability::HasPlaceholders` —
-the empty string is a placeholder the author fills in.
+For the missing-reason case: insert `, reason = ""` immediately
+before the closing `)` of the attribute's argument list.
+`Applicability::HasPlaceholders` — the empty string is a
+placeholder the author fills in.
 
 For a `cfg_attr`-wrapped lint attribute
 (`#[cfg_attr(<cfg>, allow(...))]`), the closing `)` targeted is
@@ -106,6 +109,10 @@ uses the same insertion point as the outer form.
 If the attribute is laid out across multiple lines, the
 suggestion keeps the `reason` entry on its own line matching the
 existing indentation.
+
+The too-short case has no autofix: the lint cannot synthesise a
+longer rationale on the author's behalf. The diagnostic points
+at the `reason` literal's span; the author rewrites it.
 
 ## Configuration
 

--- a/planned-rules/lint-silence-reason.md
+++ b/planned-rules/lint-silence-reason.md
@@ -43,8 +43,17 @@ This is a stylistic preference, not a correctness issue.
 
 For every `#[allow(<lints>, ...)]` or `#[expect(<lints>, ...)]`
 attribute, check whether any nested meta item has the shape
-`reason = "<str>"`. If absent, emit a diagnostic at the
-attribute's span.
+`reason = "<str>"`:
+
+- **Absent.** Emit a "missing reason" diagnostic at the
+  attribute's span.
+- **Present but shorter than `min_reason_length` (default 3).**
+  Emit a "reason too short" diagnostic at the `reason` literal's
+  span. A one-character `reason = "x"` satisfies the literal
+  presence requirement but conveys no rationale; the length
+  floor exists to catch this. Set `min_reason_length = 0` to
+  disable the length branch entirely (presence still enforced).
+- **Present and long enough.** Accept.
 
 `#[warn]`, `#[deny]`, and `#[forbid]` are not in scope for this
 rule. A `#[warn]` that lowers an inherited `#[deny]` *is* a
@@ -85,8 +94,14 @@ pub fn parse(/* ... */) {}
 ## Autofix
 
 Insert `, reason = ""` immediately before the closing `)` of the
-argument list. `Applicability::HasPlaceholders` — the empty
-string is a placeholder the author fills in.
+attribute's argument list. `Applicability::HasPlaceholders` —
+the empty string is a placeholder the author fills in.
+
+For a `cfg_attr`-wrapped lint attribute
+(`#[cfg_attr(<cfg>, allow(...))]`), the closing `)` targeted is
+the *inner* `allow(...)` / `expect(...)` argument list, not the
+outer `cfg_attr` one. The inner-attribute form `#![allow(...)]`
+uses the same insertion point as the outer form.
 
 If the attribute is laid out across multiple lines, the
 suggestion keeps the `reason` entry on its own line matching the
@@ -113,10 +128,14 @@ min_reason_length = 3
 ## Implementation notes
 
 - `EarlyLintPass::check_attribute`. Match `attr.path` against
-  `sym::allow` and `sym::expect`. Iterate
-  `attr.meta_item_list()` and check whether any item has the
-  shape `reason = "<str>"`. If absent, emit at the attribute's
-  span.
+  `sym::allow` and `sym::expect`. For `cfg_attr`-wrapped lint
+  attributes, walk into the `cfg_attr` argument list and apply
+  the same match to each inner attribute — `src/enclosing_hir.rs`
+  carries the established walker shape; reuse it here.
+- Iterate `attr.meta_item_list()` (or the equivalent inner
+  meta-item list for `cfg_attr`-wrapped attributes) and check
+  whether any item has the shape `reason = "<str>"`. If absent,
+  emit at the attribute's span.
 - Per-named-lint handling: an attribute that names multiple
   lints (`#[allow(a, b)]`) is treated as a single relaxation
   for diagnostic purposes — one missing `reason` triggers one
@@ -125,9 +144,11 @@ min_reason_length = 3
   per-attribute set; if every named lint is exempt, the
   attribute is not flagged.
 - The `reason`-presence check is shared with
+  [`lint-reason-from-comment`](./lint-reason-from-comment.md)
+  and
   [`lint-downgrade-reason`](./lint-downgrade-reason.md). Factor
-  it into `src/common.rs::attr_has_reason` the first time
-  either rule lands.
+  it into `src/common.rs::attr_has_reason` the first time any
+  of the three rules lands.
 
 ### Difficulty
 

--- a/planned-rules/lint-silence-reason.md
+++ b/planned-rules/lint-silence-reason.md
@@ -1,0 +1,165 @@
+# `lint_silence_reason`
+
+**Source:** project convention.
+
+## Statement
+
+Every `#[allow(<lints>)]` and `#[expect(<lints>)]` attribute must
+carry an explanatory `reason = "..."` field. `#[allow]` and
+`#[expect]` are the two levels that fully silence a lint's
+output; the project's record of suppressions needs to know why
+each one exists.
+
+The check is purely local — the attribute itself — and does not
+depend on any inherited or ambient lint level. The
+ancestry-aware case (a `#[warn]` lowering an inherited `#[deny]`,
+etc.) is covered by the sibling
+[`lint-downgrade-reason`](./lint-downgrade-reason.md).
+
+## Why restrict this?
+
+This is a stylistic preference, not a correctness issue.
+
+- Suppressions outlive the conditions that justify them. A bare
+  `#[allow(clippy::too_many_arguments)]` told the original
+  author to ignore a complaint; six months later, no one knows
+  whether the rationale was "matches upstream signature",
+  "intentional over-engineering", or "we'll fix it in the next
+  refactor". The `reason` field records intent at the moment of
+  suppression.
+- Diagnostics render the `reason` in the lint message when the
+  suppression is queried — e.g., the
+  `unfulfilled_lint_expectations` note on a stale `#[expect]`
+  shows the original rationale alongside the "no longer applies"
+  message.
+- The rule is the cheapest in this cluster to enforce
+  (`EarlyLintPass`, no resolution, no ancestry walk) and the
+  one with the highest hit rate in practice: most suppressions
+  in a typical codebase are of clippy lints whose default level
+  is `warn`, all of which are silenced by `#[allow]` /
+  `#[expect]`.
+
+## What to lint
+
+For every `#[allow(<lints>, ...)]` or `#[expect(<lints>, ...)]`
+attribute, check whether any nested meta item has the shape
+`reason = "<str>"`. If absent, emit a diagnostic at the
+attribute's span.
+
+`#[warn]`, `#[deny]`, and `#[forbid]` are not in scope for this
+rule. A `#[warn]` that lowers an inherited `#[deny]` *is* a
+relaxation and needs a reason, but detecting it requires the
+ancestry walk that
+[`lint-downgrade-reason`](./lint-downgrade-reason.md) owns.
+
+## Examples
+
+```rust
+// Bad
+#[allow(clippy::too_many_arguments)]
+fn build_fetcher(/* ... */) {}
+
+// Good
+#[allow(clippy::too_many_arguments, reason = "matches pnpm's signature")]
+fn build_fetcher(/* ... */) {}
+```
+
+```rust
+// Bad — `expect` without reason
+#[expect(clippy::too_many_arguments)]
+fn build_fetcher(/* ... */) {}
+
+// Good
+#[expect(clippy::too_many_arguments, reason = "matches pnpm's signature")]
+fn build_fetcher(/* ... */) {}
+```
+
+```rust
+// Not flagged by this rule — `#[warn]` is out of scope here.
+// `lint-downgrade-reason` decides whether the `warn` is a
+// relaxation relative to ambient policy.
+#[warn(clippy::missing_errors_doc)]
+pub fn parse(/* ... */) {}
+```
+
+## Autofix
+
+Insert `, reason = ""` immediately before the closing `)` of the
+argument list. `Applicability::HasPlaceholders` — the empty
+string is a placeholder the author fills in.
+
+If the attribute is laid out across multiple lines, the
+suggestion keeps the `reason` entry on its own line matching the
+existing indentation.
+
+## Configuration
+
+```toml
+[lint_silence_reason]
+# Lints excluded from the requirement. Useful for project-wide
+# suppressions whose rationale lives in the project README rather
+# than per-site.
+exempt_lints = [
+    # "clippy::module_name_repetitions",
+]
+
+# Minimum length of the `reason` value. A one-word reason
+# ("legacy", "TODO") satisfies the literal requirement but
+# conveys little; this knob enforces a useful floor. Set to 0 to
+# disable.
+min_reason_length = 3
+```
+
+## Implementation notes
+
+- `EarlyLintPass::check_attribute`. Match `attr.path` against
+  `sym::allow` and `sym::expect`. Iterate
+  `attr.meta_item_list()` and check whether any item has the
+  shape `reason = "<str>"`. If absent, emit at the attribute's
+  span.
+- Per-named-lint handling: an attribute that names multiple
+  lints (`#[allow(a, b)]`) is treated as a single relaxation
+  for diagnostic purposes — one missing `reason` triggers one
+  message regardless of how many lints the attribute lists.
+  Configuration entries in `exempt_lints` filter the
+  per-attribute set; if every named lint is exempt, the
+  attribute is not flagged.
+- The `reason`-presence check is shared with
+  [`lint-downgrade-reason`](./lint-downgrade-reason.md). Factor
+  it into `src/common.rs::attr_has_reason` the first time
+  either rule lands.
+
+### Difficulty
+
+**Easy.** A single attribute walk that reads the meta-item list
+for `reason = "<str>"`. The autofix span is the closing `)` of
+the attribute list, plus the inserted bytes `, reason = ""`.
+
+- See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  for cross-cutting conventions that apply to every rule in this
+  catalogue, in particular the lint-name namespacing
+  (`perfectionist::*`) that every registered lint follows.
+
+## Severity
+
+Warn.
+
+## Interaction with sibling rules
+
+- [`lint-reason-from-comment`](./lint-reason-from-comment.md)
+  lifts an adjacent comment into the attribute's `reason`
+  field. When the author has already written the rationale as a
+  comment, that rule fires first and satisfies this one
+  preemptively.
+- [`prefer-expect-over-allow`](./prefer-expect-over-allow.md)
+  rewrites `#[allow]` to `#[expect]`. The two rewrites apply to
+  overlapping attribute sets; the canonical end state is
+  `#[expect(<lint>, reason = "...")]`.
+- [`lint-downgrade-reason`](./lint-downgrade-reason.md) covers
+  the ancestry-aware case (a `#[warn]` lowering an inherited
+  `#[deny]`, etc.). The two rules together cover every
+  relaxation: local silencing here, relative downgrade there.
+  When both are enabled, an `#[allow]` / `#[expect]` whose
+  inherited level is `warn` or `deny` is flagged by both — the
+  rules deduplicate via a shared attribute-already-flagged
+  guard.

--- a/planned-rules/prefer-expect-over-allow.md
+++ b/planned-rules/prefer-expect-over-allow.md
@@ -43,10 +43,11 @@ in the attribute is one of:
   follow the standard fire-deterministically semantics).
 
 …propose `#[expect(...)]` in its place. If the attribute mixes a
-rewriteable lint with a non-rewriteable one (e.g.,
-`#[allow(dead_code, clippy::too_many_arguments)]`), split it: keep
-the non-rewriteable names under `#[allow]`, move the rewriteable
-ones to a new `#[expect]`.
+rewriteable lint with a non-rewriteable one (an exempt-list entry
+or an unknown lint, both treated as non-rewriteable for split
+purposes — e.g., `#[allow(dead_code, clippy::too_many_arguments)]`),
+split it: keep the non-rewriteable names under `#[allow]`, move
+the rewriteable ones to a new `#[expect]`.
 
 ## When `#[allow]` stays
 
@@ -160,8 +161,8 @@ apply_to_tool_namespaces = true
 ### Difficulty
 
 **Medium.** Detection is straightforward: read the attribute path,
-list the inner lint names, classify each. The simple autofix is a
-five-byte substitution.
+list the inner lint names, classify each. The simple autofix is
+a one-identifier substitution (`allow` → `expect`).
 
 What pushes this past "easy" is the eligibility decision. Some
 lints fire only in some compilations — `dead_code`, `unused_*`,

--- a/planned-rules/prefer-expect-over-allow.md
+++ b/planned-rules/prefer-expect-over-allow.md
@@ -32,8 +32,10 @@ This is a stylistic preference, not a correctness issue.
 
 ## What to lint
 
-For every `#[allow(<lints>, ...)]` attribute, if every lint named
-in the attribute is one of:
+For every `#[allow(<lints>, ...)]` attribute — including the
+inner-attribute form `#![allow(...)]` and the `cfg_attr`-wrapped
+form `#[cfg_attr(<cfg>, allow(...))]` — if every lint named in
+the attribute is one of:
 
 - A built-in rustc lint (`unused_variables`, `dead_code`, …) not
   on the exempt list below.
@@ -54,9 +56,15 @@ the rewriteable ones to a new `#[expect]`.
 Two cases the rule does not flag:
 
 - The attribute names a lint that is known not to fire
-  deterministically. `dead_code`, `unused_imports`,
-  `unused_macros`, and `unused_variables` are exempt by default
-  because their firing depends on which `cfg` arms compile.
+  deterministically. The default exempt set is the
+  `cfg`-conditional `unused_*` and reachability lints:
+  `dead_code`, `unused_imports`, `unused_macros`,
+  `unused_variables`, `unused_mut`, `unused_assignments`,
+  `unused_must_use`, and `unreachable_code`. All of these can
+  fire under one `cfg` arm and stay silent under another, so a
+  mechanical `expect` rewrite would break the build in the
+  silent arm. Projects extend or trim this set via
+  `exempt_lints`.
 - The attribute is `#![allow(...)]` at the crate root or on a
   whole module. `cfg`-conditional bodies inside the module may
   individually fire or not fire the lint, and `#[expect]` at this
@@ -64,6 +72,13 @@ Two cases the rule does not flag:
   — a fragile invariant. Configurable; default `false`.
 
 ## Examples
+
+The examples below already carry a `reason` field so that the
+only difference between Bad and Good is the `allow` → `expect`
+swap. The `reason`-presence requirement is enforced by the
+sibling [`lint-silence-reason`](./lint-silence-reason.md), not
+by this rule; an `#[allow]` without `reason` would be flagged by
+both rules independently.
 
 ```rust
 // Bad
@@ -106,6 +121,11 @@ fn scaffold(/* ... */) {}
 Replace the attribute path identifier `allow` with `expect`. The
 rewrite span is the five bytes `allow`.
 
+For a `cfg_attr`-wrapped lint attribute, the span targets the
+inner `allow` identifier inside the `cfg_attr` argument list,
+not the outer `cfg_attr` path. The cfg-arm scoping is preserved
+unchanged; only the inner level identifier moves.
+
 For the split case (mixed exempt and rewriteable lints), the
 autofix is a multi-attribute rewrite: replace the original
 attribute with two attributes, copying the `reason` field to each.
@@ -128,6 +148,10 @@ exempt_lints = [
     "unused_imports",
     "unused_macros",
     "unused_variables",
+    "unused_mut",
+    "unused_assignments",
+    "unused_must_use",
+    "unreachable_code",
 ]
 
 # When true, also rewrite crate-level `#![allow(...)]` and
@@ -145,7 +169,10 @@ apply_to_tool_namespaces = true
 
 - `EarlyLintPass::check_attribute`. Match `AttrKind::Normal` with
   `attr.path == sym::allow` and a non-empty
-  `attr.meta_item_list()`.
+  `attr.meta_item_list()`. For `cfg_attr`-wrapped lint
+  attributes, walk into the `cfg_attr` argument list and apply
+  the same match to each inner attribute — `src/enclosing_hir.rs`
+  carries the established walker shape; reuse it here.
 - For each nested meta item, classify the lint name:
   - **Built-in:** the name resolves through `LintStore::find_lints`
     to a lint registered with no tool prefix.

--- a/planned-rules/prefer-expect-over-allow.md
+++ b/planned-rules/prefer-expect-over-allow.md
@@ -196,9 +196,13 @@ Warn.
   an adjacent comment into the attribute's `reason` field before
   this rule rewrites `allow` → `expect`. The two rewrites
   compose in either order.
-- [`lint-downgrade-reason`](./lint-downgrade-reason.md)'s
-  `silenced_without_reason` sub-lint requires a `reason` field on
-  every `#[allow]` and `#[expect]`. After this rule rewrites
-  `allow` → `expect`, the `reason` requirement still applies; the
-  two rules together produce the canonical form
-  `#[expect(<lint>, reason = "...")]`.
+- [`lint-silence-reason`](./lint-silence-reason.md) requires a
+  `reason` field on every `#[allow]` and `#[expect]`. After this
+  rule rewrites `allow` → `expect`, the `reason` requirement
+  still applies; the two rules together produce the canonical
+  form `#[expect(<lint>, reason = "...")]`.
+- [`lint-downgrade-reason`](./lint-downgrade-reason.md) is
+  orthogonal: it cares about the level relative to the
+  inherited level, and `allow` and `expect` rank equally in
+  that comparison, so this rule's rewrite does not change
+  whether it fires.

--- a/planned-rules/prefer-expect-over-allow.md
+++ b/planned-rules/prefer-expect-over-allow.md
@@ -33,9 +33,10 @@ This is a stylistic preference, not a correctness issue.
 ## What to lint
 
 For every `#[allow(<lints>, ...)]` attribute — including the
-inner-attribute form `#![allow(...)]` and the `cfg_attr`-wrapped
-form `#[cfg_attr(<cfg>, allow(...))]` — if every lint named in
-the attribute is one of:
+`cfg_attr`-wrapped form `#[cfg_attr(<cfg>, allow(...))]`, and
+the inner-attribute form `#![allow(...)]` *when
+`apply_to_outer_scopes = true`* — if every lint named in the
+attribute is one of:
 
 - A built-in rustc lint (`unused_variables`, `dead_code`, …) not
   on the exempt list below.

--- a/planned-rules/prefer-expect-over-allow.md
+++ b/planned-rules/prefer-expect-over-allow.md
@@ -1,0 +1,204 @@
+# `prefer_expect_over_allow`
+
+**Source:** project convention.
+
+## Statement
+
+Prefer `#[expect(...)]` over `#[allow(...)]` wherever the
+expectation will be fulfilled. `#[expect]` triggers
+`unfulfilled_lint_expectations` at the next compilation if the
+lint stops firing — the suppression becomes self-cleaning.
+`#[allow]` stays silent forever, including after the underlying
+issue is resolved.
+
+## Why restrict this?
+
+This is a stylistic preference, not a correctness issue.
+
+- A suppression often outlives the problem it suppressed.
+  `#[allow]` has no signal when the underlying lint stops firing,
+  so a project accumulates `#[allow]` attributes that no longer
+  apply.
+- `#[expect]` emits `unfulfilled_lint_expectations` the moment the
+  named lint stops triggering at the site — exactly when the
+  suppression becomes dead. Routine compilation tells the author
+  to remove it.
+- The change is local: every `#[expect]` is also a self-test that
+  the lint *does* fire at the site, so a future refactor that
+  inadvertently fixes the issue is observed rather than hidden.
+- `#[allow]` remains appropriate when the lint cannot be relied on
+  to fire deterministically — see "When `#[allow]` stays". This
+  rule does not blanket-replace.
+
+## What to lint
+
+For every `#[allow(<lints>, ...)]` attribute, if every lint named
+in the attribute is one of:
+
+- A built-in rustc lint (`unused_variables`, `dead_code`, …) not
+  on the exempt list below.
+- A `clippy::*` lint.
+- A `rustdoc::*` lint.
+- A `perfectionist::*` lint (or any tool namespace whose lints
+  follow the standard fire-deterministically semantics).
+
+…propose `#[expect(...)]` in its place. If the attribute mixes a
+rewriteable lint with a non-rewriteable one (e.g.,
+`#[allow(dead_code, clippy::too_many_arguments)]`), split it: keep
+the non-rewriteable names under `#[allow]`, move the rewriteable
+ones to a new `#[expect]`.
+
+## When `#[allow]` stays
+
+Two cases the rule does not flag:
+
+- The attribute names a lint that is known not to fire
+  deterministically. `dead_code`, `unused_imports`,
+  `unused_macros`, and `unused_variables` are exempt by default
+  because their firing depends on which `cfg` arms compile.
+- The attribute is `#![allow(...)]` at the crate root or on a
+  whole module. `cfg`-conditional bodies inside the module may
+  individually fire or not fire the lint, and `#[expect]` at this
+  scope is fulfilled only if *some* item below it fires the lint
+  — a fragile invariant. Configurable; default `false`.
+
+## Examples
+
+```rust
+// Bad
+#[allow(clippy::too_many_arguments, reason = "matches pnpm's signature")]
+fn build_fetcher(/* ... */) {}
+
+// Good
+#[expect(clippy::too_many_arguments, reason = "matches pnpm's signature")]
+fn build_fetcher(/* ... */) {}
+```
+
+```rust
+// Not flagged — `dead_code` is on the default exempt list because
+// a `cfg(test)`-only use may keep the item alive in some builds
+// but not others.
+#[allow(dead_code, reason = "used only in integration tests")]
+struct InternalState;
+```
+
+```rust
+// Split — the rewriteable half moves; the exempt half stays.
+#[allow(
+    dead_code,
+    clippy::too_many_arguments,
+    reason = "scaffolding for the upcoming feature",
+)]
+fn scaffold(/* ... */) {}
+
+// →
+#[allow(dead_code, reason = "scaffolding for the upcoming feature")]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "scaffolding for the upcoming feature",
+)]
+fn scaffold(/* ... */) {}
+```
+
+## Autofix
+
+Replace the attribute path identifier `allow` with `expect`. The
+rewrite span is the five bytes `allow`.
+
+For the split case (mixed exempt and rewriteable lints), the
+autofix is a multi-attribute rewrite: replace the original
+attribute with two attributes, copying the `reason` field to each.
+
+`Applicability::MaybeIncorrect`. Even though the rewrite is
+mechanical, the cases where `#[expect]` is unsuitable
+(non-deterministic firing, `cfg`-gated bodies) cannot be detected
+from the call site alone. The autofix is shown as a help
+suggestion rather than applied automatically by `cargo fix`.
+
+## Configuration
+
+```toml
+[prefer_expect_over_allow]
+# Lints that are exempt — `#[allow]` for these stays. Names are
+# matched against the fully-namespaced lint name shown in
+# diagnostics (e.g. `clippy::too_many_arguments`).
+exempt_lints = [
+    "dead_code",
+    "unused_imports",
+    "unused_macros",
+    "unused_variables",
+]
+
+# When true, also rewrite crate-level `#![allow(...)]` and
+# module-level `#[allow(...)]` attributes. Default `false`
+# because `cfg`-conditional bodies inside the scope are common.
+apply_to_outer_scopes = false
+
+# When false, only `clippy::*`, `rustdoc::*`, and built-in lints
+# are rewritten; tool namespaces (`perfectionist::*` and similar)
+# are left alone.
+apply_to_tool_namespaces = true
+```
+
+## Implementation notes
+
+- `EarlyLintPass::check_attribute`. Match `AttrKind::Normal` with
+  `attr.path == sym::allow` and a non-empty
+  `attr.meta_item_list()`.
+- For each nested meta item, classify the lint name:
+  - **Built-in:** the name resolves through `LintStore::find_lints`
+    to a lint registered with no tool prefix.
+  - **`clippy::*` / `rustdoc::*` / `perfectionist::*`:**
+    tool-prefixed via `MetaItem::path.segments`.
+  - **Unknown:** bail; the lint may be a procedural plugin that
+    fires conditionally.
+- The default rewrite span covers only the `allow` identifier
+  inside `attr.path.segments[0].ident.span`. The split-attribute
+  rewrite spans the whole attribute and renders two replacement
+  attributes verbatim.
+
+### Difficulty
+
+**Medium.** Detection is straightforward: read the attribute path,
+list the inner lint names, classify each. The simple autofix is a
+five-byte substitution.
+
+What pushes this past "easy" is the eligibility decision. Some
+lints fire only in some compilations — `dead_code`, `unused_*`,
+`clippy::ptr_arg` under certain build configurations. Mechanically
+rewriting them to `#[expect]` turns a quiet suppression into a
+hard error in any configuration where the lint does not fire. The
+curated exempt list mitigates this for the well-known cases; the
+rule's autofix defaults to `MaybeIncorrect`. A project that
+enforces this rule in CI should run the cleanup behind a separate
+`cargo dylint --fix` invocation rather than batching it into a
+routine formatter pass.
+
+The split-attribute path (mixed exempt + rewriteable inputs) is
+the second source of complexity: the original attribute's
+`reason` field has to be copied to both replacement attributes,
+and any trailing comma / multi-line formatting has to be
+preserved. The rewrite is doable as a textual splice on the
+original span but the bookkeeping is worth its own helper.
+
+- See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  for cross-cutting conventions that apply to every rule in this
+  catalogue, in particular the lint-name namespacing
+  (`perfectionist::*`) that every registered lint follows.
+
+## Severity
+
+Warn.
+
+## Interaction with sibling rules
+
+- [`lint-reason-from-comment`](./lint-reason-from-comment.md) lifts
+  an adjacent comment into the attribute's `reason` field before
+  this rule rewrites `allow` → `expect`. The two rewrites
+  compose in either order.
+- [`lint-downgrade-reason`](./lint-downgrade-reason.md)'s
+  `silenced_without_reason` sub-lint requires a `reason` field on
+  every `#[allow]` and `#[expect]`. After this rule rewrites
+  `allow` → `expect`, the `reason` requirement still applies; the
+  two rules together produce the canonical form
+  `#[expect(<lint>, reason = "...")]`.

--- a/planned-rules/prefer-expect-over-allow.md
+++ b/planned-rules/prefer-expect-over-allow.md
@@ -34,9 +34,9 @@ This is a stylistic preference, not a correctness issue.
 
 For every `#[allow(<lints>, ...)]` attribute — including the
 `cfg_attr`-wrapped form `#[cfg_attr(<cfg>, allow(...))]`, and
-the inner-attribute form `#![allow(...)]` *when
-`apply_to_outer_scopes = true`* — if every lint named in the
-attribute is one of:
+(only when `apply_to_outer_scopes = true`) the inner-attribute
+form `#![allow(...)]` plus any outer `#[allow(...)]` placed on
+a module item — if every lint named in the attribute is one of:
 
 - A built-in rustc lint (`unused_variables`, `dead_code`, …) not
   on the exempt list below.


### PR DESCRIPTION
Planning files only — no rule code yet. Adds a new **Lint-level attributes** section to the index.

## Rules

- **`lint_reason_from_comment`** — when a lint-level attribute has an adjacent trailing or leading comment, lift the comment into `reason = "..."` and delete it. Motivating shape:

  ```rust
  // Bad
  #[allow(clippy::too_many_arguments)] // arg count is set by upstream pnpm's fetcher signature

  // Good
  #[allow(clippy::too_many_arguments, reason = "arg count is set by upstream pnpm's fetcher signature")]
  ```

- **`prefer_expect_over_allow`** — rewrite `#[allow]` to `#[expect]` for deterministic lints, with a curated exempt list (`dead_code`, `unused_*`) for lints whose firing depends on `cfg`. Mixed-eligibility attributes split.

- **`lint_silence_reason`** — every `#[allow]` / `#[expect]` must carry a `reason`. Local check, `EarlyLintPass`, no ancestry walk.

- **`lint_downgrade_reason`** — every `#[warn]` / `#[allow]` / `#[expect]` that lowers the *inherited* level (e.g., `#[warn]` under a crate-level `#![deny]`) must carry a `reason`. Ancestry-aware counterpart to `lint_silence_reason`, `LateLintPass`, needs `tcx.lint_level_at_node`.

## Difficulty

| Rule | Difficulty |
| --- | --- |
| `lint_reason_from_comment` | Easy |
| `prefer_expect_over_allow` | Medium |
| `lint_silence_reason` | Easy |
| `lint_downgrade_reason` | Hard |

Each file follows the catalogue's standard layout (Statement, Why restrict this?, What to lint, Examples, Autofix, Configuration, Implementation notes incl. `### Difficulty`, Severity, Interaction with sibling rules) and namespaces under `perfectionist::*` per `IMPLEMENTATION_CONVENTIONS.md`.