### PR TITLE
docs(readme): silencing unknown tool warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ Each lint registers under the `perfectionist` tool namespace. Suppress a finding
 #[expect(perfectionist::unicode_ellipsis_in_comments, reason = "3 ASCII dots would be incorrect here")]
 ```
 
+For the `perfectionist::*` path in the attribute above to be accepted, the compiler needs to know about the `perfectionist` tool namespace. Add the following to your crate root (e.g. `src/lib.rs` or `src/main.rs`):
+
+```rust
+#![cfg_attr(dylint_lib = "perfectionist", feature(register_tool))]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+```
+
+Both attributes are gated on `cfg(dylint_lib = "perfectionist")` so they only take effect when the dylint driver is loading this library; regular `cargo build` and `cargo check` runs ignore them and don't need a nightly toolchain.
+
+Then declare the `dylint_lib` cfg in `Cargo.toml` so `cargo check` doesn't warn about an unexpected cfg name:
+
+```toml
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("perfectionist"))'] }
+```
+
 ## Configuration
 
 Per-rule configuration is read from `dylint.toml` at the workspace root. The configuration knobs for each rule are documented in that rule's planning file. Once a rule is implemented, the same information is reproduced in its module documentation.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Each lint registers under the `perfectionist` tool namespace. Suppress a finding
 #[expect(perfectionist::unicode_ellipsis_in_comments, reason = "3 ASCII dots would be incorrect here")]
 ```
 
+<details>
+<summary>Boilerplate to make <code>#[expect(perfectionist::…)]</code> compile</summary>
+
 For the `perfectionist::*` path in the attribute above to be accepted, the compiler needs to know about the `perfectionist` tool namespace. Add the following to your crate root (e.g. `src/lib.rs` or `src/main.rs`):
 
 ```rust
@@ -46,6 +49,8 @@ Then declare the `dylint_lib` cfg in `Cargo.toml` so `cargo check` doesn't warn 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("perfectionist"))'] }
 ```
+
+</details>
 
 ## Configuration
 


### PR DESCRIPTION
The `#[expect(perfectionist::...)]` example a few lines above only compiles if the consuming crate declares the `perfectionist` tool namespace and silences `unexpected_cfgs` for the `dylint_lib` cfg gate. Document all three pieces so the suppression recipe works end-to-end without a hard error on stable or a warning under `cargo check`.