### PR TITLE
docs(ai): absolute vs. relative markdown links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,20 @@ The single exception is version-bump commits, whose subject is
 just the version itself (e.g. `0.0.0-rc.6`). Use this form only
 for commits that do nothing other than bump the version.
 
+## Markdown links
+
+`README.md` uses absolute links throughout, because it is
+rendered by multiple services (crates.io, docs.rs, lib.rs, etc.)
+that don't share a common base for resolving relative paths. Keep
+new links there absolute.
+
+Every other markdown file in the repository — `CLAUDE.md`,
+`planned-rules/*.md`, and anything else committed alongside the
+source — is only rendered in contexts where relative paths
+resolve correctly (GitHub, local editors, agent tooling). Prefer
+relative links in those files; they survive repository renames
+and don't bake in a hosting URL.
+
 ## Symlinks
 
 This file is the authoritative implementation guide. It is also


### PR DESCRIPTION
Adds a "Markdown links" section to `CLAUDE.md` documenting the convention already used in the repository:

- `README.md` uses absolute links because it's rendered by crates.io, docs.rs, lib.rs, etc., which don't share a base for resolving relative paths.
- Every other markdown file (`CLAUDE.md`, `planned-rules/*.md`, …) is only rendered where relative paths resolve correctly, so prefer relative links there.

Doc-only change; no code touched.