### PR TITLE
feat(macro-argument-binding): core/std compile-time macros

### DIFF
--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -178,13 +178,15 @@ The lint accepts any argument whose outermost shape is one of:
   evaluate-once-vs.-zero hazard the rule is built to catch.
   Match is tail-segment-keyed: `env!`, `std::env!`, and
   `::core::env!` all match the `"env"` entry. The macro's
-  body contents are not inspected — by construction the
-  built-in macros accept only literals or other compile-time
-  macro calls, so there is nothing for the surrounding rule
-  to mis-classify there. Curly-delimited inner macros
-  (`name! { ... }`) do *not* qualify; the rule treats those
-  as DSL bodies, the same way it treats the outer call's
-  curly form.
+  body contents are not inspected. The justification isn't
+  that the input shape is restricted — `stringify!` accepts
+  arbitrary tokens and `cfg!` accepts cfg predicates — but
+  that none of these macros evaluates a runtime user
+  expression in the first place, so there is nothing for
+  the surrounding rule to drop or duplicate regardless of
+  what's inside. Curly-delimited inner macros (`name! { ... }`)
+  do *not* qualify; the rule treats those as DSL bodies, the
+  same way it treats the outer call's curly form.
 
 Everything else is non-trivial: function and method calls, `?`,
 `.await`, macro invocations, blocks, control-flow expressions,
@@ -256,20 +258,37 @@ Three name-set lookups decide each invocation:
    → accept unconditionally.
 3. **Neither** → flag every non-trivial argument.
 
-The default allow list tracks the curated set in
-[`macro-trailing-comma`](./macro-trailing-comma.md), with the
-conditional-evaluation families (`log::*`, `tracing::*`)
-removed: `format!`, `format_args!`, `print!`, `println!`,
-`eprint!`, `eprintln!`, `write!`, `writeln!`, `vec!`,
-`panic!`, `unimplemented!`, `todo!`, `unreachable!`,
+The default allow list has two parts.
+
+The first part overlaps with
+[`macro-trailing-comma`](./macro-trailing-comma.md)'s built-in
+set, minus the conditional-evaluation families (`log::*`,
+`tracing::*`) that *do* drop arguments below the configured
+filter level: `format!`, `format_args!`, `print!`,
+`println!`, `eprint!`, `eprintln!`, `write!`, `writeln!`,
+`vec!`, `panic!`, `unimplemented!`, `todo!`, `unreachable!`,
 `assert!`, `assert_eq!`, `assert_ne!`, `matches!`, `dbg!`,
-`anyhow!`, and similar. The `core` / `std` compile-time
-macro family is on the same allow list, because their
-arguments are literals or other compile-time macro calls
-with no observable evaluation order: `concat!`, `env!`,
-`option_env!`, `include!`, `include_str!`, `include_bytes!`,
-`stringify!`, `cfg!`, `compile_error!`, `line!`, `column!`,
-`file!`, `module_path!`, `is_x86_feature_detected!`.
+`anyhow!`, and similar. These are runtime macros whose
+matchers promise exactly-once evaluation per top-level
+argument.
+
+The second part adds `core` / `std` macros whose top-level
+argument simply isn't a runtime expression — `stringify!`
+takes a token sequence, `cfg!` takes a cfg predicate, the
+`env!` / `option_env!` / `include_str!` / `include_bytes!` /
+`include!` / `is_x86_feature_detected!` family takes a
+string literal, the `line!` / `column!` / `file!` /
+`module_path!` family takes no argument, and
+`compile_error!` aborts compilation — so there is no
+once-vs.-zero hazard for the rule to flag.
+`is_x86_feature_detected!` does perform a cached CPU check
+at runtime, but the lookup runs without any user-side
+argument evaluation, so it sits comfortably in the same
+group.
+
+`macro-trailing-comma`'s built-in list is intentionally
+narrower than this one; the two lists are not kept in
+lockstep.
 
 Flagging unlisted macros by default is deliberate: the rule
 isn't useful if every unrecognised proc macro gets a free pass.

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -5,9 +5,10 @@
 Partially implemented. Modes 0-2 (`deny_only`, `blanket`,
 `allow_and_deny`) ship today, along with the `enabled`,
 `deny_extra`, `allow_extra`, `ignore`, `extra_trivial_methods`,
-and `ignore_trivial_methods` knobs. The lint emits diagnostics
-with a `let`-binding hint (no autofix, by design — the binding
-name varies per site).
+`ignore_trivial_methods`, `extra_trivial_macros`, and
+`ignore_trivial_macros` knobs. The lint emits diagnostics with
+a `let`-binding hint (no autofix, by design — the binding name
+varies per site).
 
 Still pending:
 
@@ -165,6 +166,25 @@ The lint accepts any argument whose outermost shape is one of:
   calls, and method names outside the configured set stay
   non-trivial: `map.insert(k, v)`, `iter.next()`,
   `vec.try_into::<Foo>()` still flag.
+- A function-like or array-like invocation `name!(...)` /
+  `name![...]` of a curated trivial macro: `concat!`, `env!`,
+  `option_env!`, `include_str!`, `include_bytes!`,
+  `stringify!`, `cfg!`, `line!`, `column!`, `file!`,
+  `module_path!`, plus anything in `extra_trivial_macros`.
+  These expand to compile-time constants (a literal, a
+  `&'static str`, a `bool`, a span marker) with no runtime
+  side effect, so passing one to a surrounding `debug_assert*`
+  or any other macro does not introduce the
+  evaluate-once-vs.-zero hazard the rule is built to catch.
+  Match is tail-segment-keyed: `env!`, `std::env!`, and
+  `::core::env!` all match the `"env"` entry. The macro's
+  body contents are not inspected — by construction the
+  built-in macros accept only literals or other compile-time
+  macro calls, so there is nothing for the surrounding rule
+  to mis-classify there. Curly-delimited inner macros
+  (`name! { ... }`) do *not* qualify; the rule treats those
+  as DSL bodies, the same way it treats the outer call's
+  curly form.
 
 Everything else is non-trivial: function and method calls, `?`,
 `.await`, macro invocations, blocks, control-flow expressions,
@@ -243,7 +263,13 @@ removed: `format!`, `format_args!`, `print!`, `println!`,
 `eprint!`, `eprintln!`, `write!`, `writeln!`, `vec!`,
 `panic!`, `unimplemented!`, `todo!`, `unreachable!`,
 `assert!`, `assert_eq!`, `assert_ne!`, `matches!`, `dbg!`,
-`anyhow!`, and similar.
+`anyhow!`, and similar. The `core` / `std` compile-time
+macro family is on the same allow list, because their
+arguments are literals or other compile-time macro calls
+with no observable evaluation order: `concat!`, `env!`,
+`option_env!`, `include!`, `include_str!`, `include_bytes!`,
+`stringify!`, `cfg!`, `compile_error!`, `line!`, `column!`,
+`file!`, `module_path!`, `is_x86_feature_detected!`.
 
 Flagging unlisted macros by default is deliberate: the rule
 isn't useful if every unrecognised proc macro gets a free pass.
@@ -341,6 +367,18 @@ debug_assert_eq!(count, MAX_RETRIES, "expected {MAX_RETRIES} retries");
 let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Ordering::Relaxed));
 ```
 
+### Compile-time `core` / `std` macros pass through
+
+```rust
+// Accepted — `concat!`, `env!`, `include_str!`, and the rest of
+// the compile-time family are on the allow list, and their
+// expansion is itself a literal so they also count as trivial
+// atoms when used inside another macro. Both rules together
+// make these idioms invisible to the lint:
+let msg = concat!("home: ", env!("HOME"));
+debug_assert_eq!(env!("EXPECTED"), include_str!("expected.txt"));
+```
+
 ### Array-like invocation is in scope
 
 ```rust
@@ -434,6 +472,24 @@ extra_trivial_methods = [
 # not consider trivial.
 ignore_trivial_methods = [
   # "as_ref",
+]
+
+# Macro names treated as trivial atoms when they appear as
+# arguments to another macro, in addition to the built-in set
+# (`concat`, `env`, `option_env`, `include_str`, `include_bytes`,
+# `stringify`, `cfg`, `line`, `column`, `file`, `module_path`).
+# Add project-specific compile-time macros here so that, e.g.,
+# `debug_assert_eq!(literal_table!(KEY), expected)` stops flagging
+# the inner call.
+extra_trivial_macros = [
+  # "literal_table",
+]
+
+# Macro names to drop from the trivial-macro list, even if they
+# appear in the built-in defaults or in `extra_trivial_macros`.
+# Checked after the merge, so this knob always wins.
+ignore_trivial_macros = [
+  # "cfg",
 ]
 ```
 

--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -45,15 +45,22 @@ Trivial arguments — literals, paths, field accesses, indexing
 of trivial bases, dereferences, references, casts, the unit
 literal `()`, parenthesised / tuple groups whose elements are
 all trivial, binary chains of trivial operands joined by
-side-effect-free operators, and zero-arg method calls whose
-name is in the curated pure-getter set (`len`, `is_empty`,
+side-effect-free operators, zero-arg method calls whose name
+is in the curated pure-getter set (`len`, `is_empty`,
 `as_str`, `as_bytes`, `as_ref`, `as_mut`, `as_deref`,
-`as_slice`, plus anything in `extra_trivial_methods`) — are
-accepted as-is. A comparison like `vec.len() <= cap` evaluates
-the same way regardless of how many times the macro touches
-it, so binding it to a `let` would only force the comparison
-to run in release builds for no benefit. The lint focuses on
-arguments whose evaluation is itself observable.
+`as_slice`, plus anything in `extra_trivial_methods`), and
+calls to `core` / `std` macros whose expansion is a compile-
+time constant (`concat!`, `env!`, `option_env!`,
+`include_str!`, `include_bytes!`, `stringify!`, `cfg!`,
+`line!`, `column!`, `file!`, `module_path!`, plus anything in
+`extra_trivial_macros`) — are accepted as-is. A comparison
+like `vec.len() <= cap` evaluates the same way regardless of
+how many times the macro touches it, so binding it to a `let`
+would only force the comparison to run in release builds for
+no benefit; the same logic applies to `env!("HOME")` inside
+`debug_assert_eq!(...)` — there is nothing to evaluate at
+runtime. The lint focuses on arguments whose evaluation is
+itself observable.
 
 ## Example
 ```rust,ignore
@@ -112,6 +119,23 @@ wins. Useful for opting back into linting on a default entry
 the project does not consider trivial — for example, removing
 `as_ref` for a project that wraps it in a non-pure
 implementation.
+
+### `extra_trivial_macros`: `[string]` (optional)
+
+Macro names added to the built-in trivial-macro list. Each
+entry is matched against the invocation's final path segment
+(so `my_crate::const_str` matches by the `"const_str"` tail).
+A trivial-macro call passed as an argument to another macro is
+treated as a trivial atom — the rule does not propose binding
+it to a `let`. Use this knob for project-specific macros whose
+expansion is guaranteed to be a literal or other compile-time
+constant.
+
+### `ignore_trivial_macros`: `[string]` (optional)
+
+Macro names to drop from the trivial-macro list, even if they
+appear in the built-in defaults or in `extra_trivial_macros`.
+Checked after the merge, so this knob always wins.
 
 ### Types
 

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -17,7 +17,6 @@
 //! arguments, skip non-expression arguments, classify expressions,
 //! park violation spans for the late pass to emit.
 
-use std::collections::BTreeSet;
 use std::sync::Mutex;
 
 use rustc_ast::MacCall;
@@ -35,7 +34,9 @@ mod triviality;
 
 use config::MacroArgumentBinding;
 use late::MacroArgumentBindingLate;
-use triviality::{is_trivial_expression, looks_like_expression, split_top_level_arguments};
+use triviality::{
+    TrivialContext, is_trivial_expression, looks_like_expression, split_top_level_arguments,
+};
 
 declare_tool_lint! {
     /// ### What it does
@@ -76,15 +77,22 @@ declare_tool_lint! {
     /// of trivial bases, dereferences, references, casts, the unit
     /// literal `()`, parenthesised / tuple groups whose elements are
     /// all trivial, binary chains of trivial operands joined by
-    /// side-effect-free operators, and zero-arg method calls whose
-    /// name is in the curated pure-getter set (`len`, `is_empty`,
+    /// side-effect-free operators, zero-arg method calls whose name
+    /// is in the curated pure-getter set (`len`, `is_empty`,
     /// `as_str`, `as_bytes`, `as_ref`, `as_mut`, `as_deref`,
-    /// `as_slice`, plus anything in `extra_trivial_methods`) — are
-    /// accepted as-is. A comparison like `vec.len() <= cap` evaluates
-    /// the same way regardless of how many times the macro touches
-    /// it, so binding it to a `let` would only force the comparison
-    /// to run in release builds for no benefit. The lint focuses on
-    /// arguments whose evaluation is itself observable.
+    /// `as_slice`, plus anything in `extra_trivial_methods`), and
+    /// calls to `core` / `std` macros whose expansion is a compile-
+    /// time constant (`concat!`, `env!`, `option_env!`,
+    /// `include_str!`, `include_bytes!`, `stringify!`, `cfg!`,
+    /// `line!`, `column!`, `file!`, `module_path!`, plus anything in
+    /// `extra_trivial_macros`) — are accepted as-is. A comparison
+    /// like `vec.len() <= cap` evaluates the same way regardless of
+    /// how many times the macro touches it, so binding it to a `let`
+    /// would only force the comparison to run in release builds for
+    /// no benefit; the same logic applies to `env!("HOME")` inside
+    /// `debug_assert_eq!(...)` — there is nothing to evaluate at
+    /// runtime. The lint focuses on arguments whose evaluation is
+    /// itself observable.
     ///
     /// ### Example
     /// ```rust,ignore
@@ -146,20 +154,24 @@ impl EarlyLintPass for MacroArgumentBinding {
         let Some(arguments) = split_top_level_arguments(&mac_call.args.tokens) else {
             return;
         };
+        let ctx = TrivialContext {
+            methods: self.trivial_methods(),
+            macros: self.trivial_macros(),
+        };
         for argument in arguments {
-            check_argument(&argument, self.trivial_methods());
+            check_argument(&argument, ctx);
         }
     }
 }
 
-fn check_argument(argument: &[TokenTree], trivial_methods: &BTreeSet<String>) {
+fn check_argument(argument: &[TokenTree], ctx: TrivialContext<'_>) {
     if argument.is_empty() {
         return;
     }
     if !looks_like_expression(argument) {
         return;
     }
-    if is_trivial_expression(argument, trivial_methods) {
+    if is_trivial_expression(argument, ctx) {
         return;
     }
     let first = argument.first().expect("non-empty checked above");

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -23,7 +23,7 @@ const BUILTIN_DENY: &[&str] = &["debug_assert", "debug_assert_eq", "debug_assert
 
 /// Macros known to evaluate every top-level argument exactly once,
 /// plus the curated set of `core` / `std` macros that operate purely
-/// at compile time (`concat!`, `env!`, `include_str!`, …): their
+/// at compile time (`concat!`, `env!`, `include_str!`, ...): their
 /// arguments are either literals or other compile-time-pure macro
 /// calls, never runtime expressions whose evaluation order matters.
 /// The list mirrors the curated set in `macro_trailing_comma`, with

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -21,11 +21,17 @@ const CONFIG_KEY: &str = "perfectionist::macro_argument_binding";
 /// (`debug_assert*`) or to drop them entirely in release builds.
 const BUILTIN_DENY: &[&str] = &["debug_assert", "debug_assert_eq", "debug_assert_ne"];
 
-/// Macros known to evaluate every top-level argument exactly once. The
-/// list mirrors the curated set in `macro_trailing_comma`, with the
-/// conditional-evaluation families (`log::*`, `tracing::*`) removed
-/// because those *do* drop arguments below the configured filter level.
+/// Macros known to evaluate every top-level argument exactly once,
+/// plus the curated set of `core` / `std` macros that operate purely
+/// at compile time (`concat!`, `env!`, `include_str!`, …): their
+/// arguments are either literals or other compile-time-pure macro
+/// calls, never runtime expressions whose evaluation order matters.
+/// The list mirrors the curated set in `macro_trailing_comma`, with
+/// the conditional-evaluation families (`log::*`, `tracing::*`)
+/// removed because those *do* drop arguments below the configured
+/// filter level.
 const BUILTIN_ALLOW: &[&str] = &[
+    // Runtime macros that promise exactly-once evaluation per argument.
     "format",
     "format_args",
     "print",
@@ -45,6 +51,54 @@ const BUILTIN_ALLOW: &[&str] = &[
     "matches",
     "dbg",
     "anyhow",
+    // `core` / `std` compile-time macros. Each accepts only literals,
+    // identifiers, or other compile-time macro calls (and `is_x86_*` /
+    // `cfg!` accept only literal-shaped feature / cfg predicates).
+    // There is no observable evaluation order to disturb, so passing
+    // any expression — even a nested macro that itself produces a
+    // literal — is safe.
+    "cfg",
+    "column",
+    "compile_error",
+    "concat",
+    "env",
+    "file",
+    "include",
+    "include_bytes",
+    "include_str",
+    "is_x86_feature_detected",
+    "line",
+    "module_path",
+    "option_env",
+    "stringify",
+];
+
+/// `core` / `std` macros whose invocation expands to a value the
+/// compiler computes at build time — a literal, a `&'static str`, a
+/// byte string, a `bool` cfg verdict, a line / column / file marker.
+/// None evaluates a runtime expression, none has side effects, so an
+/// `inner!(...)` call to one of these is itself a trivial argument
+/// for the surrounding macro: it cannot be evaluated more than once
+/// at runtime no matter what the outer macro does with it.
+///
+/// `include!` is deliberately excluded — its expansion is arbitrary
+/// Rust code rather than a literal, so its triviality depends on the
+/// included file's contents and the rule cannot prove it.
+/// `compile_error!` is also excluded: its expansion is the diverging
+/// `!` type rather than a value, and the planning doc reserves the
+/// trivial-atom slot for value-producing macros.
+const BUILTIN_TRIVIAL_MACROS: &[&str] = &[
+    "cfg",
+    "column",
+    "concat",
+    "env",
+    "file",
+    "include_bytes",
+    "include_str",
+    "line",
+    "module_path",
+    "option_env",
+    "stringify",
 ];
 
 /// Zero-arg method names that are conventionally side-effect-free
@@ -118,6 +172,19 @@ pub(super) struct Config {
     /// `as_ref` for a project that wraps it in a non-pure
     /// implementation.
     pub ignore_trivial_methods: Vec<String>,
+    /// Macro names added to the built-in trivial-macro list. Each
+    /// entry is matched against the invocation's final path segment
+    /// (so `my_crate::const_str` matches by the `"const_str"` tail).
+    /// A trivial-macro call passed as an argument to another macro is
+    /// treated as a trivial atom — the rule does not propose binding
+    /// it to a `let`. Use this knob for project-specific macros whose
+    /// expansion is guaranteed to be a literal or other compile-time
+    /// constant.
+    pub extra_trivial_macros: Vec<String>,
+    /// Macro names to drop from the trivial-macro list, even if they
+    /// appear in the built-in defaults or in `extra_trivial_macros`.
+    /// Checked after the merge, so this knob always wins.
+    pub ignore_trivial_macros: Vec<String>,
 }
 
 impl Default for Config {
@@ -130,6 +197,8 @@ impl Default for Config {
             ignore: Vec::new(),
             extra_trivial_methods: Vec::new(),
             ignore_trivial_methods: Vec::new(),
+            extra_trivial_macros: Vec::new(),
+            ignore_trivial_macros: Vec::new(),
         }
     }
 }
@@ -155,6 +224,13 @@ pub(super) struct MacroArgumentBinding {
     /// consulted by the trivial-expression walker to accept
     /// `expr.method()` as a trivial postfix on a trivial base.
     trivial_methods: BTreeSet<String>,
+    /// Built-in trivial-macro list plus `extra_trivial_macros`,
+    /// consulted by the trivial-expression walker to accept
+    /// `inner!(...)` as a trivial atom when the macro's expansion
+    /// is a compile-time constant. Match is tail-segment-based:
+    /// an entry of `"env"` accepts `env!(...)`, `std::env!(...)`,
+    /// and `::core::env!(...)` alike.
+    trivial_macros: BTreeSet<String>,
 }
 
 impl MacroArgumentBinding {
@@ -170,6 +246,11 @@ impl MacroArgumentBinding {
             config.extra_trivial_methods,
             config.ignore_trivial_methods,
         );
+        let trivial_macros = merge_string_allowlist(
+            BUILTIN_TRIVIAL_MACROS,
+            config.extra_trivial_macros,
+            config.ignore_trivial_macros,
+        );
         Self {
             enabled: config.enabled,
             mode: config.mode,
@@ -178,6 +259,7 @@ impl MacroArgumentBinding {
             allow_extra: extra_allow,
             ignore,
             trivial_methods,
+            trivial_macros,
         }
     }
 
@@ -185,6 +267,13 @@ impl MacroArgumentBinding {
     /// on a trivial base are accepted as trivial postfixes.
     pub(super) fn trivial_methods(&self) -> &BTreeSet<String> {
         &self.trivial_methods
+    }
+
+    /// The merged set of macro names whose `inner!(...)` invocations
+    /// are accepted as trivial atoms. Matched by final path segment,
+    /// so a single-name entry covers fully-qualified call sites too.
+    pub(super) fn trivial_macros(&self) -> &BTreeSet<String> {
+        &self.trivial_macros
     }
 
     /// Path-side eligibility: combines the `enabled` switch, the

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -21,15 +21,30 @@ const CONFIG_KEY: &str = "perfectionist::macro_argument_binding";
 /// (`debug_assert*`) or to drop them entirely in release builds.
 const BUILTIN_DENY: &[&str] = &["debug_assert", "debug_assert_eq", "debug_assert_ne"];
 
-/// Macros known to evaluate every top-level argument exactly once,
-/// plus the curated set of `core` / `std` macros that operate purely
-/// at compile time (`concat!`, `env!`, `include_str!`, ...): their
-/// arguments are either literals or other compile-time-pure macro
-/// calls, never runtime expressions whose evaluation order matters.
-/// The list mirrors the curated set in `macro_trailing_comma`, with
-/// the conditional-evaluation families (`log::*`, `tracing::*`)
-/// removed because those *do* drop arguments below the configured
-/// filter level.
+/// Macros for which the call site is known not to introduce the
+/// "evaluate zero, one, or many times" hazard. Two disjoint groups:
+///
+/// 1. Runtime macros (`format!`, `vec!`, `assert!`, `dbg!`, …) that
+///    promise to evaluate every top-level argument exactly once.
+///    Shares its core with `macro_trailing_comma`'s built-in set,
+///    minus the conditional-evaluation families (`log::*`,
+///    `tracing::*`) that *do* drop arguments below the configured
+///    filter level.
+/// 2. `core` / `std` macros whose top-level argument simply isn't a
+///    runtime expression — `stringify!` takes a token sequence,
+///    `cfg!` takes a cfg predicate, the `env!` / `include_*` /
+///    `is_x86_feature_detected!` family takes a string literal, the
+///    `line!` / `column!` / `file!` / `module_path!` family takes
+///    no argument, `compile_error!` aborts compilation — or, in the
+///    matryoshka case from issue #71, is itself a call to another
+///    macro from this group. None of these evaluates a user
+///    expression at runtime, so no exactly-once-vs.-zero hazard
+///    surfaces at the call site.
+///
+/// `macro_trailing_comma`'s own built-in list is intentionally
+/// narrower than this one (it has no reason to care about
+/// `stringify!` / `cfg!` / `include_*` etc.); the two lists are not
+/// kept in lockstep.
 const BUILTIN_ALLOW: &[&str] = &[
     // Runtime macros that promise exactly-once evaluation per argument.
     "format",
@@ -51,12 +66,9 @@ const BUILTIN_ALLOW: &[&str] = &[
     "matches",
     "dbg",
     "anyhow",
-    // `core` / `std` compile-time macros. Each accepts only literals,
-    // identifiers, or other compile-time macro calls (and `is_x86_*` /
-    // `cfg!` accept only literal-shaped feature / cfg predicates).
-    // There is no observable evaluation order to disturb, so passing
-    // any expression — even a nested macro that itself produces a
-    // literal — is safe.
+    // `core` / `std` macros that do not evaluate a runtime user
+    // expression at the call site (see the doc comment above for
+    // the per-macro rationale).
     "cfg",
     "column",
     "compile_error",

--- a/src/rules/macro_argument_binding/triviality.rs
+++ b/src/rules/macro_argument_binding/triviality.rs
@@ -24,6 +24,19 @@ use rustc_ast::token::{Delimiter, IdentIsRaw, Token, TokenKind};
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
 use rustc_span::kw;
 
+/// Bundle of the two name-set tables the triviality walker consults:
+/// the pure-getter method names accepted as `.method()` postfixes,
+/// and the compile-time-pure macro names accepted as `name!(...)`
+/// atoms. Both are tail-segment-keyed (single-segment matching) and
+/// owned by the rule's [`super::config::MacroArgumentBinding`] state;
+/// passing them as one borrow keeps the recursive walker's signatures
+/// short.
+#[derive(Clone, Copy)]
+pub(super) struct TrivialContext<'a> {
+    pub methods: &'a BTreeSet<String>,
+    pub macros: &'a BTreeSet<String>,
+}
+
 /// Split the top-level token stream of a macro invocation into one
 /// segment per comma-separated argument. Returns `None` if a top-level
 /// `;` is encountered (the repeat form, `vec![v; count]`), which
@@ -146,25 +159,22 @@ fn is_dsl_marker(token: &Token) -> bool {
 /// Anything outside that grammar is non-trivial — including most
 /// `const fn` calls, generic method calls, and other "morally pure"
 /// expressions the walker cannot prove side-effect-free.
-pub(super) fn is_trivial_expression(
-    tokens: &[TokenTree],
-    trivial_methods: &BTreeSet<String>,
-) -> bool {
-    take_trivial_expression(tokens, trivial_methods).is_some_and(<[_]>::is_empty)
+pub(super) fn is_trivial_expression(tokens: &[TokenTree], ctx: TrivialContext<'_>) -> bool {
+    take_trivial_expression(tokens, ctx).is_some_and(<[_]>::is_empty)
 }
 
 fn take_trivial_expression<'a>(
     tokens: &'a [TokenTree],
-    trivial_methods: &BTreeSet<String>,
+    ctx: TrivialContext<'_>,
 ) -> Option<&'a [TokenTree]> {
-    let after_atom = take_trivial_atom(tokens, trivial_methods)?;
-    let after_suffix = take_trivial_suffixes(after_atom, trivial_methods);
-    Some(take_trivial_binary_tail(after_suffix, trivial_methods))
+    let after_atom = take_trivial_atom(tokens, ctx)?;
+    let after_suffix = take_trivial_suffixes(after_atom, ctx);
+    Some(take_trivial_binary_tail(after_suffix, ctx))
 }
 
 fn take_trivial_atom<'a>(
     tokens: &'a [TokenTree],
-    trivial_methods: &BTreeSet<String>,
+    ctx: TrivialContext<'_>,
 ) -> Option<&'a [TokenTree]> {
     let (head, rest) = tokens.split_first()?;
     match head {
@@ -180,7 +190,7 @@ fn take_trivial_atom<'a>(
         // runs pre-expansion and never sees invisible delimiters
         // in practice.
         TokenTree::Delimited(_, _, Delimiter::Parenthesis, inner) => {
-            if is_trivial_paren_inner(inner, trivial_methods) {
+            if is_trivial_paren_inner(inner, ctx) {
                 Some(rest)
             } else {
                 None
@@ -193,15 +203,24 @@ fn take_trivial_atom<'a>(
                 Some(rest)
             }
             // `&` expr or `&mut` expr.
-            TokenKind::And => take_reference_tail(rest, trivial_methods),
+            TokenKind::And => take_reference_tail(rest, ctx),
             // `&&` expr or `&& mut` expr (double reference).
-            TokenKind::AndAnd => take_reference_tail(rest, trivial_methods),
+            TokenKind::AndAnd => take_reference_tail(rest, ctx),
             // `*expr` (deref).
-            TokenKind::Star => take_trivial_expression(rest, trivial_methods),
-            // Path: ident (`::` ident)*.
-            TokenKind::Ident(_, _) => Some(take_path_tail(rest)),
+            TokenKind::Star => take_trivial_expression(rest, ctx),
+            // Path: ident (`::` ident)*. If the path is followed by
+            // `!` and the path's final segment names a curated
+            // trivial macro (`concat!`, `env!`, `include_str!`, …),
+            // the whole `name!(...)` / `name![...]` is a trivial
+            // atom — the expansion is a compile-time constant. The
+            // body contents are unchecked: by construction the
+            // macro accepts only literals or other trivial macro
+            // calls, so there is no runtime expression to bind.
+            TokenKind::Ident(name, _) => {
+                Some(take_path_and_optional_macro_call(name, rest, ctx.macros))
+            }
             // Leading `::` — must be followed by an ident.
-            TokenKind::PathSep => take_path_after_sep(rest),
+            TokenKind::PathSep => take_atom_path_after_sep(rest, ctx.macros),
             _ => None,
         },
         _ => None,
@@ -212,27 +231,56 @@ fn take_trivial_atom<'a>(
 /// `(a, b, ...)` (tuple, optional trailing comma) when every element is
 /// itself trivial. Empty elements in the middle (`(a,,b)`) are not
 /// Rust syntax and are rejected.
-fn is_trivial_paren_inner(stream: &TokenStream, trivial_methods: &BTreeSet<String>) -> bool {
+fn is_trivial_paren_inner(stream: &TokenStream, ctx: TrivialContext<'_>) -> bool {
     let Some(arguments) = split_top_level_arguments(stream) else {
         return false;
     };
     arguments
         .iter()
-        .all(|argument| !argument.is_empty() && is_trivial_expression(argument, trivial_methods))
+        .all(|argument| !argument.is_empty() && is_trivial_expression(argument, ctx))
 }
 
 fn take_reference_tail<'a>(
     tokens: &'a [TokenTree],
-    trivial_methods: &BTreeSet<String>,
+    ctx: TrivialContext<'_>,
 ) -> Option<&'a [TokenTree]> {
     let after_mut = match tokens.split_first() {
         Some((TokenTree::Token(token, _), rest)) if token.is_keyword(kw::Mut) => rest,
         _ => tokens,
     };
-    take_trivial_expression(after_mut, trivial_methods)
+    take_trivial_expression(after_mut, ctx)
+}
+
+/// Walk a path tail beginning after a leading ident, tracking the
+/// path's final segment so the caller can match it against the
+/// trivial-macro list when a `!` follows. The first segment's name
+/// is passed in; the walker reads `::ident` runs and returns the
+/// last segment seen along with the slice after the path.
+fn walk_path_tail<'a>(
+    first_name: rustc_span::Symbol,
+    mut tokens: &'a [TokenTree],
+) -> (rustc_span::Symbol, &'a [TokenTree]) {
+    let mut last = first_name;
+    while let Some((TokenTree::Token(sep, _), after_sep)) = tokens.split_first() {
+        if sep.kind != TokenKind::PathSep {
+            break;
+        }
+        let Some((TokenTree::Token(ident, _), after_ident)) = after_sep.split_first() else {
+            break;
+        };
+        let TokenKind::Ident(name, _) = ident.kind else {
+            break;
+        };
+        last = name;
+        tokens = after_ident;
+    }
+    (last, tokens)
 }
 
 fn take_path_tail(mut tokens: &[TokenTree]) -> &[TokenTree] {
+    // Type-position paths and `as`-cast paths don't need to know the
+    // tail segment's name (no trailing `!` is recognised there), so
+    // this variant skips the tracking that `walk_path_tail` does.
     while let Some((TokenTree::Token(sep, _), after_sep)) = tokens.split_first() {
         if sep.kind != TokenKind::PathSep {
             break;
@@ -248,6 +296,70 @@ fn take_path_tail(mut tokens: &[TokenTree]) -> &[TokenTree] {
     tokens
 }
 
+/// After consuming the leading ident of an atom path, walk the rest
+/// of the path and optionally consume a trailing trivial macro call.
+/// `first_name` is the leading ident's symbol; `tokens` is the slice
+/// following it.
+fn take_path_and_optional_macro_call<'a>(
+    first_name: rustc_span::Symbol,
+    tokens: &'a [TokenTree],
+    trivial_macros: &BTreeSet<String>,
+) -> &'a [TokenTree] {
+    let (tail_name, after_path) = walk_path_tail(first_name, tokens);
+    take_trivial_macro_call(after_path, tail_name, trivial_macros).unwrap_or(after_path)
+}
+
+/// If `tokens` starts with `! ( ... )` or `! [ ... ]` AND
+/// `macro_name`'s final segment is in `trivial_macros`, consume the
+/// `!` and the delimited body and return the slice after it.
+/// Returns `None` otherwise; the caller falls back to leaving the
+/// tokens unconsumed (so a non-trivial macro call correctly drops
+/// the whole expression into the non-trivial bucket).
+fn take_trivial_macro_call<'a>(
+    tokens: &'a [TokenTree],
+    macro_name: rustc_span::Symbol,
+    trivial_macros: &BTreeSet<String>,
+) -> Option<&'a [TokenTree]> {
+    let (bang, after_bang) = tokens.split_first()?;
+    let TokenTree::Token(bang_token, _) = bang else {
+        return None;
+    };
+    if bang_token.kind != TokenKind::Bang {
+        return None;
+    }
+    if !trivial_macros.contains(macro_name.as_str()) {
+        return None;
+    }
+    let (delim, after_delim) = after_bang.split_first()?;
+    let TokenTree::Delimited(_, _, delim_kind, _) = delim else {
+        return None;
+    };
+    // Curly-delimited inner macros are out of scope for the same
+    // reason curly-delimited outer macros are: `name! { ... }` is
+    // conventionally a DSL body, not a value-producing call.
+    if !matches!(delim_kind, Delimiter::Parenthesis | Delimiter::Bracket) {
+        return None;
+    }
+    Some(after_delim)
+}
+
+fn take_atom_path_after_sep<'a>(
+    tokens: &'a [TokenTree],
+    trivial_macros: &BTreeSet<String>,
+) -> Option<&'a [TokenTree]> {
+    let (ident, rest) = tokens.split_first()?;
+    let TokenTree::Token(token, _) = ident else {
+        return None;
+    };
+    let TokenKind::Ident(name, _) = token.kind else {
+        return None;
+    };
+    Some(take_path_and_optional_macro_call(name, rest, trivial_macros))
+}
+
+/// Type-position path tail: `take_atom_path_after_sep`'s sibling
+/// for `take_trivial_type`. Types don't carry trailing `!` macro
+/// calls so this variant only walks the `::ident` chain.
 fn take_path_after_sep(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
     let (ident, rest) = tokens.split_first()?;
     let TokenTree::Token(token, _) = ident else {
@@ -261,7 +373,7 @@ fn take_path_after_sep(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
 
 fn take_trivial_suffixes<'a>(
     mut tokens: &'a [TokenTree],
-    trivial_methods: &BTreeSet<String>,
+    ctx: TrivialContext<'_>,
 ) -> &'a [TokenTree] {
     loop {
         let Some((head, rest)) = tokens.split_first() else {
@@ -297,7 +409,7 @@ fn take_trivial_suffixes<'a>(
                             // as a plain field access and let the
                             // suffix loop decide what to do with the
                             // tokens that follow.
-                            if is_trivial_method_call(after, name.as_str(), trivial_methods) {
+                            if is_trivial_method_call(after, name.as_str(), ctx.methods) {
                                 tokens = &after[1..];
                             } else {
                                 tokens = after;
@@ -328,7 +440,7 @@ fn take_trivial_suffixes<'a>(
             // `[expr]` — index. Both base and index must be trivial;
             // the recursion happens here for the index.
             TokenTree::Delimited(_, _, Delimiter::Bracket, inner) => {
-                if !is_trivial_expression_stream(inner, trivial_methods) {
+                if !is_trivial_expression_stream(inner, ctx) {
                     return tokens;
                 }
                 tokens = rest;
@@ -369,16 +481,16 @@ fn is_trivial_method_call(
 /// suffix in the chain has trivial operands.
 fn take_trivial_binary_tail<'a>(
     mut tokens: &'a [TokenTree],
-    trivial_methods: &BTreeSet<String>,
+    ctx: TrivialContext<'_>,
 ) -> &'a [TokenTree] {
     while let Some(after_op) = take_trivial_binary_operator(tokens) {
-        let Some(after_atom) = take_trivial_atom(after_op, trivial_methods) else {
+        let Some(after_atom) = take_trivial_atom(after_op, ctx) else {
             // The operator looked like a binop but no trivial atom
             // followed; leave the operator unconsumed so the caller
             // sees the whole rest as non-trivial.
             return tokens;
         };
-        tokens = take_trivial_suffixes(after_atom, trivial_methods);
+        tokens = take_trivial_suffixes(after_atom, ctx);
     }
     tokens
 }
@@ -424,7 +536,7 @@ fn take_trivial_type(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
     }
 }
 
-fn is_trivial_expression_stream(stream: &TokenStream, trivial_methods: &BTreeSet<String>) -> bool {
+fn is_trivial_expression_stream(stream: &TokenStream, ctx: TrivialContext<'_>) -> bool {
     let trees: Vec<TokenTree> = stream.iter().cloned().collect();
-    is_trivial_expression(&trees, trivial_methods)
+    is_trivial_expression(&trees, ctx)
 }

--- a/src/rules/macro_argument_binding/triviality.rs
+++ b/src/rules/macro_argument_binding/triviality.rs
@@ -354,7 +354,11 @@ fn take_atom_path_after_sep<'a>(
     let TokenKind::Ident(name, _) = token.kind else {
         return None;
     };
-    Some(take_path_and_optional_macro_call(name, rest, trivial_macros))
+    Some(take_path_and_optional_macro_call(
+        name,
+        rest,
+        trivial_macros,
+    ))
 }
 
 /// Type-position path tail: `take_atom_path_after_sep`'s sibling

--- a/src/rules/macro_argument_binding/triviality.rs
+++ b/src/rules/macro_argument_binding/triviality.rs
@@ -256,10 +256,10 @@ fn take_reference_tail<'a>(
 /// trivial-macro list when a `!` follows. The first segment's name
 /// is passed in; the walker reads `::ident` runs and returns the
 /// last segment seen along with the slice after the path.
-fn walk_path_tail<'a>(
+fn walk_path_tail(
     first_name: rustc_span::Symbol,
-    mut tokens: &'a [TokenTree],
-) -> (rustc_span::Symbol, &'a [TokenTree]) {
+    mut tokens: &[TokenTree],
+) -> (rustc_span::Symbol, &[TokenTree]) {
     let mut last = first_name;
     while let Some((TokenTree::Token(sep, _), after_sep)) = tokens.split_first() {
         if sep.kind != TokenKind::PathSep {

--- a/src/rules/macro_argument_binding/triviality.rs
+++ b/src/rules/macro_argument_binding/triviality.rs
@@ -210,7 +210,7 @@ fn take_trivial_atom<'a>(
             TokenKind::Star => take_trivial_expression(rest, ctx),
             // Path: ident (`::` ident)*. If the path is followed by
             // `!` and the path's final segment names a curated
-            // trivial macro (`concat!`, `env!`, `include_str!`, …),
+            // trivial macro (`concat!`, `env!`, `include_str!`, ...),
             // the whole `name!(...)` / `name![...]` is a trivial
             // atom — the expansion is a compile-time constant. The
             // body contents are unchecked: by construction the

--- a/src/rules/macro_argument_binding/triviality.rs
+++ b/src/rules/macro_argument_binding/triviality.rs
@@ -212,10 +212,14 @@ fn take_trivial_atom<'a>(
             // `!` and the path's final segment names a curated
             // trivial macro (`concat!`, `env!`, `include_str!`, ...),
             // the whole `name!(...)` / `name![...]` is a trivial
-            // atom — the expansion is a compile-time constant. The
-            // body contents are unchecked: by construction the
-            // macro accepts only literals or other trivial macro
-            // calls, so there is no runtime expression to bind.
+            // atom — the expansion is a compile-time constant and
+            // the macro itself does not evaluate any runtime user
+            // expression (`stringify!` takes a token sequence and
+            // `cfg!` takes a cfg predicate, but neither evaluates
+            // them as Rust code). The body contents are therefore
+            // unchecked: there is no runtime expression for the
+            // surrounding macro to drop or duplicate, regardless of
+            // what the inner macro's input shape is.
             TokenKind::Ident(name, _) => {
                 Some(take_path_and_optional_macro_call(name, rest, ctx.macros))
             }

--- a/tests/macro_argument_binding.rs
+++ b/tests/macro_argument_binding.rs
@@ -31,6 +31,10 @@ struct RuleConfig {
     extra_trivial_methods: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     ignore_trivial_methods: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    extra_trivial_macros: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    ignore_trivial_macros: Vec<String>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -117,6 +121,28 @@ fn ignore_trivial_methods_drops_a_built_in_pure_getter() {
         "ui-toml/macro_argument_binding/ignore_trivial_methods",
         RuleConfig {
             ignore_trivial_methods: vec!["as_ref".into()],
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn extra_trivial_macros_adds_a_compile_time_macro_to_the_atom_set() {
+    run(
+        "ui-toml/macro_argument_binding/extra_trivial_macros",
+        RuleConfig {
+            extra_trivial_macros: vec!["literal_table".into()],
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn ignore_trivial_macros_drops_a_built_in_compile_time_macro() {
+    run(
+        "ui-toml/macro_argument_binding/ignore_trivial_macros",
+        RuleConfig {
+            ignore_trivial_macros: vec!["cfg".into()],
             ..Default::default()
         },
     );

--- a/ui-toml/macro_argument_binding/extra_trivial_macros/fixture.rs
+++ b/ui-toml/macro_argument_binding/extra_trivial_macros/fixture.rs
@@ -1,0 +1,26 @@
+// `extra_trivial_macros` adds project-specific macro names to the
+// built-in trivial-macro set. A call to one of these macros — even
+// nested inside a deny-listed macro — qualifies as a trivial atom
+// and the surrounding expression is accepted.
+//
+// This fixture's `dylint.toml` (see `tests/macro_argument_binding.rs`)
+// adds `literal_table`; the call below would otherwise be flagged
+// because macro invocations outside the built-in trivial set are
+// non-trivial by default.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+
+macro_rules! literal_table {
+    ($key:ident) => {
+        "table-literal"
+    };
+}
+
+fn check() {
+    debug_assert_eq!(literal_table!(KEY), "table-literal");
+}
+
+fn main() {
+    check();
+}

--- a/ui-toml/macro_argument_binding/ignore_trivial_macros/fixture.rs
+++ b/ui-toml/macro_argument_binding/ignore_trivial_macros/fixture.rs
@@ -1,0 +1,18 @@
+// `ignore_trivial_macros` drops names from the curated trivial-macro
+// list. After putting `cfg` in `ignore_trivial_macros`, the call is
+// treated as a regular macro invocation again and the surrounding
+// `debug_assert!` argument is flagged as non-trivial.
+//
+// `cfg!` is genuinely pure across the standard library, so this is a
+// hypothetical example — its purpose is to exercise the override.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+
+fn check() {
+    debug_assert!(cfg!(any()));
+}
+
+fn main() {
+    check();
+}

--- a/ui-toml/macro_argument_binding/ignore_trivial_macros/fixture.stderr
+++ b/ui-toml/macro_argument_binding/ignore_trivial_macros/fixture.stderr
@@ -1,0 +1,11 @@
+warning: non-trivial expression passed directly to a macro
+  --> $DIR/fixture.rs:13:19
+   |
+LL |     debug_assert!(cfg!(any()));
+   |                   ^^^^^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+   = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
+
+warning: 1 warning emitted
+

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -264,6 +264,34 @@ fn _turbofish_method_call_flagged(text: &str) {
     debug_assert!(text.parse::<u32>().is_ok());
 }
 
+// `core` / `std` compile-time macros (`concat!`, `env!`,
+// `option_env!`, `include_str!`, `include_bytes!`, `stringify!`,
+// `cfg!`, `line!`, `column!`, `file!`, `module_path!`) are on the
+// allow list AND count as trivial atoms when nested inside another
+// macro. The expansion is a compile-time constant — a literal, a
+// `&'static str`, a `bool`, a span marker — with no runtime
+// evaluation to disturb. Both behaviours together make the patterns
+// flagged in issue #71 invisible to the lint.
+fn _compile_time_macros_accepted() {
+    // Outer compile-time macros are allow-listed: their arguments
+    // (literals, paths, other compile-time macro calls) are
+    // unconditionally accepted.
+    let _ = concat!("home is at ", env!("CARGO_PKG_NAME"));
+    let _ = concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"));
+    let _ = stringify!(let x = compute(););
+    // Inner compile-time macros are trivial atoms inside any
+    // surrounding (even deny-listed) macro: there is no runtime
+    // expression to bind.
+    debug_assert_eq!(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_NAME"));
+    debug_assert!(cfg!(any()) || cfg!(all()));
+    debug_assert_eq!(line!(), line!());
+    debug_assert_eq!(concat!("a", "b"), "ab");
+    // Qualified-path call sites still hit the trivial-macro
+    // recognition: tail-segment matching makes `::std::stringify!`
+    // line up with the same `"stringify"` entry as the bare form.
+    debug_assert_eq!(::std::stringify!(x), std::stringify!(x));
+}
+
 #[allow(dead_code)]
 struct NameType;
 


### PR DESCRIPTION
Fixes <https://github.com/KSXGitHub/perfectionist/issues/71>.

Two complementary changes so the `core` / `std` compile-time macro family stops being flagged:

- **Allow list (outer-macro role).** Adds `concat!`, `env!`, `option_env!`, `include!`, `include_str!`, `include_bytes!`, `stringify!`, `cfg!`, `compile_error!`, `line!`, `column!`, `file!`, `module_path!`, `is_x86_feature_detected!` to the curated allow list — their arguments are no longer checked when they are the outer call.
- **Trivial-atom recognition (inner-macro role).** New `BUILTIN_TRIVIAL_MACROS` table (the value-producing subset) consulted by the triviality walker, so a call like `env!("X")` nested inside `debug_assert_eq!(...)` is recognised as a trivial atom and no longer triggers the let-bind hint.

Two new knobs (`extra_trivial_macros`, `ignore_trivial_macros`) mirror the existing trivial-method ones.