### PR TITLE
ci: lock by lockfile

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      CARGO_LOCKED: 'true'
+
     steps:
       - uses: actions/checkout@v6
 
@@ -82,23 +85,23 @@ jobs:
 
       - name: Build
         shell: bash
-        run: just build --locked
+        run: just build
 
       - name: Doc
         shell: bash
-        run: just doc --locked
+        run: just doc
 
       - name: Lint
         shell: bash
-        run: just lint --locked
+        run: just lint
 
       - name: Test
         shell: bash
-        run: just test --locked
+        run: just test
 
       - name: Self-lint
         shell: bash
-        run: just self-lint --locked
+        run: just self-lint
 
       - name: Clean workspace artifacts before cache
         if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,23 +82,23 @@ jobs:
 
       - name: Build
         shell: bash
-        run: just build
+        run: just build --locked
 
       - name: Doc
         shell: bash
-        run: just doc
+        run: just doc --locked
 
       - name: Lint
         shell: bash
-        run: just lint
+        run: just lint --locked
 
       - name: Test
         shell: bash
-        run: just test
+        run: just test --locked
 
       - name: Self-lint
         shell: bash
-        run: just self-lint
+        run: just self-lint --locked
 
       - name: Clean workspace artifacts before cache
         if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CARGO_LOCKED: 'true'
+      PERFECTIONIST_CARGO_LOCKED: 'true'
 
     steps:
       - uses: actions/checkout@v6

--- a/justfile
+++ b/justfile
@@ -1,5 +1,19 @@
 export PATH := justfile_directory() + "/.dev-tools/bin:" + env_var("PATH")
 
+# Set CARGO_LOCKED=true to pass `--locked` to the cargo invocations in
+# `build`, `doc`, `lint`, `test`, and `self-lint`. Empty, `false`, and
+# unset all leave the lockfile writable; any other value is rejected.
+cargo_locked := env_var_or_default("CARGO_LOCKED", "")
+locked := if cargo_locked == "true" {
+    "--locked"
+  } else if cargo_locked == "false" {
+    ""
+  } else if cargo_locked == "" {
+    ""
+  } else {
+    error("CARGO_LOCKED must be 'true', 'false', empty, or unset; got: " + cargo_locked)
+  }
+
 _default:
   @just --list
 
@@ -17,27 +31,27 @@ fmt:
   cargo fmt -- --check
 
 # Build in debug mode
-build *cargo_flags:
-  cargo build --workspace --all-targets {{cargo_flags}}
+build:
+  cargo build --workspace --all-targets {{locked}}
 
 # Check documentation
-doc *cargo_flags:
+doc:
   just gen-docs
   just check-rules-md
-  RUSTFLAGS='-D warnings' cargo doc --no-deps --document-private-items {{cargo_flags}}
+  RUSTFLAGS='-D warnings' cargo doc --no-deps --document-private-items {{locked}}
 
 # Run all the lints
-lint *cargo_flags:
-  cargo clippy --workspace --all-targets {{cargo_flags}} -- -D warnings
+lint:
+  cargo clippy --workspace --all-targets {{locked}} -- -D warnings
 
 # Run all the tests
-test *cargo_flags:
+test:
   just warmup-integration-tests
-  cargo test --workspace --all-targets {{cargo_flags}}
+  cargo test --workspace --all-targets {{locked}}
 
 # Run perfectionist's own lints on its source
-self-lint *cargo_flags:
-  DYLINT_RUSTFLAGS='-D warnings' cargo dylint --all -- --all-targets {{cargo_flags}}
+self-lint:
+  DYLINT_RUSTFLAGS='-D warnings' cargo dylint --all -- --all-targets {{locked}}
 
 # Pre-warm `target/integration-fixtures`
 warmup-integration-tests:

--- a/justfile
+++ b/justfile
@@ -6,7 +6,9 @@ export PATH := justfile_directory() + "/.dev-tools/bin:" + env_var("PATH")
 cargo_locked := env_var_or_default("CARGO_LOCKED", "")
 locked := if cargo_locked == "true" {
     "--locked"
-  } else if cargo_locked == "false" || cargo_locked == "" {
+  } else if cargo_locked == "false" {
+    ""
+  } else if cargo_locked == "" {
     ""
   } else {
     error("CARGO_LOCKED must be 'true', 'false', empty, or unset; got: " + cargo_locked)

--- a/justfile
+++ b/justfile
@@ -17,27 +17,27 @@ fmt:
   cargo fmt -- --check
 
 # Build in debug mode
-build:
-  cargo build --workspace --all-targets
+build *cargo_flags:
+  cargo build --workspace --all-targets {{cargo_flags}}
 
 # Check documentation
-doc:
+doc *cargo_flags:
   just gen-docs
   just check-rules-md
-  RUSTFLAGS='-D warnings' cargo doc --no-deps --document-private-items
+  RUSTFLAGS='-D warnings' cargo doc --no-deps --document-private-items {{cargo_flags}}
 
 # Run all the lints
-lint:
-  cargo clippy --workspace --all-targets -- -D warnings
+lint *cargo_flags:
+  cargo clippy --workspace --all-targets {{cargo_flags}} -- -D warnings
 
 # Run all the tests
-test:
+test *cargo_flags:
   just warmup-integration-tests
-  cargo test --workspace --all-targets
+  cargo test --workspace --all-targets {{cargo_flags}}
 
 # Run perfectionist's own lints on its source
-self-lint:
-  DYLINT_RUSTFLAGS='-D warnings' cargo dylint --all -- --all-targets
+self-lint *cargo_flags:
+  DYLINT_RUSTFLAGS='-D warnings' cargo dylint --all -- --all-targets {{cargo_flags}}
 
 # Pre-warm `target/integration-fixtures`
 warmup-integration-tests:

--- a/justfile
+++ b/justfile
@@ -1,19 +1,19 @@
 export PATH := justfile_directory() + "/.dev-tools/bin:" + env_var("PATH")
 
-# Set CARGO_LOCKED=true to pass `--locked` to the cargo invocations the
+# Set PERFECTIONIST_CARGO_LOCKED=true to pass `--locked` to the cargo invocations the
 # gating CI recipes (`build`, `doc`, `lint`, `test`, `self-lint`) reach,
 # including the warmup / doc-generation recipes they delegate to. Empty,
 # `false`, and unset all leave the lockfile writable; any other value
 # is rejected.
-cargo_locked := env_var_or_default("CARGO_LOCKED", "")
-locked := if cargo_locked == "true" {
+perfectionist_cargo_locked := env_var_or_default("PERFECTIONIST_CARGO_LOCKED", "")
+locked := if perfectionist_cargo_locked == "true" {
     "--locked"
-  } else if cargo_locked == "false" {
+  } else if perfectionist_cargo_locked == "false" {
     ""
-  } else if cargo_locked == "" {
+  } else if perfectionist_cargo_locked == "" {
     ""
   } else {
-    error("CARGO_LOCKED must be 'true', 'false', empty, or unset; got: " + cargo_locked)
+    error("PERFECTIONIST_CARGO_LOCKED must be 'true', 'false', empty, or unset; got: " + perfectionist_cargo_locked)
   }
 
 _default:

--- a/justfile
+++ b/justfile
@@ -6,9 +6,7 @@ export PATH := justfile_directory() + "/.dev-tools/bin:" + env_var("PATH")
 cargo_locked := env_var_or_default("CARGO_LOCKED", "")
 locked := if cargo_locked == "true" {
     "--locked"
-  } else if cargo_locked == "false" {
-    ""
-  } else if cargo_locked == "" {
+  } else if cargo_locked == "false" || cargo_locked == "" {
     ""
   } else {
     error("CARGO_LOCKED must be 'true', 'false', empty, or unset; got: " + cargo_locked)

--- a/justfile
+++ b/justfile
@@ -1,8 +1,10 @@
 export PATH := justfile_directory() + "/.dev-tools/bin:" + env_var("PATH")
 
-# Set CARGO_LOCKED=true to pass `--locked` to the cargo invocations in
-# `build`, `doc`, `lint`, `test`, and `self-lint`. Empty, `false`, and
-# unset all leave the lockfile writable; any other value is rejected.
+# Set CARGO_LOCKED=true to pass `--locked` to the cargo invocations the
+# gating CI recipes (`build`, `doc`, `lint`, `test`, `self-lint`) reach,
+# including the warmup / doc-generation recipes they delegate to. Empty,
+# `false`, and unset all leave the lockfile writable; any other value
+# is rejected.
 cargo_locked := env_var_or_default("CARGO_LOCKED", "")
 locked := if cargo_locked == "true" {
     "--locked"
@@ -55,7 +57,7 @@ self-lint:
 
 # Pre-warm `target/integration-fixtures`
 warmup-integration-tests:
-  time cargo run --package _utils --bin warmup -- "$(pwd)"
+  time cargo run {{locked}} --package _utils --bin warmup -- "$(pwd)"
 
 # Install cargo-dylint and dylint-link into `.dev-tools/`
 install-dev-tools:
@@ -80,12 +82,12 @@ gen-docs out_dir="gh-pages" git_ref="":
   if [ -z "$ref" ]; then
     ref="$(git rev-parse HEAD)"
   fi
-  cargo run --package _gen_docs --bin gen-docs -- --root "$(pwd)" html "{{out_dir}}" --git-ref="$ref"
+  cargo run {{locked}} --package _gen_docs --bin gen-docs -- --root "$(pwd)" html "{{out_dir}}" --git-ref="$ref"
 
 # Regenerate the in-tree markdown catalogue under `rules/`.
 gen-rules-md rules_dir="rules":
-  cargo run --package _gen_docs --bin gen-docs -- --root "$(pwd)" write-md "{{rules_dir}}"
+  cargo run {{locked}} --package _gen_docs --bin gen-docs -- --root "$(pwd)" write-md "{{rules_dir}}"
 
 # Verify the in-tree markdown catalogue is in sync with `src/rules/`.
 check-rules-md rules_dir="rules":
-  cargo run --package _gen_docs --bin gen-docs -- --root "$(pwd)" check-md "{{rules_dir}}"
+  cargo run {{locked}} --package _gen_docs --bin gen-docs -- --root "$(pwd)" check-md "{{rules_dir}}"


### PR DESCRIPTION
## Summary

Lets CI lock the dependency graph against `Cargo.lock` during the gating run.

- New `PERFECTIONIST_CARGO_LOCKED` env var, read once at the top of the `justfile` into a `locked` variable.
  - `true` → `--locked` is passed to every cargo invocation reached from the gating recipes (`build`, `doc`, `lint`, `test`, `self-lint`), including the warmup and doc-generation sub-recipes (`warmup-integration-tests`, `gen-docs`, `gen-rules-md`, `check-rules-md`) they delegate to.
  - `false`, empty, or unset → no flag is passed (default for local dev).
  - Any other value → just aborts with a validation error.
- `.github/workflows/test.yaml` sets `PERFECTIONIST_CARGO_LOCKED: 'true'` once at the job level so every step inherits it; no per-step changes needed.
- The variable is project-namespaced rather than `CARGO_*`, since `CARGO_*` is cargo's own reserved env-var namespace.

## Test plan

- [ ] CI on this branch is green with `PERFECTIONIST_CARGO_LOCKED=true` in effect.
- [ ] `just build` locally (no env var set) still works as before.
- [ ] `PERFECTIONIST_CARGO_LOCKED=bogus just build` fails with the validation error.