### PR TITLE
feat(macro-argument-binding): exempt `insta` macros

### DIFF
--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -258,7 +258,7 @@ Three name-set lookups decide each invocation:
    → accept unconditionally.
 3. **Neither** → flag every non-trivial argument.
 
-The default allow list has two parts.
+The default allow list has three parts.
 
 The first part overlaps with
 [`macro-trailing-comma`](./macro-trailing-comma.md)'s built-in
@@ -285,6 +285,21 @@ once-vs.-zero hazard for the rule to flag.
 at runtime, but the lookup runs without any user-side
 argument evaluation, so it sits comfortably in the same
 group.
+
+The third part is the `insta` snapshot-assertion family:
+`assert_snapshot!`, `assert_debug_snapshot!`,
+`assert_display_snapshot!`, `assert_compact_debug_snapshot!`,
+`assert_yaml_snapshot!`, `assert_json_snapshot!`,
+`assert_compact_json_snapshot!`, `assert_ron_snapshot!`,
+`assert_csv_snapshot!`, `assert_toml_snapshot!`, and
+`assert_binary_snapshot!`. Every variant evaluates its value
+argument exactly once before serialising it through the matching
+formatter (`Debug`, `Display`, or a `serde::Serialize` backend) for
+comparison against the on-disk snapshot, so the rule's
+once-vs.-zero hazard does not apply. `assert_display_snapshot!`
+is deprecated upstream in favour of `assert_snapshot!` but is
+still present in older `insta` releases and is listed for
+projects that have not yet migrated.
 
 `macro-trailing-comma`'s built-in list is intentionally
 narrower than this one; the two lists are not kept in

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -286,20 +286,20 @@ at runtime, but the lookup runs without any user-side
 argument evaluation, so it sits comfortably in the same
 group.
 
-The third part is the `insta` snapshot-assertion family:
+The third part collects third-party macros whose matchers are
+known to evaluate every top-level argument exactly once before
+forwarding it, so the rule's once-vs.-zero hazard does not apply.
+The current entries are the `insta` snapshot-assertion family —
 `assert_snapshot!`, `assert_debug_snapshot!`,
 `assert_display_snapshot!`, `assert_compact_debug_snapshot!`,
 `assert_yaml_snapshot!`, `assert_json_snapshot!`,
 `assert_compact_json_snapshot!`, `assert_ron_snapshot!`,
 `assert_csv_snapshot!`, `assert_toml_snapshot!`, and
-`assert_binary_snapshot!`. Every variant evaluates its value
-argument exactly once before serialising it through the matching
-formatter (`Debug`, `Display`, or a `serde::Serialize` backend) for
-comparison against the on-disk snapshot, so the rule's
-once-vs.-zero hazard does not apply. `assert_display_snapshot!`
-is deprecated upstream in favour of `assert_snapshot!` but is
-still present in older `insta` releases and is listed for
-projects that have not yet migrated.
+`assert_binary_snapshot!` — but the group is open-ended; further
+crates can be added as their matchers are vetted.
+`assert_display_snapshot!` is deprecated upstream in favour of
+`assert_snapshot!` but is retained for projects on older `insta`
+releases.
 
 `macro-trailing-comma`'s built-in list is intentionally
 narrower than this one; the two lists are not kept in

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -22,7 +22,7 @@ const CONFIG_KEY: &str = "perfectionist::macro_argument_binding";
 const BUILTIN_DENY: &[&str] = &["debug_assert", "debug_assert_eq", "debug_assert_ne"];
 
 /// Macros for which the call site is known not to introduce the
-/// "evaluate zero, one, or many times" hazard. Two disjoint groups:
+/// "evaluate zero, one, or many times" hazard. Three disjoint groups:
 ///
 /// 1. Runtime macros (`format!`, `vec!`, `assert!`, `dbg!`, …) that
 ///    promise to evaluate every top-level argument exactly once.
@@ -40,6 +40,13 @@ const BUILTIN_DENY: &[&str] = &["debug_assert", "debug_assert_eq", "debug_assert
 ///    macro from this group. None of these evaluates a user
 ///    expression at runtime, so no exactly-once-vs.-zero hazard
 ///    surfaces at the call site.
+/// 3. Third-party assertion macros from `insta`'s snapshot-testing
+///    family. Each `assert_*_snapshot!` call evaluates its value
+///    argument exactly once and feeds the result through a
+///    formatter (`Debug`, `Display`, or a `serde::Serialize`
+///    backend) before comparing against the on-disk snapshot. The
+///    matchers are uniform across the family, so the same
+///    once-evaluation guarantee holds for every variant.
 ///
 /// `macro_trailing_comma`'s own built-in list is intentionally
 /// narrower than this one (it has no reason to care about
@@ -83,6 +90,24 @@ const BUILTIN_ALLOW: &[&str] = &[
     "module_path",
     "option_env",
     "stringify",
+    // `insta` snapshot-assertion macros. Every variant evaluates its
+    // value argument exactly once before serialising it for
+    // comparison against the stored snapshot. `assert_display_snapshot`
+    // is deprecated upstream in favour of `assert_snapshot` but is
+    // still present in older `insta` releases, so it is listed for
+    // projects that have not yet migrated. `assert_binary_snapshot`
+    // is the newer byte-slice variant.
+    "assert_binary_snapshot",
+    "assert_compact_debug_snapshot",
+    "assert_compact_json_snapshot",
+    "assert_csv_snapshot",
+    "assert_debug_snapshot",
+    "assert_display_snapshot",
+    "assert_json_snapshot",
+    "assert_ron_snapshot",
+    "assert_snapshot",
+    "assert_toml_snapshot",
+    "assert_yaml_snapshot",
 ];
 
 /// `core` / `std` macros whose invocation expands to a value the

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -40,13 +40,11 @@ const BUILTIN_DENY: &[&str] = &["debug_assert", "debug_assert_eq", "debug_assert
 ///    macro from this group. None of these evaluates a user
 ///    expression at runtime, so no exactly-once-vs.-zero hazard
 ///    surfaces at the call site.
-/// 3. Third-party assertion macros from `insta`'s snapshot-testing
-///    family. Each `assert_*_snapshot!` call evaluates its value
-///    argument exactly once and feeds the result through a
-///    formatter (`Debug`, `Display`, or a `serde::Serialize`
-///    backend) before comparing against the on-disk snapshot. The
-///    matchers are uniform across the family, so the same
-///    once-evaluation guarantee holds for every variant.
+/// 3. Third-party macros whose matchers are known to evaluate every
+///    top-level argument exactly once before forwarding it, so the
+///    once-vs.-zero hazard does not surface at the call site. New
+///    entries land here as they're identified; the group is open-
+///    ended and not tied to any single crate.
 ///
 /// `macro_trailing_comma`'s own built-in list is intentionally
 /// narrower than this one (it has no reason to care about
@@ -90,13 +88,14 @@ const BUILTIN_ALLOW: &[&str] = &[
     "module_path",
     "option_env",
     "stringify",
-    // `insta` snapshot-assertion macros. Every variant evaluates its
-    // value argument exactly once before serialising it for
-    // comparison against the stored snapshot. `assert_display_snapshot`
-    // is deprecated upstream in favour of `assert_snapshot` but is
-    // still present in older `insta` releases, so it is listed for
-    // projects that have not yet migrated. `assert_binary_snapshot`
-    // is the newer byte-slice variant.
+    // Third-party macros whose matchers evaluate every top-level
+    // argument exactly once. The current entries are `insta`'s
+    // snapshot-assertion family; add further crates here as their
+    // matchers are vetted to honour the same guarantee.
+    // `assert_display_snapshot` is deprecated upstream in favour of
+    // `assert_snapshot` but is retained for projects on older
+    // `insta` releases; `assert_binary_snapshot` is the newer
+    // byte-slice variant.
     "assert_binary_snapshot",
     "assert_compact_debug_snapshot",
     "assert_compact_json_snapshot",

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -29,6 +29,20 @@ macro_rules! in_separator_macro {
     ($($tokens:tt)*) => {{ 0 }};
 }
 
+// Stand-ins for the `insta` snapshot-assertion family, which the
+// rule recognises by tail-segment match. Each one swallows its
+// arguments unevaluated; the fixture only needs the call site to
+// parse, not to run.
+macro_rules! assert_snapshot {
+    ($($tokens:tt)*) => {{}};
+}
+macro_rules! assert_debug_snapshot {
+    ($($tokens:tt)*) => {{}};
+}
+macro_rules! assert_yaml_snapshot {
+    ($($tokens:tt)*) => {{}};
+}
+
 // `debug_assert_eq!` is on the built-in deny list. The first argument
 // is a non-trivial method call; in release builds the macro folds to
 // `if false { ... }` and the call never runs, leaving the map in a
@@ -75,6 +89,17 @@ fn _format_allow_listed() {
 // are accepted under the default config.
 fn _vec_allow_listed() {
     let _ = vec![value(), value(), value()];
+}
+
+// Allow-listed `insta` snapshot-assertion macros. Each variant
+// evaluates its value argument exactly once before serialising, so
+// the rule accepts non-trivial arguments under the default config.
+// Tail-segment matching means the rule recognises both bare and
+// path-qualified call sites.
+fn _insta_snapshots_allow_listed() {
+    assert_snapshot!(value().unwrap());
+    assert_debug_snapshot!(value().unwrap());
+    assert_yaml_snapshot!(value().unwrap());
 }
 
 // Repeat-form `vec![v; count]` uses a top-level `;`, which signals

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -1,5 +1,5 @@
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:38:22
+  --> $DIR/macro_argument_binding.rs:52:22
    |
 LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
    |                      ^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
    = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:44:19
+  --> $DIR/macro_argument_binding.rs:58:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:52:22
+  --> $DIR/macro_argument_binding.rs:66:22
    |
 LL |     debug_assert_ne!(value(), Some(0));
    |                      ^^^^^^^
@@ -24,7 +24,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:52:31
+  --> $DIR/macro_argument_binding.rs:66:31
    |
 LL |     debug_assert_ne!(value(), Some(0));
    |                               ^^^^^^^
@@ -32,7 +32,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:60:23
+  --> $DIR/macro_argument_binding.rs:74:23
    |
 LL |     let _ = my_macro!(value(), count);
    |                       ^^^^^^^
@@ -40,7 +40,7 @@ LL |     let _ = my_macro!(value(), count);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:118:19
+  --> $DIR/macro_argument_binding.rs:143:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:131:26
+  --> $DIR/macro_argument_binding.rs:156:26
    |
 LL |     let _ = await_macro!(future.await);
    |                          ^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     let _ = await_macro!(future.await);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:208:27
+  --> $DIR/macro_argument_binding.rs:233:27
    |
 LL |     let _ = my_macro!((), value());
    |                           ^^^^^^^
@@ -64,7 +64,7 @@ LL |     let _ = my_macro!((), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:209:30
+  --> $DIR/macro_argument_binding.rs:234:30
    |
 LL |     let _ = my_macro!((MAX), value());
    |                              ^^^^^^^
@@ -72,7 +72,7 @@ LL |     let _ = my_macro!((MAX), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:210:43
+  --> $DIR/macro_argument_binding.rs:235:43
    |
 LL |     let _ = my_macro!((point.0, point.1), value());
    |                                           ^^^^^^^
@@ -80,7 +80,7 @@ LL |     let _ = my_macro!((point.0, point.1), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:211:31
+  --> $DIR/macro_argument_binding.rs:236:31
    |
 LL |     let _ = my_macro!((MAX,), value());
    |                               ^^^^^^^
@@ -88,7 +88,7 @@ LL |     let _ = my_macro!((MAX,), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:254:19
+  --> $DIR/macro_argument_binding.rs:279:19
    |
 LL |     debug_assert!(slice.clear() == ());
    |                   ^^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL |     debug_assert!(slice.clear() == ());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: non-trivial expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:264:19
+  --> $DIR/macro_argument_binding.rs:289:19
    |
 LL |     debug_assert!(text.parse::<u32>().is_ok());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add the `insta` snapshot-assertion family to the built-in allow list so projects no longer have to enumerate them under `ignore`. Every variant — `assert_snapshot!`, `assert_debug_snapshot!`, `assert_display_snapshot!`, `assert_compact_debug_snapshot!`, `assert_yaml_snapshot!`, `assert_json_snapshot!`,
`assert_compact_json_snapshot!`, `assert_ron_snapshot!`, `assert_csv_snapshot!`, `assert_toml_snapshot!`, and `assert_binary_snapshot!` — evaluates its value argument exactly once before serialising for the snapshot comparison, so the once-vs.-zero hazard the rule guards against does not apply.