### PR TITLE
feat(macro-argument-binding)!: reduce false-positives

### DIFF
--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -152,7 +152,7 @@ pattern that several rules call out by reference — live in
   optional-trailing-comma idioms (harder, not yet implemented
   and therefore not configurable).
 - [`macro-argument-binding.md`](./macro-argument-binding.md) —
-  require non-trivial expressions passed to function-like and
+  require impure expressions passed to function-like and
   array-like macro invocations to be bound to a `let` first.
   Targets the `debug_assert_eq!(map.insert(k, v), None)` footgun
   (release builds skip evaluation entirely) and the general

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -4,9 +4,9 @@
 
 Partially implemented. Modes 0-2 (`deny_only`, `blanket`,
 `allow_and_deny`) ship today, along with the `enabled`,
-`deny_extra`, `allow_extra`, `ignore`, `extra_trivial_methods`,
-`ignore_trivial_methods`, `extra_trivial_macros`, and
-`ignore_trivial_macros` knobs. The lint emits diagnostics with
+`deny_extra`, `allow_extra`, `ignore`, `extra_pure_methods`,
+`ignore_pure_methods`, `extra_pure_macros`, and
+`ignore_pure_macros` knobs. The lint emits diagnostics with
 a `let`-binding hint (no autofix, by design — the binding name
 varies per site).
 
@@ -17,33 +17,33 @@ Still pending:
   fails to deserialise. The matcher-walking infrastructure is
   shared with the equivalent eligibility check planned for
   `macro-trailing-comma`; both will land together.
-- **Range expressions over trivial operands.** The spec couples
-  range-expression triviality to operand triviality the same way
+- **Range expressions over pure operands.** The spec couples
+  range-expression purity to operand purity the same way
   it does for binary expressions, but the walker only recognises
-  binary chains; `start..end` and `start..=end` over trivial
-  operands still fall through as non-trivial. Extending
-  `take_trivial_expression` to optionally consume a range tail is
+  binary chains; `start..end` and `start..=end` over pure
+  operands still fall through as impure. Extending
+  `take_pure_expression` to optionally consume a range tail is
   a small follow-up.
-- **Cast suffix beyond path-shaped types.** The trivial-expression
+- **Cast suffix beyond path-shaped types.** The pure-expression
   predicate currently recognises `expr as Path` (e.g., `x as u64`,
   `x as my::Type`) but treats `expr as &Path`, `expr as *const T`,
-  and other non-path type forms as non-trivial. Expanding the
+  and other non-path type forms as impure. Expanding the
   type recogniser is a small, additive change.
 - **Turbofish in path arguments.** A path with explicit generics
   (`Vec::<u32>::new`, `Some::<u32>`) is parsed as `path-segment` plus
   `::<...>` plus more segments; the current path walker only consumes
-  `::ident` runs and so falls through to non-trivial on the turbofish.
-  These should be trivial per the spec's intent ("a path resolving to
+  `::ident` runs and so falls through to impure on the turbofish.
+  These should be pure per the spec's intent ("a path resolving to
   a function name, or unit / tuple variant"); extend `take_path_tail`
   to consume an optional `::<...>` token-tree per segment.
-- **Keyword idents as path starts.** The trivial-atom matcher's
+- **Keyword idents as path starts.** The pure-atom matcher's
   `Ident(_, _)` branch dispatches to the path walker regardless of
   whether the ident is a valid path-start keyword (`self`, `Self`,
   `super`, `crate`, the empty set otherwise). Reserved keywords like
   `let`, `if`, `match`, `for`, `while` are accepted as path heads
-  and the resulting "trivial path" leaves an unexpected tail in the
-  suffix walk, which still bottoms out as non-trivial — so the lint
-  classification is correct by coincidence. Tighten `take_trivial_atom`
+  and the resulting "pure path" leaves an unexpected tail in the
+  suffix walk, which still bottoms out as impure — so the lint
+  classification is correct by coincidence. Tighten `take_pure_atom`
   to reject reserved-keyword idents so the right door owns the
   decision.
 
@@ -112,7 +112,7 @@ what the macro does with its captures.
 For a function-like (`name!(...)`) or array-like (`name![...]`)
 macro invocation:
 
-- If the macro is on the **deny list**, every non-trivial
+- If the macro is on the **deny list**, every impure
   top-level argument is flagged.
 - If the macro is on the **allow list**, the argument shape is
   unconstrained.
@@ -128,7 +128,7 @@ uses: the same `macro_rules!` accepts all three call shapes,
 and the definition site doesn't fix which one the author chose
 at any given call site.
 
-### What counts as a "non-trivial" argument
+### What counts as a "impure" argument
 
 The lint accepts any argument whose outermost shape is one of:
 
@@ -136,41 +136,41 @@ The lint accepts any argument whose outermost shape is one of:
 - A path resolving to a `const`, `static`, local binding,
   function name, or unit / tuple variant (`MAX`, `count`,
   `Foo::BAR`, `Result::Ok`).
-- A reference to a trivial expression (`&count`, `&mut buffer`).
-- A field access or tuple-index on a trivial base
+- A reference to a pure expression (`&count`, `&mut buffer`).
+- A field access or tuple-index on a pure base
   (`config.threshold`, `point.0`).
 - An index `base[index]` where both `base` and `index` are
-  themselves trivial (`buffer[0]`, `lookup[Foo::KEY]`).
-- A unary deref of a trivial expression (`*ptr`).
-- A trivial expression annotated with a type (`x as u64`).
-- The unit literal `()`, a parenthesised trivial expression
-  (`(x)`), or a tuple whose every element is trivial
+  themselves pure (`buffer[0]`, `lookup[Foo::KEY]`).
+- A unary deref of a pure expression (`*ptr`).
+- A pure expression annotated with a type (`x as u64`).
+- The unit literal `()`, a parenthesised pure expression
+  (`(x)`), or a tuple whose every element is pure
   (`(a, b)`, `(a,)`).
-- A binary chain whose every operand is trivial and whose
+- A binary chain whose every operand is pure and whose
   every operator is side-effect-free in the syntactic sense:
   the arithmetic operators (`+`, `-`, `*`, `/`, `%`), the
   bitwise operators (`&`, `|`, `^`, `<<`, `>>`), the
   comparison operators (`==`, `!=`, `<`, `>`, `<=`, `>=`),
   and the short-circuit operators (`&&`, `||`). `a <= b`,
-  `count + offset`, `flags & MASK == 0` are all trivial when
+  `count + offset`, `flags & MASK == 0` are all pure when
   the operands are.
-- A zero-argument method call `expr.method()` on a trivial
+- A zero-argument method call `expr.method()` on a pure
   base, where `method` is in the curated pure-getter set
   (`len`, `is_empty`, `as_str`, `as_bytes`, `as_ref`, `as_mut`,
   `as_deref`, `as_slice`) or in the project's
-  `extra_trivial_methods`. `vec.len()`, `s.is_empty()`,
+  `extra_pure_methods`. `vec.len()`, `s.is_empty()`,
   `opt.as_ref()` evaluate the same way no matter how many
   times the macro touches them, so the let-bind rewrite
   would only force the call to run in release builds for
   no benefit. Method calls with arguments, generic method
   calls, and method names outside the configured set stay
-  non-trivial: `map.insert(k, v)`, `iter.next()`,
+  impure: `map.insert(k, v)`, `iter.next()`,
   `vec.try_into::<Foo>()` still flag.
 - A function-like or array-like invocation `name!(...)` /
-  `name![...]` of a curated trivial macro: `concat!`, `env!`,
+  `name![...]` of a curated pure macro: `concat!`, `env!`,
   `option_env!`, `include_str!`, `include_bytes!`,
   `stringify!`, `cfg!`, `line!`, `column!`, `file!`,
-  `module_path!`, plus anything in `extra_trivial_macros`.
+  `module_path!`, plus anything in `extra_pure_macros`.
   These expand to compile-time constants (a literal, a
   `&'static str`, a `bool`, a span marker) with no runtime
   side effect, so passing one to a surrounding `debug_assert*`
@@ -188,20 +188,20 @@ The lint accepts any argument whose outermost shape is one of:
   do *not* qualify; the rule treats those as DSL bodies, the
   same way it treats the outer call's curly form.
 
-Everything else is non-trivial: function and method calls, `?`,
+Everything else is impure: function and method calls, `?`,
 `.await`, macro invocations, blocks, control-flow expressions,
 assignments, range expressions, and any binary expression whose
-operands are non-trivial. The classification is purely
+operands are impure. The classification is purely
 syntactic — `const fn` calls and other "morally pure"
-expressions are non-trivial; hoist them to a `const` if they
+expressions are impure; hoist them to a `const` if they
 need to appear inline.
 
 The binary-chain rule reflects an important consequence for
-`debug_assert*`: a side-effect-free comparison of trivial
+`debug_assert*`: a side-effect-free comparison of pure
 operands evaluates the same way regardless of how many times the
 macro touches it, and the lint's `let`-binding hint would
 *force* the comparison to evaluate even in release builds. The
-trivial-chain carve-out keeps the lint focused on the genuine
+pure-chain carve-out keeps the lint focused on the genuine
 hazard (side-effecting expressions like `map.insert(k, v)`
 passed where the macro might drop them) and away from the noise
 case (comparing two locals).
@@ -212,14 +212,14 @@ The pure-getter rule is **syntactic, name-based, type-blind**. A
 third-party type that defines an inherent method named
 `is_empty`, `len`, `as_bytes`, `as_ref`, … and that performs
 observable side effects in that method will be incorrectly
-accepted as trivial. The curated list is restricted to names
+accepted as pure. The curated list is restricted to names
 whose pure-getter convention is essentially universal across the
 ecosystem, but the lint cannot prove the convention holds for
 any given call site. Projects that hit this corner can drop
 specific names from the built-in set via the
-`ignore_trivial_methods` knob — for example, a project that
+`ignore_pure_methods` knob — for example, a project that
 wraps `as_ref` in a non-pure implementation can put `"as_ref"`
-in `ignore_trivial_methods` and the lint will flag every
+in `ignore_pure_methods` and the lint will flag every
 `.as_ref()` call as a method call again.
 
 ## Eligibility modes
@@ -240,7 +240,7 @@ macros.
 ### Mode 1 — `blanket`
 
 Flag every function-like or array-like invocation that carries
-a non-trivial top-level argument, regardless of macro. Add
+an impure top-level argument, regardless of macro. Add
 specific exceptions to `allow_extra`; there is no built-in
 allow list in this mode.
 
@@ -253,10 +253,10 @@ flagging every macro invocation is exhausting.
 Three name-set lookups decide each invocation:
 
 1. **Deny-list hit** (`debug_assert*` plus `deny_extra`) → flag
-   every non-trivial argument.
+   every impure argument.
 2. **Allow-list hit** (the curated set below plus `allow_extra`)
    → accept unconditionally.
-3. **Neither** → flag every non-trivial argument.
+3. **Neither** → flag every impure argument.
 
 The default allow list has three parts.
 
@@ -364,8 +364,8 @@ For every macro invocation:
    All are syntactic positions the macro author chose, and the
    let-bind rewrite the rule would propose is meaningless for
    the macro's matcher arm.
-7. Classify the expression with the trivial / non-trivial split.
-   If trivial, accept; if non-trivial, emit a diagnostic
+7. Classify the expression with the pure / impure split.
+   If pure, accept; if impure, emit a diagnostic
    suggesting a `let` binding immediately before the macro
    call.
 
@@ -386,10 +386,10 @@ let ejected = my_map.insert(key, value);
 debug_assert_eq!(ejected, None, "duplicate key");
 ```
 
-### Trivial arguments stay inline
+### Pure arguments stay inline
 
 ```rust
-// Accepted — `count`, `MAX_RETRIES`, `&buffer` are all trivial.
+// Accepted — `count`, `MAX_RETRIES`, `&buffer` are all pure.
 debug_assert_eq!(count, MAX_RETRIES, "expected {MAX_RETRIES} retries");
 ```
 
@@ -406,7 +406,7 @@ let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Orde
 ```rust
 // Accepted — `concat!`, `env!`, `include_str!`, and the rest of
 // the compile-time family are on the allow list, and their
-// expansion is itself a literal so they also count as trivial
+// expansion is itself a literal so they also count as pure
 // atoms when used inside another macro. Both rules together
 // make these idioms invisible to the lint:
 let msg = concat!("home: ", env!("HOME"));
@@ -421,7 +421,7 @@ let xs = vec![compute(), compute(), compute()];
 ```
 
 ```rust
-// Flagged under blanket mode — every non-trivial argument is
+// Flagged under blanket mode — every impure argument is
 // a candidate, allow list or not.
 let xs = vec![compute(), compute(), compute()];
 
@@ -489,40 +489,40 @@ ignore = [
   # "my_crate::ad_hoc",
 ]
 
-# Zero-argument method names treated as trivial postfixes on a
-# trivial base, in addition to the built-in set (`len`,
+# Zero-argument method names treated as pure postfixes on a
+# pure base, in addition to the built-in set (`len`,
 # `is_empty`, `as_str`, `as_bytes`, `as_ref`, `as_mut`,
 # `as_deref`, `as_slice`). Add project-specific pure getters
 # here so `debug_assert!(value.my_cached_getter() <= limit)`
 # stops flagging.
-extra_trivial_methods = [
+extra_pure_methods = [
   # "my_cached_getter",
 ]
 
 # Method names to drop from the pure-method list, even if they
-# appear in the built-in defaults or in `extra_trivial_methods`.
+# appear in the built-in defaults or in `extra_pure_methods`.
 # Checked after the merge, so this knob always wins. Useful for
 # opting back into linting on a default entry the project does
-# not consider trivial.
-ignore_trivial_methods = [
+# not consider pure.
+ignore_pure_methods = [
   # "as_ref",
 ]
 
-# Macro names treated as trivial atoms when they appear as
+# Macro names treated as pure atoms when they appear as
 # arguments to another macro, in addition to the built-in set
 # (`concat`, `env`, `option_env`, `include_str`, `include_bytes`,
 # `stringify`, `cfg`, `line`, `column`, `file`, `module_path`).
 # Add project-specific compile-time macros here so that, e.g.,
 # `debug_assert_eq!(literal_table!(KEY), expected)` stops flagging
 # the inner call.
-extra_trivial_macros = [
+extra_pure_macros = [
   # "literal_table",
 ]
 
-# Macro names to drop from the trivial-macro list, even if they
-# appear in the built-in defaults or in `extra_trivial_macros`.
+# Macro names to drop from the pure-macro list, even if they
+# appear in the built-in defaults or in `extra_pure_macros`.
 # Checked after the merge, so this knob always wins.
-ignore_trivial_macros = [
+ignore_pure_macros = [
   # "cfg",
 ]
 ```
@@ -546,11 +546,11 @@ ignore_trivial_macros = [
 - Per-argument expression re-parse uses `rustc_parse`'s
   `Parser::parse_expr` (or the equivalent restriction-
   respecting helper for the surrounding context).
-- Trivial/non-trivial predicate: a `match` on `ast::ExprKind`
-  over the seven trivial variants (`Lit`, `Path`, `AddrOf`,
+- Pure/impure predicate: a `match` on `ast::ExprKind`
+  over the seven pure variants (`Lit`, `Path`, `AddrOf`,
   `Field`, `Index`, `Unary(Deref, _)`, `Cast`) with recursive
-  triviality checks on the sub-expressions. Default any
-  unrecognised variant to non-trivial.
+  purity checks on the sub-expressions. Default any
+  unrecognised variant to impure.
 - Matcher walker (mode 3): builds on the matcher-access
   infrastructure
   [`macro-trailing-comma`](./macro-trailing-comma.md)
@@ -559,7 +559,7 @@ ignore_trivial_macros = [
 ### Difficulty
 
 **Modes 0 / 1 / 2: easy.** A syntactic name-set lookup, a
-top-level argument splitter, and the trivial / non-trivial
+top-level argument splitter, and the pure / impure
 predicate. The three modes differ only in which lookup table
 the matcher consults.
 

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -618,14 +618,25 @@ ignore_pure_macros = [
 - Argument splitting walks `MacCall::args.tokens`, tracks
   delimiter nesting, and splits on top-level commas. Share
   the splitter with `macro-trailing-comma`.
-- Per-argument expression re-parse uses `rustc_parse`'s
-  `Parser::parse_expr` (or the equivalent restriction-
-  respecting helper for the surrounding context).
-- Pure/impure predicate: a `match` on `ast::ExprKind`
-  over the seven pure variants (`Lit`, `Path`, `AddrOf`,
-  `Field`, `Index`, `Unary(Deref, _)`, `Cast`) with recursive
-  purity checks on the sub-expressions. Default any
-  unrecognised variant to impure.
+- Per-argument classification is a hand-rolled token-stream
+  walker (`src/rules/macro_argument_binding/purity.rs`), not a
+  `rustc_parse` re-parse. The walker pairs a
+  `looks_like_expression` heuristic that filters out DSL-shaped
+  arguments (top-level `=>`, `:` outside a `let`, `=`, `+=`, …,
+  and brace-delimited arguments whose inner top level matches
+  the same predicate) with a `take_*`-style combinator that
+  consumes pure-shape atoms, suffixes, and binary tails.
+  Anything the combinator can't consume is impure.
+
+  The original design called for a `Parser::parse_expr` re-parse
+  with an `ast::ExprKind` match over the seven pure variants
+  (`Lit`, `Path`, `AddrOf`, `Field`, `Index`, `Unary(Deref, _)`,
+  `Cast`) — see issue #64 for the deferral rationale. The
+  walker is the practical compromise: it avoids spawning
+  parser-recovery diagnostics on arbitrary macro inputs, runs
+  pre-expansion without an AST, and lets the rule honour the
+  cross-cutting parser-style convention in
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md).
 - Matcher walker (mode 3): builds on the matcher-access
   infrastructure
   [`macro-trailing-comma`](./macro-trailing-comma.md)

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -128,7 +128,34 @@ uses: the same `macro_rules!` accepts all three call shapes,
 and the definition site doesn't fix which one the author chose
 at any given call site.
 
-### What counts as a "impure" argument
+### Terminology: "pure" vs "impure"
+
+In this rule's vocabulary, an expression is **pure** if it is
+*safe for the surrounding macro to drop or duplicate* —
+evaluating it zero, one, or many times is observationally
+equivalent. **Impure** is anything else, and is what the rule
+flags.
+
+The classification is **syntactic and conservative**. The rule
+recognises a curated set of shapes (literals, paths,
+field accesses, the curated method names listed below, …) that
+are known to satisfy the property, and treats everything else as
+impure even if it is in fact side-effect-free. A `const fn`
+call, a `Result::map` chain over a pure base, or `vec.fold(...)`
+is therefore impure under this rule unless its shape is
+recognised — the lint cannot prove side-effect-freedom in
+general, only spot it.
+
+The set is intentionally narrower than the functional-
+programming notion of purity (which would accept any
+deterministic, observable-state-free expression) and keyed to
+what a function-like or array-like macro can actually do with
+its captures: drop them (`debug_assert*` in release) or
+duplicate them (`min!`-style, retry loops). Side-effect-freedom
+in the abstract is not enough; what matters is *exactly-once
+safety under the macro's specific transformation*.
+
+### What counts as a pure argument
 
 The lint accepts any argument whose outermost shape is one of:
 

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -281,6 +281,20 @@ filter level: `format!`, `format_args!`, `print!`,
 matchers promise exactly-once evaluation per top-level
 argument.
 
+Alongside the standard-library set, the first group also
+includes a small curated set of third-party companions whose
+published expansions match the same exactly-once contract:
+the `anyhow!` companions `bail!` / `ensure!`,
+`serde_json::json!`, and the `maplit::{hashmap, btreemap,
+hashset, btreeset}!` builders. Each walks its input token
+tree once, emits one runtime evaluation per captured Rust
+expression, and contains no `cfg` gate or repetition that
+could drop or duplicate a capture. Tail-segment matching
+means the entry covers fully-qualified and bare call sites
+alike. `bail!` / `ensure!` share the same conditional-
+arguments shape as the already-allowed `assert!` — the
+trade-off is identical and accepted on the same terms.
+
 The second part adds `core` / `std` macros whose top-level
 argument simply isn't a runtime expression — `stringify!`
 takes a token sequence, `cfg!` takes a cfg predicate, the
@@ -474,8 +488,11 @@ the expansion, so the macro fails the exactly-once check.
 
 ```rust
 // Whether this is safe depends on the proc macro's expansion,
-// which the lint cannot inspect. A project adds
-// `serde_json::json` to `allow_extra` once project-wide after
+// which the lint cannot inspect. `serde_json::json` already
+// ships on the built-in allow list (the macro walks its input
+// once and evaluates each captured expression once); a project
+// that uses a *different* proc macro with the same contract
+// adds its path to `allow_extra` once project-wide after
 // confirming each argument is evaluated exactly once.
 let payload = serde_json::json!({ "id": next_id(), "ts": now() });
 ```
@@ -499,7 +516,7 @@ deny_extra = [
 
 # Macros added to the built-in allow list.
 allow_extra = [
-  # "serde_json::json",
+  # "my_crate::tt_builder_macro",
 ]
 
 # Macros to skip entirely, regardless of which list they would

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -373,6 +373,16 @@ For every macro invocation:
    All are syntactic positions the macro author chose, and the
    let-bind rewrite the rule would propose is meaningless for
    the macro's matcher arm.
+
+   When the argument itself is a single brace-delimited group
+   (`name!({"k": "v"})`, `name!({"k" => "v"})`), descend one
+   level and re-apply the DSL-marker check to the brace's inner
+   top level. A top-level `=>` or a top-level `:` outside a
+   `let` statement signals a DSL body (JSON-shaped or maplit-
+   shaped) rather than a Rust block expression, and is skipped
+   for the same reason. Real block expressions like
+   `{ let x: T = e; x }` survive the check because the `let`
+   keyword licenses the `:`.
 7. Classify the expression with the pure / impure split.
    If pure, accept; if impure, emit a diagnostic
    suggesting a `let` binding immediately before the macro

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -339,17 +339,29 @@ group.
 The third part collects third-party macros whose matchers are
 known to evaluate every top-level argument exactly once before
 forwarding it, so the rule's once-vs.-zero hazard does not apply.
-The current entries are the `insta` snapshot-assertion family —
-`assert_snapshot!`, `assert_debug_snapshot!`,
-`assert_display_snapshot!`, `assert_compact_debug_snapshot!`,
-`assert_yaml_snapshot!`, `assert_json_snapshot!`,
-`assert_compact_json_snapshot!`, `assert_ron_snapshot!`,
-`assert_csv_snapshot!`, `assert_toml_snapshot!`, and
-`assert_binary_snapshot!` — but the group is open-ended; further
-crates can be added as their matchers are vetted.
-`assert_display_snapshot!` is deprecated upstream in favour of
-`assert_snapshot!` but is retained for projects on older `insta`
-releases.
+The current entries cover four crates; the group is open-ended
+and further crates can be added as their matchers are vetted.
+
+- The `insta` snapshot-assertion family: `assert_snapshot!`,
+  `assert_debug_snapshot!`, `assert_display_snapshot!`,
+  `assert_compact_debug_snapshot!`, `assert_yaml_snapshot!`,
+  `assert_json_snapshot!`, `assert_compact_json_snapshot!`,
+  `assert_ron_snapshot!`, `assert_csv_snapshot!`,
+  `assert_toml_snapshot!`, and `assert_binary_snapshot!`.
+  `assert_display_snapshot!` is deprecated upstream in favour of
+  `assert_snapshot!` but is retained for projects on older
+  `insta` releases.
+- The `anyhow!` companions `bail!` and `ensure!`. `bail!(args)`
+  expands to `return Err(anyhow!(args))` and evaluates each
+  captured expression once; `ensure!(cond, args)` matches the
+  conditional-arguments shape of `assert!(cond, args)` already
+  on group 1.
+- The `maplit::{hashmap, btreemap, hashset, btreeset}!` builders.
+  Each expands to one `.insert` call per key/value pair, so every
+  captured expression is evaluated exactly once.
+- `serde_json::json!`. The macro walks its input token tree once
+  and routes every embedded Rust expression through
+  `to_value(&expr)` exactly once.
 
 `macro-trailing-comma`'s built-in list is intentionally
 narrower than this one; the two lists are not kept in

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -254,7 +254,7 @@ ecosystem, but the lint cannot prove the convention holds for
 any given call site. Projects that hit this corner can drop
 specific names from the built-in set via the
 `ignore_pure_methods` knob — for example, a project that
-wraps `as_ref` in a non-pure implementation can put `"as_ref"`
+wraps `as_ref` in an impure implementation can put `"as_ref"`
 in `ignore_pure_methods` and the lint will flag every
 `.as_ref()` call as a method call again.
 

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -146,6 +146,15 @@ The lint accepts any argument whose outermost shape is one of:
 - The unit literal `()`, a parenthesised pure expression
   (`(x)`), or a tuple whose every element is pure
   (`(a, b)`, `(a,)`).
+- The empty array literal `[]`, an array literal whose every
+  element is pure (`[a, b, c]`, optional trailing comma), or an
+  array-repeat `[expr; count]` whose `expr` and `count` are both
+  pure (`[0; 4]`, `[MAX; LEN]`). Array literals introduce no
+  side effect beyond their elements, and the array-repeat form
+  evaluates `expr` at most once at runtime, so neither shape
+  benefits from a let-bind rewrite when its parts are already
+  pure. The indexing suffix `base[index]` is handled by the
+  postfix walker and is unaffected by this carve-out.
 - A binary chain whose every operand is pure and whose
   every operator is side-effect-free in the syntactic sense:
   the arithmetic operators (`+`, `-`, `*`, `/`, `%`), the

--- a/rules/README.md
+++ b/rules/README.md
@@ -17,7 +17,7 @@ Lint-control attributes use the `perfectionist::` namespace.
   submodule defined as `module/mod.rs`; prefer the flat `module.rs` layout
 - [`macro_argument_binding`](./macro_argument_binding.md) (default: `enabled`).
 
-  macro invocation passes a non-trivial expression that should be bound to a `let` first
+  macro invocation passes an impure expression that should be bound to a `let` first
 - [`macro_trailing_comma`](./macro_trailing_comma.md) (default: `enabled`).
 
   macro invocation does not follow rustfmt's vertical trailing-comma policy

--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -142,7 +142,7 @@ appear in the built-in defaults or in `extra_pure_methods`.
 Empty by default; checked after the merge, so this knob always
 wins. Useful for opting back into linting on a default entry
 the project does not consider pure — for example, removing
-`as_ref` for a project that wraps it in a non-pure
+`as_ref` for a project that wraps it in an impure
 implementation.
 
 ### `extra_pure_macros`: `[string]` (optional)

--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -5,10 +5,10 @@
 **Default state:** `enabled`  
 **Source:** [`src/rules/macro_argument_binding.rs`](../src/rules/macro_argument_binding.rs)
 
-> macro invocation passes a non-trivial expression that should be bound to a `let` first
+> macro invocation passes an impure expression that should be bound to a `let` first
 
 ## What it does
-Flags non-trivial expressions passed as top-level arguments to a
+Flags impure expressions passed as top-level arguments to a
 function-like (`name!(...)`) or array-like (`name![...]`) macro
 invocation. The fix is to bind the expression to a `let` first
 and pass the binding instead, guaranteeing exactly-once
@@ -41,19 +41,19 @@ The same trap covers any macro that expands its capture more
 than once (`min!`/`max!`-style, retry loops): a side-effecting
 expression repeated produces wrong results.
 
-Trivial arguments — literals, paths, field accesses, indexing
-of trivial bases, dereferences, references, casts, the unit
+Pure arguments — literals, paths, field accesses, indexing
+of pure bases, dereferences, references, casts, the unit
 literal `()`, parenthesised / tuple groups whose elements are
-all trivial, binary chains of trivial operands joined by
+all pure, binary chains of pure operands joined by
 side-effect-free operators, zero-arg method calls whose name
 is in the curated pure-getter set (`len`, `is_empty`,
 `as_str`, `as_bytes`, `as_ref`, `as_mut`, `as_deref`,
-`as_slice`, plus anything in `extra_trivial_methods`), and
+`as_slice`, plus anything in `extra_pure_methods`), and
 calls to `core` / `std` macros whose expansion is a compile-
 time constant (`concat!`, `env!`, `option_env!`,
 `include_str!`, `include_bytes!`, `stringify!`, `cfg!`,
 `line!`, `column!`, `file!`, `module_path!`, plus anything in
-`extra_trivial_macros`) — are accepted as-is. A comparison
+`extra_pure_macros`) — are accepted as-is. A comparison
 like `vec.len() <= cap` evaluates the same way regardless of
 how many times the macro touches it, so binding it to a `let`
 would only force the comparison to run in release builds for
@@ -103,38 +103,38 @@ as `deny_extra`. Only meaningful in `AllowAndDeny` and
 Macros to skip entirely, regardless of which list they would
 otherwise hit. Same matching rules as `deny_extra`.
 
-### `extra_trivial_methods`: `[string]` (optional)
+### `extra_pure_methods`: `[string]` (optional)
 
 Method names added to the built-in pure-method list. Each
 entry is a bare method identifier (no `()`, no receiver). A
-`.method()` invocation on a trivial base is then accepted as a
-trivial postfix when the method takes no arguments.
+`.method()` invocation on a pure base is then accepted as a
+pure postfix when the method takes no arguments.
 
-### `ignore_trivial_methods`: `[string]` (optional)
+### `ignore_pure_methods`: `[string]` (optional)
 
 Method names to drop from the pure-method list, even if they
-appear in the built-in defaults or in `extra_trivial_methods`.
+appear in the built-in defaults or in `extra_pure_methods`.
 Empty by default; checked after the merge, so this knob always
 wins. Useful for opting back into linting on a default entry
-the project does not consider trivial — for example, removing
+the project does not consider pure — for example, removing
 `as_ref` for a project that wraps it in a non-pure
 implementation.
 
-### `extra_trivial_macros`: `[string]` (optional)
+### `extra_pure_macros`: `[string]` (optional)
 
-Macro names added to the built-in trivial-macro list. Each
+Macro names added to the built-in pure-macro list. Each
 entry is matched against the invocation's final path segment
 (so `my_crate::const_str` matches by the `"const_str"` tail).
-A trivial-macro call passed as an argument to another macro is
-treated as a trivial atom — the rule does not propose binding
+A pure-macro call passed as an argument to another macro is
+treated as a pure atom — the rule does not propose binding
 it to a `let`. Use this knob for project-specific macros whose
 expansion is guaranteed to be a literal or other compile-time
 constant.
 
-### `ignore_trivial_macros`: `[string]` (optional)
+### `ignore_pure_macros`: `[string]` (optional)
 
-Macro names to drop from the trivial-macro list, even if they
-appear in the built-in defaults or in `extra_trivial_macros`.
+Macro names to drop from the pure-macro list, even if they
+appear in the built-in defaults or in `extra_pure_macros`.
 Checked after the merge, so this knob always wins.
 
 ### Types
@@ -155,7 +155,7 @@ plus `deny_extra`). Every other macro is silently accepted.
 ##### `"blanket"` (Rust: `Blanket`)
 
 Flag every function-like or array-like invocation that carries
-a non-trivial top-level argument, regardless of any built-in
+an impure top-level argument, regardless of any built-in
 classification — unless the invocation matches an `allow_extra`
 entry. The built-in allow list is deliberately ignored in this
 mode; project exceptions go in `allow_extra`.

--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -43,8 +43,9 @@ expression repeated produces wrong results.
 
 Pure arguments — literals, paths, field accesses, indexing
 of pure bases, dereferences, references, casts, the unit
-literal `()`, parenthesised / tuple groups whose elements are
-all pure, binary chains of pure operands joined by
+literal `()`, parenthesised / tuple / array-literal /
+array-repeat groups whose elements are all pure, binary
+chains of pure operands joined by
 side-effect-free operators, zero-arg method calls whose name
 is in the curated pure-getter set (`len`, `is_empty`,
 `as_str`, `as_bytes`, `as_ref`, `as_mut`, `as_deref`,

--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -41,11 +41,31 @@ The same trap covers any macro that expands its capture more
 than once (`min!`/`max!`-style, retry loops): a side-effecting
 expression repeated produces wrong results.
 
-Pure arguments — literals, paths, field accesses, indexing
-of pure bases, dereferences, references, casts, the unit
-literal `()`, parenthesised / tuple / array-literal /
-array-repeat groups whose elements are all pure, binary
-chains of pure operands joined by
+## Terminology
+
+In this rule, **pure** means *safe for the surrounding macro
+to drop or duplicate*: evaluating the argument zero, one, or
+many times is observationally equivalent. **Impure** is
+anything else, and is what the rule flags.
+
+The classification is *syntactic*: the rule recognises a
+curated set of shapes known to satisfy the property and
+treats everything else as impure. A `const fn` call, a
+`Result::map` chain over a pure base, or `vec.fold(...)` is
+therefore impure under this rule unless its shape is
+recognised — the lint cannot prove side-effect-freedom in
+general, only spot it. The trade-off favours flagging
+side-effect-free expressions over silently passing a real
+hazard. The set is narrower than the functional-programming
+notion of purity and is keyed to what a macro can actually
+do with its captures, not to side-effect-freedom in the
+abstract.
+
+The recognised pure shapes are: literals, paths, field
+accesses, indexing of pure bases, dereferences, references,
+casts, the unit literal `()`, parenthesised / tuple /
+array-literal / array-repeat groups whose elements are all
+pure, binary chains of pure operands joined by
 side-effect-free operators, zero-arg method calls whose name
 is in the curated pure-getter set (`len`, `is_empty`,
 `as_str`, `as_bytes`, `as_ref`, `as_mut`, `as_deref`,
@@ -54,14 +74,13 @@ calls to `core` / `std` macros whose expansion is a compile-
 time constant (`concat!`, `env!`, `option_env!`,
 `include_str!`, `include_bytes!`, `stringify!`, `cfg!`,
 `line!`, `column!`, `file!`, `module_path!`, plus anything in
-`extra_pure_macros`) — are accepted as-is. A comparison
-like `vec.len() <= cap` evaluates the same way regardless of
-how many times the macro touches it, so binding it to a `let`
-would only force the comparison to run in release builds for
-no benefit; the same logic applies to `env!("HOME")` inside
+`extra_pure_macros`). A comparison like `vec.len() <= cap`
+evaluates the same way regardless of how many times the
+macro touches it, so binding it to a `let` would only force
+the comparison to run in release builds for no benefit; the
+same logic applies to `env!("HOME")` inside
 `debug_assert_eq!(...)` — there is nothing to evaluate at
-runtime. The lint focuses on arguments whose evaluation is
-itself observable.
+runtime.
 
 ## Example
 ```rust,ignore
@@ -109,7 +128,12 @@ otherwise hit. Same matching rules as `deny_extra`.
 Method names added to the built-in pure-method list. Each
 entry is a bare method identifier (no `()`, no receiver). A
 `.method()` invocation on a pure base is then accepted as a
-pure postfix when the method takes no arguments.
+pure postfix when the method takes no arguments. Add a
+project-local method here only when it is genuinely safe
+for the surrounding macro to drop or duplicate the call
+(the rule's working definition of *pure*) — typically an
+`O(1)` side-effect-free getter that the lint's syntactic
+classification can't otherwise see.
 
 ### `ignore_pure_methods`: `[string]` (optional)
 
@@ -128,9 +152,12 @@ entry is matched against the invocation's final path segment
 (so `my_crate::const_str` matches by the `"const_str"` tail).
 A pure-macro call passed as an argument to another macro is
 treated as a pure atom — the rule does not propose binding
-it to a `let`. Use this knob for project-specific macros whose
-expansion is guaranteed to be a literal or other compile-time
-constant.
+it to a `let`. Use this knob for project-specific macros
+whose expansion is a compile-time constant (a literal, a
+`&'static str`, a `bool`); their inclusion satisfies the
+rule's pure-as-drop-or-duplicate-safe definition trivially,
+since there is no runtime expression for the surrounding
+macro to drop or duplicate.
 
 ### `ignore_pure_macros`: `[string]` (optional)
 

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -75,8 +75,9 @@ declare_tool_lint! {
     ///
     /// Pure arguments — literals, paths, field accesses, indexing
     /// of pure bases, dereferences, references, casts, the unit
-    /// literal `()`, parenthesised / tuple groups whose elements are
-    /// all pure, binary chains of pure operands joined by
+    /// literal `()`, parenthesised / tuple / array-literal /
+    /// array-repeat groups whose elements are all pure, binary
+    /// chains of pure operands joined by
     /// side-effect-free operators, zero-arg method calls whose name
     /// is in the curated pure-getter set (`len`, `is_empty`,
     /// `as_str`, `as_bytes`, `as_ref`, `as_mut`, `as_deref`,

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -71,11 +71,31 @@ declare_tool_lint! {
     /// than once (`min!`/`max!`-style, retry loops): a side-effecting
     /// expression repeated produces wrong results.
     ///
-    /// Pure arguments — literals, paths, field accesses, indexing
-    /// of pure bases, dereferences, references, casts, the unit
-    /// literal `()`, parenthesised / tuple / array-literal /
-    /// array-repeat groups whose elements are all pure, binary
-    /// chains of pure operands joined by
+    /// ### Terminology
+    ///
+    /// In this rule, **pure** means *safe for the surrounding macro
+    /// to drop or duplicate*: evaluating the argument zero, one, or
+    /// many times is observationally equivalent. **Impure** is
+    /// anything else, and is what the rule flags.
+    ///
+    /// The classification is *syntactic*: the rule recognises a
+    /// curated set of shapes known to satisfy the property and
+    /// treats everything else as impure. A `const fn` call, a
+    /// `Result::map` chain over a pure base, or `vec.fold(...)` is
+    /// therefore impure under this rule unless its shape is
+    /// recognised — the lint cannot prove side-effect-freedom in
+    /// general, only spot it. The trade-off favours flagging
+    /// side-effect-free expressions over silently passing a real
+    /// hazard. The set is narrower than the functional-programming
+    /// notion of purity and is keyed to what a macro can actually
+    /// do with its captures, not to side-effect-freedom in the
+    /// abstract.
+    ///
+    /// The recognised pure shapes are: literals, paths, field
+    /// accesses, indexing of pure bases, dereferences, references,
+    /// casts, the unit literal `()`, parenthesised / tuple /
+    /// array-literal / array-repeat groups whose elements are all
+    /// pure, binary chains of pure operands joined by
     /// side-effect-free operators, zero-arg method calls whose name
     /// is in the curated pure-getter set (`len`, `is_empty`,
     /// `as_str`, `as_bytes`, `as_ref`, `as_mut`, `as_deref`,
@@ -84,14 +104,13 @@ declare_tool_lint! {
     /// time constant (`concat!`, `env!`, `option_env!`,
     /// `include_str!`, `include_bytes!`, `stringify!`, `cfg!`,
     /// `line!`, `column!`, `file!`, `module_path!`, plus anything in
-    /// `extra_pure_macros`) — are accepted as-is. A comparison
-    /// like `vec.len() <= cap` evaluates the same way regardless of
-    /// how many times the macro touches it, so binding it to a `let`
-    /// would only force the comparison to run in release builds for
-    /// no benefit; the same logic applies to `env!("HOME")` inside
+    /// `extra_pure_macros`). A comparison like `vec.len() <= cap`
+    /// evaluates the same way regardless of how many times the
+    /// macro touches it, so binding it to a `let` would only force
+    /// the comparison to run in release builds for no benefit; the
+    /// same logic applies to `env!("HOME")` inside
     /// `debug_assert_eq!(...)` — there is nothing to evaluate at
-    /// runtime. The lint focuses on arguments whose evaluation is
-    /// itself observable.
+    /// runtime.
     ///
     /// ### Example
     /// ```rust,ignore

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -1,4 +1,4 @@
-//! `perfectionist::macro_argument_binding` — flag non-trivial top-level
+//! `perfectionist::macro_argument_binding` — flag impure top-level
 //! arguments to function-like (`name!(...)`) and array-like (`name![...]`)
 //! macro invocations.
 //!
@@ -7,8 +7,8 @@
 //! - [`config`] — user-facing configuration (`Mode`, `Config`,
 //!   `MacroArgumentBinding` state) and the curated built-in deny /
 //!   allow lists.
-//! - [`triviality`] — top-level argument splitter, the
-//!   `looks_like_expression` heuristic, and the trivial-expression
+//! - [`purity`] — top-level argument splitter, the
+//!   `looks_like_expression` heuristic, and the pure-expression
 //!   token-stream walker.
 //! - [`late`] — late pass that drains [`PENDING_VIOLATIONS`] and emits
 //!   each diagnostic at the deepest enclosing HIR node.
@@ -30,17 +30,17 @@ use crate::common::{DefaultState, resolved_state};
 
 mod config;
 mod late;
-mod triviality;
+mod purity;
 
 use config::MacroArgumentBinding;
 use late::MacroArgumentBindingLate;
-use triviality::{
-    TrivialContext, is_trivial_expression, looks_like_expression, split_top_level_arguments,
+use purity::{
+    PurityContext, is_pure_expression, looks_like_expression, split_top_level_arguments,
 };
 
 declare_tool_lint! {
     /// ### What it does
-    /// Flags non-trivial expressions passed as top-level arguments to a
+    /// Flags impure expressions passed as top-level arguments to a
     /// function-like (`name!(...)`) or array-like (`name![...]`) macro
     /// invocation. The fix is to bind the expression to a `let` first
     /// and pass the binding instead, guaranteeing exactly-once
@@ -73,19 +73,19 @@ declare_tool_lint! {
     /// than once (`min!`/`max!`-style, retry loops): a side-effecting
     /// expression repeated produces wrong results.
     ///
-    /// Trivial arguments — literals, paths, field accesses, indexing
-    /// of trivial bases, dereferences, references, casts, the unit
+    /// Pure arguments — literals, paths, field accesses, indexing
+    /// of pure bases, dereferences, references, casts, the unit
     /// literal `()`, parenthesised / tuple groups whose elements are
-    /// all trivial, binary chains of trivial operands joined by
+    /// all pure, binary chains of pure operands joined by
     /// side-effect-free operators, zero-arg method calls whose name
     /// is in the curated pure-getter set (`len`, `is_empty`,
     /// `as_str`, `as_bytes`, `as_ref`, `as_mut`, `as_deref`,
-    /// `as_slice`, plus anything in `extra_trivial_methods`), and
+    /// `as_slice`, plus anything in `extra_pure_methods`), and
     /// calls to `core` / `std` macros whose expansion is a compile-
     /// time constant (`concat!`, `env!`, `option_env!`,
     /// `include_str!`, `include_bytes!`, `stringify!`, `cfg!`,
     /// `line!`, `column!`, `file!`, `module_path!`, plus anything in
-    /// `extra_trivial_macros`) — are accepted as-is. A comparison
+    /// `extra_pure_macros`) — are accepted as-is. A comparison
     /// like `vec.len() <= cap` evaluates the same way regardless of
     /// how many times the macro touches it, so binding it to a `let`
     /// would only force the comparison to run in release builds for
@@ -105,7 +105,7 @@ declare_tool_lint! {
     /// ```
     pub perfectionist::MACRO_ARGUMENT_BINDING,
     Warn,
-    "macro invocation passes a non-trivial expression that should be bound to a `let` first",
+    "macro invocation passes an impure expression that should be bound to a `let` first",
     report_in_external_macro: false
 }
 
@@ -154,9 +154,9 @@ impl EarlyLintPass for MacroArgumentBinding {
         let Some(arguments) = split_top_level_arguments(&mac_call.args.tokens) else {
             return;
         };
-        let ctx = TrivialContext {
-            methods: self.trivial_methods(),
-            macros: self.trivial_macros(),
+        let ctx = PurityContext {
+            methods: self.pure_methods(),
+            macros: self.pure_macros(),
         };
         for argument in arguments {
             check_argument(&argument, ctx);
@@ -164,14 +164,14 @@ impl EarlyLintPass for MacroArgumentBinding {
     }
 }
 
-fn check_argument(argument: &[TokenTree], ctx: TrivialContext<'_>) {
+fn check_argument(argument: &[TokenTree], ctx: PurityContext<'_>) {
     if argument.is_empty() {
         return;
     }
     if !looks_like_expression(argument) {
         return;
     }
-    if is_trivial_expression(argument, ctx) {
+    if is_pure_expression(argument, ctx) {
         return;
     }
     let first = argument.first().expect("non-empty checked above");

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -34,9 +34,7 @@ mod purity;
 
 use config::MacroArgumentBinding;
 use late::MacroArgumentBindingLate;
-use purity::{
-    PurityContext, is_pure_expression, looks_like_expression, split_top_level_arguments,
-};
+use purity::{PurityContext, is_pure_expression, looks_like_expression, split_top_level_arguments};
 
 declare_tool_lint! {
     /// ### What it does

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -226,7 +226,12 @@ pub(super) struct Config {
     /// Method names added to the built-in pure-method list. Each
     /// entry is a bare method identifier (no `()`, no receiver). A
     /// `.method()` invocation on a pure base is then accepted as a
-    /// pure postfix when the method takes no arguments.
+    /// pure postfix when the method takes no arguments. Add a
+    /// project-local method here only when it is genuinely safe
+    /// for the surrounding macro to drop or duplicate the call
+    /// (the rule's working definition of *pure*) — typically an
+    /// `O(1)` side-effect-free getter that the lint's syntactic
+    /// classification can't otherwise see.
     pub extra_pure_methods: Vec<String>,
     /// Method names to drop from the pure-method list, even if they
     /// appear in the built-in defaults or in `extra_pure_methods`.
@@ -241,9 +246,12 @@ pub(super) struct Config {
     /// (so `my_crate::const_str` matches by the `"const_str"` tail).
     /// A pure-macro call passed as an argument to another macro is
     /// treated as a pure atom — the rule does not propose binding
-    /// it to a `let`. Use this knob for project-specific macros whose
-    /// expansion is guaranteed to be a literal or other compile-time
-    /// constant.
+    /// it to a `let`. Use this knob for project-specific macros
+    /// whose expansion is a compile-time constant (a literal, a
+    /// `&'static str`, a `bool`); their inclusion satisfies the
+    /// rule's pure-as-drop-or-duplicate-safe definition trivially,
+    /// since there is no runtime expression for the surrounding
+    /// macro to drop or duplicate.
     pub extra_pure_macros: Vec<String>,
     /// Macro names to drop from the pure-macro list, even if they
     /// appear in the built-in defaults or in `extra_pure_macros`.

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -113,17 +113,17 @@ const BUILTIN_ALLOW: &[&str] = &[
 /// compiler computes at build time — a literal, a `&'static str`, a
 /// byte string, a `bool` cfg verdict, a line / column / file marker.
 /// None evaluates a runtime expression, none has side effects, so an
-/// `inner!(...)` call to one of these is itself a trivial argument
+/// `inner!(...)` call to one of these is itself a pure argument
 /// for the surrounding macro: it cannot be evaluated more than once
 /// at runtime no matter what the outer macro does with it.
 ///
 /// `include!` is deliberately excluded — its expansion is arbitrary
-/// Rust code rather than a literal, so its triviality depends on the
+/// Rust code rather than a literal, so its purity depends on the
 /// included file's contents and the rule cannot prove it.
 /// `compile_error!` is also excluded: its expansion is the diverging
 /// `!` type rather than a value, and the planning doc reserves the
-/// trivial-atom slot for value-producing macros.
-const BUILTIN_TRIVIAL_MACROS: &[&str] = &[
+/// pure-atom slot for value-producing macros.
+const BUILTIN_PURE_MACROS: &[&str] = &[
     "cfg",
     "column",
     "concat",
@@ -140,12 +140,12 @@ const BUILTIN_TRIVIAL_MACROS: &[&str] = &[
 /// Zero-arg method names that are conventionally side-effect-free
 /// across the standard library and ecosystem. `vec.len()`,
 /// `s.is_empty()`, `opt.as_ref()` evaluate the same way no matter how
-/// many times the macro touches them, so they are accepted as trivial
-/// postfixes on a trivial base. Names whose pure-getter convention is
+/// many times the macro touches them, so they are accepted as pure
+/// postfixes on a pure base. Names whose pure-getter convention is
 /// less universal (e.g. `count` is consuming on `Iterator` but
 /// `O(1)` and pure on indexed collections) are left for projects to
-/// add via `extra_trivial_methods`.
-const BUILTIN_TRIVIAL_METHODS: &[&str] = &[
+/// add via `extra_pure_methods`.
+const BUILTIN_PURE_METHODS: &[&str] = &[
     "as_bytes", "as_deref", "as_mut", "as_ref", "as_slice", "as_str", "is_empty", "len",
 ];
 
@@ -161,7 +161,7 @@ pub(super) enum Mode {
     /// plus `deny_extra`). Every other macro is silently accepted.
     DenyOnly,
     /// Flag every function-like or array-like invocation that carries
-    /// a non-trivial top-level argument, regardless of any built-in
+    /// an impure top-level argument, regardless of any built-in
     /// classification — unless the invocation matches an `allow_extra`
     /// entry. The built-in allow list is deliberately ignored in this
     /// mode; project exceptions go in `allow_extra`.
@@ -197,30 +197,30 @@ pub(super) struct Config {
     pub ignore: Vec<String>,
     /// Method names added to the built-in pure-method list. Each
     /// entry is a bare method identifier (no `()`, no receiver). A
-    /// `.method()` invocation on a trivial base is then accepted as a
-    /// trivial postfix when the method takes no arguments.
-    pub extra_trivial_methods: Vec<String>,
+    /// `.method()` invocation on a pure base is then accepted as a
+    /// pure postfix when the method takes no arguments.
+    pub extra_pure_methods: Vec<String>,
     /// Method names to drop from the pure-method list, even if they
-    /// appear in the built-in defaults or in `extra_trivial_methods`.
+    /// appear in the built-in defaults or in `extra_pure_methods`.
     /// Empty by default; checked after the merge, so this knob always
     /// wins. Useful for opting back into linting on a default entry
-    /// the project does not consider trivial — for example, removing
+    /// the project does not consider pure — for example, removing
     /// `as_ref` for a project that wraps it in a non-pure
     /// implementation.
-    pub ignore_trivial_methods: Vec<String>,
-    /// Macro names added to the built-in trivial-macro list. Each
+    pub ignore_pure_methods: Vec<String>,
+    /// Macro names added to the built-in pure-macro list. Each
     /// entry is matched against the invocation's final path segment
     /// (so `my_crate::const_str` matches by the `"const_str"` tail).
-    /// A trivial-macro call passed as an argument to another macro is
-    /// treated as a trivial atom — the rule does not propose binding
+    /// A pure-macro call passed as an argument to another macro is
+    /// treated as a pure atom — the rule does not propose binding
     /// it to a `let`. Use this knob for project-specific macros whose
     /// expansion is guaranteed to be a literal or other compile-time
     /// constant.
-    pub extra_trivial_macros: Vec<String>,
-    /// Macro names to drop from the trivial-macro list, even if they
-    /// appear in the built-in defaults or in `extra_trivial_macros`.
+    pub extra_pure_macros: Vec<String>,
+    /// Macro names to drop from the pure-macro list, even if they
+    /// appear in the built-in defaults or in `extra_pure_macros`.
     /// Checked after the merge, so this knob always wins.
-    pub ignore_trivial_macros: Vec<String>,
+    pub ignore_pure_macros: Vec<String>,
 }
 
 impl Default for Config {
@@ -231,10 +231,10 @@ impl Default for Config {
             deny_extra: Vec::new(),
             allow_extra: Vec::new(),
             ignore: Vec::new(),
-            extra_trivial_methods: Vec::new(),
-            ignore_trivial_methods: Vec::new(),
-            extra_trivial_macros: Vec::new(),
-            ignore_trivial_macros: Vec::new(),
+            extra_pure_methods: Vec::new(),
+            ignore_pure_methods: Vec::new(),
+            extra_pure_macros: Vec::new(),
+            ignore_pure_macros: Vec::new(),
         }
     }
 }
@@ -256,17 +256,17 @@ pub(super) struct MacroArgumentBinding {
     /// Macros to skip entirely. Checked before deny / allow lookup, so
     /// an entry here wins over any other classification.
     ignore: BTreeSet<Vec<String>>,
-    /// Built-in pure-method list plus `extra_trivial_methods`,
-    /// consulted by the trivial-expression walker to accept
-    /// `expr.method()` as a trivial postfix on a trivial base.
-    trivial_methods: BTreeSet<String>,
-    /// Built-in trivial-macro list plus `extra_trivial_macros`,
-    /// consulted by the trivial-expression walker to accept
-    /// `inner!(...)` as a trivial atom when the macro's expansion
+    /// Built-in pure-method list plus `extra_pure_methods`,
+    /// consulted by the pure-expression walker to accept
+    /// `expr.method()` as a pure postfix on a pure base.
+    pure_methods: BTreeSet<String>,
+    /// Built-in pure-macro list plus `extra_pure_macros`,
+    /// consulted by the pure-expression walker to accept
+    /// `inner!(...)` as a pure atom when the macro's expansion
     /// is a compile-time constant. Match is tail-segment-based:
     /// an entry of `"env"` accepts `env!(...)`, `std::env!(...)`,
     /// and `::core::env!(...)` alike.
-    trivial_macros: BTreeSet<String>,
+    pure_macros: BTreeSet<String>,
 }
 
 impl MacroArgumentBinding {
@@ -277,15 +277,15 @@ impl MacroArgumentBinding {
         let deny = merge_with_builtins(BUILTIN_DENY, &extra_deny);
         let allow = merge_with_builtins(BUILTIN_ALLOW, &extra_allow);
         let ignore = parse_path_list(&config.ignore);
-        let trivial_methods = merge_string_allowlist(
-            BUILTIN_TRIVIAL_METHODS,
-            config.extra_trivial_methods,
-            config.ignore_trivial_methods,
+        let pure_methods = merge_string_allowlist(
+            BUILTIN_PURE_METHODS,
+            config.extra_pure_methods,
+            config.ignore_pure_methods,
         );
-        let trivial_macros = merge_string_allowlist(
-            BUILTIN_TRIVIAL_MACROS,
-            config.extra_trivial_macros,
-            config.ignore_trivial_macros,
+        let pure_macros = merge_string_allowlist(
+            BUILTIN_PURE_MACROS,
+            config.extra_pure_macros,
+            config.ignore_pure_macros,
         );
         Self {
             enabled: config.enabled,
@@ -294,22 +294,22 @@ impl MacroArgumentBinding {
             allow,
             allow_extra: extra_allow,
             ignore,
-            trivial_methods,
-            trivial_macros,
+            pure_methods,
+            pure_macros,
         }
     }
 
     /// The merged set of method names whose `.method()` invocations
-    /// on a trivial base are accepted as trivial postfixes.
-    pub(super) fn trivial_methods(&self) -> &BTreeSet<String> {
-        &self.trivial_methods
+    /// on a pure base are accepted as pure postfixes.
+    pub(super) fn pure_methods(&self) -> &BTreeSet<String> {
+        &self.pure_methods
     }
 
     /// The merged set of macro names whose `inner!(...)` invocations
-    /// are accepted as trivial atoms. Matched by final path segment,
+    /// are accepted as pure atoms. Matched by final path segment,
     /// so a single-name entry covers fully-qualified call sites too.
-    pub(super) fn trivial_macros(&self) -> &BTreeSet<String> {
-        &self.trivial_macros
+    pub(super) fn pure_macros(&self) -> &BTreeSet<String> {
+        &self.pure_macros
     }
 
     /// Path-side eligibility: combines the `enabled` switch, the

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -25,14 +25,11 @@ const BUILTIN_DENY: &[&str] = &["debug_assert", "debug_assert_eq", "debug_assert
 /// "evaluate zero, one, or many times" hazard. Three disjoint groups:
 ///
 /// 1. Runtime macros (`format!`, `vec!`, `assert!`, `dbg!`, …) that
-///    promise to evaluate every top-level argument exactly once,
-///    plus a small set of third-party companions (`anyhow!` /
-///    `bail!` / `ensure!`, `serde_json::json!`, the `maplit::*`
-///    builders) whose published semantics match the same
-///    contract. Shares its core with `macro_trailing_comma`'s
-///    built-in set, minus the conditional-evaluation families
-///    (`log::*`, `tracing::*`) that *do* drop arguments below
-///    the configured filter level.
+///    promise to evaluate every top-level argument exactly once.
+///    Shares its core with `macro_trailing_comma`'s built-in set,
+///    minus the conditional-evaluation families (`log::*`,
+///    `tracing::*`) that *do* drop arguments below the configured
+///    filter level.
 /// 2. `core` / `std` macros whose top-level argument simply isn't a
 ///    runtime expression — `stringify!` takes a token sequence,
 ///    `cfg!` takes a cfg predicate, the `env!` / `include_*` /
@@ -74,31 +71,6 @@ const BUILTIN_ALLOW: &[&str] = &[
     "matches",
     "dbg",
     "anyhow",
-    // Anyhow companions. `bail!(args)` expands to `return Err(anyhow!(args))`
-    // and evaluates each captured expression once; `ensure!(cond, args)`
-    // matches the shape of `assert!(cond, args)` already on this list — `cond`
-    // always evaluates, `args` only on failure, identical conditional-args
-    // semantics to `assert!`.
-    "bail",
-    "ensure",
-    // Third-party `tt`-based literal builders. The macros walk their
-    // input token tree once and emit one runtime evaluation per
-    // captured Rust expression — no cfg gate, no repetition, no
-    // conditional branch.
-    //
-    // - `serde_json::json` builds a `serde_json::Value` tree; each
-    //   embedded Rust expression goes through `to_value(&expr)`
-    //   exactly once.
-    // - `maplit::{hashmap, btreemap, hashset, btreeset}` expand to
-    //   one `.insert` call per pair; each captured key and value
-    //   is evaluated once. Single-segment tail matching means
-    //   `maplit::hashmap!`, fully-qualified call sites, and any
-    //   project-local re-export all line up with the same entry.
-    "btreemap",
-    "btreeset",
-    "hashmap",
-    "hashset",
-    "json",
     // `core` / `std` macros that do not evaluate a runtime user
     // expression at the call site (see the doc comment above for
     // the per-macro rationale).
@@ -117,13 +89,30 @@ const BUILTIN_ALLOW: &[&str] = &[
     "option_env",
     "stringify",
     // Third-party macros whose matchers evaluate every top-level
-    // argument exactly once. The current entries are `insta`'s
-    // snapshot-assertion family; add further crates here as their
-    // matchers are vetted to honour the same guarantee.
-    // `assert_display_snapshot` is deprecated upstream in favour of
-    // `assert_snapshot` but is retained for projects on older
-    // `insta` releases; `assert_binary_snapshot` is the newer
-    // byte-slice variant.
+    // argument exactly once. Entries are grouped by crate in the
+    // commentary below; the array itself is alphabetised because
+    // the matcher is tail-segment-keyed and doesn't care about
+    // origin.
+    //
+    // - `anyhow::{bail, ensure}` are companions to `anyhow!` (in
+    //   group 1). `bail!(args)` expands to `return Err(anyhow!(args))`
+    //   and evaluates each captured expression once; `ensure!(cond,
+    //   args)` matches the shape of `assert!(cond, args)` already on
+    //   group 1 — `cond` always evaluates, `args` only on failure.
+    // - `insta`'s snapshot-assertion family. Each variant
+    //   evaluates its value argument exactly once before
+    //   serialising; `assert_display_snapshot` is deprecated
+    //   upstream but retained for projects on older `insta`;
+    //   `assert_binary_snapshot` is the newer byte-slice variant.
+    // - `maplit::{hashmap, btreemap, hashset, btreeset}` expand to
+    //   one `.insert` call per pair; each captured key and value is
+    //   evaluated once.
+    // - `serde_json::json` builds a `serde_json::Value` tree; each
+    //   embedded Rust expression goes through `to_value(&expr)`
+    //   exactly once.
+    //
+    // Add further crates here as their matchers are vetted to
+    // honour the same once-only contract.
     "assert_binary_snapshot",
     "assert_compact_debug_snapshot",
     "assert_compact_json_snapshot",
@@ -135,6 +124,13 @@ const BUILTIN_ALLOW: &[&str] = &[
     "assert_snapshot",
     "assert_toml_snapshot",
     "assert_yaml_snapshot",
+    "bail",
+    "btreemap",
+    "btreeset",
+    "ensure",
+    "hashmap",
+    "hashset",
+    "json",
 ];
 
 /// `core` / `std` macros whose invocation expands to a value the

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -243,7 +243,7 @@ pub(super) struct Config {
     /// Empty by default; checked after the merge, so this knob always
     /// wins. Useful for opting back into linting on a default entry
     /// the project does not consider pure — for example, removing
-    /// `as_ref` for a project that wraps it in a non-pure
+    /// `as_ref` for a project that wraps it in an impure
     /// implementation.
     pub ignore_pure_methods: Vec<String>,
     /// Macro names added to the built-in pure-macro list. Each

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -105,11 +105,20 @@ const BUILTIN_ALLOW: &[&str] = &[
     //   upstream but retained for projects on older `insta`;
     //   `assert_binary_snapshot` is the newer byte-slice variant.
     // - `maplit::{hashmap, btreemap, hashset, btreeset}` expand to
-    //   one `.insert` call per pair; each captured key and value is
-    //   evaluated once.
+    //   one `.insert` call per pair; each captured key and value
+    //   is evaluated once. These entries are functionally
+    //   redundant given `looks_like_expression`'s top-level `=>`
+    //   DSL-marker skip (every non-empty maplit call form emits
+    //   `=>` at the top level of each argument and is skipped
+    //   regardless); they're retained as an explicit declaration
+    //   that the project has vetted these macros for the once-
+    //   only contract.
     // - `serde_json::json` builds a `serde_json::Value` tree; each
     //   embedded Rust expression goes through `to_value(&expr)`
-    //   exactly once.
+    //   exactly once. Unlike `maplit::*`, this entry is load-
+    //   bearing for direct-expression arguments — `json!(expr)`
+    //   has no DSL marker, so removing the entry would re-flag
+    //   `json!(value().unwrap())` and similar.
     //
     // Add further crates here as their matchers are vetted to
     // honour the same once-only contract.

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -25,11 +25,14 @@ const BUILTIN_DENY: &[&str] = &["debug_assert", "debug_assert_eq", "debug_assert
 /// "evaluate zero, one, or many times" hazard. Three disjoint groups:
 ///
 /// 1. Runtime macros (`format!`, `vec!`, `assert!`, `dbg!`, …) that
-///    promise to evaluate every top-level argument exactly once.
-///    Shares its core with `macro_trailing_comma`'s built-in set,
-///    minus the conditional-evaluation families (`log::*`,
-///    `tracing::*`) that *do* drop arguments below the configured
-///    filter level.
+///    promise to evaluate every top-level argument exactly once,
+///    plus a small set of third-party companions (`anyhow!` /
+///    `bail!` / `ensure!`, `serde_json::json!`, the `maplit::*`
+///    builders) whose published semantics match the same
+///    contract. Shares its core with `macro_trailing_comma`'s
+///    built-in set, minus the conditional-evaluation families
+///    (`log::*`, `tracing::*`) that *do* drop arguments below
+///    the configured filter level.
 /// 2. `core` / `std` macros whose top-level argument simply isn't a
 ///    runtime expression — `stringify!` takes a token sequence,
 ///    `cfg!` takes a cfg predicate, the `env!` / `include_*` /
@@ -71,6 +74,31 @@ const BUILTIN_ALLOW: &[&str] = &[
     "matches",
     "dbg",
     "anyhow",
+    // Anyhow companions. `bail!(args)` expands to `return Err(anyhow!(args))`
+    // and evaluates each captured expression once; `ensure!(cond, args)`
+    // matches the shape of `assert!(cond, args)` already on this list — `cond`
+    // always evaluates, `args` only on failure, identical conditional-args
+    // semantics to `assert!`.
+    "bail",
+    "ensure",
+    // Third-party `tt`-based literal builders. The macros walk their
+    // input token tree once and emit one runtime evaluation per
+    // captured Rust expression — no cfg gate, no repetition, no
+    // conditional branch.
+    //
+    // - `serde_json::json` builds a `serde_json::Value` tree; each
+    //   embedded Rust expression goes through `to_value(&expr)`
+    //   exactly once.
+    // - `maplit::{hashmap, btreemap, hashset, btreeset}` expand to
+    //   one `.insert` call per pair; each captured key and value
+    //   is evaluated once. Single-segment tail matching means
+    //   `maplit::hashmap!`, fully-qualified call sites, and any
+    //   project-local re-export all line up with the same entry.
+    "btreemap",
+    "btreeset",
+    "hashmap",
+    "hashset",
+    "json",
     // `core` / `std` macros that do not evaluate a runtime user
     // expression at the call site (see the doc comment above for
     // the per-macro rationale).

--- a/src/rules/macro_argument_binding/late.rs
+++ b/src/rules/macro_argument_binding/late.rs
@@ -40,7 +40,7 @@ fn emit(lint_context: &LateContext<'_>, hir_id: hir::HirId, span: Span) {
         MACRO_ARGUMENT_BINDING,
         hir_id,
         span,
-        "non-trivial expression passed directly to a macro",
+        "impure expression passed directly to a macro",
         |diag| {
             diag.help(
                 "bind the expression to a `let` immediately before the macro \

--- a/src/rules/macro_argument_binding/purity.rs
+++ b/src/rules/macro_argument_binding/purity.rs
@@ -154,36 +154,85 @@ pub(super) fn looks_like_expression(argument: &[TokenTree]) -> bool {
 ///   put the `:` one delimiter level deeper than the surrounding
 ///   block.
 ///
-/// Statements are split by top-level `;`. A labeled loop or block
-/// (`'a: loop { ... }`) at the brace's immediate top level is a
-/// known false positive — its `:` sits in the same position as a
-/// DSL key — but in macro-argument position labeled blocks are
-/// vanishingly rare.
+/// Statements are split by top-level `;`. At each statement's
+/// start, leading outer / inner attributes (`#[cfg(...)]`,
+/// `#![allow(...)]`) and doc comments are skipped before the
+/// `let`-whitelist check, so `{ #[cfg(foo)] let x: T = e; x }`
+/// (an attribute-annotated `let` binding inside a real block) is
+/// still treated as a Rust block.
+///
+/// A labeled loop or block (`'a: loop { ... }`) at the brace's
+/// immediate top level is a known false positive — its `:` sits
+/// in the same position as a DSL key — but in macro-argument
+/// position labeled blocks are vanishingly rare.
 fn brace_inner_looks_like_dsl(stream: &TokenStream) -> bool {
-    let mut statement_starts_with_let = false;
-    let mut at_statement_start = true;
-    for tree in stream.iter() {
-        match tree {
-            TokenTree::Token(token, _) => {
+    let trees: Vec<&TokenTree> = stream.iter().collect();
+    let mut whitelist_let = false;
+    let mut cursor = 0;
+    while cursor < trees.len() {
+        // Statement boundary: re-evaluate the `let`-whitelist on
+        // the new statement's first non-attribute token.
+        let after_attrs = skip_leading_attributes(&trees, cursor);
+        if let Some(TokenTree::Token(token, _)) = trees.get(after_attrs)
+            && token.is_keyword(kw::Let)
+        {
+            whitelist_let = true;
+        }
+        cursor = after_attrs;
+        // Walk the statement body until `;` or end of stream.
+        while cursor < trees.len() {
+            if let TokenTree::Token(token, _) = trees[cursor] {
                 match token.kind {
                     TokenKind::Semi => {
-                        statement_starts_with_let = false;
-                        at_statement_start = true;
-                        continue;
+                        whitelist_let = false;
+                        cursor += 1;
+                        break;
                     }
                     TokenKind::FatArrow => return true,
-                    TokenKind::Colon if !statement_starts_with_let => return true,
+                    TokenKind::Colon if !whitelist_let => return true,
                     _ => {}
                 }
-                if at_statement_start && token.is_keyword(kw::Let) {
-                    statement_starts_with_let = true;
-                }
-                at_statement_start = false;
             }
-            _ => at_statement_start = false,
+            cursor += 1;
         }
     }
     false
+}
+
+/// Advance past any leading outer (`#[...]`) or inner (`#![...]`)
+/// attributes and doc comments at position `start`, returning the
+/// index of the first non-attribute token tree. The check at
+/// statement start uses this so leading attributes don't disable
+/// the `let`-whitelist for the `:` in a `let pattern: type`
+/// binding.
+fn skip_leading_attributes(trees: &[&TokenTree], mut start: usize) -> usize {
+    loop {
+        let Some(tree) = trees.get(start) else {
+            return start;
+        };
+        let TokenTree::Token(token, _) = tree else {
+            return start;
+        };
+        match token.kind {
+            TokenKind::DocComment(..) => start += 1,
+            TokenKind::Pound => {
+                let mut after_pound = start + 1;
+                if matches!(trees.get(after_pound), Some(TokenTree::Token(t, _)) if t.kind == TokenKind::Bang)
+                {
+                    after_pound += 1;
+                }
+                if matches!(
+                    trees.get(after_pound),
+                    Some(TokenTree::Delimited(_, _, Delimiter::Bracket, _)),
+                ) {
+                    start = after_pound + 1;
+                } else {
+                    return start;
+                }
+            }
+            _ => return start,
+        }
+    }
 }
 
 fn is_dsl_marker(token: &Token) -> bool {

--- a/src/rules/macro_argument_binding/purity.rs
+++ b/src/rules/macro_argument_binding/purity.rs
@@ -233,10 +233,7 @@ fn take_pure_expression<'a>(
     Some(take_pure_binary_tail(after_suffix, ctx))
 }
 
-fn take_pure_atom<'a>(
-    tokens: &'a [TokenTree],
-    ctx: PurityContext<'_>,
-) -> Option<&'a [TokenTree]> {
+fn take_pure_atom<'a>(tokens: &'a [TokenTree], ctx: PurityContext<'_>) -> Option<&'a [TokenTree]> {
     let (head, rest) = tokens.split_first()?;
     match head {
         // `()` (unit literal), `(expr)` (parenthesised pure
@@ -485,11 +482,7 @@ fn take_atom_path_after_sep<'a>(
     let TokenKind::Ident(name, _) = token.kind else {
         return None;
     };
-    Some(take_path_and_optional_macro_call(
-        name,
-        rest,
-        pure_macros,
-    ))
+    Some(take_path_and_optional_macro_call(name, rest, pure_macros))
 }
 
 /// Type-position path tail: `take_atom_path_after_sep`'s sibling
@@ -506,10 +499,7 @@ fn take_path_after_sep(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
     Some(take_path_tail(rest))
 }
 
-fn take_pure_suffixes<'a>(
-    mut tokens: &'a [TokenTree],
-    ctx: PurityContext<'_>,
-) -> &'a [TokenTree] {
+fn take_pure_suffixes<'a>(mut tokens: &'a [TokenTree], ctx: PurityContext<'_>) -> &'a [TokenTree] {
     loop {
         let Some((head, rest)) = tokens.split_first() else {
             return tokens;

--- a/src/rules/macro_argument_binding/purity.rs
+++ b/src/rules/macro_argument_binding/purity.rs
@@ -1,4 +1,4 @@
-//! Argument splitting and the trivial-expression predicate.
+//! Argument splitting and the pure-expression predicate.
 //!
 //! [`split_top_level_arguments`] turns the macro invocation's
 //! token stream into one segment per comma-separated argument.
@@ -6,10 +6,10 @@
 //! macro author chose (`Type => [...]`, `name = value`, `name += value`,
 //! `lhs -> rhs` arrow-paired matchers, `name in name`-style separators,
 //! bare operators like `==`, and friends).
-//! [`is_trivial_expression`] decides whether the surviving expression
-//! falls in the spec's trivial shapes (literals, paths, references,
+//! [`is_pure_expression`] decides whether the surviving expression
+//! falls in the spec's pure shapes (literals, paths, references,
 //! field accesses, indexing, dereferences, casts, parenthesised /
-//! tuple groups, binary chains over trivial operands, and
+//! tuple groups, binary chains over pure operands, and
 //! `expr.method()` postfixes for a curated / configured set of
 //! pure-getter methods).
 //!
@@ -24,7 +24,7 @@ use rustc_ast::token::{Delimiter, IdentIsRaw, Token, TokenKind};
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
 use rustc_span::kw;
 
-/// Bundle of the two name-set tables the triviality walker consults:
+/// Bundle of the two name-set tables the purity walker consults:
 /// the pure-getter method names accepted as `.method()` postfixes,
 /// and the compile-time-pure macro names accepted as `name!(...)`
 /// atoms. Both are tail-segment-keyed (single-segment matching) and
@@ -32,7 +32,7 @@ use rustc_span::kw;
 /// passing them as one borrow keeps the recursive walker's signatures
 /// short.
 #[derive(Clone, Copy)]
-pub(super) struct TrivialContext<'a> {
+pub(super) struct PurityContext<'a> {
     pub methods: &'a BTreeSet<String>,
     pub macros: &'a BTreeSet<String>,
 }
@@ -99,13 +99,13 @@ pub(super) fn split_top_level_arguments(stream: &TokenStream) -> Option<Vec<Vec<
 ///    family — in the shapes the rule observes, none of these tokens
 ///    form a single Rust expression standalone. `==`, by contrast,
 ///    is a real Rust binary operator (`debug_assert!(a == b)` is the
-///    motivating trivial shape) and is intentionally absent from this
+///    motivating pure shape) and is intentionally absent from this
 ///    list.
 ///
 ///    The trade-off is asymmetric. `->` and `in` *can* legitimately
 ///    appear inside a real Rust expression — `->` in a closure return
 ///    type (`|x: u32| -> u32 { x + 1 }`), `in` in a `for`-loop
-///    expression (`for x in iter { ... }`). Both are non-trivial
+///    expression (`for x in iter { ... }`). Both are impure
 ///    expressions the rule would otherwise flag; with the markers in
 ///    place the rule now silently *skips* them (false negative)
 ///    rather than emit a confusing `let`-bind hint inside a DSL
@@ -148,40 +148,40 @@ fn is_dsl_marker(token: &Token) -> bool {
     )
 }
 
-/// Returns `true` if the entire token slice forms a "trivial"
-/// expression per the rule's grammar. Triviality is purely syntactic:
+/// Returns `true` if the entire token slice forms a "pure"
+/// expression per the rule's grammar. Purity is purely syntactic:
 /// the shapes the rule docs enumerate (literal, path, reference,
 /// field, index, deref, cast), plus parenthesised / tuple groups
-/// whose elements are all trivial, plus binary chains whose every
-/// operand is trivial, plus `.method()` postfixes when the method
-/// name is in `trivial_methods` (curated pure-getter set, extensible
+/// whose elements are all pure, plus binary chains whose every
+/// operand is pure, plus `.method()` postfixes when the method
+/// name is in `pure_methods` (curated pure-getter set, extensible
 /// via `dylint.toml`). The classification is recursive on operands.
-/// Anything outside that grammar is non-trivial — including most
+/// Anything outside that grammar is impure — including most
 /// `const fn` calls, generic method calls, and other "morally pure"
 /// expressions the walker cannot prove side-effect-free.
-pub(super) fn is_trivial_expression(tokens: &[TokenTree], ctx: TrivialContext<'_>) -> bool {
-    take_trivial_expression(tokens, ctx).is_some_and(<[_]>::is_empty)
+pub(super) fn is_pure_expression(tokens: &[TokenTree], ctx: PurityContext<'_>) -> bool {
+    take_pure_expression(tokens, ctx).is_some_and(<[_]>::is_empty)
 }
 
-fn take_trivial_expression<'a>(
+fn take_pure_expression<'a>(
     tokens: &'a [TokenTree],
-    ctx: TrivialContext<'_>,
+    ctx: PurityContext<'_>,
 ) -> Option<&'a [TokenTree]> {
-    let after_atom = take_trivial_atom(tokens, ctx)?;
-    let after_suffix = take_trivial_suffixes(after_atom, ctx);
-    Some(take_trivial_binary_tail(after_suffix, ctx))
+    let after_atom = take_pure_atom(tokens, ctx)?;
+    let after_suffix = take_pure_suffixes(after_atom, ctx);
+    Some(take_pure_binary_tail(after_suffix, ctx))
 }
 
-fn take_trivial_atom<'a>(
+fn take_pure_atom<'a>(
     tokens: &'a [TokenTree],
-    ctx: TrivialContext<'_>,
+    ctx: PurityContext<'_>,
 ) -> Option<&'a [TokenTree]> {
     let (head, rest) = tokens.split_first()?;
     match head {
-        // `()` (unit literal), `(expr)` (parenthesised trivial
-        // expression), `(a, b)` / `(a,)` (tuple of trivial elements).
-        // Each element is recursively trivial; empty parens are the
-        // canonical trivial value.
+        // `()` (unit literal), `(expr)` (parenthesised pure
+        // expression), `(a, b)` / `(a,)` (tuple of pure elements).
+        // Each element is recursively pure; empty parens are the
+        // canonical pure value.
         //
         // The match is restricted to `Delimiter::Parenthesis` —
         // `Delimiter::Invisible` (capture-wrapping delimiters
@@ -190,7 +190,7 @@ fn take_trivial_atom<'a>(
         // runs pre-expansion and never sees invisible delimiters
         // in practice.
         TokenTree::Delimited(_, _, Delimiter::Parenthesis, inner) => {
-            if is_trivial_paren_inner(inner, ctx) {
+            if is_pure_paren_inner(inner, ctx) {
                 Some(rest)
             } else {
                 None
@@ -207,11 +207,11 @@ fn take_trivial_atom<'a>(
             // `&&` expr or `&& mut` expr (double reference).
             TokenKind::AndAnd => take_reference_tail(rest, ctx),
             // `*expr` (deref).
-            TokenKind::Star => take_trivial_expression(rest, ctx),
+            TokenKind::Star => take_pure_expression(rest, ctx),
             // Path: ident (`::` ident)*. If the path is followed by
             // `!` and the path's final segment names a curated
-            // trivial macro (`concat!`, `env!`, `include_str!`, ...),
-            // the whole `name!(...)` / `name![...]` is a trivial
+            // pure macro (`concat!`, `env!`, `include_str!`, ...),
+            // the whole `name!(...)` / `name![...]` is a pure
             // atom — the expansion is a compile-time constant and
             // the macro itself does not evaluate any runtime user
             // expression (`stringify!` takes a token sequence and
@@ -233,31 +233,31 @@ fn take_trivial_atom<'a>(
 
 /// Accept `()` (empty, the unit literal), `(expr)` (parenthesised),
 /// `(a, b, ...)` (tuple, optional trailing comma) when every element is
-/// itself trivial. Empty elements in the middle (`(a,,b)`) are not
+/// itself pure. Empty elements in the middle (`(a,,b)`) are not
 /// Rust syntax and are rejected.
-fn is_trivial_paren_inner(stream: &TokenStream, ctx: TrivialContext<'_>) -> bool {
+fn is_pure_paren_inner(stream: &TokenStream, ctx: PurityContext<'_>) -> bool {
     let Some(arguments) = split_top_level_arguments(stream) else {
         return false;
     };
     arguments
         .iter()
-        .all(|argument| !argument.is_empty() && is_trivial_expression(argument, ctx))
+        .all(|argument| !argument.is_empty() && is_pure_expression(argument, ctx))
 }
 
 fn take_reference_tail<'a>(
     tokens: &'a [TokenTree],
-    ctx: TrivialContext<'_>,
+    ctx: PurityContext<'_>,
 ) -> Option<&'a [TokenTree]> {
     let after_mut = match tokens.split_first() {
         Some((TokenTree::Token(token, _), rest)) if token.is_keyword(kw::Mut) => rest,
         _ => tokens,
     };
-    take_trivial_expression(after_mut, ctx)
+    take_pure_expression(after_mut, ctx)
 }
 
 /// Walk a path tail beginning after a leading ident, tracking the
 /// path's final segment so the caller can match it against the
-/// trivial-macro list when a `!` follows. The first segment's name
+/// pure-macro list when a `!` follows. The first segment's name
 /// is passed in; the walker reads `::ident` runs and returns the
 /// last segment seen along with the slice after the path.
 fn walk_path_tail(
@@ -301,28 +301,28 @@ fn take_path_tail(mut tokens: &[TokenTree]) -> &[TokenTree] {
 }
 
 /// After consuming the leading ident of an atom path, walk the rest
-/// of the path and optionally consume a trailing trivial macro call.
+/// of the path and optionally consume a trailing pure macro call.
 /// `first_name` is the leading ident's symbol; `tokens` is the slice
 /// following it.
 fn take_path_and_optional_macro_call<'a>(
     first_name: rustc_span::Symbol,
     tokens: &'a [TokenTree],
-    trivial_macros: &BTreeSet<String>,
+    pure_macros: &BTreeSet<String>,
 ) -> &'a [TokenTree] {
     let (tail_name, after_path) = walk_path_tail(first_name, tokens);
-    take_trivial_macro_call(after_path, tail_name, trivial_macros).unwrap_or(after_path)
+    take_pure_macro_call(after_path, tail_name, pure_macros).unwrap_or(after_path)
 }
 
 /// If `tokens` starts with `! ( ... )` or `! [ ... ]` AND
-/// `macro_name`'s final segment is in `trivial_macros`, consume the
+/// `macro_name`'s final segment is in `pure_macros`, consume the
 /// `!` and the delimited body and return the slice after it.
 /// Returns `None` otherwise; the caller falls back to leaving the
-/// tokens unconsumed (so a non-trivial macro call correctly drops
-/// the whole expression into the non-trivial bucket).
-fn take_trivial_macro_call<'a>(
+/// tokens unconsumed (so an impure macro call correctly drops
+/// the whole expression into the impure bucket).
+fn take_pure_macro_call<'a>(
     tokens: &'a [TokenTree],
     macro_name: rustc_span::Symbol,
-    trivial_macros: &BTreeSet<String>,
+    pure_macros: &BTreeSet<String>,
 ) -> Option<&'a [TokenTree]> {
     let (bang, after_bang) = tokens.split_first()?;
     let TokenTree::Token(bang_token, _) = bang else {
@@ -331,7 +331,7 @@ fn take_trivial_macro_call<'a>(
     if bang_token.kind != TokenKind::Bang {
         return None;
     }
-    if !trivial_macros.contains(macro_name.as_str()) {
+    if !pure_macros.contains(macro_name.as_str()) {
         return None;
     }
     let (delim, after_delim) = after_bang.split_first()?;
@@ -349,7 +349,7 @@ fn take_trivial_macro_call<'a>(
 
 fn take_atom_path_after_sep<'a>(
     tokens: &'a [TokenTree],
-    trivial_macros: &BTreeSet<String>,
+    pure_macros: &BTreeSet<String>,
 ) -> Option<&'a [TokenTree]> {
     let (ident, rest) = tokens.split_first()?;
     let TokenTree::Token(token, _) = ident else {
@@ -361,12 +361,12 @@ fn take_atom_path_after_sep<'a>(
     Some(take_path_and_optional_macro_call(
         name,
         rest,
-        trivial_macros,
+        pure_macros,
     ))
 }
 
 /// Type-position path tail: `take_atom_path_after_sep`'s sibling
-/// for `take_trivial_type`. Types don't carry trailing `!` macro
+/// for `take_pure_type`. Types don't carry trailing `!` macro
 /// calls so this variant only walks the `::ident` chain.
 fn take_path_after_sep(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
     let (ident, rest) = tokens.split_first()?;
@@ -379,9 +379,9 @@ fn take_path_after_sep(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
     Some(take_path_tail(rest))
 }
 
-fn take_trivial_suffixes<'a>(
+fn take_pure_suffixes<'a>(
     mut tokens: &'a [TokenTree],
-    ctx: TrivialContext<'_>,
+    ctx: PurityContext<'_>,
 ) -> &'a [TokenTree] {
     loop {
         let Some((head, rest)) = tokens.split_first() else {
@@ -391,11 +391,11 @@ fn take_trivial_suffixes<'a>(
             TokenTree::Token(token, _) => match token.kind {
                 // `.ident` (field access), `.0` (tuple index), or
                 // `.method()` (zero-arg pure-getter call) when the
-                // method name is in the configured trivial-methods
+                // method name is in the configured pure-methods
                 // set. Postfix `.await` is *not* a field access —
                 // it's `ExprKind::Await`, which the rule docs list as
-                // non-trivial. Reject the `await` keyword explicitly
-                // so `future.await` correctly falls out as non-trivial.
+                // impure. Reject the `await` keyword explicitly
+                // so `future.await` correctly falls out as impure.
                 // (`r#await` as a raw ident remains a literal field
                 // access and stays accepted via the catch-all arm.)
                 TokenKind::Dot => {
@@ -410,14 +410,14 @@ fn take_trivial_suffixes<'a>(
                             return tokens;
                         }
                         TokenKind::Ident(name, IdentIsRaw::No) => {
-                            // `.name()` (empty parens) is a trivial
+                            // `.name()` (empty parens) is a pure
                             // postfix when the method is conventionally
                             // pure (`vec.len()`, `s.is_empty()`,
                             // `opt.as_ref()`). Otherwise treat `.name`
                             // as a plain field access and let the
                             // suffix loop decide what to do with the
                             // tokens that follow.
-                            if is_trivial_method_call(after, name.as_str(), ctx.methods) {
+                            if is_pure_method_call(after, name.as_str(), ctx.methods) {
                                 tokens = &after[1..];
                             } else {
                                 tokens = after;
@@ -436,19 +436,19 @@ fn take_trivial_suffixes<'a>(
                 }
                 // `as path` — type annotation. Only path-shaped types
                 // are recognised; references, slices, function pointers,
-                // etc. fall back to non-trivial.
+                // etc. fall back to impure.
                 TokenKind::Ident(name, IdentIsRaw::No) if name == kw::As => {
-                    let Some(after) = take_trivial_type(rest) else {
+                    let Some(after) = take_pure_type(rest) else {
                         return tokens;
                     };
                     tokens = after;
                 }
                 _ => return tokens,
             },
-            // `[expr]` — index. Both base and index must be trivial;
+            // `[expr]` — index. Both base and index must be pure;
             // the recursion happens here for the index.
             TokenTree::Delimited(_, _, Delimiter::Bracket, inner) => {
-                if !is_trivial_expression_stream(inner, ctx) {
+                if !is_pure_expression_stream(inner, ctx) {
                     return tokens;
                 }
                 tokens = rest;
@@ -459,51 +459,51 @@ fn take_trivial_suffixes<'a>(
 }
 
 /// `true` iff `tokens` starts with `()` (empty parentheses) AND the
-/// preceding method name is in `trivial_methods`. The caller has
+/// preceding method name is in `pure_methods`. The caller has
 /// already consumed the `.` and the method ident; it passes the
 /// remaining tokens (starting with the `(...)` delimiter) here.
-fn is_trivial_method_call(
+fn is_pure_method_call(
     tokens: &[TokenTree],
     method_name: &str,
-    trivial_methods: &BTreeSet<String>,
+    pure_methods: &BTreeSet<String>,
 ) -> bool {
     let Some(TokenTree::Delimited(_, _, Delimiter::Parenthesis, inner)) = tokens.first() else {
         return false;
     };
-    inner.is_empty() && trivial_methods.contains(method_name)
+    inner.is_empty() && pure_methods.contains(method_name)
 }
 
-/// Consume a tail of `OP trivial` pairs where `OP` is a side-effect-
+/// Consume a tail of `OP pure` pairs where `OP` is a side-effect-
 /// free binary operator (arithmetic, bitwise, comparison, logical).
-/// The spec's "non-trivial" boundary explicitly couples binary
-/// expression triviality to operand triviality: `a <= b` and
-/// `count + offset` are side-effect-free over trivial operands and
-/// should themselves be trivial. Without this tail, simple comparisons
+/// The spec's "impure" boundary explicitly couples binary
+/// expression purity to operand purity: `a <= b` and
+/// `count + offset` are side-effect-free over pure operands and
+/// should themselves be pure. Without this tail, simple comparisons
 /// in `debug_assert!(a <= b)` would be flagged and the suggested `let`
 /// binding would force the comparison to evaluate in release builds —
 /// the opposite of the user's intent.
 ///
 /// The walker does not honour Rust's binary-operator precedence
 /// (`a + b * c` is consumed left-to-right rather than as `a + (b * c)`),
-/// but that does not affect the triviality verdict: every prefix /
-/// suffix in the chain has trivial operands.
-fn take_trivial_binary_tail<'a>(
+/// but that does not affect the purity verdict: every prefix /
+/// suffix in the chain has pure operands.
+fn take_pure_binary_tail<'a>(
     mut tokens: &'a [TokenTree],
-    ctx: TrivialContext<'_>,
+    ctx: PurityContext<'_>,
 ) -> &'a [TokenTree] {
-    while let Some(after_op) = take_trivial_binary_operator(tokens) {
-        let Some(after_atom) = take_trivial_atom(after_op, ctx) else {
-            // The operator looked like a binop but no trivial atom
+    while let Some(after_op) = take_pure_binary_operator(tokens) {
+        let Some(after_atom) = take_pure_atom(after_op, ctx) else {
+            // The operator looked like a binop but no pure atom
             // followed; leave the operator unconsumed so the caller
-            // sees the whole rest as non-trivial.
+            // sees the whole rest as impure.
             return tokens;
         };
-        tokens = take_trivial_suffixes(after_atom, ctx);
+        tokens = take_pure_suffixes(after_atom, ctx);
     }
     tokens
 }
 
-fn take_trivial_binary_operator(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+fn take_pure_binary_operator(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
     let (head, rest) = tokens.split_first()?;
     let TokenTree::Token(token, _) = head else {
         return None;
@@ -532,7 +532,7 @@ fn take_trivial_binary_operator(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
     .then_some(rest)
 }
 
-fn take_trivial_type(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
+fn take_pure_type(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
     let (head, rest) = tokens.split_first()?;
     let TokenTree::Token(token, _) = head else {
         return None;
@@ -544,7 +544,7 @@ fn take_trivial_type(tokens: &[TokenTree]) -> Option<&[TokenTree]> {
     }
 }
 
-fn is_trivial_expression_stream(stream: &TokenStream, ctx: TrivialContext<'_>) -> bool {
+fn is_pure_expression_stream(stream: &TokenStream, ctx: PurityContext<'_>) -> bool {
     let trees: Vec<TokenTree> = stream.iter().cloned().collect();
-    is_trivial_expression(&trees, ctx)
+    is_pure_expression(&trees, ctx)
 }

--- a/src/rules/macro_argument_binding/purity.rs
+++ b/src/rules/macro_argument_binding/purity.rs
@@ -119,10 +119,71 @@ pub(super) fn looks_like_expression(argument: &[TokenTree]) -> bool {
     {
         return false;
     }
-    !argument.iter().any(|tree| match tree {
+    if argument.iter().any(|tree| match tree {
         TokenTree::Token(token, _) => is_dsl_marker(token),
         _ => false,
-    })
+    }) {
+        return false;
+    }
+    // A single brace-delimited argument is a block expression in
+    // Rust, but in macro-argument position it's overwhelmingly the
+    // outer carrier for a DSL body — `json!({"k": "v"})`,
+    // `hashmap!({"k" => v})`, and similar. Descend one level and
+    // look for DSL markers that wouldn't appear at the top level of
+    // a real Rust block. If any are present, the argument is not
+    // an expression the rule can rewrite, and `let`-binding it
+    // wouldn't compile.
+    if let [TokenTree::Delimited(_, _, Delimiter::Brace, inner)] = argument
+        && brace_inner_looks_like_dsl(inner)
+    {
+        return false;
+    }
+    true
+}
+
+/// Heuristic: does a brace-delimited block's inner top level look
+/// like a DSL body rather than a Rust statement list?
+///
+/// - `=>` at top level is always a DSL marker. The Rust block
+///   grammar never produces a top-level `=>`: match arms live one
+///   delimiter level deeper than the surrounding block.
+/// - `:` at top level is a DSL key-position marker unless its
+///   *statement* begins with `let`. The only Rust block
+///   construct that emits a top-level `:` is the
+///   `let pattern: type` annotation; struct literals (`Foo { x: 1 }`)
+///   put the `:` one delimiter level deeper than the surrounding
+///   block.
+///
+/// Statements are split by top-level `;`. A labeled loop or block
+/// (`'a: loop { ... }`) at the brace's immediate top level is a
+/// known false positive — its `:` sits in the same position as a
+/// DSL key — but in macro-argument position labeled blocks are
+/// vanishingly rare.
+fn brace_inner_looks_like_dsl(stream: &TokenStream) -> bool {
+    let mut statement_starts_with_let = false;
+    let mut at_statement_start = true;
+    for tree in stream.iter() {
+        match tree {
+            TokenTree::Token(token, _) => {
+                match token.kind {
+                    TokenKind::Semi => {
+                        statement_starts_with_let = false;
+                        at_statement_start = true;
+                        continue;
+                    }
+                    TokenKind::FatArrow => return true,
+                    TokenKind::Colon if !statement_starts_with_let => return true,
+                    _ => {}
+                }
+                if at_statement_start && token.is_keyword(kw::Let) {
+                    statement_starts_with_let = true;
+                }
+                at_statement_start = false;
+            }
+            _ => at_statement_start = false,
+        }
+    }
+    false
 }
 
 fn is_dsl_marker(token: &Token) -> bool {

--- a/src/rules/macro_argument_binding/purity.rs
+++ b/src/rules/macro_argument_binding/purity.rs
@@ -9,9 +9,10 @@
 //! [`is_pure_expression`] decides whether the surviving expression
 //! falls in the spec's pure shapes (literals, paths, references,
 //! field accesses, indexing, dereferences, casts, parenthesised /
-//! tuple groups, binary chains over pure operands, and
-//! `expr.method()` postfixes for a curated / configured set of
-//! pure-getter methods).
+//! tuple groups, array literals and array-repeat forms over pure
+//! parts, binary chains over pure operands, and `expr.method()`
+//! postfixes for a curated / configured set of pure-getter
+//! methods).
 //!
 //! The predicate is a hand-rolled token-stream walker — see the
 //! rationale in `planned-rules/macro-argument-binding.md`'s

--- a/src/rules/macro_argument_binding/purity.rs
+++ b/src/rules/macro_argument_binding/purity.rs
@@ -196,6 +196,21 @@ fn take_pure_atom<'a>(
                 None
             }
         }
+        // `[]` (empty array), `[a, b, ...]` (array literal with
+        // optional trailing comma), `[expr; count]` (array repeat).
+        // Each element is recursively pure; the repeat form
+        // requires both halves to be pure. The indexing suffix
+        // `base[index]` is handled separately by
+        // `take_pure_suffixes` — it never reaches this arm because
+        // an indexed expression starts with the base path, not the
+        // bracket.
+        TokenTree::Delimited(_, _, Delimiter::Bracket, inner) => {
+            if is_pure_array_inner(inner, ctx) {
+                Some(rest)
+            } else {
+                None
+            }
+        }
         TokenTree::Token(token, _) => match token.kind {
             TokenKind::Literal(_) => Some(rest),
             // `true` and `false` are keyword idents, not `Literal` tokens.
@@ -242,6 +257,57 @@ fn is_pure_paren_inner(stream: &TokenStream, ctx: PurityContext<'_>) -> bool {
     arguments
         .iter()
         .all(|argument| !argument.is_empty() && is_pure_expression(argument, ctx))
+}
+
+/// Accept `[]` (empty array literal), `[a, b, ...]` (array literal,
+/// optional trailing comma), and `[expr; count]` (array repeat) when
+/// every contained expression is itself pure. The repeat form is
+/// recognised by the top-level `;`; mixing `;` and `,` at the top
+/// level is malformed and rejected.
+fn is_pure_array_inner(stream: &TokenStream, ctx: PurityContext<'_>) -> bool {
+    if let Some(arguments) = split_top_level_arguments(stream) {
+        return arguments
+            .iter()
+            .all(|argument| !argument.is_empty() && is_pure_expression(argument, ctx));
+    }
+    let Some((expr, count)) = split_array_repeat(stream) else {
+        return false;
+    };
+    !expr.is_empty()
+        && is_pure_expression(&expr, ctx)
+        && !count.is_empty()
+        && is_pure_expression(&count, ctx)
+}
+
+/// Split a bracket-delimited stream at the first top-level `;`,
+/// the array-repeat separator. Returns `None` if the stream has
+/// no top-level `;`, more than one top-level `;`, or any top-level
+/// `,` (the repeat form is `[expr; count]` exactly — a comma at
+/// the top level signals a malformed mixture with array-literal
+/// syntax).
+fn split_array_repeat(stream: &TokenStream) -> Option<(Vec<TokenTree>, Vec<TokenTree>)> {
+    let mut before: Vec<TokenTree> = Vec::new();
+    let mut after: Option<Vec<TokenTree>> = None;
+    for tree in stream.iter() {
+        if let TokenTree::Token(token, _) = tree {
+            match token.kind {
+                TokenKind::Semi => {
+                    if after.is_some() {
+                        return None;
+                    }
+                    after = Some(Vec::new());
+                    continue;
+                }
+                TokenKind::Comma => return None,
+                _ => {}
+            }
+        }
+        match after.as_mut() {
+            Some(buf) => buf.push(tree.clone()),
+            None => before.push(tree.clone()),
+        }
+    }
+    after.map(|count| (before, count))
 }
 
 fn take_reference_tail<'a>(

--- a/src/rules/macro_argument_binding/purity.rs
+++ b/src/rules/macro_argument_binding/purity.rs
@@ -161,10 +161,20 @@ pub(super) fn looks_like_expression(argument: &[TokenTree]) -> bool {
 /// (an attribute-annotated `let` binding inside a real block) is
 /// still treated as a Rust block.
 ///
-/// A labeled loop or block (`'a: loop { ... }`) at the brace's
-/// immediate top level is a known false positive — its `:` sits
-/// in the same position as a DSL key — but in macro-argument
-/// position labeled blocks are vanishingly rare.
+/// Known false-positive shapes — block-statement-starting tokens
+/// other than `let` that legitimately introduce a top-level `:`
+/// — are not currently whitelisted:
+///
+/// - `const NAME: type = expr;` and `static NAME: type = expr;`
+///   item declarations inside the block.
+/// - Labelled loops and blocks (`'a: loop { ... }`,
+///   `'a: { ... }`) at the brace's immediate top level — the
+///   lifetime token is followed by `:` in the same position as
+///   a DSL key.
+///
+/// All three constructs are vanishingly rare in macro-argument
+/// position; the trade-off keeps the heuristic simple at the
+/// price of a documented false skip on these shapes.
 fn brace_inner_looks_like_dsl(stream: &TokenStream) -> bool {
     let trees: Vec<&TokenTree> = stream.iter().collect();
     let mut whitelist_let = false;

--- a/tests/macro_argument_binding.rs
+++ b/tests/macro_argument_binding.rs
@@ -28,13 +28,13 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     ignore: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    extra_trivial_methods: Vec<String>,
+    extra_pure_methods: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    ignore_trivial_methods: Vec<String>,
+    ignore_pure_methods: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    extra_trivial_macros: Vec<String>,
+    extra_pure_macros: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    ignore_trivial_macros: Vec<String>,
+    ignore_pure_macros: Vec<String>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -105,44 +105,44 @@ fn allow_extra_silences_an_uncatalogued_macro() {
 }
 
 #[test]
-fn extra_trivial_methods_adds_a_pure_getter_to_the_postfix_set() {
+fn extra_pure_methods_adds_a_pure_getter_to_the_postfix_set() {
     run(
-        "ui-toml/macro_argument_binding/extra_trivial_methods",
+        "ui-toml/macro_argument_binding/extra_pure_methods",
         RuleConfig {
-            extra_trivial_methods: vec!["cached_size".into()],
+            extra_pure_methods: vec!["cached_size".into()],
             ..Default::default()
         },
     );
 }
 
 #[test]
-fn ignore_trivial_methods_drops_a_built_in_pure_getter() {
+fn ignore_pure_methods_drops_a_built_in_pure_getter() {
     run(
-        "ui-toml/macro_argument_binding/ignore_trivial_methods",
+        "ui-toml/macro_argument_binding/ignore_pure_methods",
         RuleConfig {
-            ignore_trivial_methods: vec!["as_ref".into()],
+            ignore_pure_methods: vec!["as_ref".into()],
             ..Default::default()
         },
     );
 }
 
 #[test]
-fn extra_trivial_macros_adds_a_compile_time_macro_to_the_atom_set() {
+fn extra_pure_macros_adds_a_compile_time_macro_to_the_atom_set() {
     run(
-        "ui-toml/macro_argument_binding/extra_trivial_macros",
+        "ui-toml/macro_argument_binding/extra_pure_macros",
         RuleConfig {
-            extra_trivial_macros: vec!["literal_table".into()],
+            extra_pure_macros: vec!["literal_table".into()],
             ..Default::default()
         },
     );
 }
 
 #[test]
-fn ignore_trivial_macros_drops_a_built_in_compile_time_macro() {
+fn ignore_pure_macros_drops_a_built_in_compile_time_macro() {
     run(
-        "ui-toml/macro_argument_binding/ignore_trivial_macros",
+        "ui-toml/macro_argument_binding/ignore_pure_macros",
         RuleConfig {
-            ignore_trivial_macros: vec!["cfg".into()],
+            ignore_pure_macros: vec!["cfg".into()],
             ..Default::default()
         },
     );

--- a/ui-toml/macro_argument_binding/allow_extra/fixture.rs
+++ b/ui-toml/macro_argument_binding/allow_extra/fixture.rs
@@ -1,7 +1,7 @@
 // Skipped: `my_macro!` is uncatalogued and would normally be flagged
 // under the default `AllowAndDeny` mode, but the fixture's
 // `dylint.toml` adds `my_macro` to `allow_extra`, opting the macro
-// into the trusted set. Even a non-trivial argument is now accepted.
+// into the trusted set. Even an impure argument is now accepted.
 
 macro_rules! my_macro {
     ($item:expr) => {{

--- a/ui-toml/macro_argument_binding/deny_extra/fixture.stderr
+++ b/ui-toml/macro_argument_binding/deny_extra/fixture.stderr
@@ -1,4 +1,4 @@
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/fixture.rs:31:33
    |
 LL |     let _ = inner::their_macro!(value());

--- a/ui-toml/macro_argument_binding/disabled/fixture.rs
+++ b/ui-toml/macro_argument_binding/disabled/fixture.rs
@@ -1,5 +1,5 @@
 // Skipped: `debug_assert_eq!` is on the built-in deny list and the
-// first argument is a non-trivial method call, but the fixture's
+// first argument is an impure method call, but the fixture's
 // `dylint.toml` sets `enabled = false`, so the rule must NOT fire.
 
 fn main() {

--- a/ui-toml/macro_argument_binding/extra_pure_macros/fixture.rs
+++ b/ui-toml/macro_argument_binding/extra_pure_macros/fixture.rs
@@ -1,12 +1,12 @@
-// `extra_trivial_macros` adds project-specific macro names to the
-// built-in trivial-macro set. A call to one of these macros — even
-// nested inside a deny-listed macro — qualifies as a trivial atom
+// `extra_pure_macros` adds project-specific macro names to the
+// built-in pure-macro set. A call to one of these macros — even
+// nested inside a deny-listed macro — qualifies as a pure atom
 // and the surrounding expression is accepted.
 //
 // This fixture's `dylint.toml` (see `tests/macro_argument_binding.rs`)
 // adds `literal_table`; the call below would otherwise be flagged
-// because macro invocations outside the built-in trivial set are
-// non-trivial by default.
+// because macro invocations outside the built-in pure set are
+// impure by default.
 
 #![feature(register_tool)]
 #![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]

--- a/ui-toml/macro_argument_binding/extra_pure_methods/fixture.rs
+++ b/ui-toml/macro_argument_binding/extra_pure_methods/fixture.rs
@@ -1,12 +1,12 @@
-// `extra_trivial_methods` adds project-specific method names to the
-// built-in pure-getter set. A `.method()` invocation on a trivial
-// base then qualifies as a trivial postfix and the surrounding
+// `extra_pure_methods` adds project-specific method names to the
+// built-in pure-getter set. A `.method()` invocation on a pure
+// base then qualifies as a pure postfix and the surrounding
 // expression is accepted.
 //
 // This fixture's `dylint.toml` (see `tests/macro_argument_binding.rs`)
 // adds `cached_size`; the call below would otherwise be flagged
 // because zero-arg method calls outside the built-in set are
-// non-trivial by default.
+// impure by default.
 
 #![feature(register_tool)]
 #![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]

--- a/ui-toml/macro_argument_binding/ignore/fixture.rs
+++ b/ui-toml/macro_argument_binding/ignore/fixture.rs
@@ -1,5 +1,5 @@
 // Skipped: `debug_assert_eq!` is on the built-in deny list and the
-// first argument is a non-trivial method call, but the fixture's
+// first argument is an impure method call, but the fixture's
 // `dylint.toml` adds `debug_assert_eq` to `ignore`, which always
 // wins over the deny / allow lists. The rule emits no diagnostic.
 

--- a/ui-toml/macro_argument_binding/ignore_overrides_deny_extra/fixture.rs
+++ b/ui-toml/macro_argument_binding/ignore_overrides_deny_extra/fixture.rs
@@ -1,7 +1,7 @@
 // Skipped: `my_macro!` is added to both `deny_extra` and `ignore`.
 // `ignore` is checked first and always wins, so the rule emits no
 // diagnostic even though the deny-list entry would otherwise fire on
-// the non-trivial argument.
+// the impure argument.
 
 macro_rules! my_macro {
     ($item:expr) => {{

--- a/ui-toml/macro_argument_binding/ignore_pure_macros/fixture.rs
+++ b/ui-toml/macro_argument_binding/ignore_pure_macros/fixture.rs
@@ -1,7 +1,7 @@
-// `ignore_trivial_macros` drops names from the curated trivial-macro
-// list. After putting `cfg` in `ignore_trivial_macros`, the call is
+// `ignore_pure_macros` drops names from the curated pure-macro
+// list. After putting `cfg` in `ignore_pure_macros`, the call is
 // treated as a regular macro invocation again and the surrounding
-// `debug_assert!` argument is flagged as non-trivial.
+// `debug_assert!` argument is flagged as impure.
 //
 // `cfg!` is genuinely pure across the standard library, so this is a
 // hypothetical example — its purpose is to exercise the override.

--- a/ui-toml/macro_argument_binding/ignore_pure_macros/fixture.stderr
+++ b/ui-toml/macro_argument_binding/ignore_pure_macros/fixture.stderr
@@ -1,4 +1,4 @@
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/fixture.rs:13:19
    |
 LL |     debug_assert!(cfg!(any()));

--- a/ui-toml/macro_argument_binding/ignore_pure_methods/fixture.rs
+++ b/ui-toml/macro_argument_binding/ignore_pure_methods/fixture.rs
@@ -1,7 +1,7 @@
-// `ignore_trivial_methods` drops names from the curated pure-method
-// list. After putting `as_ref` in `ignore_trivial_methods`, the call
+// `ignore_pure_methods` drops names from the curated pure-method
+// list. After putting `as_ref` in `ignore_pure_methods`, the call
 // is treated as a regular method call again and the surrounding
-// `debug_assert!` argument is flagged as non-trivial.
+// `debug_assert!` argument is flagged as impure.
 
 #![feature(register_tool)]
 #![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]

--- a/ui-toml/macro_argument_binding/ignore_pure_methods/fixture.stderr
+++ b/ui-toml/macro_argument_binding/ignore_pure_methods/fixture.stderr
@@ -1,4 +1,4 @@
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/fixture.rs:10:19
    |
 LL |     debug_assert!(value.as_ref().is_some());

--- a/ui-toml/macro_argument_binding/mode_blanket/fixture.rs
+++ b/ui-toml/macro_argument_binding/mode_blanket/fixture.rs
@@ -1,10 +1,10 @@
 // `mode = "blanket"` flags every function-like or array-like
-// invocation that carries a non-trivial argument, regardless of what
+// invocation that carries an impure argument, regardless of what
 // list (if any) the macro would otherwise hit. `format!` is on the
 // default allow list but blanket mode disregards the built-in allow
-// list, so the non-trivial format argument gets flagged. `vec!` of
-// trivial elements is still accepted because the elements themselves
-// are trivial.
+// list, so the impure format argument gets flagged. `vec!` of
+// pure elements is still accepted because the elements themselves
+// are pure.
 
 fn main() {
     let count: u32 = 0;

--- a/ui-toml/macro_argument_binding/mode_blanket/fixture.stderr
+++ b/ui-toml/macro_argument_binding/mode_blanket/fixture.stderr
@@ -1,4 +1,4 @@
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/fixture.rs:11:35
    |
 LL |     let _ = format!("count = {}", value());

--- a/ui-toml/macro_argument_binding/mode_deny_only/fixture.rs
+++ b/ui-toml/macro_argument_binding/mode_deny_only/fixture.rs
@@ -1,7 +1,7 @@
 // `mode = "deny_only"` flags only invocations of the curated deny
 // list (`debug_assert*`). Every other macro is silently accepted —
 // the uncatalogued `my_macro!` here gets a free pass even though its
-// argument is a non-trivial function call.
+// argument is an impure function call.
 
 macro_rules! my_macro {
     ($item:expr) => {{

--- a/ui-toml/macro_argument_binding/mode_deny_only/fixture.stderr
+++ b/ui-toml/macro_argument_binding/mode_deny_only/fixture.stderr
@@ -1,4 +1,4 @@
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/fixture.rs:15:19
    |
 LL |     debug_assert!(value().is_some());

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -155,6 +155,32 @@ fn _brace_argument_with_dsl_markers_skipped() {
     // matching the spec's "blocks are impure" classification.
 }
 
+// A `let`-binding inside a brace-argument may be preceded by
+// outer attributes (`#[cfg(...)]`, `#[allow(...)]`) or doc
+// comments; the `let`-whitelist must skip past them before
+// checking the statement's first token. Without the skip, the
+// `:` in `let x: T` after `#[allow(...)]` would be misread as
+// a DSL key-position marker and the brace argument would be
+// dropped from analysis entirely (false negative on attributed
+// blocks).
+//
+// The observable consequence of the fix is *uniform* treatment
+// of brace-argument blocks: with the leading attribute correctly
+// skipped, the rule now classifies this block the same way it
+// classifies the un-attributed `{ let x = e; x }` — a real Rust
+// block, walked through `looks_like_expression`, then flagged
+// by the pure-expression walker (blocks are not a pure atom
+// shape). Pre-fix, the attribute caused a silent skip; post-fix,
+// the block is flagged, matching the rule's "blocks are impure"
+// policy.
+fn _brace_argument_with_attributed_let_flagged() {
+    let _ = dsl_macro!({
+        #[allow(unused)]
+        let x: u32 = MAX;
+        x
+    });
+}
+
 // All seven pure argument shapes — accepted under every mode. The
 // outer `debug_assert_eq!` is on the deny list, so any impure
 // argument here would otherwise be flagged.

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -397,7 +397,33 @@ fn _turbofish_method_call_flagged(text: &str) {
 // already holds. Tail-segment matching means `serde_json::json!`,
 // `::serde_json::json!`, and the bare `json!` form all line up
 // with the same entry.
+//
+// Each call below was chosen so the allow-list entry is *load-
+// bearing*: the impure argument shape would otherwise be flagged
+// by the default `AllowAndDeny` mode. Without that property the
+// test passes trivially and a regression that drops the entry
+// from `BUILTIN_ALLOW` would slip through.
+//
+// - `json!(value().unwrap())` — direct impure expression, no
+//   DSL marker, not brace-delimited. Without `json` on the allow
+//   list, the rule reaches `is_pure_expression` and flags it.
+// - `bail!("error: {}", value())` — second argument is an impure
+//   function call. Without `bail`, the second-argument check
+//   flags it.
+// - `ensure!(value().is_some(), "missing: {}", value())` — first
+//   argument is an impure method call; second / third are
+//   impure. Without `ensure`, all three flag.
+// - `json!({...})` and `hashmap!(k => v)` are also exercised, but
+//   note these would *also* be skipped by the brace-DSL and
+//   `=>`-DSL heuristics respectively even without their
+//   `BUILTIN_ALLOW` entries — they're here for shape coverage,
+//   not as load-bearing assertions. The `maplit::*` entries are
+//   in the same boat by design: every form of the macros emits
+//   `=>` at top level, which the DSL-marker check already
+//   skips. The allow-list entries serve as documentation of
+//   intent more than functional gates.
 fn _third_party_allow_listed_accepted() {
+    let _ = json!(value().unwrap());
     let _ = json!({ "ts": value(), "items": [value(), value()] });
     let _ = hashmap!("a" => value(), "b" => value());
     let _ = bail!("error: {}", value());

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -113,7 +113,7 @@ fn _vec_allow_listed() {
 
 // Allow-listed `insta` snapshot-assertion macros. Each variant
 // evaluates its value argument exactly once before serialising, so
-// the rule accepts non-trivial arguments under the default config.
+// the rule accepts impure arguments under the default config.
 // Tail-segment matching means the rule recognises both bare and
 // path-qualified call sites.
 fn _insta_snapshots_allow_listed() {

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -319,6 +319,22 @@ fn _array_literal_with_impure_element_flagged() {
     let _ = my_macro!([value(), value()]);
 }
 
+// Negative coverage on the array-repeat halves. `[expr; count]`
+// is pure only when *both* halves are pure, so each side
+// independently breaking purity must still flag. `await_macro!`
+// is a `tt`-capturing stand-in that discards its body so the
+// fixture compiles even though Rust would otherwise reject a
+// non-const count in expression position; the rule's check runs
+// on tokens, before that semantic constraint applies.
+//
+// `await_macro!` is uncatalogued, default-mode flags impure
+// args, and the bracket atom routes the halves through
+// `is_pure_expression` independently via `split_array_repeat`.
+fn _array_repeat_with_impure_half_flagged() {
+    let _ = await_macro!([value(); 4]);
+    let _ = await_macro!([0; size()]);
+}
+
 // Binary chains over pure operands are pure — comparisons and
 // arithmetic on local bindings, fields, and constants are side-effect-
 // free and produce the same result regardless of how many times the
@@ -428,6 +444,10 @@ impl Map {
 
 const MAX: u32 = 0;
 const INDEX: usize = 0;
+
+fn size() -> usize {
+    0
+}
 
 fn value() -> Option<u32> {
     None

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -47,6 +47,22 @@ macro_rules! dsl_macro {
     ($($tokens:tt)*) => {{ 0 }};
 }
 
+macro_rules! json {
+    ($($tokens:tt)*) => {{ 0 }};
+}
+
+macro_rules! hashmap {
+    ($($tokens:tt)*) => {{ 0 }};
+}
+
+macro_rules! bail {
+    ($($tokens:tt)*) => {{ 0 }};
+}
+
+macro_rules! ensure {
+    ($($tokens:tt)*) => {{ 0 }};
+}
+
 // `debug_assert_eq!` is on the built-in deny list. The first argument
 // is an impure method call; in release builds the macro folds to
 // `if false { ... }` and the call never runs, leaving the map in a
@@ -328,6 +344,22 @@ fn _zero_arg_mutating_method_flagged(slice: &mut Vec<u32>) {
 // method calls, ... still flag".
 fn _turbofish_method_call_flagged(text: &str) {
     debug_assert!(text.parse::<u32>().is_ok());
+}
+
+// Third-party `tt`-based literal builders on the curated allow
+// list (`serde_json::json!`, `maplit::{hashmap, btreemap, ...}!`,
+// `anyhow::{bail, ensure}!`) accept impure top-level arguments
+// without flagging. Each macro evaluates every captured Rust
+// expression exactly once at runtime — no cfg gate, no repeated
+// substitution — so the exactly-once contract the rule defends
+// already holds. Tail-segment matching means `serde_json::json!`,
+// `::serde_json::json!`, and the bare `json!` form all line up
+// with the same entry.
+fn _third_party_allow_listed_accepted() {
+    let _ = json!({ "ts": value(), "items": [value(), value()] });
+    let _ = hashmap!("a" => value(), "b" => value());
+    let _ = bail!("error: {}", value());
+    let _ = ensure!(value().is_some(), "missing: {}", value());
 }
 
 // `core` / `std` compile-time macros (`concat!`, `env!`,

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -181,9 +181,14 @@ fn _brace_argument_with_attributed_let_flagged() {
     });
 }
 
-// All seven pure argument shapes — accepted under every mode. The
-// outer `debug_assert_eq!` is on the deny list, so any impure
-// argument here would otherwise be flagged.
+// The atom-shaped pure arguments — literal, path, reference,
+// mut-reference, tuple-index, deref, indexed pure base, pure
+// cast, rooted path — accepted under every mode. The outer
+// `debug_assert_eq!` is on the deny list, so any impure argument
+// here would otherwise be flagged. The grammar is open-ended
+// (array literals / repeats are exercised in a dedicated fixture
+// below; binary chains and pure-getter postfixes likewise); this
+// function only covers the atom shapes.
 fn _all_pure_shapes_accepted() {
     let pair: (u32, u32) = (0, 0);
     let buffer: [u32; 4] = [0; 4];

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -43,6 +43,10 @@ macro_rules! assert_yaml_snapshot {
     ($($tokens:tt)*) => {{}};
 }
 
+macro_rules! dsl_macro {
+    ($($tokens:tt)*) => {{ 0 }};
+}
+
 // `debug_assert_eq!` is on the built-in deny list. The first argument
 // is an impure method call; in release builds the macro folds to
 // `if false { ... }` and the call never runs, leaving the map in a
@@ -115,6 +119,24 @@ fn _vec_repeat_form_skipped() {
 // form via the surrounding `macro_rules!` dispatch.
 fn _brace_delimiter_skipped() {
     debug_assert! { value().is_some() }
+}
+
+// A brace-delimited *argument* (the macro's outer delimiter is `(`,
+// the argument's outer delimiter is `{`) carries DSL body syntax
+// that isn't a Rust expression — `{"key": "value"}` (JSON-shaped),
+// `{"key" => "value"}` (maplit-shaped). The rule cannot propose a
+// let-bind rewrite for these because they don't compile in
+// expression position, so the argument is treated as
+// not-an-expression and skipped. The DSL signal is a top-level `:`
+// (not in a `let` statement) or a top-level `=>`.
+fn _brace_argument_with_dsl_markers_skipped() {
+    let _ = dsl_macro!({ "key": "value" });
+    let _ = dsl_macro!({ "key" => "value", "other" => "value" });
+    // Real Rust block expressions still go through the regular
+    // pure-expression analysis: `{ let x: T = e; x }` reaches the
+    // walker (the `let` keyword whitelists the `:`) and bottoms
+    // out as impure (block expressions aren't a pure atom),
+    // matching the spec's "blocks are impure" classification.
 }
 
 // All seven pure argument shapes — accepted under every mode. The

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -44,16 +44,16 @@ macro_rules! assert_yaml_snapshot {
 }
 
 // `debug_assert_eq!` is on the built-in deny list. The first argument
-// is a non-trivial method call; in release builds the macro folds to
+// is an impure method call; in release builds the macro folds to
 // `if false { ... }` and the call never runs, leaving the map in a
 // state the author did not intend. The literal `None` and the string
-// literal panic message are trivial and accepted.
+// literal panic message are pure and accepted.
 fn _motivating_bug(map: &mut Map) {
     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
 }
 
 // Bare `debug_assert!` likewise: the condition is a method call, the
-// argument is non-trivial, the rule flags it.
+// argument is impure, the rule flags it.
 fn _debug_assert_method_call() {
     debug_assert!(value().is_some());
 }
@@ -61,21 +61,21 @@ fn _debug_assert_method_call() {
 // `debug_assert_ne!` flagged on both arguments. `value()` is a
 // function call; `Some(0)` is a tuple-variant *call*, not a bare
 // path. Only the bare-path form (e.g., `Some` as a function pointer)
-// is trivial, so the constructor invocation is flagged separately.
+// is pure, so the constructor invocation is flagged separately.
 fn _debug_assert_ne_call() {
     debug_assert_ne!(value(), Some(0));
 }
 
 // An uncatalogued macro under the default `AllowAndDeny` mode is
 // neither denied nor allowed: the rule defaults to flagging non-
-// trivial arguments. `value()` is non-trivial; `count` (a path) is
-// trivial and accepted.
+// pure arguments. `value()` is impure; `count` (a path) is
+// pure and accepted.
 fn _unknown_macro_default_flags(count: u32) {
     let _ = my_macro!(value(), count);
 }
 
 // Allow-listed `format!` evaluates each argument exactly once. Even a
-// non-trivial expression in a format-args slot is accepted.
+// impure expression in a format-args slot is accepted.
 fn _format_allow_listed() {
     let mut count: u32 = 0;
     let _ = format!("retrying {} times", {
@@ -85,7 +85,7 @@ fn _format_allow_listed() {
 }
 
 // Allow-listed `vec!`. Comma-form is the array-like shape the rule
-// targets, but `vec!` is on the allow list, so non-trivial elements
+// targets, but `vec!` is on the allow list, so impure elements
 // are accepted under the default config.
 fn _vec_allow_listed() {
     let _ = vec![value(), value(), value()];
@@ -117,10 +117,10 @@ fn _brace_delimiter_skipped() {
     debug_assert! { value().is_some() }
 }
 
-// All seven trivial argument shapes — accepted under every mode. The
-// outer `debug_assert_eq!` is on the deny list, so any non-trivial
+// All seven pure argument shapes — accepted under every mode. The
+// outer `debug_assert_eq!` is on the deny list, so any impure
 // argument here would otherwise be flagged.
-fn _all_trivial_shapes_accepted() {
+fn _all_pure_shapes_accepted() {
     let pair: (u32, u32) = (0, 0);
     let buffer: [u32; 4] = [0; 4];
     let pointer: &u32 = &MAX;
@@ -132,22 +132,22 @@ fn _all_trivial_shapes_accepted() {
     debug_assert_eq!(&owned, &MAX, "references");
     debug_assert_ne!(&mut left, &mut right, "mut reference");
     debug_assert_eq!(pair.0, pair.1, "tuple index");
-    debug_assert_eq!(buffer[0], buffer[INDEX], "indexing trivial bases");
+    debug_assert_eq!(buffer[0], buffer[INDEX], "indexing pure bases");
     debug_assert_eq!(*pointer, *pointer, "deref of a path");
-    debug_assert_eq!(0u32 as u64, MAX as u64, "trivial cast");
+    debug_assert_eq!(0u32 as u64, MAX as u64, "pure cast");
     debug_assert_eq!(::std::u32::MAX, std::u32::MAX, "rooted path");
 }
 
-// Single-argument deny-listed call with a non-trivial expression.
+// Single-argument deny-listed call with an impure expression.
 fn _single_argument_deny() {
     debug_assert!(value().is_some());
 }
 
-// `.await` is `ExprKind::Await`, not a field access — non-trivial
+// `.await` is `ExprKind::Await`, not a field access — impure
 // per the spec. Without the explicit `await`-keyword rejection in
 // the dot-suffix branch, the walker would consume `.await` as a
-// "trivial field access" and silently accept the whole expression.
-// `await_macro!` is uncatalogued so default-mode flags non-trivial
+// "pure field access" and silently accept the whole expression.
+// `await_macro!` is uncatalogued so default-mode flags impure
 // args — that's what we verify here. The macro swallows the tokens
 // rather than emitting an `expr` so the fixture stays valid under
 // the test harness's default edition (no real `async fn` needed).
@@ -165,7 +165,7 @@ fn _empty_argument_list() {
 // position the macro author chose (`Type => [LINT_NAMES]` is the
 // canonical example, courtesy of `impl_lint_pass!`), not a Rust
 // expression. The rule does not flag these — `value()` here is
-// non-trivial but lives on the right-hand side of `=>`, so the whole
+// impure but lives on the right-hand side of `=>`, so the whole
 // argument is skipped rather than parsed as an expression.
 fn _fat_arrow_skips_argument() {
     let _ = arrow_macro!(NameType => value());
@@ -219,30 +219,30 @@ fn _in_keyword_separator_skipped() {
 // Rust expression standalone, and any `let` binding the rule could
 // suggest would break the matcher's structural pattern. The `->`
 // alone is enough to disqualify the argument; `==` stays a real Rust
-// binary operator so that `debug_assert!(a == b)` keeps being trivial.
+// binary operator so that `debug_assert!(a == b)` keeps being pure.
 fn _mixed_definition_dsl_skipped() {
     let _ = arrow_separator_macro!(plain_number -> 65_535 in PlainNumber == "65535");
 }
 
-// `()` is the canonical trivial value: the empty-tuple / unit literal.
-// Parenthesised trivial expressions and tuples of trivial elements are
-// also trivial, since none of these introduce a side effect beyond
+// `()` is the canonical pure value: the empty-tuple / unit literal.
+// Parenthesised pure expressions and tuples of pure elements are
+// also pure, since none of these introduce a side effect beyond
 // their contents. Without these, callers that pass `()` as a marker
 // argument would be flagged with a meaningless let-binding hint.
-fn _parenthesised_trivial_accepted(point: (u32, u32)) {
+fn _parenthesised_pure_accepted(point: (u32, u32)) {
     let _ = my_macro!((), value());
     let _ = my_macro!((MAX), value());
     let _ = my_macro!((point.0, point.1), value());
     let _ = my_macro!((MAX,), value());
 }
 
-// Binary chains over trivial operands are trivial — comparisons and
+// Binary chains over pure operands are pure — comparisons and
 // arithmetic on local bindings, fields, and constants are side-effect-
 // free and produce the same result regardless of how many times the
 // macro evaluates them. Flagging these would defeat the debug-only
 // optimisation of `debug_assert!(a <= b)` by forcing the comparison to
 // evaluate in release builds.
-fn _binary_chain_of_trivial_operands_accepted(left: u32, right: u32, point: (u32, u32)) {
+fn _binary_chain_of_pure_operands_accepted(left: u32, right: u32, point: (u32, u32)) {
     debug_assert!(left <= right);
     debug_assert!(left == right);
     debug_assert!(left != right && left < MAX);
@@ -250,10 +250,10 @@ fn _binary_chain_of_trivial_operands_accepted(left: u32, right: u32, point: (u32
     debug_assert!(left * 2 == right + 1);
 }
 
-// Pure-getter method calls on a trivial base are trivial postfixes.
+// Pure-getter method calls on a pure base are pure postfixes.
 // `len`, `is_empty`, `as_str`, `as_bytes`, `as_ref`, `as_mut`,
 // `as_deref`, `as_slice` are the built-in pure-getter set; projects
-// extend it via `dylint.toml`'s `extra_trivial_methods` knob (see
+// extend it via `dylint.toml`'s `extra_pure_methods` knob (see
 // `tests/macro_argument_binding.rs`). Combined with the binary-chain
 // rule above, `debug_assert!(vec.len() <= cap)` no longer drags the
 // comparison out of its `cfg(debug_assertions)` guard.
@@ -274,15 +274,15 @@ fn _pure_method_postfix_accepted(slice: &[u32], text: &String) {
 // built-in pure-getter list still flags. `clear` is a state-mutating
 // method despite its zero-arg shape, so the rule must keep flagging
 // it under the default config (users who want it accepted explicitly
-// opt in via `extra_trivial_methods`).
+// opt in via `extra_pure_methods`).
 fn _zero_arg_mutating_method_flagged(slice: &mut Vec<u32>) {
     debug_assert!(slice.clear() == ());
 }
 
-// Negative coverage: a turbofish-generic method call is non-trivial.
+// Negative coverage: a turbofish-generic method call is impure.
 // The `::<T>` token sequence sits between `.method` and `()`, so the
 // suffix walker's `.method()` recogniser does not match and the
-// argument falls through to the non-trivial bucket. Matches the
+// argument falls through to the impure bucket. Matches the
 // docstring promise that "method calls with arguments, generic
 // method calls, ... still flag".
 fn _turbofish_method_call_flagged(text: &str) {
@@ -292,7 +292,7 @@ fn _turbofish_method_call_flagged(text: &str) {
 // `core` / `std` compile-time macros (`concat!`, `env!`,
 // `option_env!`, `include_str!`, `include_bytes!`, `stringify!`,
 // `cfg!`, `line!`, `column!`, `file!`, `module_path!`) are on the
-// allow list AND count as trivial atoms when nested inside another
+// allow list AND count as pure atoms when nested inside another
 // macro. The expansion is a compile-time constant — a literal, a
 // `&'static str`, a `bool`, a span marker — with no runtime
 // evaluation to disturb. Both behaviours together make the patterns
@@ -304,14 +304,14 @@ fn _compile_time_macros_accepted() {
     let _ = concat!("home is at ", env!("CARGO_PKG_NAME"));
     let _ = concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"));
     let _ = stringify!(let x = compute(););
-    // Inner compile-time macros are trivial atoms inside any
+    // Inner compile-time macros are pure atoms inside any
     // surrounding (even deny-listed) macro: there is no runtime
     // expression to bind.
     debug_assert_eq!(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_NAME"));
     debug_assert!(cfg!(any()) || cfg!(all()));
     debug_assert_eq!(line!(), line!());
     debug_assert_eq!(concat!("a", "b"), "ab");
-    // Qualified-path call sites still hit the trivial-macro
+    // Qualified-path call sites still hit the pure-macro
     // recognition: tail-segment matching makes `::std::stringify!`
     // line up with the same `"stringify"` entry as the bare form.
     debug_assert_eq!(::std::stringify!(x), std::stringify!(x));

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -236,6 +236,25 @@ fn _parenthesised_pure_accepted(point: (u32, u32)) {
     let _ = my_macro!((MAX,), value());
 }
 
+// Array literals over pure elements are pure. The bracketed shape
+// is the canonical Rust array literal `[a, b, c]` and the repeat
+// form `[expr; count]`; both forms evaluate every captured Rust
+// expression at most once and so don't introduce the side-effect
+// hazard the rule is built to catch. Indexing (`base[index]`) is
+// handled separately by the suffix walker and is unaffected.
+fn _array_literal_of_pure_elements_accepted() {
+    debug_assert_eq!([0, 1, 2], [MAX, MAX, MAX], "array literal");
+    debug_assert_eq!([0; 4], [MAX; 4], "array repeat");
+}
+
+// Negative coverage: an array literal with at least one impure
+// element is still flagged. The let-bind rewrite the rule suggests
+// is meaningful here — the caller can bind the impure element
+// first and pass the resulting array.
+fn _array_literal_with_impure_element_flagged() {
+    let _ = my_macro!([value(), value()]);
+}
+
 // Binary chains over pure operands are pure — comparisons and
 // arithmetic on local bindings, fields, and constants are side-effect-
 // free and produce the same result regardless of how many times the

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -1,5 +1,5 @@
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:56:22
+  --> $DIR/macro_argument_binding.rs:72:22
    |
 LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
    |                      ^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
    = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:62:19
+  --> $DIR/macro_argument_binding.rs:78:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:70:22
+  --> $DIR/macro_argument_binding.rs:86:22
    |
 LL |     debug_assert_ne!(value(), Some(0));
    |                      ^^^^^^^
@@ -24,7 +24,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:70:31
+  --> $DIR/macro_argument_binding.rs:86:31
    |
 LL |     debug_assert_ne!(value(), Some(0));
    |                               ^^^^^^^
@@ -32,7 +32,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:78:23
+  --> $DIR/macro_argument_binding.rs:94:23
    |
 LL |     let _ = my_macro!(value(), count);
    |                       ^^^^^^^
@@ -40,7 +40,7 @@ LL |     let _ = my_macro!(value(), count);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:165:19
+  --> $DIR/macro_argument_binding.rs:181:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:178:26
+  --> $DIR/macro_argument_binding.rs:194:26
    |
 LL |     let _ = await_macro!(future.await);
    |                          ^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     let _ = await_macro!(future.await);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:255:27
+  --> $DIR/macro_argument_binding.rs:271:27
    |
 LL |     let _ = my_macro!((), value());
    |                           ^^^^^^^
@@ -64,7 +64,7 @@ LL |     let _ = my_macro!((), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:256:30
+  --> $DIR/macro_argument_binding.rs:272:30
    |
 LL |     let _ = my_macro!((MAX), value());
    |                              ^^^^^^^
@@ -72,7 +72,7 @@ LL |     let _ = my_macro!((MAX), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:257:43
+  --> $DIR/macro_argument_binding.rs:273:43
    |
 LL |     let _ = my_macro!((point.0, point.1), value());
    |                                           ^^^^^^^
@@ -80,7 +80,7 @@ LL |     let _ = my_macro!((point.0, point.1), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:258:31
+  --> $DIR/macro_argument_binding.rs:274:31
    |
 LL |     let _ = my_macro!((MAX,), value());
    |                               ^^^^^^^
@@ -88,7 +88,7 @@ LL |     let _ = my_macro!((MAX,), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:277:23
+  --> $DIR/macro_argument_binding.rs:293:23
    |
 LL |     let _ = my_macro!([value(), value()]);
    |                       ^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL |     let _ = my_macro!([value(), value()]);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:320:19
+  --> $DIR/macro_argument_binding.rs:336:19
    |
 LL |     debug_assert!(slice.clear() == ());
    |                   ^^^^^^^^^^^^^^^^^^^
@@ -104,7 +104,7 @@ LL |     debug_assert!(slice.clear() == ());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:330:19
+  --> $DIR/macro_argument_binding.rs:346:19
    |
 LL |     debug_assert!(text.parse::<u32>().is_ok());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -88,7 +88,15 @@ LL |     let _ = my_macro!((MAX,), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:279:19
+  --> $DIR/macro_argument_binding.rs:255:23
+   |
+LL |     let _ = my_macro!([value(), value()]);
+   |                       ^^^^^^^^^^^^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: impure expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:298:19
    |
 LL |     debug_assert!(slice.clear() == ());
    |                   ^^^^^^^^^^^^^^^^^^^
@@ -96,12 +104,12 @@ LL |     debug_assert!(slice.clear() == ());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:289:19
+  --> $DIR/macro_argument_binding.rs:308:19
    |
 LL |     debug_assert!(text.parse::<u32>().is_ok());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: 13 warnings emitted
+warning: 14 warnings emitted
 

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -1,5 +1,5 @@
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:52:22
+  --> $DIR/macro_argument_binding.rs:56:22
    |
 LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
    |                      ^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
    = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:58:19
+  --> $DIR/macro_argument_binding.rs:62:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:66:22
+  --> $DIR/macro_argument_binding.rs:70:22
    |
 LL |     debug_assert_ne!(value(), Some(0));
    |                      ^^^^^^^
@@ -24,7 +24,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:66:31
+  --> $DIR/macro_argument_binding.rs:70:31
    |
 LL |     debug_assert_ne!(value(), Some(0));
    |                               ^^^^^^^
@@ -32,7 +32,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:74:23
+  --> $DIR/macro_argument_binding.rs:78:23
    |
 LL |     let _ = my_macro!(value(), count);
    |                       ^^^^^^^
@@ -40,7 +40,7 @@ LL |     let _ = my_macro!(value(), count);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:143:19
+  --> $DIR/macro_argument_binding.rs:165:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -48,7 +48,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:156:26
+  --> $DIR/macro_argument_binding.rs:178:26
    |
 LL |     let _ = await_macro!(future.await);
    |                          ^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |     let _ = await_macro!(future.await);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:233:27
+  --> $DIR/macro_argument_binding.rs:255:27
    |
 LL |     let _ = my_macro!((), value());
    |                           ^^^^^^^
@@ -64,7 +64,7 @@ LL |     let _ = my_macro!((), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:234:30
+  --> $DIR/macro_argument_binding.rs:256:30
    |
 LL |     let _ = my_macro!((MAX), value());
    |                              ^^^^^^^
@@ -72,7 +72,7 @@ LL |     let _ = my_macro!((MAX), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:235:43
+  --> $DIR/macro_argument_binding.rs:257:43
    |
 LL |     let _ = my_macro!((point.0, point.1), value());
    |                                           ^^^^^^^
@@ -80,7 +80,7 @@ LL |     let _ = my_macro!((point.0, point.1), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:236:31
+  --> $DIR/macro_argument_binding.rs:258:31
    |
 LL |     let _ = my_macro!((MAX,), value());
    |                               ^^^^^^^
@@ -88,7 +88,7 @@ LL |     let _ = my_macro!((MAX,), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:255:23
+  --> $DIR/macro_argument_binding.rs:277:23
    |
 LL |     let _ = my_macro!([value(), value()]);
    |                       ^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL |     let _ = my_macro!([value(), value()]);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:298:19
+  --> $DIR/macro_argument_binding.rs:320:19
    |
 LL |     debug_assert!(slice.clear() == ());
    |                   ^^^^^^^^^^^^^^^^^^^
@@ -104,7 +104,7 @@ LL |     debug_assert!(slice.clear() == ());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:308:19
+  --> $DIR/macro_argument_binding.rs:330:19
    |
 LL |     debug_assert!(text.parse::<u32>().is_ok());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -53,7 +53,7 @@ LL | |     });
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:207:19
+  --> $DIR/macro_argument_binding.rs:212:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:220:26
+  --> $DIR/macro_argument_binding.rs:225:26
    |
 LL |     let _ = await_macro!(future.await);
    |                          ^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL |     let _ = await_macro!(future.await);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:297:27
+  --> $DIR/macro_argument_binding.rs:302:27
    |
 LL |     let _ = my_macro!((), value());
    |                           ^^^^^^^
@@ -77,7 +77,7 @@ LL |     let _ = my_macro!((), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:298:30
+  --> $DIR/macro_argument_binding.rs:303:30
    |
 LL |     let _ = my_macro!((MAX), value());
    |                              ^^^^^^^
@@ -85,7 +85,7 @@ LL |     let _ = my_macro!((MAX), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:299:43
+  --> $DIR/macro_argument_binding.rs:304:43
    |
 LL |     let _ = my_macro!((point.0, point.1), value());
    |                                           ^^^^^^^
@@ -93,7 +93,7 @@ LL |     let _ = my_macro!((point.0, point.1), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:300:31
+  --> $DIR/macro_argument_binding.rs:305:31
    |
 LL |     let _ = my_macro!((MAX,), value());
    |                               ^^^^^^^
@@ -101,7 +101,7 @@ LL |     let _ = my_macro!((MAX,), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:319:23
+  --> $DIR/macro_argument_binding.rs:324:23
    |
 LL |     let _ = my_macro!([value(), value()]);
    |                       ^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL |     let _ = my_macro!([value(), value()]);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:334:26
+  --> $DIR/macro_argument_binding.rs:339:26
    |
 LL |     let _ = await_macro!([value(); 4]);
    |                          ^^^^^^^^^^^^
@@ -117,7 +117,7 @@ LL |     let _ = await_macro!([value(); 4]);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:335:26
+  --> $DIR/macro_argument_binding.rs:340:26
    |
 LL |     let _ = await_macro!([0; size()]);
    |                          ^^^^^^^^^^^
@@ -125,7 +125,7 @@ LL |     let _ = await_macro!([0; size()]);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:378:19
+  --> $DIR/macro_argument_binding.rs:383:19
    |
 LL |     debug_assert!(slice.clear() == ());
    |                   ^^^^^^^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL |     debug_assert!(slice.clear() == ());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:388:19
+  --> $DIR/macro_argument_binding.rs:393:19
    |
 LL |     debug_assert!(text.parse::<u32>().is_ok());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -40,7 +40,20 @@ LL |     let _ = my_macro!(value(), count);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:181:19
+  --> $DIR/macro_argument_binding.rs:177:24
+   |
+LL |       let _ = dsl_macro!({
+   |  ________________________^
+LL | |         #[allow(unused)]
+LL | |         let x: u32 = MAX;
+LL | |         x
+LL | |     });
+   | |_____^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: impure expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:207:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -48,7 +61,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:194:26
+  --> $DIR/macro_argument_binding.rs:220:26
    |
 LL |     let _ = await_macro!(future.await);
    |                          ^^^^^^^^^^^^
@@ -56,7 +69,7 @@ LL |     let _ = await_macro!(future.await);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:271:27
+  --> $DIR/macro_argument_binding.rs:297:27
    |
 LL |     let _ = my_macro!((), value());
    |                           ^^^^^^^
@@ -64,7 +77,7 @@ LL |     let _ = my_macro!((), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:272:30
+  --> $DIR/macro_argument_binding.rs:298:30
    |
 LL |     let _ = my_macro!((MAX), value());
    |                              ^^^^^^^
@@ -72,7 +85,7 @@ LL |     let _ = my_macro!((MAX), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:273:43
+  --> $DIR/macro_argument_binding.rs:299:43
    |
 LL |     let _ = my_macro!((point.0, point.1), value());
    |                                           ^^^^^^^
@@ -80,7 +93,7 @@ LL |     let _ = my_macro!((point.0, point.1), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:274:31
+  --> $DIR/macro_argument_binding.rs:300:31
    |
 LL |     let _ = my_macro!((MAX,), value());
    |                               ^^^^^^^
@@ -88,7 +101,7 @@ LL |     let _ = my_macro!((MAX,), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:293:23
+  --> $DIR/macro_argument_binding.rs:319:23
    |
 LL |     let _ = my_macro!([value(), value()]);
    |                       ^^^^^^^^^^^^^^^^^^
@@ -96,7 +109,7 @@ LL |     let _ = my_macro!([value(), value()]);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:336:19
+  --> $DIR/macro_argument_binding.rs:362:19
    |
 LL |     debug_assert!(slice.clear() == ());
    |                   ^^^^^^^^^^^^^^^^^^^
@@ -104,12 +117,12 @@ LL |     debug_assert!(slice.clear() == ());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:346:19
+  --> $DIR/macro_argument_binding.rs:372:19
    |
 LL |     debug_assert!(text.parse::<u32>().is_ok());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: 14 warnings emitted
+warning: 15 warnings emitted
 

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -1,4 +1,4 @@
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:52:22
    |
 LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
@@ -7,7 +7,7 @@ LL |     debug_assert_eq!(map.insert(0, 0), None, "duplicate key");
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
    = note: `#[warn(perfectionist::macro_argument_binding)]` on by default
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:58:19
    |
 LL |     debug_assert!(value().is_some());
@@ -15,7 +15,7 @@ LL |     debug_assert!(value().is_some());
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:66:22
    |
 LL |     debug_assert_ne!(value(), Some(0));
@@ -23,7 +23,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:66:31
    |
 LL |     debug_assert_ne!(value(), Some(0));
@@ -31,7 +31,7 @@ LL |     debug_assert_ne!(value(), Some(0));
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:74:23
    |
 LL |     let _ = my_macro!(value(), count);
@@ -39,7 +39,7 @@ LL |     let _ = my_macro!(value(), count);
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:143:19
    |
 LL |     debug_assert!(value().is_some());
@@ -47,7 +47,7 @@ LL |     debug_assert!(value().is_some());
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:156:26
    |
 LL |     let _ = await_macro!(future.await);
@@ -55,7 +55,7 @@ LL |     let _ = await_macro!(future.await);
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:233:27
    |
 LL |     let _ = my_macro!((), value());
@@ -63,7 +63,7 @@ LL |     let _ = my_macro!((), value());
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:234:30
    |
 LL |     let _ = my_macro!((MAX), value());
@@ -71,7 +71,7 @@ LL |     let _ = my_macro!((MAX), value());
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:235:43
    |
 LL |     let _ = my_macro!((point.0, point.1), value());
@@ -79,7 +79,7 @@ LL |     let _ = my_macro!((point.0, point.1), value());
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:236:31
    |
 LL |     let _ = my_macro!((MAX,), value());
@@ -87,7 +87,7 @@ LL |     let _ = my_macro!((MAX,), value());
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:279:19
    |
 LL |     debug_assert!(slice.clear() == ());
@@ -95,7 +95,7 @@ LL |     debug_assert!(slice.clear() == ());
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: non-trivial expression passed directly to a macro
+warning: impure expression passed directly to a macro
   --> $DIR/macro_argument_binding.rs:289:19
    |
 LL |     debug_assert!(text.parse::<u32>().is_ok());

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -109,7 +109,23 @@ LL |     let _ = my_macro!([value(), value()]);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:362:19
+  --> $DIR/macro_argument_binding.rs:334:26
+   |
+LL |     let _ = await_macro!([value(); 4]);
+   |                          ^^^^^^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: impure expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:335:26
+   |
+LL |     let _ = await_macro!([0; size()]);
+   |                          ^^^^^^^^^^^
+   |
+   = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
+
+warning: impure expression passed directly to a macro
+  --> $DIR/macro_argument_binding.rs:378:19
    |
 LL |     debug_assert!(slice.clear() == ());
    |                   ^^^^^^^^^^^^^^^^^^^
@@ -117,12 +133,12 @@ LL |     debug_assert!(slice.clear() == ());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:372:19
+  --> $DIR/macro_argument_binding.rs:388:19
    |
 LL |     debug_assert!(text.parse::<u32>().is_ok());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
-warning: 15 warnings emitted
+warning: 17 warnings emitted
 


### PR DESCRIPTION
## Summary

Refines `perfectionist::macro_argument_binding` to remove three false positives that fire against `serde_json::json!` and similar `tt`-based literal macros, and renames the classification vocabulary so the criterion is explicit.

### Behavior fixes

- **Array literals of pure elements are pure.** `[1, 2, 3]` is no longer flagged. The bracket atom now accepts `[]`, comma-separated array literals, and the `[expr; count]` repeat form when their parts are pure.
- **Brace-delimited DSL arguments are skipped.** `json!({"k": "v"})` and `hashmap!({"k" => v})` previously reached the pure-expression walker as block expressions and were flagged with a `let`-binding hint that wouldn't even compile in expression position. `looks_like_expression` now descends into single-brace arguments and skips them when the inner top level carries a DSL signal — top-level `=>`, or `:` outside a `let` statement. Leading outer attributes (`#[cfg(...)]`, `#[allow(...)]`) and inner attributes / doc comments are skipped before the `let`-whitelist check, so real attributed blocks survive intact.
- **Built-in allow list grows.** Adds `serde_json::json`, the `maplit::{hashmap, btreemap, hashset, btreeset}` builders, and the anyhow companions `bail` / `ensure`. Each has a published expansion that walks its input once and evaluates every captured Rust expression exactly once.

### Terminology rename (breaking)

The previous "trivial" / "non-trivial" framing suggested syntactic simplicity, but the rule actually cares about *observable evaluation*. Renamed everywhere — source, diagnostic (`"impure expression passed directly to a macro"`), planning spec, generated rule docs, UI fixtures — and given an explicit definition: **pure** means *safe for the surrounding macro to drop or duplicate* (evaluating the argument zero, one, or many times is observationally equivalent); **impure** is anything else. The classification is syntactic and intentionally narrower than the functional-programming notion of purity — a `const fn` call that's in fact side-effect-free is still impure under this rule unless its shape is in the curated set.

Breaking config-key renames:

| Old | New |
| --- | --- |
| `extra_trivial_methods` | `extra_pure_methods` |
| `ignore_trivial_methods` | `ignore_pure_methods` |
| `extra_trivial_macros` | `extra_pure_macros` |
| `ignore_trivial_macros` | `ignore_pure_macros` |

## Test plan

- [x] `cargo test` — 14 `macro_argument_binding` config tests + UI fixture + 15 other UI tests
- [x] `cargo dylint --all` (self-lint, including perfectionist's own `single_letter_let_binding` and `macro_trailing_comma` on the new walker code)
- [x] `cargo fmt -- --check`, `cargo doc -D warnings`
- [x] Verified empirically against a fresh `serde_json` project — `json!(null)`, `json!([1,2,3])`, `json!({"k":"v"})`, and nested forms all accepted; `cargo expand` confirms each captured expression becomes exactly one `to_value(&expr)` call.

https://claude.ai/code/session_01TXV44Lhi4vv7LmEETPgKFU