### PR TITLE
docs(plan/macro-argument-binding): identifier paths

### DIFF
--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -23,9 +23,10 @@ Still pending:
   user wrote at the call site. A configured entry of
   `their_crate::their_macro` matches
   `their_crate::their_macro!(...)` and
-  `crate::their_crate::their_macro!(...)` but does *not* match
-  the ecosystem-standard call shapes that route the macro
-  through a `use` declaration:
+  `::their_crate::their_macro!(...)` (any path whose final two
+  segments are `their_crate::their_macro`, leading `::` and
+  all) but does *not* match the ecosystem-standard call shapes
+  that route the macro through a `use` declaration:
 
   ```rust
   use their_crate::their_macro;
@@ -65,22 +66,24 @@ Still pending:
   crates each, and the bare-segment match cannot pick one
   without false positives.
 
-  **The feature requires type information.** Pre-expansion —
-  where this rule's `check_mac` runs — sees raw AST paths and
-  the unexpanded `use` items, but not their resolution: rustc
-  has not yet decided which definition the bare
-  `their_macro!(...)` refers to. Reimplementing the resolver
-  from `use` items alone is an incomplete approximation: globs
-  (`use foo::*;`) have no enumerable name list at the AST
-  level, cross-crate re-exports
+  **The feature requires rustc's name-resolution output.**
+  Pre-expansion — where this rule's `check_mac` runs — sees
+  raw AST paths and the unexpanded `use` items, but not their
+  resolution: rustc has not yet decided which definition the
+  bare `their_macro!(...)` refers to (macro name resolution
+  happens *during* expansion, and type checking is a layer
+  above that — both run after pre-expansion). Reimplementing
+  the resolver from `use` items alone is an incomplete
+  approximation: globs (`use foo::*;`) have no enumerable name
+  list at the AST level, cross-crate re-exports
   (`pub use other_crate::macro_name as ours;`) are not visible
   without the re-exporting crate's metadata,
   `#[macro_use] extern crate` brings names into scope through a
   different mechanism still, and the textual macro scope (the
   legacy `macro_rules!` resolution rules) does not nest the same
   way modular paths do. Only the compiler's own resolver answers
-  every case correctly, and it only has the answer post-
-  expansion.
+  every case correctly, and it only has the answer once
+  expansion is finished.
 
   The plumbing path that *does* work: keep the pre-expansion
   pass for argument splitting and impure-shape classification,
@@ -92,22 +95,29 @@ Still pending:
   walk) against the configured paths. `DefId` comparison
   resolves cross-crate re-exports, glob imports, aliases, and
   `#[macro_use] extern crate` without reimplementing any of
-  rustc's logic — type information is the resolver, supplied
-  by rustc as a free side-effect of having already compiled
-  the consumer crate up to the late pass.
+  rustc's logic — the compiler's name-resolution output *is*
+  the resolver, available at the late pass as a free
+  side-effect of having compiled the consumer crate that far.
 
-  **Difficulty: moderate.** The plumbing change is small
-  (~150-250 lines) but it touches every list-shaped lookup and
-  changes the rule's *contract* for `deny_extra`: a project
-  that today writes a homegrown `debug_assert_eq!` macro and
-  matches it by name alone will stop matching the built-in
-  deny entry once paths are resolved against the macro's
-  actual `DefId`. The new contract is arguably more correct —
-  it's the resolved macro the rule cares about, not the
-  textual fragment — but it is a behavioural change and
-  deserves its own planning entry, migration note in this
-  `Status` section, and a release-note call-out. Land
-  separately from any PR that adds to the curated lists.
+  **Difficulty: moderate.** The plumbing change is small in
+  itself but it touches every list-shaped lookup and changes
+  the rule's *contract* for the multi-segment user-supplied
+  entries in `deny_extra` / `allow_extra` / `ignore`. Today a
+  `deny_extra = ["their_crate::their_macro"]` entry matches
+  every invocation whose syntactic path tail-equals the entry,
+  so a homegrown `other_dep::their_crate::their_macro!(...)` is
+  caught by accident. Under the resolved-`DefId` matcher, the
+  same entry matches only invocations that actually resolve to
+  `their_crate::their_macro` (and matches them in *every*
+  call-site form, including the bare-after-`use` shapes today's
+  syntactic matcher misses). Built-in single-segment entries
+  (`"debug_assert_eq"`, `"format"`, `"vec"`) are untouched
+  because their bucket stays name-based — the new contract is
+  scoped to the multi-segment paths where the resolution gap
+  is felt. The change is still behavioural enough to deserve
+  its own planning entry, a migration note in this `Status`
+  section, and a release-note call-out; land it separately
+  from any PR that adds to the curated lists.
 - **Range expressions over pure operands.** The spec couples
   range-expression purity to operand purity the same way
   it does for binary expressions, but the walker only recognises

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -18,15 +18,17 @@ Still pending:
   shared with the equivalent eligibility check planned for
   `macro-trailing-comma`; both will land together.
 - **Identifier-path-aware allow / deny matching.** Multi-segment
-  entries in `deny`, `allow`, `ignore`, `deny_extra`, and
-  `allow_extra` currently tail-match the *syntactic* path the
-  user wrote at the call site. A configured entry of
-  `their_crate::their_macro` matches
-  `their_crate::their_macro!(...)` and
-  `::their_crate::their_macro!(...)` (any path whose final two
-  segments are `their_crate::their_macro`, leading `::` and
-  all) but does *not* match the ecosystem-standard call shapes
-  that route the macro through a `use` declaration:
+  entries — both the built-in deny / allow lists and the
+  user-supplied `deny_extra`, `allow_extra`, and `ignore` lists
+  — currently tail-match the *syntactic* path the user wrote
+  at the call site. A configured entry of
+  `their_crate::their_macro` matches any invocation whose
+  final two path segments are `their_crate::their_macro`
+  (`their_crate::their_macro!(...)`,
+  `::their_crate::their_macro!(...)`, and even
+  `something_else::their_crate::their_macro!(...)` all qualify)
+  but does *not* match the ecosystem-standard call shapes that
+  route the macro through a `use` declaration:
 
   ```rust
   use their_crate::their_macro;

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -17,6 +17,94 @@ Still pending:
   fails to deserialise. The matcher-walking infrastructure is
   shared with the equivalent eligibility check planned for
   `macro-trailing-comma`; both will land together.
+- **Identifier-path-aware allow / deny matching.** Multi-segment
+  entries in `deny`, `allow`, `ignore`, `deny_extra`, and
+  `allow_extra` currently tail-match the *syntactic* path the
+  user wrote at the call site. A configured entry of
+  `rusqlite::params` matches `rusqlite::params!(...)` and
+  `crate::rusqlite::params!(...)` but does *not* match the
+  ecosystem-standard call shapes that route the macro through
+  a `use` declaration:
+
+  ```rust
+  use rusqlite::params;
+  params!(...);                       // AST path: [params]
+
+  use rusqlite as r;
+  r::params!(...);                    // AST path: [r, params]
+
+  use rusqlite::params as bind;
+  bind!(...);                         // AST path: [bind]
+  ```
+
+  All three forms refer to the same macro, but the matcher only
+  sees the textual fragment the author wrote. The ambition is
+  for a single configuration entry `rusqlite::params` to cover
+  *every* form that resolves to `rusqlite::params!` — qualified,
+  absolute, aliased through `use ... as ...`, and bare after a
+  `use rusqlite::params;`. A leading `::`
+  (`"::rusqlite::params"`) should optionally pin the entry as
+  absolute, matching only the global form, but the default
+  contract for a multi-segment entry is "resolves to this macro,
+  however the call site named it."
+
+  **Bare single-segment entries stay name-based at the call
+  site.** A configured entry of `"vec"`, `"format"`, or
+  `"assert_eq"` continues to match the invocation's final
+  syntactic segment without consulting resolution — the
+  ecosystem names that earn a slot on the curated lists are
+  distinctive enough that the syntactic shape is sufficient,
+  and the matcher should not have to canonicalise the same
+  macro across `core::format` vs `std::format` re-export chains
+  to do its job. The resolution path is reserved for
+  multi-segment entries, where a path is the only way to
+  disambiguate from same-named third-party macros (`params!`
+  exists in `rusqlite`, `sqlite`, and several proc-macro
+  helpers; `json!` exists in `serde_json` and several
+  templating crates).
+
+  **The feature requires type information.** Pre-expansion —
+  where this rule's `check_mac` runs — sees raw AST paths and
+  the unexpanded `use` items, but not their resolution: rustc
+  has not yet decided which `params` the bare `params!(...)`
+  refers to. Reimplementing the resolver from `use` items alone
+  is an incomplete approximation: globs (`use foo::*;`) have no
+  enumerable name list at the AST level, cross-crate re-exports
+  (`pub use other_crate::macro_name as ours;`) are not visible
+  without the re-exporting crate's metadata,
+  `#[macro_use] extern crate` brings names into scope through a
+  different mechanism still, and the textual macro scope (the
+  legacy `macro_rules!` resolution rules) does not nest the same
+  way modular paths do. Only the compiler's own resolver answers
+  every case correctly, and it only has the answer post-
+  expansion.
+
+  The plumbing path that *does* work: keep the pre-expansion
+  pass for argument splitting and impure-shape classification,
+  but defer the deny / allow / ignore lookup to the late HIR
+  pass already running for diagnostic emission. The late pass
+  can look up the macro's `DefId` via
+  `Span::ctxt().outer_expn_data().macro_def_id` and compare
+  `tcx.def_path_str(def_id)` (or the structured `def_path`
+  walk) against the configured paths. `DefId` comparison
+  resolves cross-crate re-exports, glob imports, aliases, and
+  `#[macro_use] extern crate` without reimplementing any of
+  rustc's logic — type information is the resolver, supplied
+  by rustc as a free side-effect of having already compiled
+  the consumer crate up to the late pass.
+
+  **Difficulty: moderate.** The plumbing change is small
+  (~150-250 lines) but it touches every list-shaped lookup and
+  changes the rule's *contract* for `deny_extra`: a project
+  that today writes a homegrown `debug_assert_eq!` macro and
+  matches it by name alone will stop matching the built-in
+  deny entry once paths are resolved against the macro's
+  actual `DefId`. The new contract is arguably more correct —
+  it's the resolved macro the rule cares about, not the
+  textual fragment — but it is a behavioural change and
+  deserves its own planning entry, migration note in this
+  `Status` section, and a release-note call-out. Land
+  separately from any PR that adds to the curated lists.
 - **Range expressions over pure operands.** The spec couples
   range-expression purity to operand purity the same way
   it does for binary expressions, but the walker only recognises
@@ -614,7 +702,14 @@ ignore_pure_macros = [
   [`macro-trailing-comma`](./macro-trailing-comma.md)'s
   `matches_any` / `entry_matches` helpers; single-segment
   entries tail-match the path, multi-segment entries
-  tail-match the segment sequence.
+  tail-match the segment sequence. The Status section's
+  "Identifier-path-aware allow / deny matching" item lays out
+  the ambition to extend multi-segment matching to *every*
+  call shape that resolves to the same macro (post-`use`
+  bare, aliased, qualified, absolute), at the cost of moving
+  the path lookup into the late HIR pass so `DefId`-level
+  resolution is available; bare single-segment matching
+  stays where it is.
 - Argument splitting walks `MacCall::args.tokens`, tracks
   delimiter nesting, and splits on top-level commas. Share
   the splitter with `macro-trailing-comma`.

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -21,32 +21,34 @@ Still pending:
   entries in `deny`, `allow`, `ignore`, `deny_extra`, and
   `allow_extra` currently tail-match the *syntactic* path the
   user wrote at the call site. A configured entry of
-  `rusqlite::params` matches `rusqlite::params!(...)` and
-  `crate::rusqlite::params!(...)` but does *not* match the
-  ecosystem-standard call shapes that route the macro through
-  a `use` declaration:
+  `their_crate::their_macro` matches
+  `their_crate::their_macro!(...)` and
+  `crate::their_crate::their_macro!(...)` but does *not* match
+  the ecosystem-standard call shapes that route the macro
+  through a `use` declaration:
 
   ```rust
-  use rusqlite::params;
-  params!(...);                       // AST path: [params]
+  use their_crate::their_macro;
+  their_macro!(...);                  // AST path: [their_macro]
 
-  use rusqlite as r;
-  r::params!(...);                    // AST path: [r, params]
+  use their_crate as t;
+  t::their_macro!(...);               // AST path: [t, their_macro]
 
-  use rusqlite::params as bind;
-  bind!(...);                         // AST path: [bind]
+  use their_crate::their_macro as m;
+  m!(...);                            // AST path: [m]
   ```
 
   All three forms refer to the same macro, but the matcher only
   sees the textual fragment the author wrote. The ambition is
-  for a single configuration entry `rusqlite::params` to cover
-  *every* form that resolves to `rusqlite::params!` — qualified,
-  absolute, aliased through `use ... as ...`, and bare after a
-  `use rusqlite::params;`. A leading `::`
-  (`"::rusqlite::params"`) should optionally pin the entry as
-  absolute, matching only the global form, but the default
-  contract for a multi-segment entry is "resolves to this macro,
-  however the call site named it."
+  for a single configuration entry `their_crate::their_macro`
+  to cover *every* form that resolves to
+  `their_crate::their_macro!` — qualified, absolute, aliased
+  through `use ... as ...`, and bare after a
+  `use their_crate::their_macro;`. A leading `::`
+  (`"::their_crate::their_macro"`) should optionally pin the
+  entry as absolute, matching only the global form, but the
+  default contract for a multi-segment entry is "resolves to
+  this macro, however the call site named it."
 
   **Bare single-segment entries stay name-based at the call
   site.** A configured entry of `"vec"`, `"format"`, or
@@ -58,18 +60,19 @@ Still pending:
   macro across `core::format` vs `std::format` re-export chains
   to do its job. The resolution path is reserved for
   multi-segment entries, where a path is the only way to
-  disambiguate from same-named third-party macros (`params!`
-  exists in `rusqlite`, `sqlite`, and several proc-macro
-  helpers; `json!` exists in `serde_json` and several
-  templating crates).
+  disambiguate from same-named third-party macros — short
+  macro names are routinely claimed by several unrelated
+  crates each, and the bare-segment match cannot pick one
+  without false positives.
 
   **The feature requires type information.** Pre-expansion —
   where this rule's `check_mac` runs — sees raw AST paths and
   the unexpanded `use` items, but not their resolution: rustc
-  has not yet decided which `params` the bare `params!(...)`
-  refers to. Reimplementing the resolver from `use` items alone
-  is an incomplete approximation: globs (`use foo::*;`) have no
-  enumerable name list at the AST level, cross-crate re-exports
+  has not yet decided which definition the bare
+  `their_macro!(...)` refers to. Reimplementing the resolver
+  from `use` items alone is an incomplete approximation: globs
+  (`use foo::*;`) have no enumerable name list at the AST
+  level, cross-crate re-exports
   (`pub use other_crate::macro_name as ours;`) are not visible
   without the re-exporting crate's metadata,
   `#[macro_use] extern crate` brings names into scope through a

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -39,7 +39,7 @@ Still pending:
   multi-segment entry like `"my_crate::vec_like"` therefore
   only matches the textual call shapes
   `my_crate::vec_like!(...)` and
-  `crate::my_crate::vec_like!(...)`, not the bare
+  `::my_crate::vec_like!(...)`, not the bare
   `vec_like!(...)` call that follows a
   `use my_crate::vec_like;`. `macro-argument-binding`'s
   Status section describes the resolution-based fix in

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -19,13 +19,32 @@ The predicate keys off the first token's line, not the element
 count, matching rustfmt's actual `trailing_comma = "Vertical"`
 behaviour rather than the documented spec for function calls.
 
-Still pending: **matcher-based** declarative-macro auto-detection
-(the `$(,)?` / `$(,)*` matcher walk described under "Matcher-based
-— declarative-macro auto-detection" and "Why matcher-based is
-harder than name-based" below). Until that lands, only macros named
-in the curated list or in `name_based_extra` are linted; any
-`macro_rules!` macro the user writes themselves is silently
-ineligible regardless of its matcher shape.
+Still pending:
+
+- **Matcher-based declarative-macro auto-detection** (the
+  `$(,)?` / `$(,)*` matcher walk described under "Matcher-based
+  — declarative-macro auto-detection" and "Why matcher-based
+  is harder than name-based" below). Until that lands, only
+  macros named in the curated list or in `name_based_extra`
+  are linted; any `macro_rules!` macro the user writes
+  themselves is silently ineligible regardless of its matcher
+  shape.
+- **Identifier-path-aware name-based matching.** The
+  `Implementation notes` section below describes the
+  matching as "`MacCall::path` resolves to a `Res` via the
+  resolver. From the resolved `DefId`, look the path up …",
+  but the current code instead does a syntactic match against
+  `path.segments` via the shared
+  [`macro_path::matches_any`](../src/macro_path.rs) helper. A
+  multi-segment entry like `"my_crate::vec_like"` therefore
+  only matches the textual call shapes
+  `my_crate::vec_like!(...)` and
+  `crate::my_crate::vec_like!(...)`, not the bare
+  `vec_like!(...)` call that follows a
+  `use my_crate::vec_like;`. `macro-argument-binding`'s
+  Status section describes the resolution-based fix in
+  detail; the same plumbing change benefits this rule, and
+  the two rules' built-in lists should migrate together.
 
 **Source:** project convention. Fills a gap that
 `rustfmt`'s `trailing_comma = "Vertical"` (the default) leaves

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -37,11 +37,13 @@ Still pending:
   `path.segments` via the shared
   [`macro_path::matches_any`](../src/macro_path.rs) helper. A
   multi-segment entry like `"my_crate::vec_like"` therefore
-  only matches the textual call shapes
-  `my_crate::vec_like!(...)` and
-  `::my_crate::vec_like!(...)`, not the bare
-  `vec_like!(...)` call that follows a
-  `use my_crate::vec_like;`. `macro-argument-binding`'s
+  matches by the invocation path's *final two segments* —
+  catching `my_crate::vec_like!(...)`,
+  `::my_crate::vec_like!(...)`, and even
+  `outer::my_crate::vec_like!(...)` indiscriminately, but
+  never the bare `vec_like!(...)` call that follows a
+  `use my_crate::vec_like;` (the AST path is just
+  `[vec_like]`, one segment short of the entry). `macro-argument-binding`'s
   Status section describes the resolution-based fix in
   detail; the same plumbing change benefits this rule, and
   the two rules' built-in lists should migrate together.


### PR DESCRIPTION
Adds a planning-doc entry describing what it would take to make `macro_argument_binding`'s multi-segment allow / deny entries match every call-site form that resolves to the same macro — the bare form after `use crate_name::macro_name;`, the aliased forms after `use ... as ...`, and the qualified / absolute forms — instead of only matching the textual fragment the author wrote.

The bullet spells out three load-bearing constraints:

- **Bare single-segment entries stay name-based at the call site.** `"vec"`, `"format"`, `"assert_eq"` and friends keep matching the invocation's final syntactic segment; the curated ecosystem names are distinctive enough, and forcing them through resolution would have to canonicalise `core::format` vs `std::format` for no benefit.
- **The feature requires type information.** Pre-expansion sees raw AST paths and unexpanded `use` items, not their resolution. A `use`-item-only resolver is structurally incomplete (globs, cross-crate re-exports, `#[macro_use]`, textual macro scope). The working plumbing is to defer the deny / allow / ignore lookup to the late HIR pass already running for diagnostic emission, look up the macro's `DefId` via `Span::ctxt().outer_expn_data().macro_def_id`, and compare `tcx.def_path_str(def_id)` against the configured paths.
- **Difficulty is moderate.** The plumbing change is small (~150-250 lines) but breaks `deny_extra`'s contract — a project's homegrown `debug_assert_eq!` macro stops matching the built-in deny entry once paths are resolved against the macro's actual `DefId`. Land separately from any PR that adds to the curated lists, with a migration note in the Status section.

`macro-trailing-comma`'s Status section gets a brief cross-reference: its Implementation notes already describe `DefId`-based matching as the intended path, but the current code goes through the shared `macro_path::matches_any` helper, so the same fix benefits both rules and their built-in lists should migrate together.

Concrete additions to `BUILTIN_ALLOW` (SQLite-family bind / query macros, etc.) are tracked separately in #85, which blocks on the matcher refactor described here.