### PR TITLE
fix(pages): table layout on mobile

### DIFF
--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -56,8 +56,19 @@ table.index th {
     width: 100%;
   }
 
+  /* Visually hide the header row instead of `display: none` so
+     assistive tech can still announce the column labels before each
+     row's cells are read out. */
   table.index thead {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   table.index tr {

--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -42,6 +42,39 @@ table.index th {
   background: #f6f8fa;
 }
 
+/* On phone-sized viewports the three-column index table no longer
+   fits: long snake_case lint identifiers in column 1 either overflow
+   or squeeze the description column to an unreadable sliver. Stack
+   each row vertically into a card-like block instead. Desktop and
+   tablet (>600px) keep the original tabular layout. */
+@media (max-width: 600px) {
+  table.index,
+  table.index tbody,
+  table.index tr,
+  table.index td {
+    display: block;
+    width: 100%;
+  }
+
+  table.index thead {
+    display: none;
+  }
+
+  table.index tr {
+    border-bottom: 1px solid #eaeef2;
+    padding: 0.5rem 0;
+  }
+
+  table.index td {
+    border-bottom: none;
+    padding: 0.15rem 0;
+  }
+
+  table.index td:first-child code {
+    overflow-wrap: anywhere;
+  }
+}
+
 .state {
   font-family: ui-monospace, SFMono-Regular, monospace;
   font-size: 0.8rem;


### PR DESCRIPTION
## Problem

The gen-docs catalogue page renders its rule index as a three-column
`<table>` (Lint / Default / Description). On desktop and tablet this
looks fine, but on phone-width viewports the long `snake_case` lint
identifiers in column 1 either overflow the viewport or squeeze the
description column into an unreadable sliver.

## Fix

Add a `@media (max-width: 600px)` block to `tools/gen-docs/src/style.css`
that converts each row into a vertically-stacked card on phones:

- `<table>`, `<tbody>`, `<tr>`, `<td>` collapse to `display: block`.
- `<thead>` is hidden (column ordering — name, badge, description — is
  self-evident when stacked).
- The lint-name `<code>` gets `overflow-wrap: anywhere` so identifiers
  wrap on narrow screens.

Desktop and tablet (>600px) keep the original tabular layout untouched.

## Why this approach

Considered alternatives: wrapping the table in `overflow-x: auto`
(hides columns behind a scroll gesture), hiding the description column
on mobile (drops the most useful column), or rewriting the index as a
`<ul>`/`<dl>` (over-scoped — regresses the desktop layout that's fine
today). The responsive-table CSS pattern is the smallest change that
fixes only the broken width.

## Test plan

- [x] `cargo fmt --check`, `cargo build --workspace --all-targets`,
      `cargo doc`, `cargo clippy -- -D warnings`,
      `cargo test --workspace --all-targets`,
      `cargo dylint --all -- --all-targets` all clean.
- [x] Regenerated `gh-pages/index.html` and confirmed the media query
      is embedded.
- [ ] Eyeball the rendered page in a phone-width browser window
      (≤600px) and on desktop to confirm the layout switches at the
      breakpoint.