### PR TITLE
fix(ci/pages-preview): skip dependabot

### DIFF
--- a/.github/workflows/pages-preview.yaml
+++ b/.github/workflows/pages-preview.yaml
@@ -19,13 +19,21 @@ jobs:
     name: Build and deploy preview
     runs-on: ubuntu-latest
 
-    # Skip PRs from forks: GitHub withholds repository secrets from
-    # workflow runs triggered by fork PRs, so CLOUDFLARE_API_TOKEN
-    # would resolve to an empty string and the deploy step would
-    # fail authentication. A skipped job shows as neutral on the
-    # PR rather than as a confusing red X that external
-    # contributors can't act on.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skip PRs that won't have access to repository secrets:
+    #   * Fork PRs — GitHub withholds secrets from workflow runs
+    #     triggered by forks, so CLOUDFLARE_API_TOKEN resolves to
+    #     an empty string.
+    #   * Dependabot PRs — even though Dependabot pushes its
+    #     branches to this repo (so the fork check above passes),
+    #     `pull_request` runs for Dependabot use a restricted
+    #     security context that hides secrets by default for the
+    #     same authentication-failure reason.
+    # A skipped job shows as neutral on the PR rather than as a
+    # confusing red X that external contributors (or Dependabot)
+    # can't act on.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.login != 'dependabot[bot]'
 
     # Scopes CLOUDFLARE_API_TOKEN to this job. The deployment also
     # shows up under the repo's Environments tab so each preview is


### PR DESCRIPTION
## Summary

The job-level `if` on `pages-preview.yaml` already skipped fork PRs (added in #46), but Dependabot PRs still failed at "Deploy to Cloudflare Pages" — most recently on #90. Dependabot pushes its branches to this repo, so `head.repo.full_name == github.repository` was true and the guard let the job run, but `pull_request` runs triggered by Dependabot use a restricted security context that withholds repository secrets. `CLOUDFLARE_API_TOKEN` resolved to an empty string and `wrangler pages deploy` failed authentication.

This adds `github.event.pull_request.user.login != 'dependabot[bot]'` to the same `if`, so Dependabot PRs skip neutrally for the same reason fork PRs do, and updates the comment to spell out both cases.

## Test plan

- [ ] Next Dependabot PR shows the "Build and deploy preview" job as skipped (neutral) instead of failed.
- [ ] A fresh PR from this repo (non-Dependabot) still runs the preview deploy.
- [ ] A fork PR (if one comes in) still skips as before.