### PR TITLE
feat(pages): toml syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "strum",
  "syn",
  "syntect",
+ "two-face",
 ]
 
 [[package]]
@@ -1708,6 +1709,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "two-face"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b285c51f8a6ade109ed4566d33ac4fb289fb5d6cf87ed70908a5eaf65e948e34"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
 ]
 
 [[package]]

--- a/tools/gen-docs/Cargo.toml
+++ b/tools/gen-docs/Cargo.toml
@@ -21,3 +21,4 @@ quote = "1.0.40"
 strum = { version = "0.28.0", features = ["derive"] }
 syn = { version = "2.0.105", features = ["full", "parsing", "extra-traits"] }
 syntect = { version = "5.2.0", default-features = false, features = ["default-fancy"] }
+two-face = { version = "0.5.1", default-features = false, features = ["syntect-fancy"] }

--- a/tools/gen-docs/src/render/markdown.rs
+++ b/tools/gen-docs/src/render/markdown.rs
@@ -112,7 +112,13 @@ fn lang_class_attr(lang: &str) -> String {
     }
 }
 
-static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
+// `two_face::syntax::extra_newlines` returns a `SyntaxSet` that
+// supersets syntect's bundled defaults with extra languages —
+// notably TOML, which several rules use in `dylint.toml`
+// configuration snippets. Without it, fenced ```toml blocks fall
+// through to syntect's plain-text fallback while ```rust blocks
+// highlight normally.
+static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(two_face::syntax::extra_newlines);
 static THEME: LazyLock<Theme> = LazyLock::new(|| {
     ThemeSet::load_defaults()
         .themes


### PR DESCRIPTION
## Problem

In the gh-pages site generated by `tools/gen-docs`, fenced ` ```toml ` blocks render as plain text while ` ```rust ` blocks highlight normally. The visible offender today is the `[perfectionist]` configuration snippet on `non_exhaustive_error`, but the pattern applies to every TOML example the catalogue picks up.

## Cause

`render/markdown.rs` builds its `SyntaxSet` from `SyntaxSet::load_defaults_newlines`. `syntect`'s bundled defaults ship ~75 syntaxes (Rust, JSON, YAML, Markdown, …) but **no TOML**, so `find_syntax_by_extension("toml")` / `_by_name` / `_by_token` all miss and the code falls through to `find_syntax_plain_text()`.

## Fix

Replace the syntax-set source with [`two_face::syntax::extra_newlines`](https://docs.rs/two-face/0.5.1/two_face/syntax/fn.extra_newlines.html) — the standard companion crate to syntect — which supersets the defaults (74 of 75 syntaxes, only the embedded `JavaDoc` grammar is missing) and adds 145 extras including TOML. The `syntect-fancy` feature is selected to match the existing `syntect/default-fancy` regex backend.

After the change, the TOML block renders with the usual `source toml`, `entity name table toml`, `string quoted double basic toml`, … classed spans, picked up by the same `HIGHLIGHT_CSS` already inlined in the page.

## Validation

`just all` (`fmt`, `build`, `doc`, `lint`, `test`, `self-lint`) passes locally.