### PR TITLE
feat(derive-ordering/config)!: drop redundant `preserve` style

### DIFF
--- a/CONTROLLING_RULES.md
+++ b/CONTROLLING_RULES.md
@@ -32,7 +32,7 @@ The `DYLINT_RUSTFLAGS=-D perfectionist::<rule>` form mentioned above bypasses so
 
 ## 2. Rule registration (project-wide)
 
-Each rule is either *enabled* (its pass runs) or *disabled* (its pass is never installed, so it produces no diagnostics at all). Most rules are enabled by default; a few — currently only `non_exhaustive_error` — ship disabled and require an explicit opt-in. Flip the registration state via the crate-wide `[perfectionist]` table in `dylint.toml`:
+Each rule is either *enabled* (its pass runs) or *disabled* (its pass is never installed, so it produces no diagnostics at all). Most rules are enabled by default; a few — currently `derive_ordering` and `non_exhaustive_error` — ship disabled and require an explicit opt-in. Flip the registration state via the crate-wide `[perfectionist]` table in `dylint.toml`:
 
 ```toml
 [perfectionist]

--- a/rules/README.md
+++ b/rules/README.md
@@ -9,7 +9,7 @@ Lint-control attributes use the `perfectionist::` namespace.
 - [`arc_rc_clone`](./arc_rc_clone.md) (default: `enabled`).
 
   calling `.clone()` on an `Arc<T>` or `Rc<T>`; prefer the qualified `Arc::clone` / `Rc::clone` form
-- [`derive_ordering`](./derive_ordering.md) (default: `enabled`).
+- [`derive_ordering`](./derive_ordering.md) (default: `disabled`).
 
   trait names in a `#[derive(...)]` list are not in the configured order
 - [`flat_module_pattern`](./flat_module_pattern.md) (default: `enabled`).

--- a/rules/derive_ordering.md
+++ b/rules/derive_ordering.md
@@ -2,17 +2,16 @@
 
 # `perfectionist::derive_ordering`
 
-**Default state:** `enabled`  
+**Default state:** `disabled`  
 **Source:** [`src/rules/derive_ordering.rs`](../src/rules/derive_ordering.rs)
 
 > trait names in a `#[derive(...)]` list are not in the configured order
 
 ## What it does
 Enforces a project-wide ordering of trait names inside a single
-`#[derive(...)]` list. Three styles are configurable via
+`#[derive(...)]` list. Two styles are configurable via
 `style`:
-- `preserve` (default) — no-op.
-- `alphabetical` — every trait name must be in
+- `alphabetical` (default) — every trait name must be in
   ASCII-case-insensitive alphabetical order.
 - `prefix_then_alphabetical` — the configured `prefix` list of
   traits goes first, in the listed order; remaining traits are
@@ -33,6 +32,16 @@ derive lists scan uniformly across the codebase. `cargo fmt`
 does not reorder derives, so this lint is the only mechanism
 for enforcing one.
 
+The opinion is opt-in: a project that doesn't want to commit
+to a single ordering shouldn't have to set anything. The rule
+therefore ships disabled by default — enable it per crate by
+adding to `dylint.toml`:
+
+```toml
+[perfectionist]
+enable = ["derive_ordering"]
+```
+
 ## Example
 Under `style = "alphabetical"`:
 ```rust,ignore
@@ -51,9 +60,9 @@ Configure via `dylint.toml` under `["perfectionist::derive_ordering"]`. Every fi
 
 ### `style`: `Style` (optional)
 
-Ordering policy. Defaults to `preserve`, which is a no-op;
-a project opts in by setting `alphabetical` or
-`prefix_then_alphabetical`.
+Ordering policy. Defaults to `alphabetical`; set
+`prefix_then_alphabetical` to pin a configured `prefix` list
+of traits ahead of the alphabetised tail.
 
 ### `prefix`: `[string]` (optional)
 
@@ -66,10 +75,6 @@ path segment, so a configured `"Debug"` matches both
 ### Types
 
 #### `Style` (enum)
-
-##### `"preserve"` (Rust: `Preserve`)
-
-No-op. The lint emits nothing.
 
 ##### `"alphabetical"` (Rust: `Alphabetical`)
 

--- a/src/rules/derive_ordering.rs
+++ b/src/rules/derive_ordering.rs
@@ -21,10 +21,9 @@ use crate::common::{DefaultState, resolved_state};
 declare_tool_lint! {
     /// ### What it does
     /// Enforces a project-wide ordering of trait names inside a single
-    /// `#[derive(...)]` list. Three styles are configurable via
+    /// `#[derive(...)]` list. Two styles are configurable via
     /// `style`:
-    /// - `preserve` (default) — no-op.
-    /// - `alphabetical` — every trait name must be in
+    /// - `alphabetical` (default) — every trait name must be in
     ///   ASCII-case-insensitive alphabetical order.
     /// - `prefix_then_alphabetical` — the configured `prefix` list of
     ///   traits goes first, in the listed order; remaining traits are
@@ -45,6 +44,16 @@ declare_tool_lint! {
     /// does not reorder derives, so this lint is the only mechanism
     /// for enforcing one.
     ///
+    /// The opinion is opt-in: a project that doesn't want to commit
+    /// to a single ordering shouldn't have to set anything. The rule
+    /// therefore ships disabled by default — enable it per crate by
+    /// adding to `dylint.toml`:
+    ///
+    /// ```toml
+    /// [perfectionist]
+    /// enable = ["derive_ordering"]
+    /// ```
+    ///
     /// ### Example
     /// Under `style = "alphabetical"`:
     /// ```rust,ignore
@@ -61,6 +70,13 @@ declare_tool_lint! {
     "trait names in a `#[derive(...)]` list are not in the configured order",
     report_in_external_macro: false
 }
+
+/// Off by default — enable it in `dylint.toml` via the crate-wide
+/// `[perfectionist] enable = ["derive_ordering"]` (or the
+/// `[[perfectionist.enable]]` array-of-tables form). Read by
+/// `register_pass` below; gen-docs picks the constant up via syn
+/// to render the rule's default state.
+pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Disabled;
 
 const CONFIG_KEY: &str = "perfectionist::derive_ordering";
 
@@ -85,9 +101,9 @@ const DEFAULT_PREFIX: &[&str] = &[
 #[derive(Debug, serde::Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
-    /// Ordering policy. Defaults to `preserve`, which is a no-op;
-    /// a project opts in by setting `alphabetical` or
-    /// `prefix_then_alphabetical`.
+    /// Ordering policy. Defaults to `alphabetical`; set
+    /// `prefix_then_alphabetical` to pin a configured `prefix` list
+    /// of traits ahead of the alphabetised tail.
     style: Style,
     /// Trait names that must appear first under the
     /// `prefix_then_alphabetical` style, in the order they should
@@ -131,7 +147,7 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled = resolved_state("derive_ordering", DefaultState::Enabled) {
+    if let DefaultState::Disabled = resolved_state("derive_ordering", DEFAULT_STATE) {
         return;
     }
     // Pre-expansion: derives are consumed during macro expansion, so
@@ -144,9 +160,6 @@ pub fn register_pass(lint_store: &mut LintStore) {
 
 impl EarlyLintPass for DeriveOrdering {
     fn check_attribute(&mut self, lint_context: &EarlyContext<'_>, attribute: &Attribute) {
-        if matches!(self.style, Style::Preserve) {
-            return;
-        }
         if !attribute.has_name(sym::derive) {
             return;
         }
@@ -235,7 +248,6 @@ impl DeriveOrdering {
             Style::PrefixThenAlphabetical => {
                 "derive list does not match the configured `prefix_then_alphabetical` order"
             }
-            Style::Preserve => unreachable!(),
         };
         span_lint_and_then(
             lint_context,

--- a/src/rules/derive_ordering/ordering.rs
+++ b/src/rules/derive_ordering/ordering.rs
@@ -11,11 +11,9 @@ use rustc_span::Span;
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum Style {
-    /// No-op. The lint emits nothing.
-    #[default]
-    Preserve,
     /// Every trait name must appear in ASCII-case-insensitive
     /// alphabetical order.
+    #[default]
     Alphabetical,
     /// Traits listed in the configured `prefix` come first, in the
     /// listed order; remaining traits are sorted alphabetically
@@ -42,7 +40,6 @@ pub(super) fn desired_order(
     entries: &[DeriveEntry],
 ) -> Vec<usize> {
     match style {
-        Style::Preserve => (0..entries.len()).collect(),
         Style::Alphabetical => {
             let mut indices: Vec<usize> = (0..entries.len()).collect();
             // `slice::sort_by` is stable, so equal-key entries

--- a/tests/derive_ordering.rs
+++ b/tests/derive_ordering.rs
@@ -29,13 +29,38 @@ struct RuleConfig {
     prefix: Option<Vec<&'static str>>,
 }
 
+/// The `[perfectionist]` table, kept minimal so every fixture below
+/// turns the rule on. The rule ships disabled by default
+/// (`DEFAULT_STATE = DefaultState::Disabled` in
+/// `src/rules/derive_ordering.rs`), so without this `enable` entry
+/// the pass would never register and the fixture's out-of-order
+/// derives wouldn't trigger a diagnostic.
+#[derive(serde::Serialize)]
+struct GlobalConfig {
+    enable: Vec<&'static str>,
+}
+
 fn dylint_toml(config: RuleConfig) -> String {
-    // A single-entry map gets serialised by `toml` as a top-level
-    // table keyed by `LINT_NAME` — the same shape `dylint_linting`'s
-    // `config_or_default` reads from `dylint.toml`. The `::` in the
-    // key is quoted automatically.
-    let table: BTreeMap<&str, RuleConfig> = [(LINT_NAME, config)].into_iter().collect();
-    toml::to_string(&table).expect("serialise rule config as dylint.toml")
+    // Serialise as two top-level tables: `[perfectionist]` (enables
+    // the rule globally) and `[perfectionist::derive_ordering]`
+    // (per-rule knobs the test exercises). `toml::to_string` on a
+    // serde-friendly wrapper emits both with one call; building the
+    // string by concatenation would risk producing `[perfectionist]`
+    // table contents bleeding into the rule table when the rule
+    // config happens to be empty.
+    #[derive(serde::Serialize)]
+    struct WholeToml<'a> {
+        perfectionist: GlobalConfig,
+        #[serde(flatten)]
+        rule: BTreeMap<&'a str, RuleConfig>,
+    }
+    let whole = WholeToml {
+        perfectionist: GlobalConfig {
+            enable: vec!["derive_ordering"],
+        },
+        rule: [(LINT_NAME, config)].into_iter().collect(),
+    };
+    toml::to_string(&whole).expect("serialise rule config as dylint.toml")
 }
 
 fn run(src_base: &str, config: RuleConfig) {

--- a/ui/derive_ordering.rs
+++ b/ui/derive_ordering.rs
@@ -1,7 +1,10 @@
-// The default `style = "preserve"` makes the rule a no-op. No
-// fixture in this file should produce a diagnostic; the
-// configuration-driven styles are exercised under
-// `ui-toml/derive_ordering/`.
+// The rule ships disabled by default
+// (`DEFAULT_STATE = DefaultState::Disabled` in
+// `src/rules/derive_ordering.rs`), so without a `dylint.toml` that
+// enables it the pass never registers and nothing in this file
+// produces a diagnostic. The configuration-driven styles are
+// exercised under `ui-toml/derive_ordering/`, each with its own
+// `dylint.toml` that opts the rule in.
 
 #[derive(Debug, Clone, Copy)]
 struct _DeliberatelyOutOfOrder;


### PR DESCRIPTION
`derive_ordering` shipped with `style = "preserve"` as the default, documented as a "no-op". That sentinel pre-dated the global `[perfectionist] enable / disable` arrays — once the project-wide knob exists, `Preserve` is a strict subset of `disable = ["derive_ordering"]`: both leave the rule producing zero diagnostics and the user has to set something either way to turn the rule on.

This commit:

- Removes `Style::Preserve` from the `Style` enum and drops the matching early-return / `unreachable!()` arm in the pass.
- Switches the rule to `DEFAULT_STATE = DefaultState::Disabled`, matching the precedent already set by `non_exhaustive_error`.
- Promotes `Style::Alphabetical` to the new default, so an opted-in rule has a useful out-of-the-box behaviour.
- Updates the rustdoc on the lint declaration to document the opt-in via `[perfectionist] enable = ["derive_ordering"]`, and the `tests/derive_ordering.rs` fixtures so each test wraps its per-rule config with `enable = ["derive_ordering"]` (the same pattern `tests/non_exhaustive_error.rs` uses).
- Regenerates `rules/derive_ordering.md` and updates `rules/README.md`, `CONTROLLING_RULES.md`, and the `ui/derive_ordering.rs` header comment to reflect the new default state.

Users who relied on `[perfectionist::derive_ordering] style = "preserve"` should migrate to `[perfectionist] disable = ["derive_ordering"]` (or simply remove the setting, since the rule is now off by default).