### PR TITLE
docs(config): active/inactive instead of enabled/disabled

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -6,45 +6,45 @@ Auto-generated catalogue of implemented lints. Each entry links to a per-rule ma
 
 Lint-control attributes use the `perfectionist::` namespace.
 
-- [`arc_rc_clone`](./arc_rc_clone.md) (default: `enabled`).
+- [`arc_rc_clone`](./arc_rc_clone.md) (default: `active`).
 
   calling `.clone()` on an `Arc<T>` or `Rc<T>`; prefer the qualified `Arc::clone` / `Rc::clone` form
-- [`derive_ordering`](./derive_ordering.md) (default: `disabled`).
+- [`derive_ordering`](./derive_ordering.md) (default: `inactive`).
 
   trait names in a `#[derive(...)]` list are not in the configured order
-- [`flat_module_pattern`](./flat_module_pattern.md) (default: `enabled`).
+- [`flat_module_pattern`](./flat_module_pattern.md) (default: `active`).
 
   submodule defined as `module/mod.rs`; prefer the flat `module.rs` layout
-- [`macro_argument_binding`](./macro_argument_binding.md) (default: `enabled`).
+- [`macro_argument_binding`](./macro_argument_binding.md) (default: `active`).
 
   macro invocation passes an impure expression that should be bound to a `let` first
-- [`macro_trailing_comma`](./macro_trailing_comma.md) (default: `enabled`).
+- [`macro_trailing_comma`](./macro_trailing_comma.md) (default: `active`).
 
   macro invocation does not follow rustfmt's vertical trailing-comma policy
-- [`non_exhaustive_error`](./non_exhaustive_error.md) (default: `disabled`).
+- [`non_exhaustive_error`](./non_exhaustive_error.md) (default: `inactive`).
 
   error-shaped type is missing `#[non_exhaustive]`
-- [`prefer_raw_string`](./prefer_raw_string.md) (default: `enabled`).
+- [`prefer_raw_string`](./prefer_raw_string.md) (default: `active`).
 
   string literal contains only raw-expressible escapes; prefer the raw-string form
-- [`single_letter_closure_param`](./single_letter_closure_param.md) (default: `enabled`).
+- [`single_letter_closure_param`](./single_letter_closure_param.md) (default: `active`).
 
   closure parameter has a single-letter name
-- [`single_letter_function_param`](./single_letter_function_param.md) (default: `enabled`).
+- [`single_letter_function_param`](./single_letter_function_param.md) (default: `active`).
 
   function parameter has a single-letter name
-- [`single_letter_generic`](./single_letter_generic.md) (default: `enabled`).
+- [`single_letter_generic`](./single_letter_generic.md) (default: `active`).
 
   generic type parameter has a single-letter name
-- [`single_letter_let_binding`](./single_letter_let_binding.md) (default: `enabled`).
+- [`single_letter_let_binding`](./single_letter_let_binding.md) (default: `active`).
 
   `let` binding has a single-letter name
-- [`unicode_ellipsis_in_comments`](./unicode_ellipsis_in_comments.md) (default: `enabled`).
+- [`unicode_ellipsis_in_comments`](./unicode_ellipsis_in_comments.md) (default: `active`).
 
   U+2026 HORIZONTAL ELLIPSIS in non-doc comments; prefer `...`
-- [`unicode_ellipsis_in_panic_messages`](./unicode_ellipsis_in_panic_messages.md) (default: `enabled`).
+- [`unicode_ellipsis_in_panic_messages`](./unicode_ellipsis_in_panic_messages.md) (default: `active`).
 
   U+2026 HORIZONTAL ELLIPSIS in panic / assertion / expect messages; prefer `...`
-- [`unknown_perfectionist_lints`](./unknown_perfectionist_lints.md) (default: `enabled`).
+- [`unknown_perfectionist_lints`](./unknown_perfectionist_lints.md) (default: `active`).
 
   lint-control attribute references a `perfectionist::*` lint that this plugin does not register

--- a/rules/arc_rc_clone.md
+++ b/rules/arc_rc_clone.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::arc_rc_clone`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/arc_rc_clone.rs`](../src/rules/arc_rc_clone.rs)
 
 > calling `.clone()` on an `Arc<T>` or `Rc<T>`; prefer the qualified `Arc::clone` / `Rc::clone` form

--- a/rules/derive_ordering.md
+++ b/rules/derive_ordering.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::derive_ordering`
 
-**Default state:** `disabled`  
+**Default state:** `inactive`  
 **Source:** [`src/rules/derive_ordering.rs`](../src/rules/derive_ordering.rs)
 
 > trait names in a `#[derive(...)]` list are not in the configured order
@@ -34,7 +34,7 @@ for enforcing one.
 
 The opinion is opt-in: a project that doesn't want to commit
 to a single ordering shouldn't have to set anything. The rule
-therefore ships disabled by default — enable it per crate by
+is therefore inactive by default — enable it per crate by
 adding to `dylint.toml`:
 
 ```toml

--- a/rules/flat_module_pattern.md
+++ b/rules/flat_module_pattern.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::flat_module_pattern`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/flat_module_pattern.rs`](../src/rules/flat_module_pattern.rs)
 
 > submodule defined as `module/mod.rs`; prefer the flat `module.rs` layout

--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::macro_argument_binding`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/macro_argument_binding.rs`](../src/rules/macro_argument_binding.rs)
 
 > macro invocation passes an impure expression that should be bound to a `let` first

--- a/rules/macro_trailing_comma.md
+++ b/rules/macro_trailing_comma.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::macro_trailing_comma`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/macro_trailing_comma.rs`](../src/rules/macro_trailing_comma.rs)
 
 > macro invocation does not follow rustfmt's vertical trailing-comma policy

--- a/rules/non_exhaustive_error.md
+++ b/rules/non_exhaustive_error.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::non_exhaustive_error`
 
-**Default state:** `disabled`  
+**Default state:** `inactive`  
 **Source:** [`src/rules/non_exhaustive_error.rs`](../src/rules/non_exhaustive_error.rs)
 
 > error-shaped type is missing `#[non_exhaustive]`
@@ -30,7 +30,7 @@ enum.
 The opinion is opt-in: some projects deliberately use exhaustive
 error enums to force downstream consumers to handle every new
 variant, and binary crates have no SemVer surface to protect.
-The rule therefore ships disabled by default — enable it per
+The rule is therefore inactive by default — enable it per
 crate by adding to `dylint.toml`:
 
 ```toml

--- a/rules/prefer_raw_string.md
+++ b/rules/prefer_raw_string.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::prefer_raw_string`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/prefer_raw_string.rs`](../src/rules/prefer_raw_string.rs)
 
 > string literal contains only raw-expressible escapes; prefer the raw-string form

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::single_letter_closure_param`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/single_letter_closure_param.rs`](../src/rules/single_letter_closure_param.rs)
 
 > closure parameter has a single-letter name

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::single_letter_function_param`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/single_letter_function_param.rs`](../src/rules/single_letter_function_param.rs)
 
 > function parameter has a single-letter name

--- a/rules/single_letter_generic.md
+++ b/rules/single_letter_generic.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::single_letter_generic`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/single_letter_generic.rs`](../src/rules/single_letter_generic.rs)
 
 > generic type parameter has a single-letter name

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::single_letter_let_binding`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/single_letter_let_binding.rs`](../src/rules/single_letter_let_binding.rs)
 
 > `let` binding has a single-letter name

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::unicode_ellipsis_in_comments`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/unicode_ellipsis_in_comments.rs`](../src/rules/unicode_ellipsis_in_comments.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in non-doc comments; prefer `...`

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::unicode_ellipsis_in_panic_messages`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/unicode_ellipsis_in_panic_messages.rs`](../src/rules/unicode_ellipsis_in_panic_messages.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in panic / assertion / expect messages; prefer `...`

--- a/rules/unknown_perfectionist_lints.md
+++ b/rules/unknown_perfectionist_lints.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::unknown_perfectionist_lints`
 
-**Default state:** `enabled`  
+**Default state:** `active`  
 **Source:** [`src/rules/unknown_perfectionist_lints.rs`](../src/rules/unknown_perfectionist_lints.rs)
 
 > lint-control attribute references a `perfectionist::*` lint that this plugin does not register

--- a/src/common.rs
+++ b/src/common.rs
@@ -117,8 +117,8 @@ impl RuleSelector {
 /// directly to render the rule's catalogue entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DefaultState {
-    Enabled,
-    Disabled,
+    Active,
+    Inactive,
 }
 
 /// Resolved per-rule override map, built once from the
@@ -147,8 +147,8 @@ pub(crate) fn init_global_config() {
     let config: GlobalConfig = dylint_linting::config_or_default("perfectionist");
     let mut overrides: HashMap<String, DefaultState> = HashMap::new();
     for (selectors, state) in [
-        (&config.enable, DefaultState::Enabled),
-        (&config.disable, DefaultState::Disabled),
+        (&config.enable, DefaultState::Active),
+        (&config.disable, DefaultState::Inactive),
     ] {
         for selector in selectors {
             let name = selector.name();
@@ -171,15 +171,15 @@ pub(crate) fn init_global_config() {
 /// — no `perfectionist::` prefix). Resolution order:
 ///
 /// 1. If `name` appears under `disable` in the `[perfectionist]`
-///    table, return [`DefaultState::Disabled`].
-/// 2. If it appears under `enable`, return [`DefaultState::Enabled`].
+///    table, return [`DefaultState::Inactive`].
+/// 2. If it appears under `enable`, return [`DefaultState::Active`].
 /// 3. Otherwise return `default` — the per-rule baseline.
 ///
 /// Each rule's `register_pass` passes its own baseline as
-/// `default`: most rules pass [`DefaultState::Enabled`]; rules
+/// `default`: most rules pass [`DefaultState::Active`]; rules
 /// listed in `src/rules/<name>.rs` as
-/// `DEFAULT_STATE: DefaultState = DefaultState::Disabled` pass
-/// `Disabled` and ship turned off until the user opts in.
+/// `DEFAULT_STATE: DefaultState = DefaultState::Inactive` pass
+/// `Inactive` and ship turned off until the user opts in.
 pub(crate) fn resolved_state(name: &str, default: DefaultState) -> DefaultState {
     let overrides = GLOBAL_OVERRIDES
         .get()

--- a/src/rules/arc_rc_clone.rs
+++ b/src/rules/arc_rc_clone.rs
@@ -96,7 +96,7 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled = resolved_state("arc_rc_clone", DefaultState::Enabled) {
+    if let DefaultState::Inactive = resolved_state("arc_rc_clone", DefaultState::Active) {
         return;
     }
     lint_store.register_late_pass(|_| Box::new(ArcRcClone::new()));

--- a/src/rules/derive_ordering.rs
+++ b/src/rules/derive_ordering.rs
@@ -46,7 +46,7 @@ declare_tool_lint! {
     ///
     /// The opinion is opt-in: a project that doesn't want to commit
     /// to a single ordering shouldn't have to set anything. The rule
-    /// therefore ships disabled by default — enable it per crate by
+    /// is therefore inactive by default — enable it per crate by
     /// adding to `dylint.toml`:
     ///
     /// ```toml

--- a/src/rules/derive_ordering.rs
+++ b/src/rules/derive_ordering.rs
@@ -76,7 +76,7 @@ declare_tool_lint! {
 /// `[[perfectionist.enable]]` array-of-tables form). Read by
 /// `register_pass` below; gen-docs picks the constant up via syn
 /// to render the rule's default state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Disabled;
+pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
 
 const CONFIG_KEY: &str = "perfectionist::derive_ordering";
 
@@ -147,7 +147,7 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled = resolved_state("derive_ordering", DEFAULT_STATE) {
+    if let DefaultState::Inactive = resolved_state("derive_ordering", DEFAULT_STATE) {
         return;
     }
     // Pre-expansion: derives are consumed during macro expansion, so

--- a/src/rules/flat_module_pattern.rs
+++ b/src/rules/flat_module_pattern.rs
@@ -66,7 +66,7 @@ pub fn register_lint(lint_store: &mut LintStore) {
 
 /// Install this rule's late pass.
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled = resolved_state("flat_module_pattern", DefaultState::Enabled) {
+    if let DefaultState::Inactive = resolved_state("flat_module_pattern", DefaultState::Active) {
         return;
     }
     lint_store.register_late_pass(|_| Box::new(FlatModulePattern::new()));

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -135,8 +135,7 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled = resolved_state("macro_argument_binding", DefaultState::Enabled)
-    {
+    if let DefaultState::Inactive = resolved_state("macro_argument_binding", DefaultState::Active) {
         return;
     }
     // Same split as `macro_trailing_comma`: a pre-expansion pass parks

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -103,7 +103,7 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled = resolved_state("macro_trailing_comma", DefaultState::Enabled) {
+    if let DefaultState::Inactive = resolved_state("macro_trailing_comma", DefaultState::Active) {
         return;
     }
     // Split across two passes per

--- a/src/rules/non_exhaustive_error.rs
+++ b/src/rules/non_exhaustive_error.rs
@@ -39,7 +39,7 @@ declare_tool_lint! {
     /// The opinion is opt-in: some projects deliberately use exhaustive
     /// error enums to force downstream consumers to handle every new
     /// variant, and binary crates have no SemVer surface to protect.
-    /// The rule therefore ships disabled by default — enable it per
+    /// The rule is therefore inactive by default — enable it per
     /// crate by adding to `dylint.toml`:
     ///
     /// ```toml

--- a/src/rules/non_exhaustive_error.rs
+++ b/src/rules/non_exhaustive_error.rs
@@ -73,7 +73,7 @@ declare_tool_lint! {
 /// `[[perfectionist.enable]]` array-of-tables form). Read by
 /// `register_pass` below; gen-docs picks the constant up via syn
 /// to render the rule's default state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Disabled;
+pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
 
 const CONFIG_KEY: &str = "perfectionist::non_exhaustive_error";
 
@@ -177,7 +177,7 @@ pub fn register_lint(lint_store: &mut LintStore) {
 
 /// Install this rule's late pass.
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled = resolved_state("non_exhaustive_error", DEFAULT_STATE) {
+    if let DefaultState::Inactive = resolved_state("non_exhaustive_error", DEFAULT_STATE) {
         return;
     }
     lint_store.register_late_pass(|_| Box::new(NonExhaustiveError::new()));

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -145,7 +145,7 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled = resolved_state("prefer_raw_string", DefaultState::Enabled) {
+    if let DefaultState::Inactive = resolved_state("prefer_raw_string", DefaultState::Active) {
         return;
     }
     lint_store.register_late_pass(|_| Box::new(PreferRawString::new()));

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -188,8 +188,8 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled =
-        resolved_state("single_letter_closure_param", DefaultState::Enabled)
+    if let DefaultState::Inactive =
+        resolved_state("single_letter_closure_param", DefaultState::Active)
     {
         return;
     }

--- a/src/rules/single_letter_function_param.rs
+++ b/src/rules/single_letter_function_param.rs
@@ -87,8 +87,8 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled =
-        resolved_state("single_letter_function_param", DefaultState::Enabled)
+    if let DefaultState::Inactive =
+        resolved_state("single_letter_function_param", DefaultState::Active)
     {
         return;
     }

--- a/src/rules/single_letter_generic.rs
+++ b/src/rules/single_letter_generic.rs
@@ -82,7 +82,7 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled = resolved_state("single_letter_generic", DefaultState::Enabled) {
+    if let DefaultState::Inactive = resolved_state("single_letter_generic", DefaultState::Active) {
         return;
     }
     lint_store.register_late_pass(|_| Box::new(SingleLetterGeneric::new()));

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -87,8 +87,8 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled =
-        resolved_state("single_letter_let_binding", DefaultState::Enabled)
+    if let DefaultState::Inactive =
+        resolved_state("single_letter_let_binding", DefaultState::Active)
     {
         return;
     }

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -102,8 +102,8 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled =
-        resolved_state("unicode_ellipsis_in_comments", DefaultState::Enabled)
+    if let DefaultState::Inactive =
+        resolved_state("unicode_ellipsis_in_comments", DefaultState::Active)
     {
         return;
     }

--- a/src/rules/unicode_ellipsis_in_panic_messages.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages.rs
@@ -84,8 +84,8 @@ pub fn register_lint(lint_store: &mut LintStore) {
 }
 
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled =
-        resolved_state("unicode_ellipsis_in_panic_messages", DefaultState::Enabled)
+    if let DefaultState::Inactive =
+        resolved_state("unicode_ellipsis_in_panic_messages", DefaultState::Active)
     {
         return;
     }

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -86,8 +86,8 @@ pub fn register_lint(lint_store: &mut LintStore) {
 /// has registered its lints, since the pass snapshots the registered
 /// `perfectionist::*` names from `lint_store` at construction time.
 pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Disabled =
-        resolved_state("unknown_perfectionist_lints", DefaultState::Enabled)
+    if let DefaultState::Inactive =
+        resolved_state("unknown_perfectionist_lints", DefaultState::Active)
     {
         return;
     }

--- a/tools/gen-docs/src/check_md.rs
+++ b/tools/gen-docs/src/check_md.rs
@@ -240,7 +240,7 @@ mod tests {
     fn fake_rule(name: &str) -> Rule {
         Rule {
             namespaced: format!("perfectionist::{name}"),
-            default_state: DefaultState::Enabled,
+            default_state: DefaultState::Active,
             short_desc: format!("{name} short desc"),
             doc_markdown: "Body.".to_owned(),
             relative_source: PathBuf::from(format!("src/rules/{name}.rs")),

--- a/tools/gen-docs/src/extract.rs
+++ b/tools/gen-docs/src/extract.rs
@@ -142,7 +142,7 @@ fn extract_rules(source_path: &Path) -> Vec<Rule> {
             // `declare_tool_lint!` declares level `Warn`. The
             // default-disabled axis lives in
             // `pub(crate) const DEFAULT_STATE: DefaultState =
-            // DefaultState::Disabled;` alongside the macro, not in
+            // DefaultState::Inactive;` alongside the macro, not in
             // the level. A non-`Warn` here means the source has
             // drifted from the policy; we panic so a doc
             // regeneration catches it rather than silently
@@ -153,7 +153,7 @@ fn extract_rules(source_path: &Path) -> Vec<Rule> {
                      every `declare_tool_lint!` uses level `Warn`. Move the \
                      off-by-default signal into \
                      `pub(crate) const DEFAULT_STATE: DefaultState = \
-                     DefaultState::Disabled;` next to the macro and change \
+                     DefaultState::Inactive;` next to the macro and change \
                      the level to `Warn`.",
                     source_path.display(),
                 );
@@ -178,11 +178,11 @@ fn extract_rules(source_path: &Path) -> Vec<Rule> {
 /// every rule keeps it next to `declare_tool_lint!`). Absence of the
 /// constant means the rule is on out of the box — the common case
 /// across the catalogue — so the function returns
-/// [`DefaultState::Enabled`].
+/// [`DefaultState::Active`].
 ///
 /// No `bool` intermediate: the runtime constant uses the same enum
 /// shape gen-docs renders, and we read its initializer's *path* end
-/// segment directly. `DefaultState::Disabled` and a `use … Disabled`
+/// segment directly. `DefaultState::Inactive` and a `use … Inactive`
 /// alias both work because we only inspect the last segment.
 fn extract_default_state(source_path: &Path, merged_file: &syn::File) -> DefaultState {
     use syn::{Expr, ExprPath, Type, TypePath};
@@ -210,7 +210,7 @@ fn extract_default_state(source_path: &Path, merged_file: &syn::File) -> Default
         else {
             panic!(
                 "{}: `DEFAULT_STATE` initializer must be a `DefaultState` \
-                 variant path (e.g. `DefaultState::Enabled`); other \
+                 variant path (e.g. `DefaultState::Active`); other \
                  expressions defeat the gen-docs syntactic extraction",
                 source_path.display(),
             );
@@ -222,16 +222,16 @@ fn extract_default_state(source_path: &Path, merged_file: &syn::File) -> Default
             );
         };
         return match last_segment.ident.to_string().as_str() {
-            "Enabled" => DefaultState::Enabled,
-            "Disabled" => DefaultState::Disabled,
+            "Active" => DefaultState::Active,
+            "Inactive" => DefaultState::Inactive,
             other => panic!(
                 "{}: `DEFAULT_STATE` initializer names unknown `DefaultState` \
-                 variant `{other}`; only `Enabled` and `Disabled` are valid.",
+                 variant `{other}`; only `Active` and `Inactive` are valid.",
                 source_path.display(),
             ),
         };
     }
-    DefaultState::Enabled
+    DefaultState::Active
 }
 
 /// Return a `syn::File` containing `parent`'s items followed by every

--- a/tools/gen-docs/src/model.rs
+++ b/tools/gen-docs/src/model.rs
@@ -87,8 +87,8 @@ impl DefaultState {
     /// list, and the HTML badge agree on wording.
     pub(crate) fn word(self) -> &'static str {
         match self {
-            DefaultState::Enabled => "enabled",
-            DefaultState::Disabled => "disabled",
+            DefaultState::Enabled => "active",
+            DefaultState::Disabled => "inactive",
         }
     }
 
@@ -97,8 +97,8 @@ impl DefaultState {
     /// border tweaks per state are a one-rule CSS change.
     pub(crate) fn css_class(self) -> &'static str {
         match self {
-            DefaultState::Enabled => "state state-enabled",
-            DefaultState::Disabled => "state state-disabled",
+            DefaultState::Enabled => "state state-active",
+            DefaultState::Disabled => "state state-inactive",
         }
     }
 }

--- a/tools/gen-docs/src/model.rs
+++ b/tools/gen-docs/src/model.rs
@@ -46,7 +46,7 @@ pub(crate) struct Rule {
     /// `[perfectionist] enable = ["<rule>"]` in `dylint.toml`. Read
     /// from a `pub(crate) const DEFAULT_STATE: DefaultState = ...;`
     /// item in the rule's source file when present; absent
-    /// constants imply [`DefaultState::Enabled`] (the catalogue
+    /// constants imply [`DefaultState::Active`] (the catalogue
     /// default). The runtime side uses its own `DefaultState` enum
     /// of the same shape (`src/common.rs`), so the constant's
     /// initializer is read directly here as an enum-variant path
@@ -73,12 +73,12 @@ pub(crate) struct Rule {
 /// the extractor reads from the rule's source. The runtime side
 /// defines its own `DefaultState` of the same shape; gen-docs has
 /// its own copy because the two crates don't link. Defaults to
-/// [`DefaultState::Enabled`] when a rule omits the constant — the
+/// [`DefaultState::Active`] when a rule omits the constant — the
 /// common case across the catalogue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DefaultState {
-    Enabled,
-    Disabled,
+    Active,
+    Inactive,
 }
 
 impl DefaultState {
@@ -87,8 +87,8 @@ impl DefaultState {
     /// list, and the HTML badge agree on wording.
     pub(crate) fn word(self) -> &'static str {
         match self {
-            DefaultState::Enabled => "active",
-            DefaultState::Disabled => "inactive",
+            DefaultState::Active => "active",
+            DefaultState::Inactive => "inactive",
         }
     }
 
@@ -97,8 +97,8 @@ impl DefaultState {
     /// border tweaks per state are a one-rule CSS change.
     pub(crate) fn css_class(self) -> &'static str {
         match self {
-            DefaultState::Enabled => "state state-active",
-            DefaultState::Disabled => "state state-inactive",
+            DefaultState::Active => "state state-active",
+            DefaultState::Inactive => "state state-inactive",
         }
     }
 }
@@ -197,7 +197,7 @@ pub(crate) struct StructField {
 /// convention is that every rule declares `Warn`; rules that should
 /// be off out of the box live behind a
 /// `pub(crate) const DEFAULT_STATE: DefaultState =
-/// DefaultState::Disabled;` instead of a stricter or looser level.
+/// DefaultState::Inactive;` instead of a stricter or looser level.
 /// The extractor still parses the identifier so a future rule that
 /// drifts from the convention
 /// trips a clear panic naming the file.

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -215,7 +215,7 @@ mod tests {
     fn fake_rule(name: &str) -> Rule {
         Rule {
             namespaced: format!("perfectionist::{name}"),
-            default_state: DefaultState::Enabled,
+            default_state: DefaultState::Active,
             short_desc: format!("demo rule {name}"),
             doc_markdown: "### What it does\nDoes a demo.".to_owned(),
             relative_source: PathBuf::from(format!("src/rules/{name}.rs")),

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -436,18 +436,18 @@ mod tests {
     fn rule_md_includes_header_state_and_short_desc() {
         let md = render_rule_md(&fake_rule(), "../");
         assert!(md.contains("# `perfectionist::demo_rule`\n"));
-        assert!(md.contains("**Default state:** `enabled`"));
+        assert!(md.contains("**Default state:** `active`"));
         assert!(md.contains("> demo rule used in tests"));
         assert!(md.ends_with('\n'));
         assert!(!md.ends_with("\n\n"));
     }
 
     #[test]
-    fn rule_md_renders_disabled_state_for_opt_in_rules() {
+    fn rule_md_renders_inactive_state_for_opt_in_rules() {
         let mut rule = fake_rule();
         rule.default_state = DefaultState::Disabled;
         let md = render_rule_md(&rule, "../");
-        assert!(md.contains("**Default state:** `disabled`"));
+        assert!(md.contains("**Default state:** `inactive`"));
     }
 
     #[test]
@@ -507,7 +507,7 @@ mod tests {
         // Each entry spans two lines: the link/state line, then a
         // blank line, then the indented short-description
         // continuation paragraph.
-        assert!(index.contains("- [`demo_rule`](./demo_rule.md) (default: `enabled`).\n"));
+        assert!(index.contains("- [`demo_rule`](./demo_rule.md) (default: `active`).\n"));
         assert!(index.contains("\n  uses | inside\n"));
         // The bullet-list form needs no `|` escaping (unlike a
         // table) — the pipe in the description appears raw.

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -418,7 +418,7 @@ mod tests {
     fn fake_rule() -> Rule {
         Rule {
             namespaced: "perfectionist::demo_rule".to_owned(),
-            default_state: DefaultState::Enabled,
+            default_state: DefaultState::Active,
             short_desc: "demo rule used in tests".to_owned(),
             doc_markdown: "### What it does\nDoes a demo.".to_owned(),
             relative_source: PathBuf::from("src/rules/demo_rule.rs"),
@@ -445,7 +445,7 @@ mod tests {
     #[test]
     fn rule_md_renders_inactive_state_for_opt_in_rules() {
         let mut rule = fake_rule();
-        rule.default_state = DefaultState::Disabled;
+        rule.default_state = DefaultState::Inactive;
         let md = render_rule_md(&rule, "../");
         assert!(md.contains("**Default state:** `inactive`"));
     }

--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -370,11 +370,11 @@ table.index th {
   margin-right: 0.5rem;
 }
 
-.state-enabled {
+.state-active {
   background: #dafbe1;
 }
 
-.state-disabled {
+.state-inactive {
   background: #eaeef2;
 }
 


### PR DESCRIPTION
Rename the rule-state terminology from `enabled`/`disabled` to `active`/`inactive` — true adjectives instead of past participles of the toggle action, and visually distinct from the like-named `enable` / `disable` config arrays. Reads cleaner: "the rule is `active` by default; add it to `disable` to turn it off."

## Scope

- **User-facing labels** (rendered in `rules/*.md` and the gh-pages HTML): `enabled` / `disabled` → `active` / `inactive`. CSS class names follow: `.state-enabled` / `.state-disabled` → `.state-active` / `.state-inactive`.
- **Internal Rust identifiers**: `DefaultState::Enabled` / `Disabled` → `DefaultState::Active` / `Inactive` (in both `src/common.rs` and the duplicate enum in `tools/gen-docs/src/model.rs`). The string-match keys in `tools/gen-docs/src/extract.rs` that read the variant name out of a rule's source follow.
- **Per-rule `DEFAULT_STATE` constants**: opt-in rules now use `DefaultState::Inactive` instead of `Disabled`.
- **Rustdoc prose**: "ships disabled by default" → "is inactive by default" in `non_exhaustive_error` and `derive_ordering`.

## What stays as-is

The user-facing **config field names** `enable` / `disable` (the arrays in `dylint.toml`) — verbs for acts, adjectives for states.

## Verification

`just all` green (fmt, build, doc, lint, test, self-lint); `rules/*.md` regenerated via `just gen-rules-md`; gh-pages HTML confirmed to render the new badges.