### PR TITLE
fix(pages): wrap long lint identifiers on narrow viewports

### DIFF
--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -559,6 +559,19 @@ code {
   padding: 0.1rem 0.35rem;
   border-radius: 3px;
   font-size: 0.9rem;
+  /* Long lint identifiers and file paths (e.g.
+     `perfectionist::unicode_ellipsis_in_panic_messages` or
+     `src/rules/unicode_ellipsis_in_panic_messages.rs`) have no soft-wrap
+     opportunities by default — `_`, `::`, and `/` don't break — so on
+     phone-portrait widths an inline `<code>` snippet, the article-rule
+     `<h2>`, or the source-file link would push the page wider than the
+     viewport and make the whole document horizontally scrollable. Allow
+     such runs to wrap anywhere, matching the same idiom already used by
+     the nav sidebar list and the mobile-stacked index table. `<pre><code>`
+     is unaffected: `<pre>`'s `white-space: pre` suppresses automatic
+     line-wrapping entirely, so `overflow-wrap` has nothing to act on — the
+     horizontal scrollbar from `pre { overflow-x: auto }` keeps working. */
+  overflow-wrap: anywhere;
 }
 
 pre code {

--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -559,18 +559,6 @@ code {
   padding: 0.1rem 0.35rem;
   border-radius: 3px;
   font-size: 0.9rem;
-  /* Long lint identifiers and file paths (e.g.
-     `perfectionist::unicode_ellipsis_in_panic_messages` or
-     `src/rules/unicode_ellipsis_in_panic_messages.rs`) have no soft-wrap
-     opportunities by default — `_`, `::`, and `/` don't break — so on
-     phone-portrait widths an inline `<code>` snippet, the article-rule
-     `<h2>`, or the source-file link would push the page wider than the
-     viewport and make the whole document horizontally scrollable. Allow
-     such runs to wrap anywhere, matching the same idiom already used by
-     the nav sidebar list and the mobile-stacked index table. `<pre><code>`
-     is unaffected: `<pre>`'s `white-space: pre` suppresses automatic
-     line-wrapping entirely, so `overflow-wrap` has nothing to act on — the
-     horizontal scrollbar from `pre { overflow-x: auto }` keeps working. */
   overflow-wrap: anywhere;
 }
 


### PR DESCRIPTION
## Problem

On phone-portrait viewports (e.g. 414×897), the catalogue page was horizontally scrollable into empty space. The culprit was long, unbreakable identifiers — `perfectionist::unicode_ellipsis_in_panic_messages` and friends — appearing in three places:

- the rule-article `<h2>` headings,
- inline `<code>` snippets in prose (e.g. `["perfectionist::single_letter_function_param"]`),
- the source-file link (`src/rules/unicode_ellipsis_in_panic_messages.rs`).

None of `_`, `::`, or `/` are soft-wrap opportunities by default, so any of these elements could push the body wider than the viewport.

## Fix

Add `overflow-wrap: anywhere` to the base `code` rule. This is the same idiom already used by the nav sidebar list (`style.css:189`) and the mobile-stacked index table (`style.css:361`) for the identical problem.

`<pre><code>` is unaffected: `<pre>`'s `white-space: pre` suppresses automatic line-wrapping entirely, so `overflow-wrap` has nothing to act on and the existing `pre { overflow-x: auto }` scrollbar still handles long source lines.

## Alternatives considered

- **Hide `perfectionist::` on narrow widths** — loses copy-pasteable info, and the un-prefixed name alone (`unicode_ellipsis_in_panic_messages`, 34 chars) still overflows.
- **Shrink the prefix font further** — partial mitigation; doesn't address inline snippets or the source link.
- **`overflow: hidden`** — silently truncates information, easy to regress.
- **Per-heading horizontal scroll** — low touch-discoverability, adds visual noise.

## Verification

Headless Chromium at 414×897, 800×1000, and 1400×900: `scrollWidth == clientWidth` at all three; no descendant overflows the document. The widest `<pre>` block on phone (679px) still scrolls horizontally inside its 382px box — confirming code-block behaviour is unchanged.

`just all` was not run: only CSS changed, no Rust touched, and the environment has neither `just` nor `cargo-dylint` provisioned.