### PR TITLE
feat(pages): use more horizontal real-estate

### DIFF
--- a/tools/gen-docs/src/style.css
+++ b/tools/gen-docs/src/style.css
@@ -275,6 +275,27 @@ body {
   }
 }
 
+/* Desktop / large-desktop tiers: bump the body's max-width so
+   the page doesn't strand huge bands of empty whitespace on
+   either side of the content. At the base 820px width, a 1920px
+   monitor with the 280px sidebar leaves ~410px of empty gutter
+   on each side of the body — roughly half the body width again,
+   wasted. Two graduated tiers widen the body without going so
+   far that paragraph line-length becomes uncomfortable: the
+   index table, TOML/code blocks, and rule articles all benefit
+   from the extra room while prose stays readable. */
+@media (min-width: 1400px) {
+  body {
+    max-width: 1040px;
+  }
+}
+
+@media (min-width: 1700px) {
+  body {
+    max-width: 1200px;
+  }
+}
+
 h1 {
   border-bottom: 1px solid #d0d7de;
   padding-bottom: 0.3rem;


### PR DESCRIPTION
## Problem

On a 1920px-wide desktop, the catalogue body's `max-width: 820px` strands ~410px of empty gutter on each side of the body — roughly half the body width again, wasted. Only ~58% of the viewport carries content (280px sidebar + 820px body); the remaining ~42% is whitespace.

## Fix

Two graduated tiers in `tools/gen-docs/src/style.css`:

- `@media (min-width: 1400px)` → `body { max-width: 1040px }`
- `@media (min-width: 1700px)` → `body { max-width: 1200px }`

At 1920px the body grows to 1200px, lifting utilization to ~77%. The 3-column index table, TOML config blocks, and rule articles all gain room; prose line-length stays in a comfortable range. Narrow viewports (<1400px) are unchanged.

## Test plan

- [ ] Open `gh-pages/index.html` in a desktop browser at 1920×1080 and confirm reduced side gutters.
- [ ] Resize through the breakpoints (~1400px, ~1700px) and confirm the body widens at each step without layout glitches.
- [ ] Confirm narrow viewports (<1100px overlay, <600px stacked) are unchanged.