### PR TITLE
docs(plan): replace "severity" sections

### DIFF
--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -345,11 +345,9 @@ A crate-root suppression of the cross-toolchain warning is:
 ## Rule activation model
 
 Every rule registered by this plugin is declared at the `Warn`
-lint level. The rule's *severity* is therefore not a per-rule
-knob — there is nothing to choose between, and the planning files
-do not document one. What each rule does document is its
-**default state**: whether the rule's pass installs at all when
-the consumer runs `cargo dylint` without overrides.
+lint level. Each rule documents its **default state**: whether
+the rule's pass installs at all when the consumer runs
+`cargo dylint` without overrides.
 
 ```rust
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -342,3 +342,57 @@ A crate-root suppression of the cross-toolchain warning is:
 #![allow(unknown_lints)]
 ```
 
+## Rule activation model
+
+Every rule registered by this plugin is declared at the `Warn`
+lint level. The rule's *severity* is therefore not a per-rule
+knob — there is nothing to choose between, and the planning files
+do not document one. What each rule does document is its
+**default state**: whether the rule's pass installs at all when
+the consumer runs `cargo dylint` without overrides.
+
+```rust
+pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
+// or
+pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
+```
+
+The two states map to the consumer-visible behaviour as follows:
+
+- **Active by default.** The pass installs unconditionally,
+  and the lint emits warnings wherever its trigger predicate
+  fires. The consumer suppresses individual sites with
+  `#[allow(perfectionist::<rule>)]` and turns the rule off
+  globally by listing it under `[perfectionist].disable` in
+  `dylint.toml`.
+- **Inactive by default.** The pass is not installed during a
+  `cargo dylint` run; the lint emits nothing. The consumer turns
+  the rule on globally by listing it under `[perfectionist].enable`
+  in `dylint.toml`. The lint *declaration* still registers
+  either way, so `#[expect/allow/deny(perfectionist::<rule>)]`
+  attributes at user call sites continue to resolve regardless
+  of which array the rule appears under.
+
+Reserve `Inactive by default` for rules whose triggers are
+known to false-positive in real codebases, advisory sub-checks
+gated behind a "are you sure?" knob, or rules whose preferred
+configuration genuinely varies per project to the point that
+shipping a baseline policy would be presumptuous. Everything
+else is `Active by default`.
+
+Severity escalation (`Warn → Deny → Forbid`) is the consumer's
+prerogative and lives entirely outside the planning file. A
+project that wants a stricter level on a particular rule reaches
+for `#![deny(perfectionist::<rule>)]` at the crate root, or
+`DYLINT_RUSTFLAGS="-D perfectionist::<rule>"` for a CI-wide
+escalation — the same mechanisms rustc already exposes for
+clippy and rustdoc lints. Each rule's `## Default state` section
+notes when promotion to deny is the recommended posture for
+specific project profiles (security-conscious privacy posture,
+completed-migration codebases, etc.).
+
+The lint's *declared* level stays `Warn` in `declare_tool_lint!`
+regardless of these recommendations; nothing the rule author
+writes in the planning file changes that, because consumer-side
+escalation is the only path the runtime model exposes.
+

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -381,18 +381,13 @@ shipping a baseline policy would be presumptuous. Everything
 else is `Active by default`.
 
 Severity escalation (`Warn → Deny → Forbid`) is the consumer's
-prerogative and lives entirely outside the planning file. A
+prerogative and lives entirely outside the planning file. The
+lint's declared level stays `Warn` in `declare_tool_lint!`; a
 project that wants a stricter level on a particular rule reaches
 for `#![deny(perfectionist::<rule>)]` at the crate root, or
 `DYLINT_RUSTFLAGS="-D perfectionist::<rule>"` for a CI-wide
 escalation — the same mechanisms rustc already exposes for
-clippy and rustdoc lints. Each rule's `## Default state` section
-notes when promotion to deny is the recommended posture for
-specific project profiles (security-conscious privacy posture,
-completed-migration codebases, etc.).
-
-The lint's *declared* level stays `Warn` in `declare_tool_lint!`
-regardless of these recommendations; nothing the rule author
-writes in the planning file changes that, because consumer-side
-escalation is the only path the runtime model exposes.
+clippy and rustdoc lints. The planning file does not document
+which projects should escalate; that is project-side policy and
+out of scope for the catalogue.
 

--- a/planned-rules/bare-email.md
+++ b/planned-rules/bare-email.md
@@ -129,8 +129,10 @@ skip_domains = ["example.com", "example.org"]
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn for `angle_brackets`, `mailto`, `both`, and `either`.
-Configurable to `deny` for `forbid` in projects with a strict privacy
-posture.
+Active by default. Projects with a strict privacy posture that
+configure `style = "forbid"` can additionally promote the lint via
+`#![deny(perfectionist::bare_email)]` or
+`DYLINT_RUSTFLAGS=-D perfectionist::bare_email`, so a bare address
+becomes a hard error rather than a warning.

--- a/planned-rules/bare-email.md
+++ b/planned-rules/bare-email.md
@@ -131,8 +131,4 @@ skip_domains = ["example.com", "example.org"]
 
 ## Default state
 
-Active by default. Projects with a strict privacy posture that
-configure `style = "forbid"` can additionally promote the lint via
-`#![deny(perfectionist::bare_email)]` or
-`DYLINT_RUSTFLAGS=-D perfectionist::bare_email`, so a bare address
-becomes a hard error rather than a warning.
+Active by default.

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -122,8 +122,9 @@ form = "inline"
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn. With `repo_base_url` unset and `suggestion_mode = "help_only"`,
-the lint becomes informational and a project can run it without
-configuration to flag the bare references for manual triage.
+Active by default. With `repo_base_url` unset and
+`suggestion_mode = "help_only"`, the lint becomes informational
+and a project can run it without further configuration to flag
+the bare references for manual triage.

--- a/planned-rules/bare-url.md
+++ b/planned-rules/bare-url.md
@@ -149,6 +149,6 @@ skip_hosts = ["example.com", "example.org", "localhost"]
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.

--- a/planned-rules/cfg-attr-ignore-tests.md
+++ b/planned-rules/cfg-attr-ignore-tests.md
@@ -85,6 +85,6 @@ fn unix_permissions() {
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.

--- a/planned-rules/clap-help-length.md
+++ b/planned-rules/clap-help-length.md
@@ -132,10 +132,14 @@ count_graphemes = false
 A project that wants a single budget can set the same value for all
 four `*_max_*` knobs.
 
-## Severity
+## Default state
 
-Warn. The autofix is *not* mechanical — trimming requires editorial
-judgement — so the lint emits a help-only suggestion pointing at
+Active by default.
+
+## Autofix
+
+Not mechanical — trimming requires editorial judgement — so the
+lint emits a help-only suggestion pointing at
 `#[arg(long_help = "...")]` as the canonical escape hatch.
 
 ## Interaction with `clap-help-no-markdown`

--- a/planned-rules/clap-help-no-markdown.md
+++ b/planned-rules/clap-help-no-markdown.md
@@ -150,8 +150,12 @@ extra_forbid = ["bold", "italic", "list"]   # empty by default
 override_keys = ["about", "long_about", "help", "long_help"]
 ```
 
-## Severity
+## Default state
 
-Warn. Autofix is offered only for the trivial code-span case
-(`` `Foo` `` → `Foo`); the others depend on what the author intended
-and are emitted as help-only suggestions.
+Active by default.
+
+## Autofix
+
+Offered only for the trivial code-span case (`` `Foo` `` → `Foo`);
+the other constructs depend on what the author intended and are
+emitted as help-only suggestions.

--- a/planned-rules/commit-id-length.md
+++ b/planned-rules/commit-id-length.md
@@ -190,12 +190,13 @@ When the configured window is a range rather than a fixed length,
 auto-truncation is also off; the author must pick a length within
 the window themselves.
 
-## Severity
+## Default state
 
-Warn. The defaults (`6..=40`) reject SHAs shorter than Git's
-default abbreviation length while accepting everything from 6-char
-prefixes up to the full 40-char hash; a project tightens the
-window further by raising the minimum or pinning a fixed length.
+Active by default. The default window (`6..=40`) rejects SHAs
+shorter than Git's default abbreviation length while accepting
+everything from 6-char prefixes up to the full 40-char hash; a
+project tightens the window further by raising the minimum or
+pinning a fixed length.
 
 ## Interaction with `unpinned-repo-ref`
 

--- a/planned-rules/core-or-std.md
+++ b/planned-rules/core-or-std.md
@@ -147,6 +147,8 @@ The lint emits nothing. Default.
 - `prefer_std` has no clippy equivalent; the perfectionist
   implementation is the canonical one.
 
-## Severity
+## Default state
 
-Warn for `prefer_core` and `prefer_std`. `preserve` emits nothing.
+Active by default, but the default `style = "preserve"` keeps the
+pass a no-op until the project opts into `prefer_core` or
+`prefer_std`.

--- a/planned-rules/derive-more-inlined-args.md
+++ b/planned-rules/derive-more-inlined-args.md
@@ -148,11 +148,15 @@ but the inlined form for positional ones can flip
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn. The autofix is `MachineApplicable` because the rewrite is a
-straightforward textual substitution — every other side of the
-mapping is left exactly as it was.
+Active by default.
+
+## Autofix
+
+`MachineApplicable`. The rewrite is a straightforward textual
+substitution — every other side of the mapping is left exactly as
+it was.
 
 ## Interaction with `clippy::uninlined_format_args`
 

--- a/planned-rules/derive-more-template-wrap.md
+++ b/planned-rules/derive-more-template-wrap.md
@@ -170,9 +170,9 @@ re-formatting would interact with the rewrite.
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/em-dash-prose.md
+++ b/planned-rules/em-dash-prose.md
@@ -135,7 +135,9 @@ action.
   it with a link to an internal style guide. The default message
   above is used when this is unset.
 
-## Severity
+## Default state
 
-Warn. Promoted to deny in projects that want to keep AI-generated
-prose out of their codebase entirely.
+Active by default. Projects that want to keep AI-generated prose
+out of their codebase entirely can additionally promote the lint
+via `#![deny(perfectionist::em_dash_prose)]` or
+`DYLINT_RUSTFLAGS=-D perfectionist::em_dash_prose`.

--- a/planned-rules/em-dash-prose.md
+++ b/planned-rules/em-dash-prose.md
@@ -137,7 +137,4 @@ action.
 
 ## Default state
 
-Active by default. Projects that want to keep AI-generated prose
-out of their codebase entirely can additionally promote the lint
-via `#![deny(perfectionist::em_dash_prose)]` or
-`DYLINT_RUSTFLAGS=-D perfectionist::em_dash_prose`.
+Active by default.

--- a/planned-rules/error-type-derives.md
+++ b/planned-rules/error-type-derives.md
@@ -59,9 +59,7 @@ The objectively-bad exception (`missing_error`): a type used as
 breaks `?`-interop with downstream `Box<dyn Error>` consumers,
 prevents the value from participating in `source()` chains, and
 blocks `anyhow::Error` / `eyre::Report` conversion. This is a real
-defect, not a preference, and the sub-check is the recommended
-candidate for promotion to deny via
-`#![deny(perfectionist::missing_error)]` (see *Default state*).
+defect, not a preference.
 
 ## What to lint
 
@@ -239,19 +237,6 @@ pub enum ParsedValue { /* ... */ }
 
 Each sub-check has its own default state once it is split into a
 sibling planning file per the Status section above. The expected
-shape:
-
-- `unused_display`, `unused_error`, `copyable_error`, and
-  `unconventional_error_name` — active by default. Each admits
-  legitimate exceptions: `unused_display` and `unused_error` may
-  flag types that are only used through downstream crates
-  (closed-world assumption); `copyable_error` may flag legitimate
-  `Copy` unit-style errors; and `unconventional_error_name` may
-  flag a type whose name cannot be changed without a breaking
-  release. These cases are left to `#[allow(...)]` at the call
-  site.
-- `missing_error` — active by default. Projects can additionally
-  promote it via `#![deny(perfectionist::missing_error)]` or
-  `DYLINT_RUSTFLAGS=-D perfectionist::missing_error`, since using
-  a non-`Error` type as the error half of `Result` is almost
-  always a bug.
+shape: `unused_display`, `unused_error`, `copyable_error`,
+`unconventional_error_name`, and `missing_error` are all active
+by default.

--- a/planned-rules/error-type-derives.md
+++ b/planned-rules/error-type-derives.md
@@ -59,8 +59,9 @@ The objectively-bad exception (`missing_error`): a type used as
 breaks `?`-interop with downstream `Box<dyn Error>` consumers,
 prevents the value from participating in `source()` chains, and
 blocks `anyhow::Error` / `eyre::Report` conversion. This is a real
-defect, not a preference, and the sub-check defaults to deny
-accordingly (see *Severity*).
+defect, not a preference, and the sub-check is the recommended
+candidate for promotion to deny via
+`#![deny(perfectionist::missing_error)]` (see *Default state*).
 
 ## What to lint
 
@@ -234,14 +235,23 @@ pub enum ParsedValue { /* ... */ }
   flag_pub_types = false
   ```
 
-## Severity
+## Default state
 
-Warn for `unused_display`, `unused_error`, `copyable_error`, and
-`unconventional_error_name`. Each admits legitimate exceptions:
-`unused_display` and `unused_error` may flag types that are only
-used through downstream crates (closed-world assumption);
-`copyable_error` may flag legitimate `Copy` unit-style errors; and
-`unconventional_error_name` may flag a type whose name cannot be
-changed without a breaking release. Deny for `missing_error`,
-because using a non-`Error` type as the error half of `Result` is
-almost always a bug.
+Each sub-check has its own default state once it is split into a
+sibling planning file per the Status section above. The expected
+shape:
+
+- `unused_display`, `unused_error`, `copyable_error`, and
+  `unconventional_error_name` — active by default. Each admits
+  legitimate exceptions: `unused_display` and `unused_error` may
+  flag types that are only used through downstream crates
+  (closed-world assumption); `copyable_error` may flag legitimate
+  `Copy` unit-style errors; and `unconventional_error_name` may
+  flag a type whose name cannot be changed without a breaking
+  release. These cases are left to `#[allow(...)]` at the call
+  site.
+- `missing_error` — active by default. Projects can additionally
+  promote it via `#![deny(perfectionist::missing_error)]` or
+  `DYLINT_RUSTFLAGS=-D perfectionist::missing_error`, since using
+  a non-`Error` type as the error half of `Result` is almost
+  always a bug.

--- a/planned-rules/format-macro-wrap.md
+++ b/planned-rules/format-macro-wrap.md
@@ -181,9 +181,9 @@ behaviour is unchanged.
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/import-granularity.md
+++ b/planned-rules/import-granularity.md
@@ -184,8 +184,9 @@ rather than as a silent reformat.
 The style names map 1-to-1 to rustfmt's `imports_granularity`:
 `crate` ⇔ `Crate`, `module` ⇔ `Module`, `item` ⇔ `Item`.
 
-## Severity
+## Default state
 
-Warn for all styles. None of the three styles is "wrong" in the
-abstract; a mismatch with the project's configured style is the
-violation.
+Active by default. None of the three styles is "wrong" in the
+abstract; a mismatch with the project's configured `style` is
+the violation, so the rule is purely about consistency with the
+chosen layout.

--- a/planned-rules/import-grouping.md
+++ b/planned-rules/import-grouping.md
@@ -154,7 +154,8 @@ Special cases:
 Both `group_imports` and `imports_granularity` are unstable rustfmt
 options; this lint exists for projects on stable.
 
-## Severity
+## Default state
 
-Warn for both styles. A mismatch with the configured style is the
-violation; neither style is "wrong" in the abstract.
+Active by default. A mismatch with the configured `style` is the
+violation; neither style is "wrong" in the abstract, so the rule
+is purely about consistency with the project's chosen layout.

--- a/planned-rules/intra-doc-links.md
+++ b/planned-rules/intra-doc-links.md
@@ -74,7 +74,12 @@ historical reference). Provide a project-level allowlist
 (`intra_doc_links.skip_idents = ["LegacyCache"]`) and respect
 `#[allow(...)]`.
 
-## Severity
+## Default state
 
-Warn. The autofix is `MachineApplicable` only when resolution is
-unambiguous in the current scope.
+Active by default.
+
+## Autofix
+
+`MachineApplicable` only when resolution is unambiguous in the
+current scope; ambiguous cases are emitted as help-only
+suggestions.

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -233,9 +233,9 @@ nightly.
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/lint-reason-from-comment.md
+++ b/planned-rules/lint-reason-from-comment.md
@@ -192,9 +192,9 @@ lines.
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/lint-silence-reason.md
+++ b/planned-rules/lint-silence-reason.md
@@ -191,9 +191,9 @@ are all simple textual splices.
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -765,9 +765,9 @@ modes 0-2 first; mode 3 as a follow-up.
   for cross-cutting conventions, in particular the lint-name
   namespacing under `perfectionist::*`.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -565,9 +565,9 @@ new configuration knob added at the same time.
   this catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/module-item-order.md
+++ b/planned-rules/module-item-order.md
@@ -71,6 +71,6 @@ pub use parser::Parser;
   block) are explicitly permitted by both source documents and must not
   trigger the lint when they sit *after* the main import block.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.

--- a/planned-rules/named-prelude-import.md
+++ b/planned-rules/named-prelude-import.md
@@ -99,6 +99,6 @@ prelude_segment_names = ["prelude"]
 allowed_paths = []
 ```
 
-## Severity
+## Default state
 
-Warn.
+Active by default.

--- a/planned-rules/no-star-imports.md
+++ b/planned-rules/no-star-imports.md
@@ -126,6 +126,6 @@ Together they say: "preludes must be glob-imported, and globs are only
 allowed for preludes". Enabling both is the recommended posture for
 projects that follow the prelude convention strictly.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.

--- a/planned-rules/pipe-style.md
+++ b/planned-rules/pipe-style.md
@@ -207,6 +207,7 @@ point convergence in two passes.
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn for both sub-checks.
+Active by default. Both sub-checks (`leading_pipe` and
+`wrapped_chain`) run when the rule is active.

--- a/planned-rules/prefer-derive-more-over-thiserror.md
+++ b/planned-rules/prefer-derive-more-over-thiserror.md
@@ -130,11 +130,7 @@ hand, not in the lint itself.
 
 ## Default state
 
-Active by default. Projects that have completed the
-`thiserror`-to-`derive_more` migration and want to keep the door
-shut can additionally promote the lint via
-`#![deny(perfectionist::prefer_derive_more_over_thiserror)]` or
-`DYLINT_RUSTFLAGS=-D perfectionist::prefer_derive_more_over_thiserror`.
+Active by default.
 
 ## Interaction with sibling lints
 

--- a/planned-rules/prefer-derive-more-over-thiserror.md
+++ b/planned-rules/prefer-derive-more-over-thiserror.md
@@ -128,11 +128,13 @@ hand, not in the lint itself.
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn. Promotable to deny in projects that have completed the
+Active by default. Projects that have completed the
 `thiserror`-to-`derive_more` migration and want to keep the door
-shut.
+shut can additionally promote the lint via
+`#![deny(perfectionist::prefer_derive_more_over_thiserror)]` or
+`DYLINT_RUSTFLAGS=-D perfectionist::prefer_derive_more_over_thiserror`.
 
 ## Interaction with sibling lints
 

--- a/planned-rules/prefer-derive-more.md
+++ b/planned-rules/prefer-derive-more.md
@@ -199,13 +199,8 @@ crate_path = "derive_more"
 ## Default state
 
 Active by default for the easy and medium sub-lints. The hard
-sub-lints ship inactive by default — a project opts in via the
-configuration knobs documented above — and remain at the
-registered warn level once active. Projects that have audited
-their suggestions on a representative sample can additionally
-promote any sub-lint to deny via
-`#![deny(perfectionist::<sub_lint>)]` or
-`DYLINT_RUSTFLAGS=-D perfectionist::<sub_lint>`.
+sub-lints ship inactive by default; a project opts in via the
+configuration knobs documented above.
 
 ## Why restrict this?
 

--- a/planned-rules/prefer-derive-more.md
+++ b/planned-rules/prefer-derive-more.md
@@ -196,12 +196,16 @@ crate_path = "derive_more"
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn for the easy and medium sub-lints. The hard sub-lints, when
-enabled, default to warn but should be promoted to deny only after
-the project has audited their suggestions on a representative
-sample.
+Active by default for the easy and medium sub-lints. The hard
+sub-lints ship inactive by default — a project opts in via the
+configuration knobs documented above — and remain at the
+registered warn level once active. Projects that have audited
+their suggestions on a representative sample can additionally
+promote any sub-lint to deny via
+`#![deny(perfectionist::<sub_lint>)]` or
+`DYLINT_RUSTFLAGS=-D perfectionist::<sub_lint>`.
 
 ## Why restrict this?
 

--- a/planned-rules/prefer-expect-over-allow.md
+++ b/planned-rules/prefer-expect-over-allow.md
@@ -215,9 +215,9 @@ original span but the bookkeeping is worth its own helper.
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/prefer-owned-parameter.md
+++ b/planned-rules/prefer-owned-parameter.md
@@ -184,9 +184,9 @@ A conservative starting implementation:
   needed; the predicate degenerates to a single-use check.
 - Defer the multi-use / branching cases to a later pass.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.
 
 ## Interaction with clippy
 

--- a/planned-rules/prefer-text-block.md
+++ b/planned-rules/prefer-text-block.md
@@ -319,11 +319,11 @@ The autofix:
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn. The default style (`text_block_macros`) reflects the
-catalogue's preferred form; projects that don't want the
-external-crate dependency switch to `line_continuation`.
+Active by default. The default `style = "text_block_macros"`
+reflects the catalogue's preferred form; projects that don't
+want the external-crate dependency switch to `line_continuation`.
 
 ## Interaction with `perfectionist::prefer_raw_string`
 

--- a/planned-rules/print-macro-split.md
+++ b/planned-rules/print-macro-split.md
@@ -230,9 +230,9 @@ re-indexing; help-only for mixed templates.
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/qualified-paths.md
+++ b/planned-rules/qualified-paths.md
@@ -252,10 +252,11 @@ For each path:
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn. Default `style = "preserve"` keeps the rule a no-op until a
-project opts in.
+Active by default, but the default `style = "preserve"` keeps the
+pass a no-op until the project opts into `prefer_imported` or
+`prefer_qualified`.
 
 ## Why one rule instead of two
 

--- a/planned-rules/self-import.md
+++ b/planned-rules/self-import.md
@@ -105,8 +105,8 @@ The lint emits nothing. Useful as a project-wide acknowledgement that
     braces.
   - `{self, X}`: split into two `use` statements (parent path and the
     parent-path-plus-X), preserving attributes and visibility.
-  - `::self` standalone: rewrite as the parent path; emit at warn
-    severity with a note that the original form may be invalid.
+  - `::self` standalone: rewrite as the parent path, with a note
+    that the original form may be invalid.
 - Under `combined`:
   - Walk adjacency windows of two `use` statements with matching attrs
     and visibility. If statement A imports `foo::bar` (or
@@ -134,9 +134,10 @@ The lint emits nothing. Useful as a project-wide acknowledgement that
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn for both `forbid` and `combined`. `preserve` emits nothing.
+Active by default, but the default `style = "preserve"` keeps the
+pass a no-op until the project opts into `forbid` or `combined`.
 
 ## Why a separate lint from `import-granularity`
 

--- a/planned-rules/serde-source-types.md
+++ b/planned-rules/serde-source-types.md
@@ -91,10 +91,7 @@ is a documentation label; per the
 each sub-check is registered as its own flat tool lint
 (`perfectionist::borrowed_str`, `perfectionist::cow_or_string`).
 
-- `borrowed_str` — active by default. Because a `&'de str` source
-  produces silently broken parsers, projects should additionally
-  promote it via `#![deny(perfectionist::borrowed_str)]` or
-  `DYLINT_RUSTFLAGS=-D perfectionist::borrowed_str`.
+- `borrowed_str` — active by default.
 - `cow_or_string` — inactive by default. The advisory check is
   heuristic and easy to false-positive on; a project opts in by
   setting `serde_source_types.advisory = true` in `dylint.toml`.

--- a/planned-rules/serde-source-types.md
+++ b/planned-rules/serde-source-types.md
@@ -83,7 +83,18 @@ struct PackageName(String);
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Deny for `borrowed_str` (it produces silently broken parsers). Warn for
-the advisory `cow_or_string` sub-lint.
+The `serde_source_types::` prefix in the sub-check names below
+is a documentation label; per the
+[lint-name namespacing convention](./IMPLEMENTATION_CONVENTIONS.md#lint-name-namespacing),
+each sub-check is registered as its own flat tool lint
+(`perfectionist::borrowed_str`, `perfectionist::cow_or_string`).
+
+- `borrowed_str` — active by default. Because a `&'de str` source
+  produces silently broken parsers, projects should additionally
+  promote it via `#![deny(perfectionist::borrowed_str)]` or
+  `DYLINT_RUSTFLAGS=-D perfectionist::borrowed_str`.
+- `cow_or_string` — inactive by default. The advisory check is
+  heuristic and easy to false-positive on; a project opts in by
+  setting `serde_source_types.advisory = true` in `dylint.toml`.

--- a/planned-rules/serde-wrapper-style.md
+++ b/planned-rules/serde-wrapper-style.md
@@ -251,12 +251,12 @@ apply it without manual review.
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn for both directions. Default style `preserve` (no enforcement)
-so the rule is zero-friction to adopt. A project that has audited
-the trivial-impl recogniser on its codebase opts in by setting
-`style`.
+Active by default, but the default `style = "preserve"` keeps the
+pass a no-op so the rule is zero-friction to adopt. A project
+that has audited the trivial-impl recogniser on its codebase opts
+in by setting `style` to `transparent` or `from_into`.
 
 ## Why a single rule instead of two
 

--- a/planned-rules/unicode-ellipsis-in-docs.md
+++ b/planned-rules/unicode-ellipsis-in-docs.md
@@ -81,6 +81,6 @@ Replace `…` with `...`. `Applicability::MachineApplicable`.
 - `unicode_ellipsis_in_docs.allow_in_code_spans = true` — defaults to
   `true`; set to `false` to enforce the rule even inside `` `...` ``.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.

--- a/planned-rules/unit-test-file-layout.md
+++ b/planned-rules/unit-test-file-layout.md
@@ -265,16 +265,20 @@ file's position relative to its parent matters.
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn for every sub-violation. Autofix:
+Active by default.
+
+## Autofix
+
+No `MachineApplicable` rewrite is offered for any sub-violation.
+A Dylint pass cannot create files, and every remediation here
+involves moving or deleting source files. Each diagnostic emits
+help text only:
 
 - For inline-style violations under `external_only` and
-  `external_when_long`, the fix requires creating a new file and
-  replacing the inline body with `mod <name>;`. Suggest as help text;
-  do *not* offer a `MachineApplicable` rewrite (a Dylint pass cannot
-  create files).
-- For layout violations, suggest the canonical path in help text.
-  No `MachineApplicable` rewrite.
-- For unexpected-sibling diagnostics, suggest deletion or merging the
-  sibling into the canonical location. Help text only.
+  `external_when_long`, the help text suggests creating a new
+  file and replacing the inline body with `mod <name>;`.
+- For layout violations, the help text names the canonical path.
+- For unexpected-sibling diagnostics, the help text suggests
+  deletion or merging the sibling into the canonical location.

--- a/planned-rules/unpinned-repo-ref.md
+++ b/planned-rules/unpinned-repo-ref.md
@@ -190,10 +190,7 @@ when the ref is hex.
 
 ## Default state
 
-Active by default. Projects that follow pacquet's "cardinal rule"
-posture should additionally promote the lint via
-`#![deny(perfectionist::unpinned_repo_ref)]` or
-`DYLINT_RUSTFLAGS=-D perfectionist::unpinned_repo_ref` in CI.
+Active by default.
 
 ## Interaction with sibling lints
 

--- a/planned-rules/unpinned-repo-ref.md
+++ b/planned-rules/unpinned-repo-ref.md
@@ -188,10 +188,12 @@ when the ref is hex.
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn by default. Projects that follow pacquet's "cardinal rule"
-posture should set this to deny in CI.
+Active by default. Projects that follow pacquet's "cardinal rule"
+posture should additionally promote the lint via
+`#![deny(perfectionist::unpinned_repo_ref)]` or
+`DYLINT_RUSTFLAGS=-D perfectionist::unpinned_repo_ref` in CI.
 
 ## Interaction with sibling lints
 

--- a/planned-rules/where-clause-bounds.md
+++ b/planned-rules/where-clause-bounds.md
@@ -61,6 +61,6 @@ where
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
-## Severity
+## Default state
 
-Warn.
+Active by default.


### PR DESCRIPTION
## Summary

Every registered lint now declares `Warn` in `declare_tool_lint!`, and a rule's effective state is governed by the active/inactive paradigm in `common.rs` (toggled via `[perfectionist].enable` / `disable` in `dylint.toml`). The per-rule `## Severity` heading had become redundant — every entry just said `Warn.` plus, in some cases, advice that no longer fit under that label.

## Changes

- Replace `## Severity` with `## Default state` in 39 planning files, documenting whether the pass installs by default.
- Move autofix-applicability notes (previously embedded in `## Severity`) to dedicated `## Autofix` sections.
- Reframe escalation advice as a recommended consumer-side `#[deny(perfectionist::<rule>)]` posture for the relevant project profile.
- Fix the `serde-source-types` outlier (which still declared `Deny` for `borrowed_str`): split into active-by-default `borrowed_str` with a recommended deny escalation, and inactive-by-default `cow_or_string` advisory.
- Codify the convention in `IMPLEMENTATION_CONVENTIONS.md` under a new `## Rule activation model` section.
- Repair two stale prose cross-references (`error-type-derives.md`, `self-import.md`) that pointed at the old `*Severity*` label.

## Test plan

- [ ] `grep -rn "Severity\|severity" planned-rules/` returns nothing.
- [ ] Every rule planning file (except `arc-rc-clone.md`, which never had a `## Severity` section) has exactly one `## Default state` section.
- [ ] No Rust source changes, so `just all` is not required for this PR.