### PR TITLE
docs(single-letter-closure-param): clarify single-expression precondition

### DIFF
--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -10,7 +10,13 @@
 ## What it does
 Flags closure parameters whose identifier is one ASCII
 letter, unless the closure is a trivial single-expression
-callback. Two shapes qualify as trivial:
+callback. "Single-expression" is a shared precondition:
+the body must be a bare expression or a block whose only
+content is a trailing expression — a body with any `let`
+binding or other statement before the trailing expression
+disqualifies the closure regardless of which branch
+below would otherwise apply. Given that, one of two
+further shapes must hold:
 - the closure is the immediate argument of a call whose
   callee name is in the trivial-callback allowlist
   (`sort_by`, `sort_by_key`, `min_by`, `max_by`,

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -28,7 +28,13 @@ declare_tool_lint! {
     /// ### What it does
     /// Flags closure parameters whose identifier is one ASCII
     /// letter, unless the closure is a trivial single-expression
-    /// callback. Two shapes qualify as trivial:
+    /// callback. "Single-expression" is a shared precondition:
+    /// the body must be a bare expression or a block whose only
+    /// content is a trailing expression — a body with any `let`
+    /// binding or other statement before the trailing expression
+    /// disqualifies the closure regardless of which branch
+    /// below would otherwise apply. Given that, one of two
+    /// further shapes must hold:
     /// - the closure is the immediate argument of a call whose
     ///   callee name is in the trivial-callback allowlist
     ///   (`sort_by`, `sort_by_key`, `min_by`, `max_by`,


### PR DESCRIPTION
The rustdoc opened with "trivial single-expression callback" and then listed "Two shapes qualify as trivial" without restating that the single-expression body is a shared precondition for both branches. A reader could reasonably conclude that any closure passed to a name on the allowlist (`sort_by`, `fold`, …) is exempt regardless of body shape, which is not how the rule behaves. Make the precondition explicit before the bullet list.

https://claude.ai/code/session_01JrMasnHo5VRDu9xkWZJRgS