### PR TITLE
feat(single-letter-closure-param): identifier allowlist

### DIFF
--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -10,7 +10,10 @@
 ## What it does
 Flags closure parameters whose identifier is one ASCII
 letter, unless the closure is a trivial single-expression
-callback. Two shapes qualify as trivial:
+callback or the identifier is in the conventional-name
+allowlist (`n` for an unsigned count, `f` for a
+`fmt::Formatter`, `i` / `j` / `k` for indices). Two
+shapes qualify as trivial:
 - the closure is the immediate argument of a call whose
   callee name is in the trivial-callback allowlist
   (`sort_by`, `sort_by_key`, `min_by`, `max_by`,
@@ -29,6 +32,14 @@ callback. Two shapes qualify as trivial:
   operators around the parameter inside any of the
   non-macro shapes are peeled before the match, so
   `|s| (*s).foo()` qualifies.
+
+The conventional-name allowlist matches the one used by
+`perfectionist::single_letter_function_param`: `|i| ...`
+is the canonical index closure, just as `fn step(i: usize)`
+is the canonical index parameter. Bodies that use the
+index for slicing or arithmetic (`|i| &hex[i..i + 2]`)
+are not structurally trivial, so the allowlist is what
+keeps them out of the diagnostic.
 
 ## Why restrict this?
 This is a stylistic preference, not a correctness issue.
@@ -77,3 +88,18 @@ they appear in the built-in defaults or in
 after the merge with the built-ins, so this knob always
 wins. Useful for opting back into linting on a default
 entry the project does not consider trivial.
+
+### `extra_allowed_idents`: `[string]` (optional)
+
+Additional identifiers to allow as closure parameter names.
+Merged with the built-in defaults
+(`["n", "f", "i", "j", "k"]`); empty by default. Use this
+to whitelist project-specific conventional names without
+having to re-state the standard ones.
+
+### `ignore_allowed_idents`: `[string]` (optional)
+
+Identifiers to drop from the allowlist, even if they appear
+in the built-in defaults or in `extra_allowed_idents`.
+Empty by default; checked after the merge with the
+built-ins, so this knob always wins.

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -28,7 +28,10 @@ declare_tool_lint! {
     /// ### What it does
     /// Flags closure parameters whose identifier is one ASCII
     /// letter, unless the closure is a trivial single-expression
-    /// callback. Two shapes qualify as trivial:
+    /// callback or the identifier is in the conventional-name
+    /// allowlist (`n` for an unsigned count, `f` for a
+    /// `fmt::Formatter`, `i` / `j` / `k` for indices). Two
+    /// shapes qualify as trivial:
     /// - the closure is the immediate argument of a call whose
     ///   callee name is in the trivial-callback allowlist
     ///   (`sort_by`, `sort_by_key`, `min_by`, `max_by`,
@@ -47,6 +50,14 @@ declare_tool_lint! {
     ///   operators around the parameter inside any of the
     ///   non-macro shapes are peeled before the match, so
     ///   `|s| (*s).foo()` qualifies.
+    ///
+    /// The conventional-name allowlist matches the one used by
+    /// `perfectionist::single_letter_function_param`: `|i| ...`
+    /// is the canonical index closure, just as `fn step(i: usize)`
+    /// is the canonical index parameter. Bodies that use the
+    /// index for slicing or arithmetic (`|i| &hex[i..i + 2]`)
+    /// are not structurally trivial, so the allowlist is what
+    /// keeps them out of the diagnostic.
     ///
     /// ### Why restrict this?
     /// This is a stylistic preference, not a correctness issue.
@@ -78,6 +89,16 @@ declare_tool_lint! {
 }
 
 const CONFIG_KEY: &str = "perfectionist::single_letter_closure_param";
+
+/// Default allowlist for closure parameter identifiers, mirroring
+/// the `single_letter_function_param` defaults: `n` for an unsigned
+/// count, `f` for a `fmt::Formatter`, and `i` / `j` / `k` for
+/// indices. Closures use the same conventional one-letter names as
+/// function and method signatures; an `|i| &hex[i..i + 2]`
+/// indexing closure is just as canonical as a `fn step(i: usize)`
+/// signature, and is not covered by the structural trivial-wrapper
+/// shapes.
+const DEFAULT_CLOSURE_PARAM_ALLOWLIST: &[&str] = &["n", "f", "i", "j", "k"];
 
 /// Default allowlist of method names whose closure argument may
 /// use single-letter parameters when the body is a single
@@ -161,10 +182,22 @@ struct Config {
     /// wins. Useful for opting back into linting on a default
     /// entry the project does not consider trivial.
     ignore_trivial_callback_methods: Vec<String>,
+    /// Additional identifiers to allow as closure parameter names.
+    /// Merged with the built-in defaults
+    /// (`["n", "f", "i", "j", "k"]`); empty by default. Use this
+    /// to whitelist project-specific conventional names without
+    /// having to re-state the standard ones.
+    extra_allowed_idents: Vec<String>,
+    /// Identifiers to drop from the allowlist, even if they appear
+    /// in the built-in defaults or in `extra_allowed_idents`.
+    /// Empty by default; checked after the merge with the
+    /// built-ins, so this knob always wins.
+    ignore_allowed_idents: Vec<String>,
 }
 
 pub struct SingleLetterClosureParam {
     trivial_callback_methods: BTreeSet<Symbol>,
+    allowed_idents: BTreeSet<Symbol>,
 }
 
 impl SingleLetterClosureParam {
@@ -175,8 +208,14 @@ impl SingleLetterClosureParam {
             config.extra_trivial_callback_methods,
             config.ignore_trivial_callback_methods,
         );
+        let allowed_idents = merge_symbol_allowlist(
+            DEFAULT_CLOSURE_PARAM_ALLOWLIST,
+            config.extra_allowed_idents,
+            config.ignore_allowed_idents,
+        );
         Self {
             trivial_callback_methods,
+            allowed_idents,
         }
     }
 }
@@ -212,6 +251,7 @@ impl<'tcx> LateLintPass<'tcx> for SingleLetterClosureParam {
                 let ident = binding_ident(param.pat)?;
                 is_single_ascii_letter(ident.name.as_str()).then_some(ident)
             })
+            .filter(|ident| !self.allowed_idents.contains(&ident.name))
             .collect();
         if single_letter_params.is_empty() {
             return;

--- a/ui/single_letter_names.rs
+++ b/ui/single_letter_names.rs
@@ -93,6 +93,9 @@ fn run() {
     // any of the HIR-level trivial-wrapper arms, so the rule relies
     // on the body's expansion-origin span to recognise it.
     let _nested: Vec<Vec<i32>> = sorted.iter().copied().map(|x| vec![x]).collect();
+    // OK: `n` is in the default closure-parameter allowlist, so the
+    // body shape doesn't matter for this one — the conventional-name
+    // filter exempts the closure before the trivial-wrapper check.
     let _shouted: Vec<String> = sorted.iter().map(|n| format!("{n}!")).collect();
 
     // OK: `i` is in the default closure-parameter allowlist (index

--- a/ui/single_letter_names.rs
+++ b/ui/single_letter_names.rs
@@ -95,6 +95,16 @@ fn run() {
     let _nested: Vec<Vec<i32>> = sorted.iter().copied().map(|x| vec![x]).collect();
     let _shouted: Vec<String> = sorted.iter().map(|n| format!("{n}!")).collect();
 
+    // OK: `i` is in the default closure-parameter allowlist (index
+    // convention). The body slices `hex` by `i`, which is not a
+    // trivial-wrapper shape, so the allowlist is what keeps the
+    // closure quiet.
+    let hex = "deadbeef";
+    let _pairs: Vec<&str> = (0..hex.len() - 1)
+        .step_by(2)
+        .map(|i| &hex[i..i + 2])
+        .collect();
+
     // Bad: multi-statement closure body, single-letter parameter.
     let _formatted: Vec<String> = sorted
         .iter()

--- a/ui/single_letter_names.stderr
+++ b/ui/single_letter_names.stderr
@@ -57,7 +57,7 @@ LL |     let m = 5_u32;
    = note: `#[warn(perfectionist::single_letter_let_binding)]` on by default
 
 warning: closure parameter `t` has a single-letter name
-  --> $DIR/single_letter_names.rs:101:15
+  --> $DIR/single_letter_names.rs:111:15
    |
 LL |         .map(|t| {
    |               ^
@@ -66,7 +66,7 @@ LL |         .map(|t| {
    = note: `#[warn(perfectionist::single_letter_closure_param)]` on by default
 
 warning: function parameter `w` has a single-letter name
-  --> $DIR/single_letter_names.rs:116:16
+  --> $DIR/single_letter_names.rs:126:16
    |
 LL | fn write_label(w: &mut String, t: &str) {
    |                ^
@@ -75,7 +75,7 @@ LL | fn write_label(w: &mut String, t: &str) {
    = note: `#[warn(perfectionist::single_letter_function_param)]` on by default
 
 warning: function parameter `t` has a single-letter name
-  --> $DIR/single_letter_names.rs:116:32
+  --> $DIR/single_letter_names.rs:126:32
    |
 LL | fn write_label(w: &mut String, t: &str) {
    |                                ^

--- a/ui/single_letter_names.stderr
+++ b/ui/single_letter_names.stderr
@@ -57,7 +57,7 @@ LL |     let m = 5_u32;
    = note: `#[warn(perfectionist::single_letter_let_binding)]` on by default
 
 warning: closure parameter `t` has a single-letter name
-  --> $DIR/single_letter_names.rs:111:15
+  --> $DIR/single_letter_names.rs:114:15
    |
 LL |         .map(|t| {
    |               ^
@@ -66,7 +66,7 @@ LL |         .map(|t| {
    = note: `#[warn(perfectionist::single_letter_closure_param)]` on by default
 
 warning: function parameter `w` has a single-letter name
-  --> $DIR/single_letter_names.rs:126:16
+  --> $DIR/single_letter_names.rs:129:16
    |
 LL | fn write_label(w: &mut String, t: &str) {
    |                ^
@@ -75,7 +75,7 @@ LL | fn write_label(w: &mut String, t: &str) {
    = note: `#[warn(perfectionist::single_letter_function_param)]` on by default
 
 warning: function parameter `t` has a single-letter name
-  --> $DIR/single_letter_names.rs:126:32
+  --> $DIR/single_letter_names.rs:129:32
    |
 LL | fn write_label(w: &mut String, t: &str) {
    |                                ^


### PR DESCRIPTION
## Summary

`perfectionist::single_letter_function_param` allowlists `n`, `f`, `i`, `j`, `k` as canonical one-letter names. `perfectionist::single_letter_closure_param` had no identifier allowlist at all — it relied solely on its callback-method allowlist and a structural trivial-wrapper exception (field access, method call, one-arg call, reference, macro call). That left a gap: `|i| &hex[i..i + 2]` fires the lint because slice expressions aren't a trivial-wrapper shape, even though `i` is the canonical index name.

This PR closes the asymmetry by giving the closure-param rule the same conventional-name allowlist (`n`, `f`, `i`, `j`, `k`) and the same `extra_allowed_idents` / `ignore_allowed_idents` config knobs as the function-param rule.

## Changes

- `src/rules/single_letter_closure_param.rs` — `DEFAULT_CLOSURE_PARAM_ALLOWLIST`, `allowed_idents` field on the pass, filter step in `check_expr`, two new config fields, expanded rustdoc.
- `ui/single_letter_names.rs` — new fixture exercising `|i| &hex[i..i + 2]` as an OK case.
- `rules/single_letter_closure_param.md` — regenerated via `just gen-rules-md`.
- `ui/single_letter_names.stderr` — line-number bumps for the inserted fixture.

## Test plan

- [x] `just all` passes locally (fmt, build, doc, lint, test, self-lint).
- [x] New UI fixture covers the motivating `|i| &hex[i..i + 2]` shape.
- [x] Existing diagnostics in `single_letter_names.stderr` shifted only by the inserted fixture's line count; no diagnostic added or removed.
