### PR TITLE
fix(macro-argument-binding): accept unary `!` as a pure prefix

### DIFF
--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -272,6 +272,11 @@ The lint accepts any argument whose outermost shape is one of:
 - An index `base[index]` where both `base` and `index` are
   themselves pure (`buffer[0]`, `lookup[Foo::KEY]`).
 - A unary deref of a pure expression (`*ptr`).
+- A unary not of a pure expression (`!ready`,
+  `!state.is_full()`). Like the side-effect-free binary
+  operators below, the `Not` trait impl is overridable in
+  principle; the rule classifies by syntactic shape, so
+  `!`-prefixed pure operands stay pure.
 - A pure expression annotated with a type (`x as u64`).
 - The unit literal `()`, a parenthesised pure expression
   (`(x)`), or a tuple whose every element is pure

--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -63,6 +63,7 @@ abstract.
 
 The recognised pure shapes are: literals, paths, field
 accesses, indexing of pure bases, dereferences, references,
+the logical / bitwise not of a pure expression (`!ready`),
 casts, the unit literal `()`, parenthesised / tuple /
 array-literal / array-repeat groups whose elements are all
 pure, binary chains of pure operands joined by

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -93,6 +93,7 @@ declare_tool_lint! {
     ///
     /// The recognised pure shapes are: literals, paths, field
     /// accesses, indexing of pure bases, dereferences, references,
+    /// the logical / bitwise not of a pure expression (`!ready`),
     /// casts, the unit literal `()`, parenthesised / tuple /
     /// array-literal / array-repeat groups whose elements are all
     /// pure, binary chains of pure operands joined by

--- a/src/rules/macro_argument_binding/purity.rs
+++ b/src/rules/macro_argument_binding/purity.rs
@@ -341,6 +341,16 @@ fn take_pure_atom<'a>(tokens: &'a [TokenTree], ctx: PurityContext<'_>) -> Option
             TokenKind::AndAnd => take_reference_tail(rest, ctx),
             // `*expr` (deref).
             TokenKind::Star => take_pure_expression(rest, ctx),
+            // `!expr` (logical / bitwise not). Side-effect-free over
+            // a pure operand for the same reason `*expr` is: the
+            // trait impl is overridable, but the rule classifies by
+            // syntactic shape rather than semantics — the binary
+            // operators in `take_pure_binary_operator` are accepted
+            // on the same basis. Without this arm, `debug_assert!(!ready)`
+            // and `debug_assert!(!state.is_full())` would be flagged
+            // and the suggested let-bind would force the negation to
+            // evaluate in release builds.
+            TokenKind::Bang => take_pure_expression(rest, ctx),
             // Path: ident (`::` ident)*. If the path is followed by
             // `!` and the path's final segment names a curated
             // pure macro (`concat!`, `env!`, `include_str!`, ...),

--- a/ui/macro_argument_binding.rs
+++ b/ui/macro_argument_binding.rs
@@ -205,6 +205,11 @@ fn _all_pure_shapes_accepted() {
     debug_assert_eq!(*pointer, *pointer, "deref of a path");
     debug_assert_eq!(0u32 as u64, MAX as u64, "pure cast");
     debug_assert_eq!(::std::u32::MAX, std::u32::MAX, "rooted path");
+    let flag: bool = true;
+    let mask: u32 = 0;
+    debug_assert!(!flag, "unary not on a path");
+    debug_assert_eq!(!mask, !MAX, "unary not on paths");
+    debug_assert_eq!(!buffer[0], !buffer[INDEX], "unary not on pure suffix");
 }
 
 // Single-argument deny-listed call with an impure expression.

--- a/ui/macro_argument_binding.stderr
+++ b/ui/macro_argument_binding.stderr
@@ -53,7 +53,7 @@ LL | |     });
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:212:19
+  --> $DIR/macro_argument_binding.rs:217:19
    |
 LL |     debug_assert!(value().is_some());
    |                   ^^^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL |     debug_assert!(value().is_some());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:225:26
+  --> $DIR/macro_argument_binding.rs:230:26
    |
 LL |     let _ = await_macro!(future.await);
    |                          ^^^^^^^^^^^^
@@ -69,7 +69,7 @@ LL |     let _ = await_macro!(future.await);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:302:27
+  --> $DIR/macro_argument_binding.rs:307:27
    |
 LL |     let _ = my_macro!((), value());
    |                           ^^^^^^^
@@ -77,7 +77,7 @@ LL |     let _ = my_macro!((), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:303:30
+  --> $DIR/macro_argument_binding.rs:308:30
    |
 LL |     let _ = my_macro!((MAX), value());
    |                              ^^^^^^^
@@ -85,7 +85,7 @@ LL |     let _ = my_macro!((MAX), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:304:43
+  --> $DIR/macro_argument_binding.rs:309:43
    |
 LL |     let _ = my_macro!((point.0, point.1), value());
    |                                           ^^^^^^^
@@ -93,7 +93,7 @@ LL |     let _ = my_macro!((point.0, point.1), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:305:31
+  --> $DIR/macro_argument_binding.rs:310:31
    |
 LL |     let _ = my_macro!((MAX,), value());
    |                               ^^^^^^^
@@ -101,7 +101,7 @@ LL |     let _ = my_macro!((MAX,), value());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:324:23
+  --> $DIR/macro_argument_binding.rs:329:23
    |
 LL |     let _ = my_macro!([value(), value()]);
    |                       ^^^^^^^^^^^^^^^^^^
@@ -109,7 +109,7 @@ LL |     let _ = my_macro!([value(), value()]);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:339:26
+  --> $DIR/macro_argument_binding.rs:344:26
    |
 LL |     let _ = await_macro!([value(); 4]);
    |                          ^^^^^^^^^^^^
@@ -117,7 +117,7 @@ LL |     let _ = await_macro!([value(); 4]);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:340:26
+  --> $DIR/macro_argument_binding.rs:345:26
    |
 LL |     let _ = await_macro!([0; size()]);
    |                          ^^^^^^^^^^^
@@ -125,7 +125,7 @@ LL |     let _ = await_macro!([0; size()]);
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:383:19
+  --> $DIR/macro_argument_binding.rs:388:19
    |
 LL |     debug_assert!(slice.clear() == ());
    |                   ^^^^^^^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL |     debug_assert!(slice.clear() == ());
    = help: bind the expression to a `let` immediately before the macro call so it is evaluated exactly once, regardless of how the macro expands
 
 warning: impure expression passed directly to a macro
-  --> $DIR/macro_argument_binding.rs:393:19
+  --> $DIR/macro_argument_binding.rs:398:19
    |
 LL |     debug_assert!(text.parse::<u32>().is_ok());
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

`take_pure_atom` accepts `&`, `&&`, and `*` as side-effect-free prefix operators, and every standard binary operator (including `!=`) as side-effect-free over pure operands — but unary `!` was missing. Pure-base expressions like `debug_assert!(!field.bool)` were flagged, with no clean rewrite available.

This patch adds `TokenKind::Bang` to `take_pure_atom` alongside `Star` and the reference handlers, and updates the spec, rustdoc, and `_all_pure_shapes_accepted` fixture to match.

Reported in [pnpm/pnpm#11709](https://github.com/pnpm/pnpm/pull/11709).

## Test plan

- [x] `just all` (build, doc, lint, test, self-lint) — green.
- [x] `_all_pure_shapes_accepted` extended with `!flag`, `!mask`, `!buffer[0]` cases; no false positives.
