### PR TITLE
docs(plan): correct the default-state convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@ This repository's lint rules are documented in `planned-rules/`
 before they are implemented. Each markdown file describes one
 rule's intent, configuration knobs, examples, implementation
 notes, and difficulty. Cross-cutting conventions (parser style,
-lint-name namespacing) live in
+markdown parsing, lint-name namespacing, rule activation /
+default state) live in
 `planned-rules/IMPLEMENTATION_CONVENTIONS.md`.
 
 This guide tells you how to implement those rules and how to
@@ -26,16 +27,28 @@ Read three things first, in this order:
    one-sentence summary; check that the rule you're implementing
    still says what you think it says.
 3. **`planned-rules/IMPLEMENTATION_CONVENTIONS.md`** — applies
-   to every rule. Currently covers two cross-cutting conventions:
+   to every rule. Currently covers four cross-cutting conventions:
    - **Parser style.** Non-trivial string scanners (URLs,
      emails, format templates, markdown spans, serde-attribute
      type literals) are written as parser-combinator-style
      `take_*` functions, not regex.
+   - **Markdown parsing.** The handful of rules that scan
+     rustdoc-flavoured markdown share one hand-rolled
+     `take_*`-based helper at `src/markdown.rs`, not a vendored
+     parser library.
    - **Lint name namespacing.** Every lint registers under the
      `perfectionist` tool namespace via
      `rustc_session::declare_tool_lint!`. The planning files use
      the unqualified form (`qualified_paths`) for readability;
      the registered name is `perfectionist::qualified_paths`.
+   - **Rule activation model.** Every rule declares a
+     `DEFAULT_STATE` (`Active` or `Inactive`) and surfaces it as
+     a `**Default state:** \`active\` | \`inactive\`` frontmatter
+     line near the top of its planning file and generated rule
+     doc. The crate-wide on/off knob lives in `dylint.toml`'s
+     `[perfectionist] enable / disable` table — described in
+     `CONTROLLING_RULES.md` — and replaces any per-rule
+     `enabled = true` config field.
 
 If the rule is one of several that share a helper (markdown
 exclusion, format-string parsing, URL discovery, unicode-width

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -355,6 +355,14 @@ pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
 ```
 
+The consumer-facing description of the same mechanism — the
+`[perfectionist] enable = [...]` / `disable = [...]` table in
+`dylint.toml`, the per-site `#[allow / expect / deny / forbid]`
+attributes, and the `DYLINT_RUSTFLAGS` escape hatch — lives in
+[`CONTROLLING_RULES.md`](../CONTROLLING_RULES.md). This section is the
+author-side convention: how a rule declares its default and what
+`DefaultState` to pick.
+
 The two states map to the consumer-visible behaviour as follows:
 
 - **Active by default.** The pass installs unconditionally,
@@ -371,12 +379,63 @@ The two states map to the consumer-visible behaviour as follows:
   attributes at user call sites continue to resolve regardless
   of which array the rule appears under.
 
+Because the `[perfectionist] enable / disable` table is a single
+crate-wide switch for every rule, **do not add a per-rule
+`enabled = true` (or `enabled = false`) field** to a rule's own
+`[perfectionist::<rule>]` config table. The global switch already
+covers the "turn this rule on or off" case, and a within-table
+master switch is redundant with it. A rule's config table holds
+only the knobs that change *how* the rule behaves when its pass
+is installed.
+
 Reserve `Inactive by default` for rules whose triggers are
 known to false-positive in real codebases, advisory sub-checks
 gated behind a "are you sure?" knob, or rules whose preferred
 configuration genuinely varies per project to the point that
 shipping a baseline policy would be presumptuous. Everything
 else is `Active by default`.
+
+### Documenting the default state
+
+Every planning file in this directory and every generated rule
+doc in [`../rules/`](../rules/) carries the default state as a
+**frontmatter line near the top**, immediately under the H1.
+The form matches `rules/*.md` exactly:
+
+```markdown
+# `rule_name`
+
+**Default state:** `active`
+**Source:** ...
+```
+
+(`active` or `inactive` is the only payload — the planning file
+does not say "Warn" or "Allow" here; severity escalation is the
+consumer's choice and lives in `declare_tool_lint!` and
+[`CONTROLLING_RULES.md`](../CONTROLLING_RULES.md), not in the
+catalogue.)
+
+A planning file that bundles several sub-checks with different
+defaults — i.e. a file that the "One rule per file" convention
+says will be split — may instead point the frontmatter at a
+per-sub-check breakdown later in the file:
+
+```markdown
+**Default state:** per sub-check; see [Default state](#default-state).
+```
+
+A trailing `## Default state` section is only required when the
+default needs prose to explain — typically when a `style` knob
+defaults to `preserve` and effectively renders the active pass a
+no-op until the project picks a style. In that case the section
+expands on the frontmatter rather than repeating it; the bare
+"Active by default." sentence belongs in the frontmatter alone.
+
+Old planning files used a `## Severity` heading (typically just
+"Warn.") that captured the lint level instead. That convention
+is retired: the user-facing concept is the default state, the
+lint level is fixed at `Warn` in `declare_tool_lint!`, and the
+heading is not expected in new planning files.
 
 Severity escalation (`Warn → Deny → Forbid`) is the consumer's
 prerogative and lives entirely outside the planning file. The

--- a/planned-rules/arc-rc-clone.md
+++ b/planned-rules/arc-rc-clone.md
@@ -1,5 +1,6 @@
 # `arc_rc_clone`
 
+**Default state:** `active`  
 **Source:** pacquet *Cloning `Arc` and `Rc`*.
 
 ## Status

--- a/planned-rules/bare-email.md
+++ b/planned-rules/bare-email.md
@@ -1,5 +1,6 @@
 # `bare_email`
 
+**Default state:** `active`  
 **Source:** project convention.
 
 ## Statement
@@ -128,7 +129,3 @@ skip_domains = ["example.com", "example.org"]
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
-
-## Default state
-
-Active by default.

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -1,5 +1,6 @@
 # `bare_issue_reference`
 
+**Default state:** `active`  
 **Source:** project convention.
 
 ## Statement
@@ -124,7 +125,7 @@ form = "inline"
 
 ## Default state
 
-Active by default. With `repo_base_url` unset and
+With `repo_base_url` unset and
 `suggestion_mode = "help_only"`, the lint becomes informational
 and a project can run it without further configuration to flag
 the bare references for manual triage.

--- a/planned-rules/bare-url.md
+++ b/planned-rules/bare-url.md
@@ -1,5 +1,6 @@
 # `bare_url`
 
+**Default state:** `active`  
 **Source:** project convention.
 
 ## Statement
@@ -148,7 +149,3 @@ skip_hosts = ["example.com", "example.org", "localhost"]
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
-
-## Default state
-
-Active by default.

--- a/planned-rules/cfg-attr-ignore-tests.md
+++ b/planned-rules/cfg-attr-ignore-tests.md
@@ -1,5 +1,6 @@
 # `cfg_attr_ignore_tests`
 
+**Default state:** `active`  
 **Sources:** parallel-disk-usage *Conditional Test Skipping*; pacquet
 *Conditional Test Skipping*.
 
@@ -84,7 +85,3 @@ fn unix_permissions() {
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
-
-## Default state
-
-Active by default.

--- a/planned-rules/clap-help-length.md
+++ b/planned-rules/clap-help-length.md
@@ -1,5 +1,6 @@
 # `clap_help_length`
 
+**Default state:** `active`  
 **Source:** project convention. Sibling lint to
 [`clap-help-no-markdown`](./clap-help-no-markdown.md); both share the
 same "is this a clap-derived item, and is the help text overridden?"
@@ -131,10 +132,6 @@ count_graphemes = false
 
 A project that wants a single budget can set the same value for all
 four `*_max_*` knobs.
-
-## Default state
-
-Active by default.
 
 ## Autofix
 

--- a/planned-rules/clap-help-no-markdown.md
+++ b/planned-rules/clap-help-no-markdown.md
@@ -1,5 +1,6 @@
 # `clap_help_no_markdown`
 
+**Default state:** `active`  
 **Source:** project convention.
 
 ## Statement
@@ -149,10 +150,6 @@ extra_forbid = ["bold", "italic", "list"]   # empty by default
 # Recognise these attribute keys as overrides that disable the lint.
 override_keys = ["about", "long_about", "help", "long_help"]
 ```
-
-## Default state
-
-Active by default.
 
 ## Autofix
 

--- a/planned-rules/commit-id-length.md
+++ b/planned-rules/commit-id-length.md
@@ -1,5 +1,6 @@
 # `commit_id_length`
 
+**Default state:** `active`  
 **Source:** project convention. Sibling lint to
 [`unpinned-repo-ref`](./unpinned-repo-ref.md), which decides whether
 a forge URL's ref is pinned at all. This rule decides whether the
@@ -192,7 +193,7 @@ the window themselves.
 
 ## Default state
 
-Active by default. The default window (`6..=40`) rejects SHAs
+The default window (`6..=40`) rejects SHAs
 shorter than Git's default abbreviation length while accepting
 everything from 6-char prefixes up to the full 40-char hash; a
 project tightens the window further by raising the minimum or

--- a/planned-rules/core-or-std.md
+++ b/planned-rules/core-or-std.md
@@ -1,5 +1,6 @@
 # `core_or_std`
 
+**Default state:** `active`  
 **Source:** project convention.
 
 ## Statement
@@ -149,6 +150,6 @@ The lint emits nothing. Default.
 
 ## Default state
 
-Active by default, but the default `style = "preserve"` keeps the
+The default `style = "preserve"` keeps the
 pass a no-op until the project opts into `prefer_core` or
 `prefer_std`.

--- a/planned-rules/derive-more-inlined-args.md
+++ b/planned-rules/derive-more-inlined-args.md
@@ -1,5 +1,6 @@
 # `derive_more_inlined_args`
 
+**Default state:** `active`  
 **Source:** project convention. Clippy's `clippy::uninlined_format_args`
 catches the `format!("... {} ...", name)` → `format!("... {name} ...")`
 rewrite for the standard formatting macros, but it does not extend
@@ -147,10 +148,6 @@ but the inlined form for positional ones can flip
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
-
-## Default state
-
-Active by default.
 
 ## Autofix
 

--- a/planned-rules/derive-more-template-wrap.md
+++ b/planned-rules/derive-more-template-wrap.md
@@ -1,5 +1,6 @@
 # `derive_more_template_wrap`
 
+**Default state:** `active`  
 **Source:** project convention. Sibling to
 [`format-macro-wrap`](./format-macro-wrap.md) and
 [`print-macro-split`](./print-macro-split.md). The same
@@ -169,10 +170,6 @@ re-formatting would interact with the rewrite.
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
-
-## Default state
-
-Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/em-dash-prose.md
+++ b/planned-rules/em-dash-prose.md
@@ -1,5 +1,6 @@
 # `em_dash_prose`
 
+**Default state:** `active`  
 **Source:** parallel-disk-usage *Writing Style*.
 
 ## Statement
@@ -134,7 +135,3 @@ action.
   Useful for projects that want to localise the diagnostic or expand
   it with a link to an internal style guide. The default message
   above is used when this is unset.
-
-## Default state
-
-Active by default.

--- a/planned-rules/error-type-derives.md
+++ b/planned-rules/error-type-derives.md
@@ -1,5 +1,6 @@
 # `error_type_derives`
 
+**Default state:** `active`  
 **Sources:** parallel-disk-usage *Error Handling*; pacquet *Error
 Handling*.
 
@@ -235,8 +236,8 @@ pub enum ParsedValue { /* ... */ }
 
 ## Default state
 
-Each sub-check has its own default state once it is split into a
-sibling planning file per the Status section above. The expected
-shape: `unused_display`, `unused_error`, `copyable_error`,
-`unconventional_error_name`, and `missing_error` are all active
-by default.
+The five sub-checks (`unused_display`, `unused_error`,
+`copyable_error`, `unconventional_error_name`, and `missing_error`)
+are all active by default. Once the rule is split into one
+planning file per sub-check per the Status section above, each
+resulting file inherits this default.

--- a/planned-rules/format-macro-wrap.md
+++ b/planned-rules/format-macro-wrap.md
@@ -1,5 +1,6 @@
 # `format_macro_wrap`
 
+**Default state:** `active`  
 **Source:** project convention. Sibling to
 [`print-macro-split`](./print-macro-split.md), which covers the
 splittable side-effect macros. This rule handles the *un*splittable
@@ -180,10 +181,6 @@ behaviour is unchanged.
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
-
-## Default state
-
-Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/import-granularity.md
+++ b/planned-rules/import-granularity.md
@@ -1,5 +1,6 @@
 # `import_granularity`
 
+**Default state:** `active`  
 **Sources:** parallel-disk-usage *Code Style › Import Organization*; pacquet
 *Import Organization*. Both source documents show examples in the **`crate`**
 shape; the default in this catalogue is **`module`** because it is the
@@ -186,7 +187,7 @@ The style names map 1-to-1 to rustfmt's `imports_granularity`:
 
 ## Default state
 
-Active by default. None of the three styles is "wrong" in the
+None of the three styles is "wrong" in the
 abstract; a mismatch with the project's configured `style` is
 the violation, so the rule is purely about consistency with the
 chosen layout.

--- a/planned-rules/import-grouping.md
+++ b/planned-rules/import-grouping.md
@@ -1,5 +1,6 @@
 # `import_grouping`
 
+**Default state:** `active`  
 **Source:** project convention. Distinct from
 [`import-granularity`](./import-granularity.md), which decides
 *merge vs separate*; this rule decides *how use statements are
@@ -156,6 +157,6 @@ options; this lint exists for projects on stable.
 
 ## Default state
 
-Active by default. A mismatch with the configured `style` is the
+A mismatch with the configured `style` is the
 violation; neither style is "wrong" in the abstract, so the rule
 is purely about consistency with the project's chosen layout.

--- a/planned-rules/intra-doc-links.md
+++ b/planned-rules/intra-doc-links.md
@@ -1,5 +1,6 @@
 # `intra_doc_links`
 
+**Default state:** `active`  
 **Source:** pacquet *Doc comment intra-links*.
 
 ## Statement
@@ -73,10 +74,6 @@ deliberately *did not* want to link (e.g., a future type, or a
 historical reference). Provide a project-level allowlist
 (`intra_doc_links.skip_idents = ["LegacyCache"]`) and respect
 `#[allow(...)]`.
-
-## Default state
-
-Active by default.
 
 ## Autofix
 

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -1,5 +1,6 @@
 # `lint_downgrade_reason`
 
+**Default state:** `active`  
 **Source:** project convention.
 
 ## Statement
@@ -235,10 +236,6 @@ for the target nightly.
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
-
-## Default state
-
-Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/lint-reason-from-comment.md
+++ b/planned-rules/lint-reason-from-comment.md
@@ -1,5 +1,6 @@
 # `lint_reason_from_comment`
 
+**Default state:** `active`  
 **Source:** project convention.
 
 ## Statement
@@ -194,10 +195,6 @@ lines.
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
-
-## Default state
-
-Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -1,5 +1,7 @@
 # `macro_argument_binding`
 
+**Default state:** `active`
+
 ## Status
 
 Partially implemented. Modes 0-2 (`deny_only`, `blanket`,
@@ -769,10 +771,6 @@ modes 0-2 first; mode 3 as a follow-up.
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
   for cross-cutting conventions, in particular the lint-name
   namespacing under `perfectionist::*`.
-
-## Default state
-
-Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -1,5 +1,7 @@
 # `macro_trailing_comma`
 
+**Default state:** `active`
+
 ## Status
 
 Name-based eligibility is **implemented** in `src/rules/macro_trailing_comma.rs`
@@ -564,10 +566,6 @@ new configuration knob added at the same time.
   for cross-cutting conventions that apply to every rule in
   this catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
-
-## Default state
-
-Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/module-item-order.md
+++ b/planned-rules/module-item-order.md
@@ -1,5 +1,6 @@
 # `module_item_order`
 
+**Default state:** `active`  
 **Sources:** parallel-disk-usage *Module Organization*; pacquet *Module
 Organization*.
 
@@ -70,7 +71,3 @@ pub use parser::Parser;
 - `cfg`-gated blocks of imports (e.g., a trailing `#[cfg(unix)] use ...`
   block) are explicitly permitted by both source documents and must not
   trigger the lint when they sit *after* the main import block.
-
-## Default state
-
-Active by default.

--- a/planned-rules/named-prelude-import.md
+++ b/planned-rules/named-prelude-import.md
@@ -1,5 +1,6 @@
 # `named_prelude_import`
 
+**Default state:** `active`  
 **Source:** project convention. Dual of
 [`no-star-imports`](./no-star-imports.md): that rule restricts globs in
 general but lets preludes glob freely; this rule restricts named
@@ -98,7 +99,3 @@ prelude_segment_names = ["prelude"]
 # project's internal prelude that is intentionally cherry-picked).
 allowed_paths = []
 ```
-
-## Default state
-
-Active by default.

--- a/planned-rules/no-star-imports.md
+++ b/planned-rules/no-star-imports.md
@@ -1,5 +1,6 @@
 # `no_star_imports`
 
+**Default state:** `active`  
 **Source:** pacquet *No star imports*.
 
 ## Statement
@@ -125,7 +126,3 @@ exception enabled) lets `use foo::prelude::*;` through and forbids
 Together they say: "preludes must be glob-imported, and globs are only
 allowed for preludes". Enabling both is the recommended posture for
 projects that follow the prelude convention strictly.
-
-## Default state
-
-Active by default.

--- a/planned-rules/pipe-style.md
+++ b/planned-rules/pipe-style.md
@@ -1,5 +1,6 @@
 # `pipe_style`
 
+**Default state:** `active`  
 **Sources:** parallel-disk-usage *Using `pipe-trait`* and pacquet
 *Using `pipe-trait`*. Both source documents prescribe the same
 two-direction policy: pipe is wrong at the entry point of an
@@ -209,5 +210,5 @@ point convergence in two passes.
 
 ## Default state
 
-Active by default. Both sub-checks (`leading_pipe` and
+Both sub-checks (`leading_pipe` and
 `wrapped_chain`) run when the rule is active.

--- a/planned-rules/prefer-derive-more-over-thiserror.md
+++ b/planned-rules/prefer-derive-more-over-thiserror.md
@@ -1,5 +1,6 @@
 # `prefer_derive_more_over_thiserror`
 
+**Default state:** `active`  
 **Source:** project convention. Sibling to
 [`prefer-derive-more`](./prefer-derive-more.md), which catches
 hand-written `impl` blocks. This rule catches the *other* common
@@ -127,10 +128,6 @@ hand, not in the lint itself.
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
-
-## Default state
-
-Active by default.
 
 ## Interaction with sibling lints
 

--- a/planned-rules/prefer-derive-more.md
+++ b/planned-rules/prefer-derive-more.md
@@ -1,5 +1,6 @@
 # `prefer_derive_more`
 
+**Default state:** `active`  
 **Source:** project convention. AI assistants frequently expand
 `#[derive(From)]` / `#[derive(Display)]` patterns into hand-rolled
 `impl` blocks, particularly in code that began life inside a chat
@@ -198,9 +199,9 @@ crate_path = "derive_more"
 
 ## Default state
 
-Active by default for the easy and medium sub-lints. The hard
-sub-lints ship inactive by default; a project opts in via the
-configuration knobs documented above.
+The easy and medium sub-lints are active by
+default. The hard sub-lints ship inactive by default; a project
+opts in via the configuration knobs documented above.
 
 ## Why restrict this?
 

--- a/planned-rules/prefer-expect-over-allow.md
+++ b/planned-rules/prefer-expect-over-allow.md
@@ -1,5 +1,6 @@
 # `prefer_expect_over_allow`
 
+**Default state:** `active`  
 **Source:** project convention.
 
 ## Statement
@@ -215,10 +216,6 @@ original span but the bookkeeping is worth its own helper.
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
-
-## Default state
-
-Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/prefer-owned-parameter.md
+++ b/planned-rules/prefer-owned-parameter.md
@@ -1,5 +1,6 @@
 # `prefer_owned_parameter`
 
+**Default state:** `active`  
 **Source:** pacquet *When to use owned parameter? When to use
 borrowed parameter?*. The pacquet guide gives both directions of
 the trade-off; this lint covers the *prefer owned* direction. The
@@ -183,10 +184,6 @@ A conservative starting implementation:
   and that use is the conversion to owned. No dominance analysis
   needed; the predicate degenerates to a single-use check.
 - Defer the multi-use / branching cases to a later pass.
-
-## Default state
-
-Active by default.
 
 ## Interaction with clippy
 

--- a/planned-rules/prefer-text-block.md
+++ b/planned-rules/prefer-text-block.md
@@ -1,5 +1,6 @@
 # `prefer_text_block`
 
+**Default state:** `active`  
 **Source:** project convention.
 
 ## Statement
@@ -321,7 +322,7 @@ The autofix:
 
 ## Default state
 
-Active by default. The default `style = "text_block_macros"`
+The default `style = "text_block_macros"`
 reflects the catalogue's preferred form; projects that don't
 want the external-crate dependency switch to `line_continuation`.
 

--- a/planned-rules/print-macro-split.md
+++ b/planned-rules/print-macro-split.md
@@ -1,5 +1,6 @@
 # `print_macro_split`
 
+**Default state:** `active`  
 **Source:** project convention.
 
 ## Statement
@@ -229,10 +230,6 @@ re-indexing; help-only for mixed templates.
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing
   (`perfectionist::*`) that every registered lint follows.
-
-## Default state
-
-Active by default.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/qualified-paths.md
+++ b/planned-rules/qualified-paths.md
@@ -1,5 +1,6 @@
 # `qualified_paths`
 
+**Default state:** `active`  
 **Source:** project convention; parallel-disk-usage's codebase
 implicitly enforces the unqualified form by always importing items
 before use. AI assistants — particularly those producing
@@ -254,7 +255,7 @@ For each path:
 
 ## Default state
 
-Active by default, but the default `style = "preserve"` keeps the
+The default `style = "preserve"` keeps the
 pass a no-op until the project opts into `prefer_imported` or
 `prefer_qualified`.
 

--- a/planned-rules/self-import.md
+++ b/planned-rules/self-import.md
@@ -1,5 +1,6 @@
 # `self_import`
 
+**Default state:** `active`  
 **Source:** project convention. Companion lint to
 [`import-granularity`](./import-granularity.md), which intentionally
 defers all `self`-import decisions here.
@@ -136,7 +137,7 @@ The lint emits nothing. Useful as a project-wide acknowledgement that
 
 ## Default state
 
-Active by default, but the default `style = "preserve"` keeps the
+The default `style = "preserve"` keeps the
 pass a no-op until the project opts into `forbid` or `combined`.
 
 ## Why a separate lint from `import-granularity`

--- a/planned-rules/serde-source-types.md
+++ b/planned-rules/serde-source-types.md
@@ -1,5 +1,6 @@
 # `serde_source_types`
 
+**Default state:** per sub-check; see [Default state](#default-state).  
 **Source:** pacquet *Serde `Cow<'de, str>` vs `String` source types*.
 
 ## Statement

--- a/planned-rules/serde-wrapper-style.md
+++ b/planned-rules/serde-wrapper-style.md
@@ -1,5 +1,6 @@
 # `serde_wrapper_style`
 
+**Default state:** `active`  
 **Source:** project convention.
 
 ## Statement
@@ -253,7 +254,7 @@ apply it without manual review.
 
 ## Default state
 
-Active by default, but the default `style = "preserve"` keeps the
+The default `style = "preserve"` keeps the
 pass a no-op so the rule is zero-friction to adopt. A project
 that has audited the trivial-impl recogniser on its codebase opts
 in by setting `style` to `transparent` or `from_into`.

--- a/planned-rules/unicode-ellipsis-in-docs.md
+++ b/planned-rules/unicode-ellipsis-in-docs.md
@@ -1,5 +1,6 @@
 # `unicode_ellipsis_in_docs`
 
+**Default state:** `active`  
 **Source:** project convention (not present in either source document;
 parallel to [`em-dash-prose`](./em-dash-prose.md), which targets U+2014).
 
@@ -80,7 +81,3 @@ Replace `…` with `...`. `Applicability::MachineApplicable`.
   ellipsis (`⋯`) or two-dot leader (`‥`).
 - `unicode_ellipsis_in_docs.allow_in_code_spans = true` — defaults to
   `true`; set to `false` to enforce the rule even inside `` `...` ``.
-
-## Default state
-
-Active by default.

--- a/planned-rules/unit-test-file-layout.md
+++ b/planned-rules/unit-test-file-layout.md
@@ -1,5 +1,6 @@
 # `unit_test_file_layout`
 
+**Default state:** `active`  
 **Sources:** parallel-disk-usage *Unit Tests › Where the external file
 sits*; pacquet *Unit test file layout*. The two source documents
 **diverge** on the inline-vs-external question, so this rule exposes
@@ -264,10 +265,6 @@ file's position relative to its parent matters.
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
-
-## Default state
-
-Active by default.
 
 ## Autofix
 

--- a/planned-rules/unpinned-repo-ref.md
+++ b/planned-rules/unpinned-repo-ref.md
@@ -1,5 +1,6 @@
 # `unpinned_repo_ref`
 
+**Default state:** `active`  
 **Source:** project convention. The pacquet `CODE_STYLE_GUIDE.md` calls
 the principle out as a *cardinal rule* — every upstream permalink must
 be pinned to a SHA — but the rule itself appears across many
@@ -187,10 +188,6 @@ when the ref is hex.
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
-
-## Default state
-
-Active by default.
 
 ## Interaction with sibling lints
 

--- a/planned-rules/where-clause-bounds.md
+++ b/planned-rules/where-clause-bounds.md
@@ -1,5 +1,6 @@
 # `where_clause_bounds`
 
+**Default state:** `active`  
 **Sources:** parallel-disk-usage *Trait Bounds*; pacquet *Trait Bounds*.
 
 ## Statement
@@ -60,7 +61,3 @@ where
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
-
-## Default state
-
-Active by default.


### PR DESCRIPTION
Aligns the planning catalogue with the post-PR-#67 conventions that
already shape `rules/*.md`:

- Move every planning file's default state into a
  `**Default state:** \`active\` | \`inactive\`` frontmatter line
  immediately under the H1, matching `rules/*.md`. Drop the trailing
  `## Default state` section where it said only "Active by default.";
  retain (and trim) it where the default needs prose to explain.
- Extend `IMPLEMENTATION_CONVENTIONS.md` with a "Documenting the
  default state" subsection codifying the frontmatter convention,
  cross-link the activation model to `CONTROLLING_RULES.md`, and note
  that per-rule `enabled = true` master switches are redundant with
  the global `[perfectionist] enable / disable` table.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/109>.