### PR TITLE
feat(config)!: non-zero types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "clippy_utils",
  "dylint_linting",
  "dylint_testing",
+ "pipe-trait",
  "serde",
  "text-block-macros",
  "toml 1.1.2+spec-1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 [dev-dependencies]
 _utils = { path = "utils" }
 dylint_testing = "6.0.0"
+pipe-trait = "0.4.0"
 text-block-macros = "0.2.0"
 toml = "1.1.2"
 

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -64,8 +64,9 @@ same presence / length check as
   the attribute's span.
 - **`reason` present but shorter than `min_reason_length`
   (default 3).** Emit a "reason too short" diagnostic at the
-  literal's span. Set `min_reason_length = 0` to disable the
-  length branch (presence still enforced).
+  literal's span. The knob is a `NonZeroUsize` — `0` is rejected
+  at parse time, since an empty literal is already treated as a
+  missing reason regardless of this knob.
 - **`reason` present and long enough.** Accept.
 
 `#[deny]` and `#[forbid]` are never flagged — they tighten, not
@@ -170,8 +171,9 @@ exempt_lints = [
 # reason ("x", "ok") satisfies the literal presence requirement
 # but conveys nothing; the default floor of 3 excludes those
 # cases. Projects that want a higher bar (e.g. require a full
-# sentence) can raise it. Set to 0 to disable the length branch
-# entirely.
+# sentence) can raise it. The lower bound is 1 — 0 is rejected at
+# parse time, since an empty literal is already treated as a
+# missing reason regardless of this knob.
 min_reason_length = 3
 ```
 

--- a/rules/lint_silence_reason.md
+++ b/rules/lint_silence_reason.md
@@ -51,11 +51,12 @@ rather than per-site. Each entry is the lint's full name as
 it appears inside the attribute (`clippy::module_name_repetitions`,
 `dead_code`, …).
 
-### `min_reason_length`: `unsigned integer` (optional)
+### `min_reason_length`: `non-zero unsigned integer` (optional)
 
 Minimum length of the `reason` value. A one- or two-character
 reason (`"x"`, `"ok"`) satisfies the literal presence
 requirement but conveys nothing; the default floor of 3
 excludes those cases. Projects that want a higher bar (e.g.
-require a full sentence) can raise it. Set to `0` to disable
-the length branch entirely (presence is still enforced).
+require a full sentence) can raise it. The lower bound is `1`
+— `0` is rejected at parse time, since an empty literal is
+already treated as a missing reason regardless of this knob.

--- a/rules/prefer_raw_string.md
+++ b/rules/prefer_raw_string.md
@@ -53,12 +53,16 @@ let path = r"C:\Users\foo\bar";
 
 Configure via `dylint.toml` under `["perfectionist::prefer_raw_string"]`. Every field is optional; the per-field prose below states the default.
 
-### `min_escapes_to_trigger`: `unsigned integer` (optional)
+### `min_escapes_to_trigger`: `non-zero unsigned integer` (optional)
 
 Minimum number of eliminable escapes a string must contain
-before the lint fires. Default 1 catches every escapable
-string; set to 2 to skip single-escape literals where the
-raw form is arguably noisier than the original.
+before the lint fires. Default `1` catches every escapable
+string; set to `2` to skip single-escape literals where the
+raw form is arguably noisier than the original. The lower
+bound is `1` — `0` is rejected at parse time, since a
+literal with zero eliminable escapes already cannot be
+rewritten as a raw string and is skipped regardless of this
+knob.
 
 ### `escapes_eligible`: `[string]` (optional)
 

--- a/rules/prefer_raw_string.md
+++ b/rules/prefer_raw_string.md
@@ -59,10 +59,10 @@ Minimum number of eliminable escapes a string must contain
 before the lint fires. Default `1` catches every escapable
 string; set to `2` to skip single-escape literals where the
 raw form is arguably noisier than the original. The lower
-bound is `1` — `0` is rejected at parse time, since a
-literal with zero eliminable escapes already cannot be
-rewritten as a raw string and is skipped regardless of this
-knob.
+bound is `1` — `0` is rejected at parse time, since
+suggesting `r"hello"` for `"hello"` would just trip
+`clippy::needless_raw_strings` on the next pass, and a
+minimum of `1` already excludes that case.
 
 ### `escapes_eligible`: `[string]` (optional)
 

--- a/src/rules/lint_silence_reason.rs
+++ b/src/rules/lint_silence_reason.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::num::NonZeroUsize;
 
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use rustc_ast::{Attribute, LitKind, MetaItem, MetaItemInner, MetaItemKind};
@@ -63,23 +64,29 @@ struct Config {
     /// reason (`"x"`, `"ok"`) satisfies the literal presence
     /// requirement but conveys nothing; the default floor of 3
     /// excludes those cases. Projects that want a higher bar (e.g.
-    /// require a full sentence) can raise it. Set to `0` to disable
-    /// the length branch entirely (presence is still enforced).
-    min_reason_length: usize,
+    /// require a full sentence) can raise it. The lower bound is `1`
+    /// — `0` is rejected at parse time, since an empty literal is
+    /// already treated as a missing reason regardless of this knob.
+    min_reason_length: NonZeroUsize,
 }
+
+/// Default floor for `min_reason_length`. Three characters excludes
+/// the obviously-content-free reasons `"x"`, `"ok"`, while still
+/// accepting anything that could plausibly be a word.
+const DEFAULT_MIN_REASON_LENGTH: NonZeroUsize = NonZeroUsize::new(3).expect("3 is non-zero");
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             exempt_lints: Vec::new(),
-            min_reason_length: 3,
+            min_reason_length: DEFAULT_MIN_REASON_LENGTH,
         }
     }
 }
 
 pub struct LintSilenceReason {
     exempt_lints: BTreeSet<String>,
-    min_reason_length: usize,
+    min_reason_length: NonZeroUsize,
 }
 
 impl LintSilenceReason {
@@ -205,10 +212,7 @@ impl LintSilenceReason {
                     self.emit_blank_reason(lint_context, literal.span);
                     return;
                 }
-                if self.min_reason_length == 0 {
-                    return;
-                }
-                if value_str.chars().count() < self.min_reason_length {
+                if value_str.chars().count() < self.min_reason_length.get() {
                     self.emit_too_short(lint_context, literal.span);
                 }
             }
@@ -285,10 +289,10 @@ impl LintSilenceReason {
             literal_span,
             "`reason` is shorter than the configured minimum",
             |diagnostic| {
+                let min = self.min_reason_length.get();
                 diagnostic.help(format!(
-                    "write a rationale of at least {} character{}",
-                    self.min_reason_length,
-                    if self.min_reason_length == 1 { "" } else { "s" },
+                    "write a rationale of at least {min} character{}",
+                    if min == 1 { "" } else { "s" },
                 ));
             },
         );

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -5,6 +5,8 @@
 //! file owns the lint declaration, the configuration, and the late
 //! pass that drives it.
 
+use std::num::NonZeroUsize;
+
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use rustc_ast::{LitKind, StrStyle};
 use rustc_errors::Applicability;
@@ -82,10 +84,14 @@ const CONFIG_KEY: &str = "perfectionist::prefer_raw_string";
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
     /// Minimum number of eliminable escapes a string must contain
-    /// before the lint fires. Default 1 catches every escapable
-    /// string; set to 2 to skip single-escape literals where the
-    /// raw form is arguably noisier than the original.
-    min_escapes_to_trigger: usize,
+    /// before the lint fires. Default `1` catches every escapable
+    /// string; set to `2` to skip single-escape literals where the
+    /// raw form is arguably noisier than the original. The lower
+    /// bound is `1` — `0` is rejected at parse time, since a
+    /// literal with zero eliminable escapes already cannot be
+    /// rewritten as a raw string and is skipped regardless of this
+    /// knob.
+    min_escapes_to_trigger: NonZeroUsize,
     /// Escape sequences considered eliminable by switching to raw
     /// form. Only the three Rust escapes whose decoded character
     /// is exactly the byte after the backslash — `"\""`, `"\\"`,
@@ -99,10 +105,14 @@ struct Config {
     escapes_eligible: Vec<String>,
 }
 
+/// Default floor for `min_escapes_to_trigger`. One eliminable
+/// escape is enough to make the raw form an unambiguous win.
+const DEFAULT_MIN_ESCAPES_TO_TRIGGER: NonZeroUsize = NonZeroUsize::new(1).expect("1 is non-zero");
+
 impl Default for Config {
     fn default() -> Self {
         Self {
-            min_escapes_to_trigger: 1,
+            min_escapes_to_trigger: DEFAULT_MIN_ESCAPES_TO_TRIGGER,
             escapes_eligible: DEFAULT_ESCAPES_ELIGIBLE
                 .iter()
                 .map(|entry| (*entry).to_owned())
@@ -112,7 +122,7 @@ impl Default for Config {
 }
 
 pub struct PreferRawString {
-    min_escapes_to_trigger: usize,
+    min_escapes_to_trigger: NonZeroUsize,
     escapes_eligible: Vec<String>,
 }
 
@@ -179,14 +189,13 @@ impl<'tcx> LateLintPass<'tcx> for PreferRawString {
         let Some(scan) = scan_body(body, &self.escapes_eligible) else {
             return;
         };
-        // The `eliminable_count == 0` guard is stricter than the
-        // planning file's `count >= threshold` rule and deliberate:
-        // suggesting `r"hello"` for `"hello"` would just trip
-        // `clippy::needless_raw_strings` on the next pass. The
-        // guard kicks in if a user sets `min_escapes_to_trigger`
-        // to 0, which the planning file doesn't expect but the
-        // schema doesn't forbid.
-        if scan.eliminable_count == 0 || scan.eliminable_count < self.min_escapes_to_trigger {
+        // A literal with zero eliminable escapes is skipped by the
+        // threshold itself: `min_escapes_to_trigger: NonZeroUsize`
+        // forces the minimum to at least 1, so `count < min` already
+        // catches `count == 0`. Suggesting `r"hello"` for `"hello"`
+        // would just trip `clippy::needless_raw_strings` on the next
+        // pass; the type system now guarantees we never do.
+        if scan.eliminable_count < self.min_escapes_to_trigger.get() {
             return;
         }
         let n_hashes = minimal_hash_count(&scan.decoded);

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -87,10 +87,10 @@ struct Config {
     /// before the lint fires. Default `1` catches every escapable
     /// string; set to `2` to skip single-escape literals where the
     /// raw form is arguably noisier than the original. The lower
-    /// bound is `1` — `0` is rejected at parse time, since a
-    /// literal with zero eliminable escapes already cannot be
-    /// rewritten as a raw string and is skipped regardless of this
-    /// knob.
+    /// bound is `1` — `0` is rejected at parse time, since
+    /// suggesting `r"hello"` for `"hello"` would just trip
+    /// `clippy::needless_raw_strings` on the next pass, and a
+    /// minimum of `1` already excludes that case.
     min_escapes_to_trigger: NonZeroUsize,
     /// Escape sequences considered eliminable by switching to raw
     /// form. Only the three Rust escapes whose decoded character

--- a/tests/lint_silence_reason.rs
+++ b/tests/lint_silence_reason.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::sync::Mutex;
 
+use pipe_trait::Pipe;
 use text_block_macros::text_block_fnl;
 
 const LINT_NAME: &str = "perfectionist::lint_silence_reason";
@@ -60,7 +61,7 @@ fn min_reason_length_one_accepts_any_non_blank_reason() {
     run(
         "ui-toml/lint_silence_reason/min_reason_length_one",
         dylint_toml(RuleConfig {
-            min_reason_length: Some(NonZeroUsize::new(1).expect("1 is non-zero")),
+            min_reason_length: 1.pipe(NonZeroUsize::new).unwrap().pipe(Some),
             ..Default::default()
         }),
     );
@@ -71,7 +72,7 @@ fn min_reason_length_eight_raises_the_floor() {
     run(
         "ui-toml/lint_silence_reason/min_reason_length_eight",
         dylint_toml(RuleConfig {
-            min_reason_length: Some(NonZeroUsize::new(8).expect("8 is non-zero")),
+            min_reason_length: 8.pipe(NonZeroUsize::new).unwrap().pipe(Some),
             ..Default::default()
         }),
     );

--- a/tests/lint_silence_reason.rs
+++ b/tests/lint_silence_reason.rs
@@ -11,6 +11,7 @@
 //! parallel test harness.
 
 use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
 use std::sync::Mutex;
 
 use text_block_macros::text_block_fnl;
@@ -28,7 +29,7 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     exempt_lints: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    min_reason_length: Option<usize>,
+    min_reason_length: Option<NonZeroUsize>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -55,11 +56,11 @@ fn exempt_lints_skips_attributes_whose_every_lint_is_exempt() {
 }
 
 #[test]
-fn min_reason_length_zero_disables_the_length_branch() {
+fn min_reason_length_one_accepts_any_non_blank_reason() {
     run(
-        "ui-toml/lint_silence_reason/min_reason_length_zero",
+        "ui-toml/lint_silence_reason/min_reason_length_one",
         dylint_toml(RuleConfig {
-            min_reason_length: Some(0),
+            min_reason_length: Some(NonZeroUsize::new(1).expect("1 is non-zero")),
             ..Default::default()
         }),
     );
@@ -70,7 +71,7 @@ fn min_reason_length_eight_raises_the_floor() {
     run(
         "ui-toml/lint_silence_reason/min_reason_length_eight",
         dylint_toml(RuleConfig {
-            min_reason_length: Some(8),
+            min_reason_length: Some(NonZeroUsize::new(8).expect("8 is non-zero")),
             ..Default::default()
         }),
     );

--- a/tests/prefer_raw_string.rs
+++ b/tests/prefer_raw_string.rs
@@ -11,6 +11,7 @@
 //! parallel test harness.
 
 use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
 use std::sync::Mutex;
 
 const LINT_NAME: &str = "perfectionist::prefer_raw_string";
@@ -24,7 +25,7 @@ static SERIAL: Mutex<()> = Mutex::new(());
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    min_escapes_to_trigger: Option<usize>,
+    min_escapes_to_trigger: Option<NonZeroUsize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     escapes_eligible: Option<Vec<String>>,
 }
@@ -49,7 +50,7 @@ fn min_escapes_to_trigger_skips_single_escape_literals() {
     run(
         "ui-toml/prefer_raw_string/min_escapes_to_trigger",
         RuleConfig {
-            min_escapes_to_trigger: Some(2),
+            min_escapes_to_trigger: Some(NonZeroUsize::new(2).expect("2 is non-zero")),
             ..Default::default()
         },
     );

--- a/tests/prefer_raw_string.rs
+++ b/tests/prefer_raw_string.rs
@@ -14,6 +14,8 @@ use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::sync::Mutex;
 
+use pipe_trait::Pipe;
+
 const LINT_NAME: &str = "perfectionist::prefer_raw_string";
 
 static SERIAL: Mutex<()> = Mutex::new(());
@@ -50,7 +52,7 @@ fn min_escapes_to_trigger_skips_single_escape_literals() {
     run(
         "ui-toml/prefer_raw_string/min_escapes_to_trigger",
         RuleConfig {
-            min_escapes_to_trigger: Some(NonZeroUsize::new(2).expect("2 is non-zero")),
+            min_escapes_to_trigger: 2.pipe(NonZeroUsize::new).unwrap().pipe(Some),
             ..Default::default()
         },
     );

--- a/tools/gen-docs/src/extract/ty.rs
+++ b/tools/gen-docs/src/extract/ty.rs
@@ -95,6 +95,18 @@ pub(crate) const BUILTIN_TYPES: &[&str] = &[
     "isize",
     "f32",
     "f64",
+    "NonZeroU8",
+    "NonZeroU16",
+    "NonZeroU32",
+    "NonZeroU64",
+    "NonZeroU128",
+    "NonZeroUsize",
+    "NonZeroI8",
+    "NonZeroI16",
+    "NonZeroI32",
+    "NonZeroI64",
+    "NonZeroI128",
+    "NonZeroIsize",
     // Common std types likely to appear in serde-deserialised configs.
     "String",
     "Vec",
@@ -194,6 +206,8 @@ pub(crate) fn find_type_doc(file: &syn::File, ident: &str) -> Option<TypeDoc> {
 /// - `bool` → `boolean`
 /// - `u*` / `usize` → `unsigned integer`
 /// - `i*` / `isize` → `integer`
+/// - `NonZeroU*` / `NonZeroUsize` → `non-zero unsigned integer`
+/// - `NonZeroI*` / `NonZeroIsize` → `non-zero integer`
 /// - `f32` / `f64` → `float`
 /// - `String` / `&str` / `char` / `OsString` / `PathBuf` / `Cow<…>` → `string`
 /// - `Vec<T>` / `HashSet<T>` / `BTreeSet<T>` / `VecDeque<T>` /
@@ -236,6 +250,10 @@ pub(crate) fn toml_type_label(ty: &Type) -> String {
                 }
                 "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => "unsigned integer".to_owned(),
                 "i8" | "i16" | "i32" | "i64" | "i128" | "isize" => "integer".to_owned(),
+                "NonZeroU8" | "NonZeroU16" | "NonZeroU32" | "NonZeroU64" | "NonZeroU128"
+                | "NonZeroUsize" => "non-zero unsigned integer".to_owned(),
+                "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64" | "NonZeroI128"
+                | "NonZeroIsize" => "non-zero integer".to_owned(),
                 "f32" | "f64" => "float".to_owned(),
                 "Vec" | "HashSet" | "BTreeSet" | "VecDeque" | "LinkedList" => {
                     match inner_types.first() {
@@ -279,6 +297,22 @@ mod tests {
         assert_eq!(toml_type_label(&parse_type("bool")), "boolean");
         assert_eq!(toml_type_label(&parse_type("usize")), "unsigned integer");
         assert_eq!(toml_type_label(&parse_type("i32")), "integer");
+        assert_eq!(
+            toml_type_label(&parse_type("NonZeroUsize")),
+            "non-zero unsigned integer",
+        );
+        assert_eq!(
+            toml_type_label(&parse_type("NonZeroU32")),
+            "non-zero unsigned integer",
+        );
+        assert_eq!(
+            toml_type_label(&parse_type("NonZeroIsize")),
+            "non-zero integer",
+        );
+        assert_eq!(
+            toml_type_label(&parse_type("NonZeroI64")),
+            "non-zero integer",
+        );
         assert_eq!(toml_type_label(&parse_type("f64")), "float");
         assert_eq!(toml_type_label(&parse_type("String")), "string");
         assert_eq!(toml_type_label(&parse_type("char")), "string");

--- a/ui-toml/lint_silence_reason/min_reason_length_one/fixture.rs
+++ b/ui-toml/lint_silence_reason/min_reason_length_one/fixture.rs
@@ -1,7 +1,8 @@
-// `min_reason_length = 0` disables the length branch entirely;
-// `reason` presence is still enforced, and an empty literal is
-// treated as if the field were missing regardless of the length
-// floor.
+// `min_reason_length = 1` is the floor's lowest legal value
+// (`0` is rejected at parse time by the `NonZeroUsize` field).
+// At this setting every non-blank reason satisfies the length
+// branch; presence is still enforced, and a blank literal is
+// still treated as if the field were missing.
 
 #![feature(register_tool)]
 #![register_tool(perfectionist)]
@@ -15,13 +16,13 @@ fn one_char_reason() {}
 #[allow(dead_code)]
 fn no_reason() {}
 
-// Bad — empty literal counts as missing even with the length
-// floor disabled.
+// Bad — empty literal counts as missing regardless of the
+// length floor.
 #[allow(dead_code, reason = "")]
 fn empty_reason() {}
 
 // Bad — whitespace-only literal also counts as missing,
-// regardless of the length-floor setting.
+// regardless of the length floor.
 #[allow(dead_code, reason = "   ")]
 fn whitespace_only_reason() {}
 

--- a/ui-toml/lint_silence_reason/min_reason_length_one/fixture.stderr
+++ b/ui-toml/lint_silence_reason/min_reason_length_one/fixture.stderr
@@ -1,5 +1,5 @@
 warning: lint-silencing attribute lacks an explanatory `reason = "..."` field
-  --> $DIR/fixture.rs:15:18
+  --> $DIR/fixture.rs:16:18
    |
 LL | #[allow(dead_code)]
    |                  ^ help: add a `reason` field: `, reason = ""`
@@ -7,7 +7,7 @@ LL | #[allow(dead_code)]
    = note: `#[warn(perfectionist::lint_silence_reason)]` on by default
 
 warning: lint-silencing attribute lacks an explanatory `reason = "..."` field
-  --> $DIR/fixture.rs:20:29
+  --> $DIR/fixture.rs:21:29
    |
 LL | #[allow(dead_code, reason = "")]
    |                             ^^
@@ -15,7 +15,7 @@ LL | #[allow(dead_code, reason = "")]
    = help: write a rationale into the blank `reason` literal
 
 warning: lint-silencing attribute lacks an explanatory `reason = "..."` field
-  --> $DIR/fixture.rs:25:29
+  --> $DIR/fixture.rs:26:29
    |
 LL | #[allow(dead_code, reason = "   ")]
    |                             ^^^^^


### PR DESCRIPTION
Address all of #103 in one pass — and apply the same pattern to one other rule where the scan turned up a structurally similar issue.

**gen-docs**: teach the renderer about the `NonZero*` primitive families so a `Config` field of one of those types renders cleanly.

- Add the twelve `NonZeroU8`…`NonZeroUsize` / `NonZeroI8`…`NonZeroIsize` idents to `BUILTIN_TYPES`, so they no longer surface as stray entries in the per-rule Types subsection.
- Map `NonZeroU*` → `non-zero unsigned integer` and `NonZeroI*` → `non-zero integer` in `toml_type_label`, surfacing the non-zero constraint to TOML authors instead of leaking the verbatim Rust identifier into the field-type column.
- Extend the `toml_type_label_primitives` test; the existing `builtin_types_all_map_to_toml_label` coverage test exercises every new entry automatically.

**`lint_silence_reason::min_reason_length`** (breaking config-shape change):

- Re-type the field as `NonZeroUsize`. `min_reason_length = 0` used to disable the length branch; since #102's empty-string-is-missing semantics made `0` and `1` indistinguishable, the type now forbids `0` at parse time instead of silently treating it as `1`.
- The `min_reason_length_zero` UI fixture is renamed to `min_reason_length_one` and reworked accordingly — its observable diagnostic output is identical at the new floor minimum.
- The companion planning file `planned-rules/lint-downgrade-reason.md` mirrors the same encoding for its parallel knob.

**`prefer_raw_string::min_escapes_to_trigger`** (breaking config-shape change):

A scan of the other rules' numeric config fields surfaced this knob as structurally similar to `min_reason_length` — `0` was schema-permitted but produced the same observable behaviour as `1`. The reason is different though: the rule's `eliminable_count == 0` early-return is a *defensive* guard that exists precisely to normalise `min = 0` back to `min = 1` behaviour. Without it, `min = 0` would flag every cooked string literal and the autofix would suggest `r"hello"` for `"hello"`, immediately tripping `clippy::needless_raw_strings`. The in-code comment already acknowledges this. Encoding the field as `NonZeroUsize` removes the footgun at the type level and lets the threshold guard subsume the defensive `== 0` half.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/103>.