### PR TITLE
test(config): cover the `extra_*`/`ignore_*` knobs on four rules

### DIFF
--- a/tests/single_letter_closure_param.rs
+++ b/tests/single_letter_closure_param.rs
@@ -18,9 +18,9 @@ const LINT_NAME: &str = "perfectionist::single_letter_closure_param";
 static SERIAL: Mutex<()> = Mutex::new(());
 
 /// The rule's user-facing configuration shape, mirrored here for
-/// serialisation. Kept as a separate type from the lint's own
-/// internal `Config` so the test surface is independent of the
-/// implementation's private struct.
+/// serialisation. Kept as a separate type from the lint's own internal
+/// `Config` so the test surface is independent of the implementation's
+/// private struct.
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/single_letter_closure_param.rs
+++ b/tests/single_letter_closure_param.rs
@@ -1,0 +1,58 @@
+//! UI tests for `single_letter_closure_param`'s configuration knobs.
+//! The default-config sweep lives in `ui/single_letter_names.rs` and
+//! is picked up by `tests/ui.rs`; this test points at a fixture
+//! directory under `ui-toml/single_letter_closure_param/` and passes
+//! a per-rule `dylint.toml` to [`dylint_testing::ui::Test`].
+//!
+//! `Test::dylint_toml` works by setting the `DYLINT_TOML` env var for
+//! the duration of `run_tests`. The env var is process-global, so the
+//! `#[test]`s in this binary serialise themselves on a shared
+//! `Mutex` to avoid clobbering each other under the default
+//! parallel test harness.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+const LINT_NAME: &str = "perfectionist::single_letter_closure_param";
+
+static SERIAL: Mutex<()> = Mutex::new(());
+
+/// The rule's user-facing configuration shape, mirrored here for
+/// serialisation. Kept as a separate type from the lint's own
+/// internal `Config` so the test surface is independent of the
+/// implementation's private struct.
+#[derive(Default, serde::Serialize)]
+struct RuleConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_trivial_callback_methods: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ignore_trivial_callback_methods: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_allowed_idents: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ignore_allowed_idents: Option<Vec<String>>,
+}
+
+fn dylint_toml(config: RuleConfig) -> String {
+    let table: BTreeMap<&str, RuleConfig> = [(LINT_NAME, config)].into_iter().collect();
+    toml::to_string(&table).expect("serialise rule config as dylint.toml")
+}
+
+fn run(src_base: &str, config: RuleConfig) {
+    let _serial = SERIAL.lock().unwrap_or_else(|err| err.into_inner());
+    dylint_testing::ui::Test::src_base(env!("CARGO_PKG_NAME"), src_base)
+        .dylint_toml(dylint_toml(config))
+        .run();
+}
+
+#[test]
+fn custom_trivial_callback_methods_extend_and_subtract_the_default_list() {
+    run(
+        "ui-toml/single_letter_closure_param/custom_trivial_callback_methods",
+        RuleConfig {
+            extra_trivial_callback_methods: Some(vec!["when".into()]),
+            ignore_trivial_callback_methods: Some(vec!["sort_by".into()]),
+            ..Default::default()
+        },
+    );
+}

--- a/tests/single_letter_function_param.rs
+++ b/tests/single_letter_function_param.rs
@@ -17,6 +17,10 @@ const LINT_NAME: &str = "perfectionist::single_letter_function_param";
 
 static SERIAL: Mutex<()> = Mutex::new(());
 
+/// The rule's user-facing configuration shape, mirrored here for
+/// serialisation. Kept as a separate type from the lint's own internal
+/// `Config` so the test surface is independent of the implementation's
+/// private struct.
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/single_letter_function_param.rs
+++ b/tests/single_letter_function_param.rs
@@ -1,0 +1,49 @@
+//! UI tests for `single_letter_function_param`'s configuration knobs.
+//! The default-config sweep lives in `ui/single_letter_names.rs` and
+//! is picked up by `tests/ui.rs`; this test points at a fixture
+//! directory under `ui-toml/single_letter_function_param/` and passes
+//! a per-rule `dylint.toml` to [`dylint_testing::ui::Test`].
+//!
+//! `Test::dylint_toml` works by setting the `DYLINT_TOML` env var for
+//! the duration of `run_tests`. The env var is process-global, so the
+//! `#[test]`s in this binary serialise themselves on a shared
+//! `Mutex` to avoid clobbering each other under the default
+//! parallel test harness.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+const LINT_NAME: &str = "perfectionist::single_letter_function_param";
+
+static SERIAL: Mutex<()> = Mutex::new(());
+
+#[derive(Default, serde::Serialize)]
+struct RuleConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_allowed_idents: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ignore_allowed_idents: Option<Vec<String>>,
+}
+
+fn dylint_toml(config: RuleConfig) -> String {
+    let table: BTreeMap<&str, RuleConfig> = [(LINT_NAME, config)].into_iter().collect();
+    toml::to_string(&table).expect("serialise rule config as dylint.toml")
+}
+
+fn run(src_base: &str, config: RuleConfig) {
+    let _serial = SERIAL.lock().unwrap_or_else(|err| err.into_inner());
+    dylint_testing::ui::Test::src_base(env!("CARGO_PKG_NAME"), src_base)
+        .dylint_toml(dylint_toml(config))
+        .run();
+}
+
+#[test]
+fn custom_allowed_idents_extend_and_subtract_the_default_list() {
+    run(
+        "ui-toml/single_letter_function_param/custom_allowed_idents",
+        RuleConfig {
+            extra_allowed_idents: Some(vec!["x".into()]),
+            ignore_allowed_idents: Some(vec!["n".into()]),
+        },
+    );
+}

--- a/tests/single_letter_let_binding.rs
+++ b/tests/single_letter_let_binding.rs
@@ -1,0 +1,49 @@
+//! UI tests for `single_letter_let_binding`'s configuration knobs.
+//! The default-config sweep lives in `ui/single_letter_names.rs` and
+//! is picked up by `tests/ui.rs`; this test points at a fixture
+//! directory under `ui-toml/single_letter_let_binding/` and passes a
+//! per-rule `dylint.toml` to [`dylint_testing::ui::Test`].
+//!
+//! `Test::dylint_toml` works by setting the `DYLINT_TOML` env var for
+//! the duration of `run_tests`. The env var is process-global, so the
+//! `#[test]`s in this binary serialise themselves on a shared
+//! `Mutex` to avoid clobbering each other under the default
+//! parallel test harness.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+const LINT_NAME: &str = "perfectionist::single_letter_let_binding";
+
+static SERIAL: Mutex<()> = Mutex::new(());
+
+#[derive(Default, serde::Serialize)]
+struct RuleConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_allowed_idents: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ignore_allowed_idents: Option<Vec<String>>,
+}
+
+fn dylint_toml(config: RuleConfig) -> String {
+    let table: BTreeMap<&str, RuleConfig> = [(LINT_NAME, config)].into_iter().collect();
+    toml::to_string(&table).expect("serialise rule config as dylint.toml")
+}
+
+fn run(src_base: &str, config: RuleConfig) {
+    let _serial = SERIAL.lock().unwrap_or_else(|err| err.into_inner());
+    dylint_testing::ui::Test::src_base(env!("CARGO_PKG_NAME"), src_base)
+        .dylint_toml(dylint_toml(config))
+        .run();
+}
+
+#[test]
+fn custom_allowed_idents_extend_and_subtract_the_default_list() {
+    run(
+        "ui-toml/single_letter_let_binding/custom_allowed_idents",
+        RuleConfig {
+            extra_allowed_idents: Some(vec!["x".into()]),
+            ignore_allowed_idents: Some(vec!["n".into()]),
+        },
+    );
+}

--- a/tests/single_letter_let_binding.rs
+++ b/tests/single_letter_let_binding.rs
@@ -17,6 +17,10 @@ const LINT_NAME: &str = "perfectionist::single_letter_let_binding";
 
 static SERIAL: Mutex<()> = Mutex::new(());
 
+/// The rule's user-facing configuration shape, mirrored here for
+/// serialisation. Kept as a separate type from the lint's own internal
+/// `Config` so the test surface is independent of the implementation's
+/// private struct.
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/unicode_ellipsis_in_panic_messages.rs
+++ b/tests/unicode_ellipsis_in_panic_messages.rs
@@ -18,6 +18,10 @@ const LINT_NAME: &str = "perfectionist::unicode_ellipsis_in_panic_messages";
 
 static SERIAL: Mutex<()> = Mutex::new(());
 
+/// The rule's user-facing configuration shape, mirrored here for
+/// serialisation. Kept as a separate type from the lint's own internal
+/// `Config` so the test surface is independent of the implementation's
+/// private struct.
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/unicode_ellipsis_in_panic_messages.rs
+++ b/tests/unicode_ellipsis_in_panic_messages.rs
@@ -1,0 +1,56 @@
+//! UI tests for `unicode_ellipsis_in_panic_messages`'s configuration
+//! knobs. The default-config sweep lives in
+//! `ui/unicode_ellipsis_in_panic_messages.rs` and is picked up by
+//! `tests/ui.rs`; this test points at a fixture directory under
+//! `ui-toml/unicode_ellipsis_in_panic_messages/` and passes a
+//! per-rule `dylint.toml` to [`dylint_testing::ui::Test`].
+//!
+//! `Test::dylint_toml` works by setting the `DYLINT_TOML` env var for
+//! the duration of `run_tests`. The env var is process-global, so the
+//! `#[test]`s in this binary serialise themselves on a shared
+//! `Mutex` to avoid clobbering each other under the default
+//! parallel test harness.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+const LINT_NAME: &str = "perfectionist::unicode_ellipsis_in_panic_messages";
+
+static SERIAL: Mutex<()> = Mutex::new(());
+
+#[derive(Default, serde::Serialize)]
+struct RuleConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_macros: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ignore_macros: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_methods: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ignore_methods: Option<Vec<String>>,
+}
+
+fn dylint_toml(config: RuleConfig) -> String {
+    let table: BTreeMap<&str, RuleConfig> = [(LINT_NAME, config)].into_iter().collect();
+    toml::to_string(&table).expect("serialise rule config as dylint.toml")
+}
+
+fn run(src_base: &str, config: RuleConfig) {
+    let _serial = SERIAL.lock().unwrap_or_else(|err| err.into_inner());
+    dylint_testing::ui::Test::src_base(env!("CARGO_PKG_NAME"), src_base)
+        .dylint_toml(dylint_toml(config))
+        .run();
+}
+
+#[test]
+fn custom_macros_and_methods_extend_and_subtract_the_default_lists() {
+    run(
+        "ui-toml/unicode_ellipsis_in_panic_messages/custom_macros_and_methods",
+        RuleConfig {
+            extra_macros: Some(vec!["my_panic".into()]),
+            ignore_macros: Some(vec!["panic".into()]),
+            extra_methods: Some(vec!["expect_with".into()]),
+            ignore_methods: Some(vec!["expect".into()]),
+        },
+    );
+}

--- a/ui-toml/single_letter_closure_param/custom_trivial_callback_methods/fixture.rs
+++ b/ui-toml/single_letter_closure_param/custom_trivial_callback_methods/fixture.rs
@@ -1,0 +1,29 @@
+#![feature(register_tool)]
+#![register_tool(perfectionist)]
+#![allow(unknown_lints, reason = "ui fixture")]
+#![allow(dead_code, reason = "ui fixture")]
+#![warn(perfectionist::single_letter_closure_param)]
+
+// `extra_trivial_callback_methods = ["when"]` adds to the built-in
+// list and `ignore_trivial_callback_methods = ["sort_by"]` drops the
+// default back out. The closure bodies below are single expressions
+// that are NOT trivial wrappers (`a.0.cmp(&b.0)` accesses a field
+// rather than the parameter itself), so the trivial-callback method
+// allowlist is the only thing keeping them quiet.
+
+struct Builder;
+impl Builder {
+    fn when<Cmp: FnMut(&(u32, u32), &(u32, u32)) -> std::cmp::Ordering>(&self, _: Cmp) {}
+}
+
+fn main() {
+    let mut pairs: Vec<(u32, u32)> = vec![(3, 0), (1, 0), (2, 0)];
+
+    // `sort_by` dropped from the trivial-callback allowlist via
+    // `ignore_trivial_callback_methods`: `a` and `b` now fire.
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // `when` added to the trivial-callback allowlist via
+    // `extra_trivial_callback_methods`: `a` and `b` stay quiet.
+    Builder.when(|a, b| a.0.cmp(&b.0));
+}

--- a/ui-toml/single_letter_closure_param/custom_trivial_callback_methods/fixture.stderr
+++ b/ui-toml/single_letter_closure_param/custom_trivial_callback_methods/fixture.stderr
@@ -1,0 +1,23 @@
+warning: closure parameter `a` has a single-letter name
+  --> $DIR/fixture.rs:24:20
+   |
+LL |     pairs.sort_by(|a, b| a.0.cmp(&b.0));
+   |                    ^
+   |
+   = help: rename to a descriptive identifier, or rewrite the closure as a trivial single-expression callback
+note: the lint level is defined here
+  --> $DIR/fixture.rs:5:9
+   |
+LL | #![warn(perfectionist::single_letter_closure_param)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: closure parameter `b` has a single-letter name
+  --> $DIR/fixture.rs:24:23
+   |
+LL |     pairs.sort_by(|a, b| a.0.cmp(&b.0));
+   |                       ^
+   |
+   = help: rename to a descriptive identifier, or rewrite the closure as a trivial single-expression callback
+
+warning: 2 warnings emitted
+

--- a/ui-toml/single_letter_function_param/custom_allowed_idents/fixture.rs
+++ b/ui-toml/single_letter_function_param/custom_allowed_idents/fixture.rs
@@ -1,0 +1,22 @@
+#![feature(register_tool)]
+#![register_tool(perfectionist)]
+#![allow(unknown_lints, reason = "ui fixture")]
+#![allow(dead_code, reason = "ui fixture")]
+#![warn(perfectionist::single_letter_function_param)]
+
+// `extra_allowed_idents = ["x"]` adds to the built-in
+// `["n", "f", "i", "j", "k"]` list, and `ignore_allowed_idents = ["n"]`
+// drops the default back out. After the merge `n` is no longer
+// allowed and `x` is.
+
+// `n` is dropped from the allowlist by `ignore_allowed_idents`: fires.
+fn count(n: usize) -> usize {
+    n + 1
+}
+
+// `x` is added to the allowlist by `extra_allowed_idents`: quiet.
+fn squared(x: i32) -> i32 {
+    x * x
+}
+
+fn main() {}

--- a/ui-toml/single_letter_function_param/custom_allowed_idents/fixture.stderr
+++ b/ui-toml/single_letter_function_param/custom_allowed_idents/fixture.stderr
@@ -1,0 +1,15 @@
+warning: function parameter `n` has a single-letter name
+  --> $DIR/fixture.rs:13:10
+   |
+LL | fn count(n: usize) -> usize {
+   |          ^
+   |
+   = help: rename to a descriptive identifier
+note: the lint level is defined here
+  --> $DIR/fixture.rs:5:9
+   |
+LL | #![warn(perfectionist::single_letter_function_param)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+

--- a/ui-toml/single_letter_let_binding/custom_allowed_idents/fixture.rs
+++ b/ui-toml/single_letter_let_binding/custom_allowed_idents/fixture.rs
@@ -1,0 +1,20 @@
+#![feature(register_tool)]
+#![register_tool(perfectionist)]
+#![allow(unknown_lints, reason = "ui fixture")]
+#![allow(dead_code, unused_variables, reason = "ui fixture")]
+#![warn(perfectionist::single_letter_let_binding)]
+
+// `extra_allowed_idents = ["x"]` adds to the built-in `["n"]` list,
+// and `ignore_allowed_idents = ["n"]` drops the default back out.
+// After the merge `n` is no longer allowed and `x` is.
+
+fn run() {
+    // `n` is dropped from the allowlist by `ignore_allowed_idents`: fires.
+    let n = 5_u32;
+    // `x` is added to the allowlist by `extra_allowed_idents`: quiet.
+    let x = 10_u32;
+}
+
+fn main() {
+    run();
+}

--- a/ui-toml/single_letter_let_binding/custom_allowed_idents/fixture.stderr
+++ b/ui-toml/single_letter_let_binding/custom_allowed_idents/fixture.stderr
@@ -1,0 +1,15 @@
+warning: `let` binding `n` has a single-letter name
+  --> $DIR/fixture.rs:13:9
+   |
+LL |     let n = 5_u32;
+   |         ^
+   |
+   = help: rename to a descriptive identifier
+note: the lint level is defined here
+  --> $DIR/fixture.rs:5:9
+   |
+LL | #![warn(perfectionist::single_letter_let_binding)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+

--- a/ui-toml/unicode_ellipsis_in_panic_messages/custom_macros_and_methods/fixture.rs
+++ b/ui-toml/unicode_ellipsis_in_panic_messages/custom_macros_and_methods/fixture.rs
@@ -1,0 +1,43 @@
+#![feature(register_tool)]
+#![register_tool(perfectionist)]
+#![allow(unknown_lints, reason = "ui fixture")]
+#![allow(dead_code, reason = "ui fixture")]
+#![warn(perfectionist::unicode_ellipsis_in_panic_messages)]
+
+// Both knob-pairs exercised in one fixture:
+// - `extra_macros = ["my_panic"]` + `ignore_macros = ["panic"]`
+// - `extra_methods = ["expect_with"]` + `ignore_methods = ["expect"]`
+// After the merge `panic` / `expect` are out and `my_panic` /
+// `expect_with` are in.
+
+macro_rules! my_panic {
+    ($msg:literal) => {
+        panic!($msg)
+    };
+}
+
+trait OptionExt<Inner> {
+    fn expect_with(self, message: &str) -> Inner;
+}
+
+impl<Inner> OptionExt<Inner> for Option<Inner> {
+    fn expect_with(self, message: &str) -> Inner {
+        self.expect(message)
+    }
+}
+
+fn _macros() {
+    // `panic` dropped via `ignore_macros`: stays quiet.
+    panic!("legacy panic …");
+    // `my_panic` added via `extra_macros`: fires.
+    my_panic!("project-specific panic …");
+}
+
+fn _methods() {
+    // `expect` dropped via `ignore_methods`: stays quiet.
+    let _: i32 = Some(1).expect("legacy expect …");
+    // `expect_with` added via `extra_methods`: fires.
+    let _: i32 = Some(1).expect_with("project-specific expect …");
+}
+
+fn main() {}

--- a/ui-toml/unicode_ellipsis_in_panic_messages/custom_macros_and_methods/fixture.stderr
+++ b/ui-toml/unicode_ellipsis_in_panic_messages/custom_macros_and_methods/fixture.stderr
@@ -1,0 +1,20 @@
+warning: Unicode `…` (U+2026) in `my_panic!` message
+  --> $DIR/fixture.rs:33:39
+   |
+LL |     my_panic!("project-specific panic …");
+   |                                       ^ help: use ASCII `...` instead: `...`
+   |
+note: the lint level is defined here
+  --> $DIR/fixture.rs:5:9
+   |
+LL | #![warn(perfectionist::unicode_ellipsis_in_panic_messages)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: Unicode `…` (U+2026) in `expect_with` message
+  --> $DIR/fixture.rs:40:63
+   |
+LL |     let _: i32 = Some(1).expect_with("project-specific expect …");
+   |                                                               ^ help: use ASCII `...` instead: `...`
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
`non_exhaustive_error` was the only rule whose `extra_*`/`ignore_*` pair was exercised by a `ui-toml/` fixture. The other four rules introduced by #55 — `single_letter_closure_param`, `single_letter_function_param`, `single_letter_let_binding`, `unicode_ellipsis_in_panic_messages` — had no coverage for their renamed knobs, so a merge-order regression would have landed silently.

Each new fixture clones the `non_exhaustive_error/custom_suffixes/` shape: an `extra_*` entry adds a new firing target, and an `ignore_*` entry drops a built-in default back out — proving the merge-then-subtract ordering.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/60>.