### PR TITLE
docs(plan): more `single_letter_*` rules

### DIFF
--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -72,9 +72,9 @@ pattern that several rules call out by reference — live in
   flag const generic parameter declarations
   (`<const N: usize>`) whose name is one ASCII letter. Mirrors
   `perfectionist::single_letter_generic` (`src/rules/single_letter_generic.rs`)
-  for the const-parameter side and shares its short-trait-impl
-  exemption. Single `allowed_idents` knob, empty default; projects
-  that want to keep `N` / `M` add them explicitly.
+  for the const-parameter side. Single `allowed_idents` knob and a
+  `short_impl_max_lines` opt-in for the short-trait-impl
+  exemption; both empty/zero by default.
 
 ### Trait bounds and signatures
 - [`where-clause-bounds.md`](./where-clause-bounds.md) — prefer `where` clauses

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -72,9 +72,8 @@ pattern that several rules call out by reference — live in
   flag const generic parameter declarations
   (`<const N: usize>`) whose name is one ASCII letter. Mirrors
   `perfectionist::single_letter_generic` (`src/rules/single_letter_generic.rs`)
-  for the const-parameter side. Single `allowed_idents` knob and a
-  `short_impl_max_lines` opt-in for the short-trait-impl
-  exemption; both empty/zero by default.
+  for the const-parameter side. Single `allowed_idents` knob,
+  empty default.
 
 ### Trait bounds and signatures
 - [`where-clause-bounds.md`](./where-clause-bounds.md) — prefer `where` clauses

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -63,6 +63,19 @@ pattern that several rules call out by reference — live in
   via `use` and called by the simple identifier. AI tends to produce
   the former; parallel-disk-usage prefers the latter. Configurable
   per project.
+- [`single-letter-const-item.md`](./single-letter-const-item.md) — flag
+  `const N: usize = 2;`-style `const` items (free, associated, and
+  block-level) whose name is one ASCII letter. Sibling of the four
+  existing `single_letter_*` rules; uses the same allow/ignore-list
+  configuration shape as `single_letter_let_binding`, with an empty
+  default allowlist and a `#[cfg(test)]` exemption.
+- [`single-letter-const-generic.md`](./single-letter-const-generic.md) —
+  flag const generic parameter declarations
+  (`<const N: usize>`) whose name is one ASCII letter. Mirrors
+  `perfectionist::single_letter_generic` (`src/rules/single_letter_generic.rs`)
+  for the const-parameter side, shares its short-trait-impl
+  exemption, and adds a default `["N", "M"]` allowlist covering the
+  universally-idiomatic array-length names.
 
 ### Trait bounds and signatures
 - [`where-clause-bounds.md`](./where-clause-bounds.md) — prefer `where` clauses

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -68,6 +68,11 @@ pattern that several rules call out by reference — live in
   block-level) whose name is one ASCII letter. Sibling of the four
   existing `single_letter_*` rules. Single `allowed_idents` knob,
   empty default.
+- [`single-letter-static-item.md`](./single-letter-static-item.md) — flag
+  `static N: AtomicUsize = ...;`-style `static` items (free and
+  block-level) whose name is one ASCII letter. Sibling of
+  `single-letter-const-item`. Single `allowed_idents` knob, empty
+  default.
 - [`single-letter-const-generic.md`](./single-letter-const-generic.md) —
   flag const generic parameter declarations
   (`<const N: usize>`) whose name is one ASCII letter. Mirrors

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -67,8 +67,8 @@ pattern that several rules call out by reference — live in
   `const N: usize = 2;`-style `const` items (free, associated, and
   block-level) whose name is one ASCII letter. Sibling of the four
   existing `single_letter_*` rules. Single `allowed_idents` knob,
-  empty default; no test-code exemption (unlike
-  `single_letter_let_binding`).
+  empty default; fires in test code as well as production, in line
+  with the rest of the family.
 - [`single-letter-const-generic.md`](./single-letter-const-generic.md) —
   flag const generic parameter declarations
   (`<const N: usize>`) whose name is one ASCII letter. Mirrors

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -66,17 +66,16 @@ pattern that several rules call out by reference — live in
 - [`single-letter-const-item.md`](./single-letter-const-item.md) — flag
   `const N: usize = 2;`-style `const` items (free, associated, and
   block-level) whose name is one ASCII letter. Sibling of the four
-  existing `single_letter_*` rules; uses the same
-  `extra_allowed_idents` / `ignore_allowed_idents` knobs as
-  `single_letter_let_binding`, with an empty default exempt set and
-  a `#[cfg(test)]` exemption.
+  existing `single_letter_*` rules. Single `allowed_idents` knob,
+  empty default; no test-code exemption (unlike
+  `single_letter_let_binding`).
 - [`single-letter-const-generic.md`](./single-letter-const-generic.md) —
   flag const generic parameter declarations
   (`<const N: usize>`) whose name is one ASCII letter. Mirrors
   `perfectionist::single_letter_generic` (`src/rules/single_letter_generic.rs`)
   for the const-parameter side and shares its short-trait-impl
-  exemption. Empty default exempt set; projects that want to keep
-  `N` / `M` add them via `extra_allowed_idents`.
+  exemption. Single `allowed_idents` knob, empty default; projects
+  that want to keep `N` / `M` add them explicitly.
 
 ### Trait bounds and signatures
 - [`where-clause-bounds.md`](./where-clause-bounds.md) — prefer `where` clauses

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -67,8 +67,7 @@ pattern that several rules call out by reference — live in
   `const N: usize = 2;`-style `const` items (free, associated, and
   block-level) whose name is one ASCII letter. Sibling of the four
   existing `single_letter_*` rules. Single `allowed_idents` knob,
-  empty default; fires in test code as well as production, in line
-  with the rest of the family.
+  empty default.
 - [`single-letter-const-generic.md`](./single-letter-const-generic.md) —
   flag const generic parameter declarations
   (`<const N: usize>`) whose name is one ASCII letter. Mirrors

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -66,16 +66,17 @@ pattern that several rules call out by reference — live in
 - [`single-letter-const-item.md`](./single-letter-const-item.md) — flag
   `const N: usize = 2;`-style `const` items (free, associated, and
   block-level) whose name is one ASCII letter. Sibling of the four
-  existing `single_letter_*` rules; uses the same allow/ignore-list
-  configuration shape as `single_letter_let_binding`, with an empty
-  default allowlist and a `#[cfg(test)]` exemption.
+  existing `single_letter_*` rules; uses the same
+  `extra_allowed_idents` / `ignore_allowed_idents` knobs as
+  `single_letter_let_binding`, with an empty default exempt set and
+  a `#[cfg(test)]` exemption.
 - [`single-letter-const-generic.md`](./single-letter-const-generic.md) —
   flag const generic parameter declarations
   (`<const N: usize>`) whose name is one ASCII letter. Mirrors
   `perfectionist::single_letter_generic` (`src/rules/single_letter_generic.rs`)
-  for the const-parameter side, shares its short-trait-impl
-  exemption, and adds a default `["N", "M"]` allowlist covering the
-  universally-idiomatic array-length names.
+  for the const-parameter side and shares its short-trait-impl
+  exemption. Empty default exempt set; projects that want to keep
+  `N` / `M` add them via `extra_allowed_idents`.
 
 ### Trait bounds and signatures
 - [`where-clause-bounds.md`](./where-clause-bounds.md) — prefer `where` clauses

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -95,7 +95,8 @@ declaration. Diagnostic-only matches
 
 ## Implementation notes
 
-- `allowed_idents` parses straight into a `BTreeSet<Symbol>`.
+- `allowed_idents` deserialises as `Vec<String>` and is interned
+  into a `BTreeSet<Symbol>`.
 
 ### Difficulty
 

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -43,9 +43,7 @@ filter by enclosing item kind.
 
 - **Type generic parameters** (`<T>`, `<K, V>`). Covered by the
   existing `perfectionist::single_letter_generic` lint at
-  `src/rules/single_letter_generic.rs`. The two rules are
-  disjoint at the trigger level and share only the short-trait-
-  impl exemption helper.
+  `src/rules/single_letter_generic.rs`. Disjoint trigger.
 - **Lifetime parameters** (`<'a>`, `<'de>`). Single-letter
   lifetime names are the universal Rust idiom; a lint that
   flagged them would fire on essentially every lifetime in the
@@ -57,17 +55,8 @@ filter by enclosing item kind.
 
 ```toml
 [single_letter_const_generic]
-short_impl_max_lines = 0     # default rejects every impl
-allowed_idents       = []    # default empty
+allowed_idents = []   # default empty
 ```
-
-### `short_impl_max_lines`: `unsigned integer` (optional)
-
-Maximum number of source lines a trait `impl` block may span and
-still permit single-letter const generic parameter names. Defaults
-to `0`, which rejects every impl from the exemption (no impl spans
-zero or fewer lines). A project that wants the short-trait-impl
-carve-out raises the threshold.
 
 ### `allowed_idents`: `[string]` (optional)
 
@@ -94,10 +83,7 @@ For each visited generic parameter:
    helper in `src/common.rs`).
 6. Skip if the identifier is in the configured `allowed_idents`
    set.
-7. Skip if the enclosing item is a trait `impl` block whose span
-   covers `≤ short_impl_max_lines` lines (shared with
-   `single_letter_generic`).
-8. Emit `span_lint_and_help` on the parameter's span with the
+7. Emit `span_lint_and_help` on the parameter's span with the
    message ``"const generic parameter `{ident}` has a single-letter name"``
    and the help
    ``"rename to a descriptive identifier (e.g. `LEN`, `COLS`, `LANES`)"``.
@@ -111,44 +97,30 @@ declaration. Diagnostic-only matches
 
 ## Implementation notes
 
-- `LateLintPass` is required: the short-trait-impl exemption
-  walks `tcx.hir_parent_iter(...)` and queries
-  `sess().source_map()` for the line span (see
-  `src/rules/single_letter_generic.rs`), neither of which is
-  available in early context. Use the `check_generic_param` hook.
-- Share the short-trait-impl helper with `single_letter_generic`
-  rather than re-implementing it. On the first PR to add this
-  rule, lift `enclosing_short_trait_impl` and `span_line_count`
-  out of `src/rules/single_letter_generic.rs` into a crate-
-  internal module — `src/common.rs` if they remain trivial, or a
-  dedicated `src/short_impl.rs` if either grows its own
-  invariants. The existing rule's call site updates to import the
-  helper from the new home.
-- `allowed_idents` parses straight into a `BTreeSet<Symbol>`. No
-  `extra_*` / `ignore_*` split — without built-in defaults there
-  is nothing to subtract from, so the single-field shape is
-  enough.
+- Use `LateLintPass` for consistency with `single_letter_generic`
+  and the rest of the `single_letter_*` family. The rule doesn't
+  need `TyCtxt` or resolver queries, so `EarlyLintPass` would
+  also work. Use the `check_generic_param` hook.
+- `allowed_idents` parses straight into a `BTreeSet<Symbol>`.
 
 ### Difficulty
 
-**Easy.** The trigger is a seven-step predicate over a single
-`GenericParam` visitor hook. The only non-trivial part is the
-short-trait-impl helper hoist, which is mechanical.
+**Easy.** The trigger is a six-step predicate over a single
+`GenericParam` visitor hook.
 
 ## Default state
 
-Active by default. Empty `allowed_idents`;
-`short_impl_max_lines = 0`.
+Active by default. Empty `allowed_idents`.
 
 ## Interaction with sibling rules
 
 - `perfectionist::single_letter_generic`
   (`src/rules/single_letter_generic.rs`) — the type-parameter
   counterpart. Disjoint trigger (`GenericParamKind::Type` vs.
-  `::Const`), shared short-trait-impl helper. A single
-  declaration with both type and const parameters can produce one
-  diagnostic per offending parameter, one from each rule — that
-  is the intended behaviour, not an interaction bug.
+  `::Const`). A single declaration with both type and const
+  parameters can produce one diagnostic per offending parameter,
+  one from each rule — that is the intended behaviour, not an
+  interaction bug.
 - [`single-letter-const-item`](./single-letter-const-item.md) —
   the const-item counterpart. Disjoint trigger
   (`ItemKind::Const` vs. `GenericParamKind::Const`); the two

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -77,7 +77,7 @@ filter by enclosing item kind.
 ```toml
 [single_letter_const_generic]
 short_impl_max_lines  = 20            # mirrors `single_letter_generic`
-extra_allowed_idents  = []            # default empty; merged with built-ins
+extra_allowed_idents  = []            # default empty
 ignore_allowed_idents = []            # default empty
 ```
 
@@ -164,9 +164,10 @@ declaration. Diagnostic-only matches
 **Easy.** The trigger is a three-line predicate over a single
 `GenericParam` visitor hook. The configuration replays
 `single_letter_generic`'s `short_impl_max_lines` plus
-`single_letter_let_binding`'s allow/ignore-list pair; both
-shapes already exist in the codebase. The only non-trivial part
-is the helper hoist, which is mechanical.
+`single_letter_let_binding`'s `extra_allowed_idents` /
+`ignore_allowed_idents` knobs; both shapes already exist in the
+codebase. The only non-trivial part is the helper hoist, which is
+mechanical.
 
 ## Default state
 
@@ -190,5 +191,5 @@ keep `N` / `M` as const generic names opt in via
   same node.
 - `perfectionist::single_letter_let_binding`
   (`src/rules/single_letter_let_binding.rs`) — cited here for
-  configuration shape only; the allow/ignore-list pair is the
-  same.
+  configuration shape only; the `extra_allowed_idents` /
+  `ignore_allowed_idents` knobs work the same way.

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -87,15 +87,8 @@ ignore_allowed_idents = []            # default empty
 Maximum number of source lines an `impl Trait for Type` block
 may span and still permit single-letter const generic parameter
 names. Defaults to `20`. The semantics are identical to the
-existing `single_letter_generic` knob; the helper that implements
-the check should be lifted into `src/common.rs` (or a dedicated
-internal module) so both rules call into one definition rather
-than maintaining parallel copies. CLAUDE.md's "factor it into
-`src/common.rs`" guidance applies here directly: the
-`enclosing_short_trait_impl` method on
-`SingleLetterGeneric` and a `span_line_count` helper currently
-live in `src/rules/single_letter_generic.rs`; the first PR to
-need them in a second rule should hoist them.
+existing `single_letter_generic` knob — same exemption, applied to
+const generic parameters instead of type parameters.
 
 ### `extra_allowed_idents`: `[string]` (optional)
 

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -1,0 +1,222 @@
+# `single_letter_const_generic`
+
+**Source:** sibling of `perfectionist::single_letter_generic`
+(`src/rules/single_letter_generic.rs`), extended to cover const
+generic parameters, which the existing rule deliberately scopes
+out by early-returning on every `GenericParamKind` other than
+`Type`.
+
+## Statement
+
+> A const generic parameter declared with a one-ASCII-letter name
+> propagates through the type signature the same way a
+> single-letter type parameter does.
+
+```rust
+// Bad
+struct Data<Left, Right, const M: usize, const N: usize> {
+    left:  [Left;  N],
+    right: [Right; N],
+}
+
+// Good
+struct Data<Left, Right, const LEFT_LEN: usize, const RIGHT_LEN: usize> {
+    left:  [Left;  LEFT_LEN],
+    right: [Right; RIGHT_LEN],
+}
+```
+
+This is the const-parameter counterpart of
+`perfectionist::single_letter_generic`. The same arguments apply:
+a single-letter parameter forces every reader downstream of the
+declaration to scroll back to recover its role, and in a long
+`impl` block the cost is large; in a short one it is small enough
+that the canonical `impl<const N: usize> Foo for [T; N]` shape
+remains readable. The rule reuses the existing
+`single_letter_generic` exemption mechanism — short trait `impl`
+blocks — and adds an idiomatic-name allowlist that const generics
+need but type generics do not.
+
+## Why restrict this?
+
+This is a stylistic preference, not a correctness issue. The same
+"readers must keep the parameter's role in head while reading the
+type signature" argument that motivates
+`single_letter_generic` applies here. The difference is that
+const generics carry more weight of *idiom*: `N` and `M` for
+array dimensions, matrix sizes, and slice lengths are
+overwhelmingly the names rustc's own examples and the wider Rust
+ecosystem use. The rule's default allowlist therefore admits the
+small set of names that have crystallised as universally
+understood, and the project can extend or restrict the set per
+crate. Beyond that small set, the same readability argument
+applies.
+
+## What it covers
+
+`hir::GenericParamKind::Const { .. }` — the const-generic
+declaration syntax `<const NAME: T>` in any context that accepts
+generics: items (`struct`, `enum`, `union`, `trait`, `type
+alias`, `impl`), associated items, free functions, and methods.
+
+## What it does *not* cover
+
+- **Type generic parameters** (`<T>`, `<K, V>`). Covered by the
+  existing `perfectionist::single_letter_generic` lint at
+  `src/rules/single_letter_generic.rs`. The two rules are
+  disjoint at the trigger level and share only the short-trait-
+  impl exemption helper.
+- **Lifetime parameters** (`<'a>`, `<'de>`). Single-letter
+  lifetime names are the universal Rust idiom; a lint that
+  flagged them would fire on essentially every lifetime in the
+  ecosystem. Out of scope here and not planned.
+- **`const NAME: T = ...;` items.** Covered by
+  [`single-letter-const-item`](./single-letter-const-item.md).
+- **Synthetic / compiler-introduced const generics.** If a future
+  rustc version desugars something to a synthetic const generic
+  (analogous to `impl Trait`'s synthetic type parameter), the
+  rule must skip it — there is no user-written identifier to flag.
+
+## Configuration
+
+Configure via `dylint.toml` under
+`["perfectionist::single_letter_const_generic"]`. Every field is
+optional.
+
+```toml
+[perfectionist::single_letter_const_generic]
+short_impl_max_lines  = 20            # mirrors `single_letter_generic`
+extra_allowed_idents  = []            # default empty; merged with built-ins
+ignore_allowed_idents = []            # default empty
+```
+
+### `short_impl_max_lines`: `unsigned integer` (optional)
+
+Maximum number of source lines an `impl Trait for Type` block
+may span and still permit single-letter const generic parameter
+names. Defaults to `20`. The semantics are identical to the
+existing `single_letter_generic` knob; the helper that implements
+the check should be lifted into `src/common.rs` (or a dedicated
+internal module) so both rules call into one definition rather
+than maintaining parallel copies. CLAUDE.md's "factor it into
+`src/common.rs`" guidance applies here directly: the
+`enclosing_short_trait_impl` method on
+`SingleLetterGeneric` and a `span_line_count` helper currently
+live in `src/rules/single_letter_generic.rs`; the first PR to
+need them in a second rule should hoist them.
+
+### `extra_allowed_idents`: `[string]` (optional)
+
+Additional identifiers allowed as const generic parameter names,
+merged with the built-in defaults.
+
+The built-in default set is `["N", "M"]`. Both are the
+overwhelmingly conventional names for "the length of an array" /
+"the dimension of a matrix" in Rust's const-generic ecosystem;
+flagging them by default would produce noise that obscures the
+cases the rule is actually meant to catch (project-specific
+single letters with no shared meaning). This mirrors the
+`single_letter_let_binding` rule's built-in `["n"]` — both
+defaults encode well-attested single-letter conventions for the
+position the rule targets.
+
+A project that wants the strict form bans the defaults via
+`ignore_allowed_idents`:
+
+```toml
+[perfectionist::single_letter_const_generic]
+ignore_allowed_idents = ["N", "M"]
+```
+
+### `ignore_allowed_idents`: `[string]` (optional)
+
+Identifiers to drop from the exempt set, even if they appear in
+`extra_allowed_idents` or in the built-in defaults. Empty by
+default; checked after the merge, so this knob always wins. Same
+shape as `single_letter_let_binding` and
+`single_letter_const_item`.
+
+## What to lint
+
+For each visited generic parameter:
+
+1. Match `param.kind` against `hir::GenericParamKind::Const`;
+   reject every other kind (this rule does *not* fire on
+   `Type` or `Lifetime` — those are covered by
+   `single_letter_generic` and out-of-scope respectively).
+2. Skip synthetic parameters.
+3. Skip parameters inside external macros
+   (`hir_in_external_macro`).
+4. Extract the parameter's identifier `Symbol`.
+5. Require `is_single_ascii_letter(symbol.as_str())` (shared
+   helper in `src/common.rs`).
+6. Skip if the identifier is in the resolved `allowed_idents`
+   set.
+7. Skip if the enclosing item is a trait `impl` block whose span
+   covers `≤ short_impl_max_lines` lines (shared with
+   `single_letter_generic`).
+8. Emit `span_lint_and_help` on the parameter's span with the
+   message
+   `"const generic parameter `{ident}` has a single-letter name"`
+   and the help
+   `"rename to a descriptive identifier (e.g. `LEN`, `COLS`,
+   `LANES`)"`.
+
+No autofix. Renaming a const generic parameter rewrites every
+reference in the parameter's type, where clause, body, and every
+generic argument supplied at every call site — the edit is
+project-wide and not safely `MachineApplicable` from a single
+declaration. Diagnostic-only matches
+`single_letter_generic`'s behaviour for the same reason.
+
+## Implementation notes
+
+- `LateLintPass`. Mirrors `single_letter_generic`'s pass shape;
+  use `check_generic_param`.
+- Share the short-trait-impl helper with `single_letter_generic`
+  rather than re-implementing it. On the first PR to add this
+  rule, lift `enclosing_short_trait_impl` and `span_line_count`
+  out of `src/rules/single_letter_generic.rs` into a crate-
+  internal module — `src/common.rs` if they remain trivial, or a
+  dedicated `src/short_impl.rs` if either grows its own
+  invariants. The existing rule's call site updates to import the
+  helper from the new home.
+- The `Symbol`-set configuration parsing reuses
+  `resolve_symbol_set` (see `single_letter_let_binding`); if it
+  isn't already in `src/common.rs`, lift it there at the same
+  time as the short-impl helper.
+
+### Difficulty
+
+**Easy.** The trigger is a three-line predicate over a single
+`GenericParam` visitor hook. The configuration replays
+`single_letter_generic`'s `short_impl_max_lines` plus
+`single_letter_let_binding`'s allow/ignore-list pair; both
+shapes already exist in the codebase. The only non-trivial part
+is the helper hoist, which is mechanical.
+
+## Default state
+
+Active by default. The built-in `["N", "M"]` allowlist neutralises
+the cases that would otherwise dominate the diagnostic noise; the
+remaining single letters are exactly the ones the rule is meant to
+flag.
+
+## Interaction with sibling rules
+
+- `perfectionist::single_letter_generic`
+  (`src/rules/single_letter_generic.rs`) — the type-parameter
+  counterpart. Disjoint trigger (`GenericParamKind::Type` vs.
+  `::Const`), shared short-trait-impl helper. A single
+  declaration with both type and const parameters can produce one
+  diagnostic per offending parameter, one from each rule — that
+  is the intended behaviour, not an interaction bug.
+- [`single-letter-const-item`](./single-letter-const-item.md) —
+  the const-item counterpart. Disjoint trigger
+  (`ItemKind::Const` vs. `GenericParamKind::Const`); the two
+  rules can fire on adjacent lines of source but never on the
+  same node.
+- `perfectionist::single_letter_let_binding`
+  (`src/rules/single_letter_let_binding.rs`) — cited here for
+  configuration shape only; the allow/ignore-list pair is the
+  same.

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -156,8 +156,11 @@ declaration. Diagnostic-only matches
 
 ## Implementation notes
 
-- `LateLintPass`. Mirrors `single_letter_generic`'s pass shape;
-  use `check_generic_param`.
+- `LateLintPass` is required: the short-trait-impl exemption
+  walks `tcx.hir_parent_iter(...)` and queries
+  `sess().source_map()` for the line span (see
+  `src/rules/single_letter_generic.rs`), neither of which is
+  available in early context. Use the `check_generic_param` hook.
 - Share the short-trait-impl helper with `single_letter_generic`
   rather than re-implementing it. On the first PR to add this
   rule, lift `enclosing_short_trait_impl` and `span_line_count`

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -70,15 +70,14 @@ For each visited generic parameter:
 
 1. Match `param.kind` against `hir::GenericParamKind::Const`;
    reject every other kind.
-2. Skip synthetic parameters.
-3. Skip parameters inside external macros
+2. Skip parameters inside external macros
    (`hir_in_external_macro`).
-4. Extract the parameter's identifier `Symbol`.
-5. Require `is_single_ascii_letter(symbol.as_str())` (shared
+3. Extract the parameter's identifier `Symbol`.
+4. Require `is_single_ascii_letter(symbol.as_str())` (shared
    helper in `src/common.rs`).
-6. Skip if the identifier is in the configured `allowed_idents`
+5. Skip if the identifier is in the configured `allowed_idents`
    set.
-7. Emit `span_lint_and_help` on the parameter's span with the
+6. Emit `span_lint_and_help` on the parameter's span with the
    message ``"const generic parameter `{ident}` has a single-letter name"``
    and the help
    ``"rename to a descriptive identifier (e.g. `LEN`, `COLS`, `LANES`)"``.
@@ -96,7 +95,7 @@ declaration.
 
 ### Difficulty
 
-**Easy.** The trigger is a six-step predicate over a single
+**Easy.** The trigger is a five-step predicate over a single
 `GenericParam` visitor hook.
 
 ## Default state

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -72,23 +72,19 @@ alias`, `impl`), associated items, free functions, and methods.
   ecosystem. Out of scope here and not planned.
 - **`const NAME: T = ...;` items.** Covered by
   [`single-letter-const-item`](./single-letter-const-item.md).
-- **Synthetic / compiler-introduced const generics.** If a future
-  rustc version desugars something to a synthetic const generic
-  (analogous to `impl Trait`'s synthetic type parameter), the
-  rule must skip it — there is no user-written identifier to flag.
 
 ## Configuration
 
-Configure via `dylint.toml` under
-`["perfectionist::single_letter_const_generic"]`. Every field is
-optional.
-
 ```toml
-[perfectionist::single_letter_const_generic]
+[single_letter_const_generic]
 short_impl_max_lines  = 20            # mirrors `single_letter_generic`
 extra_allowed_idents  = []            # default empty; merged with built-ins
 ignore_allowed_idents = []            # default empty
 ```
+
+(Per [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+the actual `dylint.toml` table is `[perfectionist::single_letter_const_generic]`;
+planning files use the unqualified form for readability.)
 
 ### `short_impl_max_lines`: `unsigned integer` (optional)
 
@@ -124,7 +120,7 @@ A project that wants the strict form bans the defaults via
 `ignore_allowed_idents`:
 
 ```toml
-[perfectionist::single_letter_const_generic]
+[single_letter_const_generic]
 ignore_allowed_idents = ["N", "M"]
 ```
 

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -82,10 +82,6 @@ extra_allowed_idents  = []            # default empty; merged with built-ins
 ignore_allowed_idents = []            # default empty
 ```
 
-(Per [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
-the actual `dylint.toml` table is `[perfectionist::single_letter_const_generic]`;
-planning files use the unqualified form for readability.)
-
 ### `short_impl_max_lines`: `unsigned integer` (optional)
 
 Maximum number of source lines an `impl Trait for Type` block

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -44,10 +44,8 @@ filter by enclosing item kind.
 - **Type generic parameters** (`<T>`, `<K, V>`). Covered by the
   existing `perfectionist::single_letter_generic` lint at
   `src/rules/single_letter_generic.rs`. Disjoint trigger.
-- **Lifetime parameters** (`<'a>`, `<'de>`). Single-letter
-  lifetime names are the universal Rust idiom; a lint that
-  flagged them would fire on essentially every lifetime in the
-  ecosystem. Out of scope here and not planned.
+- **Lifetime parameters** (`<'a>`, `<'de>`). Not
+  `GenericParamKind::Const`.
 - **`const NAME: T = ...;` items.** Covered by
   [`single-letter-const-item`](./single-letter-const-item.md).
 
@@ -97,10 +95,7 @@ declaration. Diagnostic-only matches
 
 ## Implementation notes
 
-- Use `LateLintPass` for consistency with `single_letter_generic`
-  and the rest of the `single_letter_*` family. The rule doesn't
-  need `TyCtxt` or resolver queries, so `EarlyLintPass` would
-  also work. Use the `check_generic_param` hook.
+- Use `LateLintPass` with the `check_generic_param` hook.
 - `allowed_idents` parses straight into a `BTreeSet<Symbol>`.
 
 ### Difficulty

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -1,10 +1,9 @@
 # `single_letter_const_generic`
 
 **Source:** sibling of `perfectionist::single_letter_generic`
-(`src/rules/single_letter_generic.rs`), extended to cover const
-generic parameters, which the existing rule deliberately scopes
-out by early-returning on every `GenericParamKind` other than
-`Type`.
+(`src/rules/single_letter_generic.rs`), covering the
+const-generic-parameter position the existing rule scopes out by
+early-returning on every `GenericParamKind` other than `Type`.
 
 ## Statement
 

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -34,10 +34,8 @@ declaration to scroll back to recover its role, and in a long
 that the canonical `impl<const N: usize> Foo for [T; N]` shape
 remains readable. The rule reuses the existing
 `single_letter_generic` exemption mechanism — short trait `impl`
-blocks — and adds the same `extra_allowed_idents` /
-`ignore_allowed_idents` knob shape that `single_letter_let_binding`
-uses, so projects can opt single letters into the exempt set per
-their own conventions.
+blocks — and adds an `allowed_idents` knob so projects can opt
+single letters into the exempt set per their own conventions.
 
 ## Why restrict this?
 
@@ -49,7 +47,7 @@ some idiomatic weight — `N` and `M` for array dimensions, matrix
 sizes, and slice lengths appear in rustc's own examples — but
 that weight is not so settled that the rule should ship a default
 exempt set; projects that want to keep those names add them
-locally via `extra_allowed_idents`.
+locally via `allowed_idents`.
 
 ## What it covers
 
@@ -76,9 +74,8 @@ filter by enclosing item kind.
 
 ```toml
 [single_letter_const_generic]
-short_impl_max_lines  = 20            # mirrors `single_letter_generic`
-extra_allowed_idents  = []            # default empty
-ignore_allowed_idents = []            # default empty
+short_impl_max_lines = 20    # mirrors `single_letter_generic`
+allowed_idents       = []    # default empty
 ```
 
 ### `short_impl_max_lines`: `unsigned integer` (optional)
@@ -89,24 +86,17 @@ names. Defaults to `20`. The semantics are identical to the
 existing `single_letter_generic` knob — same exemption, applied to
 const generic parameters instead of type parameters.
 
-### `extra_allowed_idents`: `[string]` (optional)
+### `allowed_idents`: `[string]` (optional)
 
-Additional identifiers added to the exempt set. Empty by default
-— the rule ships no built-in exempt single letters for const
-generics. A project that wants to keep the array-dimension idiom
-adds the names explicitly:
+The exempt set: identifiers the rule will not flag. Empty by
+default — the rule ships no built-in exempt single letters for
+const generics. A project that wants to keep the array-dimension
+idiom lists the names explicitly:
 
 ```toml
 [single_letter_const_generic]
-extra_allowed_idents = ["N", "M"]
+allowed_idents = ["N", "M"]
 ```
-
-### `ignore_allowed_idents`: `[string]` (optional)
-
-Identifiers to drop from the exempt set, even if they appear in
-`extra_allowed_idents`. Empty by default; checked after the
-merge, so this knob always wins. Same shape as
-`single_letter_let_binding` and `single_letter_const_item`.
 
 ## What to lint
 
@@ -122,7 +112,7 @@ For each visited generic parameter:
 4. Extract the parameter's identifier `Symbol`.
 5. Require `is_single_ascii_letter(symbol.as_str())` (shared
    helper in `src/common.rs`).
-6. Skip if the identifier is in the resolved `allowed_idents`
+6. Skip if the identifier is in the configured `allowed_idents`
    set.
 7. Skip if the enclosing item is a trait `impl` block whose span
    covers `≤ short_impl_max_lines` lines (shared with
@@ -154,26 +144,24 @@ declaration. Diagnostic-only matches
   dedicated `src/short_impl.rs` if either grows its own
   invariants. The existing rule's call site updates to import the
   helper from the new home.
-- The `Symbol`-set configuration parsing reuses
-  `resolve_symbol_set` (see `single_letter_let_binding`); if it
-  isn't already in `src/common.rs`, lift it there at the same
-  time as the short-impl helper.
+- `allowed_idents` parses straight into a `BTreeSet<Symbol>`. No
+  `extra_*` / `ignore_*` split — without built-in defaults there
+  is nothing to subtract from, so the single-field shape is
+  enough.
 
 ### Difficulty
 
-**Easy.** The trigger is a three-line predicate over a single
+**Easy.** The trigger is a small predicate over a single
 `GenericParam` visitor hook. The configuration replays
-`single_letter_generic`'s `short_impl_max_lines` plus
-`single_letter_let_binding`'s `extra_allowed_idents` /
-`ignore_allowed_idents` knobs; both shapes already exist in the
-codebase. The only non-trivial part is the helper hoist, which is
-mechanical.
+`single_letter_generic`'s `short_impl_max_lines` and adds a plain
+`allowed_idents` `BTreeSet`. The only non-trivial part is the
+short-trait-impl helper hoist, which is mechanical.
 
 ## Default state
 
 Active by default with an empty exempt set. Projects that want to
 keep `N` / `M` as const generic names opt in via
-`extra_allowed_idents`.
+`allowed_idents`.
 
 ## Interaction with sibling rules
 
@@ -190,6 +178,8 @@ keep `N` / `M` as const generic names opt in via
   rules can fire on adjacent lines of source but never on the
   same node.
 - `perfectionist::single_letter_let_binding`
-  (`src/rules/single_letter_let_binding.rs`) — cited here for
-  configuration shape only; the `extra_allowed_idents` /
-  `ignore_allowed_idents` knobs work the same way.
+  (`src/rules/single_letter_let_binding.rs`) — cited for context.
+  This rule's `allowed_idents` is the simplified single-field
+  version of let_binding's `extra_allowed_idents` /
+  `ignore_allowed_idents` pair; no built-in defaults here means
+  no need for the subtract-from-defaults knob.

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -15,7 +15,7 @@ out by early-returning on every `GenericParamKind` other than
 ```rust
 // Bad
 struct Data<Left, Right, const M: usize, const N: usize> {
-    left:  [Left;  N],
+    left:  [Left;  M],
     right: [Right; N],
 }
 
@@ -34,23 +34,22 @@ declaration to scroll back to recover its role, and in a long
 that the canonical `impl<const N: usize> Foo for [T; N]` shape
 remains readable. The rule reuses the existing
 `single_letter_generic` exemption mechanism — short trait `impl`
-blocks — and adds an idiomatic-name allowlist that const generics
-need but type generics do not.
+blocks — and adds the same `extra_allowed_idents` /
+`ignore_allowed_idents` knob shape that `single_letter_let_binding`
+uses, so projects can opt single letters into the exempt set per
+their own conventions.
 
 ## Why restrict this?
 
 This is a stylistic preference, not a correctness issue. The same
 "readers must keep the parameter's role in head while reading the
 type signature" argument that motivates
-`single_letter_generic` applies here. The difference is that
-const generics carry more weight of *idiom*: `N` and `M` for
-array dimensions, matrix sizes, and slice lengths are
-overwhelmingly the names rustc's own examples and the wider Rust
-ecosystem use. The rule's default allowlist therefore admits the
-small set of names that have crystallised as universally
-understood, and the project can extend or restrict the set per
-crate. Beyond that small set, the same readability argument
-applies.
+`single_letter_generic` applies here. Const generics do carry
+some idiomatic weight — `N` and `M` for array dimensions, matrix
+sizes, and slice lengths appear in rustc's own examples — but
+that weight is not so settled that the rule should ship a default
+exempt set; projects that want to keep those names add them
+locally via `extra_allowed_idents`.
 
 ## What it covers
 
@@ -92,34 +91,22 @@ const generic parameters instead of type parameters.
 
 ### `extra_allowed_idents`: `[string]` (optional)
 
-Additional identifiers allowed as const generic parameter names,
-merged with the built-in defaults.
-
-The built-in default set is `["N", "M"]`. Both are the
-overwhelmingly conventional names for "the length of an array" /
-"the dimension of a matrix" in Rust's const-generic ecosystem;
-flagging them by default would produce noise that obscures the
-cases the rule is actually meant to catch (project-specific
-single letters with no shared meaning). This mirrors the
-`single_letter_let_binding` rule's built-in `["n"]` — both
-defaults encode well-attested single-letter conventions for the
-position the rule targets.
-
-A project that wants the strict form bans the defaults via
-`ignore_allowed_idents`:
+Additional identifiers added to the exempt set. Empty by default
+— the rule ships no built-in exempt single letters for const
+generics. A project that wants to keep the array-dimension idiom
+adds the names explicitly:
 
 ```toml
 [single_letter_const_generic]
-ignore_allowed_idents = ["N", "M"]
+extra_allowed_idents = ["N", "M"]
 ```
 
 ### `ignore_allowed_idents`: `[string]` (optional)
 
 Identifiers to drop from the exempt set, even if they appear in
-`extra_allowed_idents` or in the built-in defaults. Empty by
-default; checked after the merge, so this knob always wins. Same
-shape as `single_letter_let_binding` and
-`single_letter_const_item`.
+`extra_allowed_idents`. Empty by default; checked after the
+merge, so this knob always wins. Same shape as
+`single_letter_let_binding` and `single_letter_const_item`.
 
 ## What to lint
 
@@ -141,11 +128,9 @@ For each visited generic parameter:
    covers `≤ short_impl_max_lines` lines (shared with
    `single_letter_generic`).
 8. Emit `span_lint_and_help` on the parameter's span with the
-   message
-   `"const generic parameter `{ident}` has a single-letter name"`
+   message ``"const generic parameter `{ident}` has a single-letter name"``
    and the help
-   `"rename to a descriptive identifier (e.g. `LEN`, `COLS`,
-   `LANES`)"`.
+   ``"rename to a descriptive identifier (e.g. `LEN`, `COLS`, `LANES`)"``.
 
 No autofix. Renaming a const generic parameter rewrites every
 reference in the parameter's type, where clause, body, and every
@@ -185,10 +170,9 @@ is the helper hoist, which is mechanical.
 
 ## Default state
 
-Active by default. The built-in `["N", "M"]` allowlist neutralises
-the cases that would otherwise dominate the diagnostic noise; the
-remaining single letters are exactly the ones the rule is meant to
-flag.
+Active by default with an empty exempt set. Projects that want to
+keep `N` / `M` as const generic names opt in via
+`extra_allowed_idents`.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -70,9 +70,7 @@ allowed_idents = ["X"]
 For each visited generic parameter:
 
 1. Match `param.kind` against `hir::GenericParamKind::Const`;
-   reject every other kind (this rule does *not* fire on
-   `Type` or `Lifetime` — those are covered by
-   `single_letter_generic` and out-of-scope respectively).
+   reject every other kind.
 2. Skip synthetic parameters.
 3. Skip parameters inside external macros
    (`hir_in_external_macro`).
@@ -90,8 +88,7 @@ No autofix. Renaming a const generic parameter rewrites every
 reference in the parameter's type, where clause, body, and every
 generic argument supplied at every call site — the edit is
 project-wide and not safely `MachineApplicable` from a single
-declaration. Diagnostic-only matches
-`single_letter_generic`'s behaviour for the same reason.
+declaration.
 
 ## Implementation notes
 
@@ -114,16 +111,7 @@ Active by default. Empty `allowed_idents`.
   counterpart. Disjoint trigger (`GenericParamKind::Type` vs.
   `::Const`). A single declaration with both type and const
   parameters can produce one diagnostic per offending parameter,
-  one from each rule — that is the intended behaviour, not an
-  interaction bug.
+  one from each rule — intended behaviour, not an interaction bug.
 - [`single-letter-const-item`](./single-letter-const-item.md) —
   the const-item counterpart. Disjoint trigger
-  (`ItemKind::Const` vs. `GenericParamKind::Const`); the two
-  rules can fire on adjacent lines of source but never on the
-  same node.
-- `perfectionist::single_letter_let_binding`
-  (`src/rules/single_letter_let_binding.rs`) — cited for context.
-  This rule's `allowed_idents` is the simplified single-field
-  version of let_binding's `extra_allowed_idents` /
-  `ignore_allowed_idents` pair; no built-in defaults here means
-  no need for the subtract-from-defaults knob.
+  (`ItemKind::Const` vs. `GenericParamKind::Const`).

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -151,11 +151,11 @@ declaration. Diagnostic-only matches
 
 ### Difficulty
 
-**Easy.** The trigger is a small predicate over a single
+**Easy.** The trigger is a seven-step predicate over a single
 `GenericParam` visitor hook. The configuration replays
-`single_letter_generic`'s `short_impl_max_lines` and adds a plain
-`allowed_idents` `BTreeSet`. The only non-trivial part is the
-short-trait-impl helper hoist, which is mechanical.
+`single_letter_generic`'s `short_impl_max_lines` and adds an
+`allowed_idents: BTreeSet<Symbol>`. The only non-trivial part is
+the short-trait-impl helper hoist, which is mechanical.
 
 ## Default state
 

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -95,7 +95,6 @@ declaration. Diagnostic-only matches
 
 ## Implementation notes
 
-- Use `LateLintPass` with the `check_generic_param` hook.
 - `allowed_idents` parses straight into a `BTreeSet<Symbol>`.
 
 ### Difficulty

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -26,28 +26,11 @@ struct Data<Left, Right, const LEFT_LEN: usize, const RIGHT_LEN: usize> {
 }
 ```
 
-This is the const-parameter counterpart of
-`perfectionist::single_letter_generic`. The same arguments apply:
-a single-letter parameter forces every reader downstream of the
-declaration to scroll back to recover its role, and in a long
-`impl` block the cost is large; in a short one it is small enough
-that the canonical `impl<const N: usize> Foo for [T; N]` shape
-remains readable. The rule reuses the existing
-`single_letter_generic` exemption mechanism — short trait `impl`
-blocks — and adds an `allowed_idents` knob so projects can opt
-single letters into the exempt set per their own conventions.
-
 ## Why restrict this?
 
-This is a stylistic preference, not a correctness issue. The same
-"readers must keep the parameter's role in head while reading the
-type signature" argument that motivates
-`single_letter_generic` applies here. Const generics do carry
-some idiomatic weight — `N` and `M` for array dimensions, matrix
-sizes, and slice lengths appear in rustc's own examples — but
-that weight is not so settled that the rule should ship a default
-exempt set; projects that want to keep those names add them
-locally via `allowed_idents`.
+This is a stylistic preference, not a correctness issue. A
+single-letter const generic parameter is opaque at every use
+site; a descriptive identifier documents the parameter's role.
 
 ## What it covers
 
@@ -74,28 +57,25 @@ filter by enclosing item kind.
 
 ```toml
 [single_letter_const_generic]
-short_impl_max_lines = 20    # mirrors `single_letter_generic`
+short_impl_max_lines = 0     # default rejects every impl
 allowed_idents       = []    # default empty
 ```
 
 ### `short_impl_max_lines`: `unsigned integer` (optional)
 
-Maximum number of source lines an `impl Trait for Type` block
-may span and still permit single-letter const generic parameter
-names. Defaults to `20`. The semantics are identical to the
-existing `single_letter_generic` knob — same exemption, applied to
-const generic parameters instead of type parameters.
+Maximum number of source lines a trait `impl` block may span and
+still permit single-letter const generic parameter names. Defaults
+to `0`, which rejects every impl from the exemption (no impl spans
+zero or fewer lines). A project that wants the short-trait-impl
+carve-out raises the threshold.
 
 ### `allowed_idents`: `[string]` (optional)
 
-The exempt set: identifiers the rule will not flag. Empty by
-default — the rule ships no built-in exempt single letters for
-const generics. A project that wants to keep the array-dimension
-idiom lists the names explicitly:
+Identifiers the rule will not flag. Empty by default. Example:
 
 ```toml
 [single_letter_const_generic]
-allowed_idents = ["N", "M"]
+allowed_idents = ["X"]
 ```
 
 ## What to lint
@@ -152,16 +132,13 @@ declaration. Diagnostic-only matches
 ### Difficulty
 
 **Easy.** The trigger is a seven-step predicate over a single
-`GenericParam` visitor hook. The configuration replays
-`single_letter_generic`'s `short_impl_max_lines` and adds an
-`allowed_idents: BTreeSet<Symbol>`. The only non-trivial part is
-the short-trait-impl helper hoist, which is mechanical.
+`GenericParam` visitor hook. The only non-trivial part is the
+short-trait-impl helper hoist, which is mechanical.
 
 ## Default state
 
-Active by default with an empty exempt set. Projects that want to
-keep `N` / `M` as const generic names opt in via
-`allowed_idents`.
+Active by default. Empty `allowed_idents`;
+`short_impl_max_lines = 0`.
 
 ## Interaction with sibling rules
 

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -55,9 +55,9 @@ applies.
 ## What it covers
 
 `hir::GenericParamKind::Const { .. }` — the const-generic
-declaration syntax `<const NAME: T>` in any context that accepts
-generics: items (`struct`, `enum`, `union`, `trait`, `type
-alias`, `impl`), associated items, free functions, and methods.
+declaration syntax `<const NAME: T>`, anywhere generics are
+syntactically allowed. The trigger is positional and does not
+filter by enclosing item kind.
 
 ## What it does *not* cover
 

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -110,13 +110,8 @@ despite locals being easier to rename than items).
 
 ## Implementation notes
 
-- Use `LateLintPass` for consistency with the rest of the
-  `single_letter_*` family. The rule itself doesn't need
-  `TyCtxt` (no `is_in_test`, no resolver queries), so
-  `EarlyLintPass` would also work; consistency is the only reason
-  to pick late.
-- Hook up the three `check_*` callbacks listed in
-  [What it covers](#what-it-covers).
+- Use `LateLintPass` with the three `check_*` callbacks listed
+  in [What it covers](#what-it-covers).
 - `allowed_idents` parses straight into a `BTreeSet<Symbol>`. No
   reuse of `resolve_symbol_set` (the helper
   `single_letter_let_binding` uses for its `extra_*` /

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -76,35 +76,25 @@ cases without re-opening the door for arbitrary single letters.
 
 ```toml
 [single_letter_const_item]
-extra_allowed_idents  = []   # default empty
-ignore_allowed_idents = []   # default empty
+allowed_idents = []   # default empty
 ```
 
-### `extra_allowed_idents`: `[string]` (optional)
+### `allowed_idents`: `[string]` (optional)
 
-Additional identifiers added to the exempt set, even outside
-`#[cfg(test)]` code. Empty by default — the rule ships no
-built-in exempt single letters for `const` items, because the
-convention for `const` items is SCREAMING_SNAKE_CASE descriptive
-identifiers. (This is the deliberate divergence from
-`single_letter_let_binding`'s built-in `["n"]`: `let n = …` for a
-local count is well-attested; `const N: usize = …` for a
-module-wide constant is not.) Use this knob to opt in to
-project-specific conventions (e.g. a numerics module that mirrors
-a paper's notation: `K` for the iteration bound, `R` for the
-radius of convergence).
-
-### `ignore_allowed_idents`: `[string]` (optional)
-
-Identifiers to drop from the exempt set, even if they appear in
-`extra_allowed_idents`. Empty by default; checked after the
-merge, so this knob always wins. Same shape as
-`single_letter_let_binding`.
+The exempt set: identifiers the rule will not flag. Empty by
+default — the rule ships no built-in exempt single letters for
+`const` items, because the convention for `const` items is
+SCREAMING_SNAKE_CASE descriptive identifiers. (This is the
+deliberate divergence from `single_letter_let_binding`'s built-in
+`["n"]`: `let n = …` for a local count is well-attested;
+`const N: usize = …` for a module-wide constant is not.) Use this
+knob to opt in to project-specific conventions (e.g. a numerics
+module that mirrors a paper's notation: `K` for the iteration
+bound, `R` for the radius of convergence).
 
 ## What to lint
 
-For each visited `const` item, in the same check order as
-`single_letter_let_binding.rs`:
+For each visited `const` item:
 
 1. Skip items inside external macros
    (`hir_in_external_macro`).
@@ -112,16 +102,16 @@ For each visited `const` item, in the same check order as
 3. Require `is_single_ascii_letter(symbol.as_str())` (shared with
    the other `single_letter_*` rules; lives in
    `src/common.rs`).
-4. Skip if the identifier is in the resolved `allowed_idents`
+4. Skip if the identifier is in the configured `allowed_idents`
    set.
-5. Skip items whose enclosing context returns true from
-   `clippy_utils::is_in_test`. (Deferred to last because it walks
-   the HIR parent chain; the cheap single-letter and exempt-set
-   tests above fast-path the common cases.)
-6. Emit `span_lint_and_help` on the identifier's span with the
+5. Emit `span_lint_and_help` on the identifier's span with the
    message ``"const item `{ident}` has a single-letter name"`` and
    the help
    ``"rename to a descriptive identifier (e.g. `DIMENSION`, `BUFFER_LEN`, `MAX_RETRIES`)"``.
+
+The rule has no test-code exemption: `const` items in
+`#[cfg(test)]` modules and `#[test]` functions are flagged the
+same way as production code.
 
 No autofix. Renaming a `const` item touches every reference; the
 edit is large and `MachineApplicable` only with a
@@ -132,22 +122,25 @@ despite locals being easier to rename than items).
 
 ## Implementation notes
 
-- `LateLintPass` is required: step 5's `clippy_utils::is_in_test`
-  takes a `TyCtxt`, which the early-pass context does not expose.
+- Use `LateLintPass` for consistency with the rest of the
+  `single_letter_*` family. The rule itself doesn't need
+  `TyCtxt` (no `is_in_test`, no resolver queries), so
+  `EarlyLintPass` would also work; consistency is the only reason
+  to pick late.
 - Hook up the three `check_*` callbacks listed in
   [What it covers](#what-it-covers).
-- The `Symbol`-set configuration parsing reuses
-  `resolve_symbol_set` from `single_letter_let_binding`. If the
-  helper isn't already crate-internal, lift it to
-  `src/common.rs` when implementing this rule — per CLAUDE.md's
-  "factor it into `src/common.rs`" guidance for cross-rule
-  helpers.
+- The `Symbol`-set configuration parsing reuses the
+  `extra_allowed_idents` / `ignore_allowed_idents` machinery that
+  `single_letter_let_binding` already runs through
+  `resolve_symbol_set`. Since this rule has only a single
+  `allowed_idents` field (no defaults to subtract from, so no
+  `ignore_*` companion), it parses straight into a
+  `BTreeSet<Symbol>` without going through `resolve_symbol_set`.
 
 ### Difficulty
 
-**Easy.** The trigger is a four-line predicate over three HIR
-node kinds; the configuration is a copy of
-`single_letter_let_binding`'s with one default-set change.
+**Easy.** The trigger is a four-step predicate over three HIR
+node kinds; the configuration is a single `[Symbol]` set.
 
 ## Default state
 
@@ -165,8 +158,11 @@ fires only on cases the project genuinely objects to.
   both.
 - `perfectionist::single_letter_let_binding`
   (`src/rules/single_letter_let_binding.rs`) — the closest
-  existing relative. Same configuration shape, different trigger
-  position (item vs. local).
+  existing relative. Different trigger position (item vs. local);
+  simpler configuration shape (single `allowed_idents` field
+  rather than let_binding's `extra_allowed_idents` /
+  `ignore_allowed_idents` pair, because this rule has no built-in
+  defaults to subtract from); no test-code exemption.
 - `perfectionist::single_letter_generic`
   (`src/rules/single_letter_generic.rs`) — the type-parameter
   counterpart. Cited here only for completeness; the const-item

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -84,10 +84,6 @@ through three distinct visitor hooks.
   `ItemKind::Const`, and the configuration shapes diverge
   (short-trait-impl exemption, idiomatic-name allowlist).
 
-The rule also exempts items inside `#[cfg(test)]` code via
-`clippy_utils::is_in_test`, following the same idiom that
-`single_letter_let_binding` already applies for test fixtures.
-
 ## Configuration
 
 ```toml
@@ -152,11 +148,8 @@ despite locals being easier to rename than items).
 - `LateLintPass`. The trigger does not need resolver state; an
   early pass would work too, but late keeps the rule consistent
   with the rest of the `single_letter_*` family.
-- Use `check_item`, `check_impl_item`, `check_trait_item` for the
-  three item-position cases. The block-level case
-  (`StmtKind::Item`) is reached transitively by `check_item`
-  because HIR lowers a function-body `const` into an `Item`
-  attached to the enclosing body's HIR map.
+- Hook up the three `check_*` callbacks listed in
+  [What it covers](#what-it-covers).
 - The `Symbol`-set configuration parsing reuses
   `resolve_symbol_set` from `single_letter_let_binding`. If the
   helper isn't already crate-internal, lift it to

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -42,7 +42,7 @@ The rule is configurable rather than absolute because a small set
 of single-letter constants do carry conventional meaning in
 specific domains — a numerics module that mirrors a paper's
 notation (`K` for the iteration bound, `R` for the radius of
-convergence) is the canonical case. An allowlist exempts those
+convergence) is the canonical case. The exempt set covers those
 cases without re-opening the door for arbitrary single letters.
 
 ## What it covers
@@ -69,8 +69,8 @@ cases without re-opening the door for arbitrary single letters.
 - **Const generic parameters** (`<const N: usize>`). Covered by
   the sibling [`single-letter-const-generic`](./single-letter-const-generic.md)
   rule. The trigger lives on `GenericParamKind::Const`, not on
-  `ItemKind::Const`, and the configuration shapes diverge
-  (short-trait-impl exemption, idiomatic-name allowlist).
+  `ItemKind::Const`, and the configuration shape adds the
+  short-trait-impl exemption that doesn't apply to items.
 
 ## Configuration
 
@@ -119,10 +119,9 @@ For each visited `const` item:
 5. Skip if the identifier is in the resolved `allowed_idents`
    set.
 6. Emit `span_lint_and_help` on the identifier's span with the
-   message
-   `"const item `{ident}` has a single-letter name"` and the help
-   `"rename to a descriptive identifier (e.g. `DIMENSION`,
-   `BUFFER_LEN`, `MAX_RETRIES`)"`.
+   message ``"const item `{ident}` has a single-letter name"`` and
+   the help
+   ``"rename to a descriptive identifier (e.g. `DIMENSION`, `BUFFER_LEN`, `MAX_RETRIES`)"``.
 
 No autofix. Renaming a `const` item touches every reference; the
 edit is large and `MachineApplicable` only with a
@@ -154,7 +153,7 @@ node kinds; the configuration is a copy of
 
 Active by default. Same justification as
 `single_letter_let_binding`: the rule reflects the project's
-baseline naming policy, and the empty allowlist means the rule
+baseline naming policy, and the empty exempt set means the rule
 fires only on cases the project genuinely objects to.
 
 ## Interaction with sibling rules

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -27,8 +27,10 @@ impl Buffer {
 ```
 
 The rule fires on the declaration of the `const` item — not on
-its use sites — and mirrors `single_letter_let_binding` in shape,
-swapping items for locals.
+its use sites. The trigger position is the item analogue of
+`single_letter_let_binding`'s local-binding trigger; the
+configuration and exemption shapes differ (see
+*Interaction with sibling rules* below).
 
 ## Why restrict this?
 
@@ -129,13 +131,11 @@ despite locals being easier to rename than items).
   to pick late.
 - Hook up the three `check_*` callbacks listed in
   [What it covers](#what-it-covers).
-- The `Symbol`-set configuration parsing reuses the
-  `extra_allowed_idents` / `ignore_allowed_idents` machinery that
-  `single_letter_let_binding` already runs through
-  `resolve_symbol_set`. Since this rule has only a single
-  `allowed_idents` field (no defaults to subtract from, so no
-  `ignore_*` companion), it parses straight into a
-  `BTreeSet<Symbol>` without going through `resolve_symbol_set`.
+- `allowed_idents` parses straight into a `BTreeSet<Symbol>`. No
+  reuse of `resolve_symbol_set` (the helper
+  `single_letter_let_binding` uses for its `extra_*` /
+  `ignore_*` pair) — without built-in defaults there is nothing
+  to subtract from, so the single-field shape doesn't need it.
 
 ### Difficulty
 

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -27,10 +27,7 @@ impl Buffer {
 ```
 
 The rule fires on the declaration of the `const` item — not on
-its use sites. The trigger position is the item analogue of
-`single_letter_let_binding`'s local-binding trigger; the
-configuration shape differs (see *Interaction with sibling rules*
-below).
+its use sites.
 
 ## Why restrict this?
 
@@ -98,19 +95,13 @@ For each visited `const` item:
    ``"rename to a descriptive identifier (e.g. `DIMENSION`, `BUFFER_LEN`, `MAX_RETRIES`)"``.
 
 No autofix. Renaming a `const` item touches every reference; the
-edit is large and `MachineApplicable` only with a
-crate-wide rename that the lint pass cannot safely emit. A
-diagnostic-only rule matches the existing
-`single_letter_let_binding` shape (which also offers no autofix
-despite locals being easier to rename than items).
+edit is large and `MachineApplicable` only with a crate-wide
+rename that the lint pass cannot safely emit.
 
 ## Implementation notes
 
-- `allowed_idents` parses straight into a `BTreeSet<Symbol>`. No
-  reuse of `resolve_symbol_set` (the helper
-  `single_letter_let_binding` uses for its `extra_*` /
-  `ignore_*` pair) — without built-in defaults there is nothing
-  to subtract from, so the single-field shape doesn't need it.
+- `allowed_idents` deserialises as `Vec<String>` and is interned
+  into a `BTreeSet<Symbol>`.
 
 ### Difficulty
 
@@ -119,26 +110,14 @@ node kinds; the configuration is a single `BTreeSet<Symbol>`.
 
 ## Default state
 
-Active by default. Same justification as
-`single_letter_let_binding`: the rule reflects the project's
-baseline naming policy, and the empty exempt set means the rule
-fires only on cases the project genuinely objects to.
+Active by default. Empty `allowed_idents`.
 
 ## Interaction with sibling rules
 
 - [`single-letter-const-generic`](./single-letter-const-generic.md)
-  — covers the const-generic parameter shape
-  (`<const N: usize>`). The two rules are disjoint at the trigger
-  level (item vs. generic parameter); a single site cannot fire
-  both.
-- `perfectionist::single_letter_let_binding`
-  (`src/rules/single_letter_let_binding.rs`) — the closest
-  existing relative. Different trigger position (item vs. local);
-  simpler configuration shape (single `allowed_idents` field
-  rather than let_binding's `extra_allowed_idents` /
-  `ignore_allowed_idents` pair, because this rule has no built-in
-  defaults to subtract from).
-- `perfectionist::single_letter_generic`
-  (`src/rules/single_letter_generic.rs`) — the type-parameter
-  counterpart. Cited here only for completeness; the const-item
-  rule has no overlap with type generics.
+  — the const-generic counterpart. Disjoint trigger
+  (`ItemKind::Const` vs. `GenericParamKind::Const`); a single
+  site cannot fire both.
+- [`single-letter-static-item`](./single-letter-static-item.md)
+  — the static-item counterpart. Disjoint trigger
+  (`ItemKind::Const` vs. `ItemKind::Static`).

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -34,18 +34,13 @@ below).
 
 ## Why restrict this?
 
-This is a stylistic preference, not a correctness issue. Const
-items spread further than `let` bindings — a `pub const` is read
-from anywhere the item is in scope, and every reader has to map
-the single letter back to its definition site. A descriptive
-identifier carries its own documentation; `N`, `M`, `K` do not.
-
-The rule is configurable rather than absolute because a small set
-of single-letter constants do carry conventional meaning in
-specific domains — a numerics module that mirrors a paper's
-notation (`K` for the iteration bound, `R` for the radius of
-convergence) is the canonical case. The exempt set covers those
-cases without re-opening the door for arbitrary single letters.
+This is a stylistic preference, not a correctness issue. A
+single-letter `const` item is opaque at every use site, and the
+item's scope (module-wide or crate-wide for `pub const`) makes
+that opacity propagate further than a `let` binding's would. A
+descriptive identifier carries its own documentation. The
+`allowed_idents` knob exists for project-specific conventional
+names; the default is empty.
 
 ## What it covers
 
@@ -83,16 +78,12 @@ allowed_idents = []   # default empty
 
 ### `allowed_idents`: `[string]` (optional)
 
-The exempt set: identifiers the rule will not flag. Empty by
-default — the rule ships no built-in exempt single letters for
-`const` items, because the convention for `const` items is
-SCREAMING_SNAKE_CASE descriptive identifiers. (This is the
-deliberate divergence from `single_letter_let_binding`'s built-in
-`["n"]`: `let n = …` for a local count is well-attested;
-`const N: usize = …` for a module-wide constant is not.) Use this
-knob to opt in to project-specific conventions (e.g. a numerics
-module that mirrors a paper's notation: `K` for the iteration
-bound, `R` for the radius of convergence).
+Identifiers the rule will not flag. Empty by default. Example:
+
+```toml
+[single_letter_const_item]
+allowed_idents = ["X"]
+```
 
 ## What to lint
 

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -29,8 +29,8 @@ impl Buffer {
 The rule fires on the declaration of the `const` item — not on
 its use sites. The trigger position is the item analogue of
 `single_letter_let_binding`'s local-binding trigger; the
-configuration and exemption shapes differ (see
-*Interaction with sibling rules* below).
+configuration shape differs (see *Interaction with sibling rules*
+below).
 
 ## Why restrict this?
 
@@ -162,7 +162,7 @@ fires only on cases the project genuinely objects to.
   simpler configuration shape (single `allowed_idents` field
   rather than let_binding's `extra_allowed_idents` /
   `ignore_allowed_idents` pair, because this rule has no built-in
-  defaults to subtract from); no test-code exemption.
+  defaults to subtract from).
 - `perfectionist::single_letter_generic`
   (`src/rules/single_letter_generic.rs`) — the type-parameter
   counterpart. Cited here only for completeness; the const-item

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -110,8 +110,6 @@ despite locals being easier to rename than items).
 
 ## Implementation notes
 
-- Use `LateLintPass` with the three `check_*` callbacks listed
-  in [What it covers](#what-it-covers).
 - `allowed_idents` parses straight into a `BTreeSet<Symbol>`. No
   reuse of `resolve_symbol_set` (the helper
   `single_letter_let_binding` uses for its `extra_*` /

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -81,32 +81,29 @@ them through different visitor hooks.
   rule. The trigger lives on `GenericParamKind::Const`, not on
   `ItemKind::Const`, and the configuration shapes diverge
   (short-trait-impl exemption, idiomatic-name allowlist).
-- **`const fn` declarations.** `const fn n() -> usize { 2 }` is a
-  function with a single-letter name; that case belongs to a
-  hypothetical `single_letter_function_name` rule, not here.
 - **Const items inside `#[cfg(test)]` modules.** Test fixtures
   follow the same idiom that exempts `single_letter_let_binding`
   under `cfg(test)`; reuse `clippy_utils::is_in_test`.
 
 ## Configuration
 
-Configure via `dylint.toml` under
-`["perfectionist::single_letter_const_item"]`. Every field is
-optional.
-
 ```toml
-[perfectionist::single_letter_const_item]
+[single_letter_const_item]
 extra_allowed_idents  = []   # default empty
 ignore_allowed_idents = []   # default empty
 ```
+
+(Per [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+the actual `dylint.toml` table is `[perfectionist::single_letter_const_item]`;
+planning files use the unqualified form for readability.)
 
 ### `extra_allowed_idents`: `[string]` (optional)
 
 Additional identifiers allowed as `const`-item names, even outside
 `#[cfg(test)]` code. Merged with the built-in defaults. Use this
-for project-wide conventional names (e.g. `["E", "PI"]` in a
-numerics-heavy crate that imports `std::f64::consts::*` constants
-under shorter aliases).
+for project-wide conventional names (e.g. a numerics module that
+mirrors a paper's notation: `K` for the iteration bound, `R` for
+the radius of convergence).
 
 The built-in default set is **empty**. The convention for `const`
 items is SCREAMING_SNAKE_CASE descriptive identifiers; the cases

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -103,18 +103,21 @@ merge, so this knob always wins. Same shape as
 
 ## What to lint
 
-For each visited `const` item:
+For each visited `const` item, in the same check order as
+`single_letter_let_binding.rs`:
 
 1. Skip items inside external macros
    (`hir_in_external_macro`).
-2. Skip items whose enclosing context returns true from
-   `clippy_utils::is_in_test`.
-3. Extract the item's identifier `Symbol`.
-4. Require `is_single_ascii_letter(symbol.as_str())` (shared with
+2. Extract the item's identifier `Symbol`.
+3. Require `is_single_ascii_letter(symbol.as_str())` (shared with
    the other `single_letter_*` rules; lives in
    `src/common.rs`).
-5. Skip if the identifier is in the resolved `allowed_idents`
+4. Skip if the identifier is in the resolved `allowed_idents`
    set.
+5. Skip items whose enclosing context returns true from
+   `clippy_utils::is_in_test`. (Deferred to last because it walks
+   the HIR parent chain; the cheap single-letter and exempt-set
+   tests above fast-path the common cases.)
 6. Emit `span_lint_and_help` on the identifier's span with the
    message ``"const item `{ident}` has a single-letter name"`` and
    the help
@@ -129,7 +132,7 @@ despite locals being easier to rename than items).
 
 ## Implementation notes
 
-- `LateLintPass` is required: step 2's `clippy_utils::is_in_test`
+- `LateLintPass` is required: step 5's `clippy_utils::is_in_test`
   takes a `TyCtxt`, which the early-pass context does not expose.
 - Hook up the three `check_*` callbacks listed in
   [What it covers](#what-it-covers).

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -34,10 +34,9 @@ its use sites.
 This is a stylistic preference, not a correctness issue. A
 single-letter `const` item is opaque at every use site, and the
 item's scope (module-wide or crate-wide for `pub const`) makes
-that opacity propagate further than a `let` binding's would. A
-descriptive identifier carries its own documentation. The
-`allowed_idents` knob exists for project-specific conventional
-names; the default is empty.
+that opacity propagate. A descriptive identifier carries its own
+documentation. The `allowed_idents` knob exists for
+project-specific conventional names; the default is empty.
 
 ## What it covers
 
@@ -58,8 +57,7 @@ names; the default is empty.
   rule.
 - **Const generic parameters** (`<const N: usize>`). Covered by
   the sibling [`single-letter-const-generic`](./single-letter-const-generic.md)
-  rule. The trigger lives on `GenericParamKind::Const`, not on
-  `ItemKind::Const`.
+  rule.
 
 ## Configuration
 

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -140,7 +140,7 @@ despite locals being easier to rename than items).
 ### Difficulty
 
 **Easy.** The trigger is a four-step predicate over three HIR
-node kinds; the configuration is a single `[Symbol]` set.
+node kinds; the configuration is a single `BTreeSet<Symbol>`.
 
 ## Default state
 

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -82,27 +82,24 @@ ignore_allowed_idents = []   # default empty
 
 ### `extra_allowed_idents`: `[string]` (optional)
 
-Additional identifiers allowed as `const`-item names, even outside
-`#[cfg(test)]` code. Merged with the built-in defaults. Use this
-for project-wide conventional names (e.g. a numerics module that
-mirrors a paper's notation: `K` for the iteration bound, `R` for
-the radius of convergence).
-
-The built-in default set is **empty**. The convention for `const`
-items is SCREAMING_SNAKE_CASE descriptive identifiers; the cases
-where a single capital letter is more readable than a word are
-rare enough that the project lint baseline should not encode any
-of them implicitly. (This is the deliberate divergence from
+Additional identifiers added to the exempt set, even outside
+`#[cfg(test)]` code. Empty by default — the rule ships no
+built-in exempt single letters for `const` items, because the
+convention for `const` items is SCREAMING_SNAKE_CASE descriptive
+identifiers. (This is the deliberate divergence from
 `single_letter_let_binding`'s built-in `["n"]`: `let n = …` for a
 local count is well-attested; `const N: usize = …` for a
-module-wide constant is not.)
+module-wide constant is not.) Use this knob to opt in to
+project-specific conventions (e.g. a numerics module that mirrors
+a paper's notation: `K` for the iteration bound, `R` for the
+radius of convergence).
 
 ### `ignore_allowed_idents`: `[string]` (optional)
 
 Identifiers to drop from the exempt set, even if they appear in
-`extra_allowed_idents` or in a future expansion of the built-in
-defaults. Empty by default; checked after the merge, so this knob
-always wins. Same shape as `single_letter_let_binding`.
+`extra_allowed_idents`. Empty by default; checked after the
+merge, so this knob always wins. Same shape as
+`single_letter_let_binding`.
 
 ## What to lint
 

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -3,7 +3,7 @@
 **Source:** sibling of the four existing `single_letter_*` rules
 (`single_letter_generic`, `single_letter_let_binding`,
 `single_letter_function_param`, `single_letter_closure_param`),
-extended to cover named `const` items — both free and associated.
+covering the `const`-item position those rules scope out.
 
 ## Statement
 

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -66,8 +66,7 @@ names; the default is empty.
 - **Const generic parameters** (`<const N: usize>`). Covered by
   the sibling [`single-letter-const-generic`](./single-letter-const-generic.md)
   rule. The trigger lives on `GenericParamKind::Const`, not on
-  `ItemKind::Const`, and the configuration shape adds the
-  short-trait-impl exemption that doesn't apply to items.
+  `ItemKind::Const`.
 
 ## Configuration
 

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -56,13 +56,9 @@ names; the default is empty.
 
 ## What it does *not* cover
 
-- **`static` items.** A `static N: AtomicUsize = ...;` is a
-  distinct construct with distinct conventions (interior
-  mutability, address stability). If a `single_letter_static`
-  rule is wanted later it should be a sibling; do not extend this
-  one. The two rules' configuration knobs would be the same
-  shape, but bundling them obscures which one a reader needs to
-  silence at a given site.
+- **`static` items.** Covered by the sibling
+  [`single-letter-static-item`](./single-letter-static-item.md)
+  rule.
 - **Const generic parameters** (`<const N: usize>`). Covered by
   the sibling [`single-letter-const-generic`](./single-letter-const-generic.md)
   rule. The trigger lives on `GenericParamKind::Const`, not on

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -14,13 +14,16 @@ extended to cover named `const` items — both free and associated.
 // Bad
 const N: usize = 2;
 
-struct Data<Left, Right, const M: usize, const N: usize> {
-    left:  [Left;  N],
-    right: [Right; N],
+impl Buffer {
+    const D: usize = 64;
 }
 
 // Good
 const DIMENSION_COUNT: usize = 2;
+
+impl Buffer {
+    const DEFAULT_CAPACITY: usize = 64;
+}
 ```
 
 The rule fires on the declaration of the `const` item — not on the
@@ -45,27 +48,26 @@ identifier carries its own documentation; `N`, `M`, `K` do not.
 
 The rule is configurable rather than absolute because a small set
 of single-letter constants do carry conventional meaning in
-specific domains (`E` for Euler's number when defining
-`const E: f64 = std::f64::consts::E;` for ergonomic reach,
-`N`/`M` inside a fixture module that mirrors a paper's notation).
-An allowlist exempts those cases without re-opening the door for
-arbitrary single letters.
+specific domains — a numerics module that mirrors a paper's
+notation (`K` for the iteration bound, `R` for the radius of
+convergence) is the canonical case. An allowlist exempts those
+cases without re-opening the door for arbitrary single letters.
 
 ## What it covers
 
-- `hir::ItemKind::Const` — free `const NAME: T = expr;`.
+- `hir::ItemKind::Const` — free `const NAME: T = expr;`, including
+  the block-level form (`const NAME: T = ...;` declared inside a
+  function body), which the HIR lowers to a nested `Item` reached
+  through the same `check_item` hook.
 - `hir::ImplItemKind::Const` — associated `const NAME: T = expr;`
   inside an `impl` block (inherent or trait).
 - `hir::TraitItemKind::Const` — associated const *declarations*
   inside a `trait` body (`const NAME: T;` with or without a
   default expression).
-- `hir::StmtKind::Item` constants — block-level
-  `const NAME: T = ...;` declared inside a function or `const`-eval
-  context.
 
-All four are the same syntactic shape (a `const` keyword followed
-by a name); they are listed separately only because the HIR walks
-them through different visitor hooks.
+All three are the same syntactic shape (a `const` keyword followed
+by a name); they are listed separately because the HIR walks them
+through three distinct visitor hooks.
 
 ## What it does *not* cover
 
@@ -81,9 +83,10 @@ them through different visitor hooks.
   rule. The trigger lives on `GenericParamKind::Const`, not on
   `ItemKind::Const`, and the configuration shapes diverge
   (short-trait-impl exemption, idiomatic-name allowlist).
-- **Const items inside `#[cfg(test)]` modules.** Test fixtures
-  follow the same idiom that exempts `single_letter_let_binding`
-  under `cfg(test)`; reuse `clippy_utils::is_in_test`.
+
+The rule also exempts items inside `#[cfg(test)]` code via
+`clippy_utils::is_in_test`, following the same idiom that
+`single_letter_let_binding` already applies for test fixtures.
 
 ## Configuration
 
@@ -92,10 +95,6 @@ them through different visitor hooks.
 extra_allowed_idents  = []   # default empty
 ignore_allowed_idents = []   # default empty
 ```
-
-(Per [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
-the actual `dylint.toml` table is `[perfectionist::single_letter_const_item]`;
-planning files use the unqualified form for readability.)
 
 ### `extra_allowed_idents`: `[string]` (optional)
 

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -1,0 +1,198 @@
+# `single_letter_const_item`
+
+**Source:** sibling of the four existing `single_letter_*` rules
+(`single_letter_generic`, `single_letter_let_binding`,
+`single_letter_function_param`, `single_letter_closure_param`),
+extended to cover named `const` items — both free and associated.
+
+## Statement
+
+> A `const` item declared with a one-ASCII-letter name carries no
+> information about what the constant *is*.
+
+```rust
+// Bad
+const N: usize = 2;
+
+struct Data<Left, Right, const M: usize, const N: usize> {
+    left:  [Left;  N],
+    right: [Right; N],
+}
+
+// Good
+const DIMENSION_COUNT: usize = 2;
+```
+
+The rule fires on the declaration of the `const` item — not on the
+use sites — and exactly mirrors the shape of
+`single_letter_let_binding` but for items rather than locals. A
+`let` binding tells the reader what a value computed; a `const`
+item is a *named* compile-time constant that propagates through
+type signatures, array lengths, and downstream documentation. The
+information loss from `N` vs. `DIMENSION_COUNT` is at least as
+large at the item level as at the `let` level, and often worse —
+the item is referenced from anywhere in the module (or anywhere
+in the crate, for `pub const`), so the reader doesn't have the
+RHS of a nearby `let` to fall back on.
+
+## Why restrict this?
+
+This is a stylistic preference, not a correctness issue. Const
+items spread further than `let` bindings — a `pub const` is read
+from anywhere the item is in scope, and every reader has to map
+the single letter back to its definition site. A descriptive
+identifier carries its own documentation; `N`, `M`, `K` do not.
+
+The rule is configurable rather than absolute because a small set
+of single-letter constants do carry conventional meaning in
+specific domains (`E` for Euler's number when defining
+`const E: f64 = std::f64::consts::E;` for ergonomic reach,
+`N`/`M` inside a fixture module that mirrors a paper's notation).
+An allowlist exempts those cases without re-opening the door for
+arbitrary single letters.
+
+## What it covers
+
+- `hir::ItemKind::Const` — free `const NAME: T = expr;`.
+- `hir::ImplItemKind::Const` — associated `const NAME: T = expr;`
+  inside an `impl` block (inherent or trait).
+- `hir::TraitItemKind::Const` — associated const *declarations*
+  inside a `trait` body (`const NAME: T;` with or without a
+  default expression).
+- `hir::StmtKind::Item` constants — block-level
+  `const NAME: T = ...;` declared inside a function or `const`-eval
+  context.
+
+All four are the same syntactic shape (a `const` keyword followed
+by a name); they are listed separately only because the HIR walks
+them through different visitor hooks.
+
+## What it does *not* cover
+
+- **`static` items.** A `static N: AtomicUsize = ...;` is a
+  distinct construct with distinct conventions (interior
+  mutability, address stability). If a `single_letter_static`
+  rule is wanted later it should be a sibling; do not extend this
+  one. The two rules' configuration knobs would be the same
+  shape, but bundling them obscures which one a reader needs to
+  silence at a given site.
+- **Const generic parameters** (`<const N: usize>`). Covered by
+  the sibling [`single-letter-const-generic`](./single-letter-const-generic.md)
+  rule. The trigger lives on `GenericParamKind::Const`, not on
+  `ItemKind::Const`, and the configuration shapes diverge
+  (short-trait-impl exemption, idiomatic-name allowlist).
+- **`const fn` declarations.** `const fn n() -> usize { 2 }` is a
+  function with a single-letter name; that case belongs to a
+  hypothetical `single_letter_function_name` rule, not here.
+- **Const items inside `#[cfg(test)]` modules.** Test fixtures
+  follow the same idiom that exempts `single_letter_let_binding`
+  under `cfg(test)`; reuse `clippy_utils::is_in_test`.
+
+## Configuration
+
+Configure via `dylint.toml` under
+`["perfectionist::single_letter_const_item"]`. Every field is
+optional.
+
+```toml
+[perfectionist::single_letter_const_item]
+extra_allowed_idents  = []   # default empty
+ignore_allowed_idents = []   # default empty
+```
+
+### `extra_allowed_idents`: `[string]` (optional)
+
+Additional identifiers allowed as `const`-item names, even outside
+`#[cfg(test)]` code. Merged with the built-in defaults. Use this
+for project-wide conventional names (e.g. `["E", "PI"]` in a
+numerics-heavy crate that imports `std::f64::consts::*` constants
+under shorter aliases).
+
+The built-in default set is **empty**. The convention for `const`
+items is SCREAMING_SNAKE_CASE descriptive identifiers; the cases
+where a single capital letter is more readable than a word are
+rare enough that the project lint baseline should not encode any
+of them implicitly. (This is the deliberate divergence from
+`single_letter_let_binding`'s built-in `["n"]`: `let n = …` for a
+local count is well-attested; `const N: usize = …` for a
+module-wide constant is not.)
+
+### `ignore_allowed_idents`: `[string]` (optional)
+
+Identifiers to drop from the exempt set, even if they appear in
+`extra_allowed_idents` or in a future expansion of the built-in
+defaults. Empty by default; checked after the merge, so this knob
+always wins. Same shape as `single_letter_let_binding`.
+
+## What to lint
+
+For each visited `const` item:
+
+1. Skip items inside external macros
+   (`hir_in_external_macro`).
+2. Skip items whose enclosing context returns true from
+   `clippy_utils::is_in_test`.
+3. Extract the item's identifier `Symbol`.
+4. Require `is_single_ascii_letter(symbol.as_str())` (shared with
+   the other `single_letter_*` rules; lives in
+   `src/common.rs`).
+5. Skip if the identifier is in the resolved `allowed_idents`
+   set.
+6. Emit `span_lint_and_help` on the identifier's span with the
+   message
+   `"const item `{ident}` has a single-letter name"` and the help
+   `"rename to a descriptive identifier (e.g. `DIMENSION`,
+   `BUFFER_LEN`, `MAX_RETRIES`)"`.
+
+No autofix. Renaming a `const` item touches every reference; the
+edit is large and `MachineApplicable` only with a
+crate-wide rename that the lint pass cannot safely emit. A
+diagnostic-only rule matches the existing
+`single_letter_let_binding` shape (which also offers no autofix
+despite locals being easier to rename than items).
+
+## Implementation notes
+
+- `LateLintPass`. The trigger does not need resolver state; an
+  early pass would work too, but late keeps the rule consistent
+  with the rest of the `single_letter_*` family.
+- Use `check_item`, `check_impl_item`, `check_trait_item` for the
+  three item-position cases. The block-level case
+  (`StmtKind::Item`) is reached transitively by `check_item`
+  because HIR lowers a function-body `const` into an `Item`
+  attached to the enclosing body's HIR map.
+- The `Symbol`-set configuration parsing reuses
+  `resolve_symbol_set` from `single_letter_let_binding`. If the
+  helper isn't already crate-internal, lift it to
+  `src/common.rs` when implementing this rule — per CLAUDE.md's
+  "factor it into `src/common.rs`" guidance for cross-rule
+  helpers.
+
+### Difficulty
+
+**Easy.** The trigger is a four-line predicate over three HIR
+node kinds; the configuration is a copy of
+`single_letter_let_binding`'s with one default-set change.
+
+## Default state
+
+Active by default. Same justification as
+`single_letter_let_binding`: the rule reflects the project's
+baseline naming policy, and the empty allowlist means the rule
+fires only on cases the project genuinely objects to.
+
+## Interaction with sibling rules
+
+- [`single-letter-const-generic`](./single-letter-const-generic.md)
+  — covers the const-generic parameter shape
+  (`<const N: usize>`). The two rules are disjoint at the trigger
+  level (item vs. generic parameter); a single site cannot fire
+  both.
+- `perfectionist::single_letter_let_binding`
+  (`src/rules/single_letter_let_binding.rs`) — the closest
+  existing relative. Same configuration shape, different trigger
+  position (item vs. local).
+- `perfectionist::single_letter_generic`
+  (`src/rules/single_letter_generic.rs`) — the type-parameter
+  counterpart. Cited here only for completeness; the const-item
+  rule has no overlap with type generics.

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -111,10 +111,6 @@ For each visited `const` item:
    the help
    ``"rename to a descriptive identifier (e.g. `DIMENSION`, `BUFFER_LEN`, `MAX_RETRIES`)"``.
 
-The rule has no test-code exemption: `const` items in
-`#[cfg(test)]` modules and `#[test]` functions are flagged the
-same way as production code.
-
 No autofix. Renaming a `const` item touches every reference; the
 edit is large and `MachineApplicable` only with a
 crate-wide rename that the lint pass cannot safely emit. A

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -26,17 +26,9 @@ impl Buffer {
 }
 ```
 
-The rule fires on the declaration of the `const` item — not on the
-use sites — and exactly mirrors the shape of
-`single_letter_let_binding` but for items rather than locals. A
-`let` binding tells the reader what a value computed; a `const`
-item is a *named* compile-time constant that propagates through
-type signatures, array lengths, and downstream documentation. The
-information loss from `N` vs. `DIMENSION_COUNT` is at least as
-large at the item level as at the `let` level, and often worse —
-the item is referenced from anywhere in the module (or anywhere
-in the crate, for `pub const`), so the reader doesn't have the
-RHS of a nearby `let` to fall back on.
+The rule fires on the declaration of the `const` item — not on
+its use sites — and mirrors `single_letter_let_binding` in shape,
+swapping items for locals.
 
 ## Why restrict this?
 
@@ -64,10 +56,6 @@ cases without re-opening the door for arbitrary single letters.
 - `hir::TraitItemKind::Const` — associated const *declarations*
   inside a `trait` body (`const NAME: T;` with or without a
   default expression).
-
-All three are the same syntactic shape (a `const` keyword followed
-by a name); they are listed separately because the HIR walks them
-through three distinct visitor hooks.
 
 ## What it does *not* cover
 
@@ -145,9 +133,8 @@ despite locals being easier to rename than items).
 
 ## Implementation notes
 
-- `LateLintPass`. The trigger does not need resolver state; an
-  early pass would work too, but late keeps the rule consistent
-  with the rest of the `single_letter_*` family.
+- `LateLintPass` is required: step 2's `clippy_utils::is_in_test`
+  takes a `TyCtxt`, which the early-pass context does not expose.
 - Hook up the three `check_*` callbacks listed in
   [What it covers](#what-it-covers).
 - The `Symbol`-set configuration parsing reuses

--- a/planned-rules/single-letter-static-item.md
+++ b/planned-rules/single-letter-static-item.md
@@ -43,6 +43,9 @@ specific conventional names; the default is empty.
   [`single-letter-const-item`](./single-letter-const-item.md).
 - **Const generic parameters.** Covered by
   [`single-letter-const-generic`](./single-letter-const-generic.md).
+- **Foreign statics in `extern` blocks**
+  (`extern { static N: c_int; }`). Different HIR node
+  (`ForeignItemKind::Static`).
 
 ## Configuration
 

--- a/planned-rules/single-letter-static-item.md
+++ b/planned-rules/single-letter-static-item.md
@@ -86,7 +86,8 @@ rename that the lint pass cannot safely emit.
 
 ## Implementation notes
 
-- `allowed_idents` parses straight into a `BTreeSet<Symbol>`.
+- `allowed_idents` deserialises as `Vec<String>` and is interned
+  into a `BTreeSet<Symbol>`.
 
 ### Difficulty
 

--- a/planned-rules/single-letter-static-item.md
+++ b/planned-rules/single-letter-static-item.md
@@ -1,0 +1,102 @@
+# `single_letter_static_item`
+
+**Source:** sibling of `single_letter_const_item`, covering the
+`static` item position that the const-item rule deliberately
+scopes out.
+
+## Statement
+
+> A `static` item declared with a one-ASCII-letter name carries
+> no information about what the static *is*.
+
+```rust
+// Bad
+static N: AtomicUsize = AtomicUsize::new(0);
+static D: u64 = 64;
+
+// Good
+static REQUEST_COUNT: AtomicUsize = AtomicUsize::new(0);
+static DEFAULT_VALUE: u64 = 64;
+```
+
+The rule fires on the declaration of the `static` item — not on
+its use sites.
+
+## Why restrict this?
+
+This is a stylistic preference, not a correctness issue. A
+single-letter `static` item is opaque at every use site, and the
+item's scope (module-wide or crate-wide for `pub static`) makes
+that opacity propagate. A descriptive identifier carries its own
+documentation. The `allowed_idents` knob exists for project-
+specific conventional names; the default is empty.
+
+## What it covers
+
+- `hir::ItemKind::Static` — `static NAME: T = expr;` at any item
+  position (free module-level, and the block-level form declared
+  inside a function body, both reached through `check_item`).
+
+## What it does *not* cover
+
+- **`const` items.** Covered by the sibling
+  [`single-letter-const-item`](./single-letter-const-item.md).
+- **Const generic parameters.** Covered by
+  [`single-letter-const-generic`](./single-letter-const-generic.md).
+
+## Configuration
+
+```toml
+[single_letter_static_item]
+allowed_idents = []   # default empty
+```
+
+### `allowed_idents`: `[string]` (optional)
+
+Identifiers the rule will not flag. Empty by default. Example:
+
+```toml
+[single_letter_static_item]
+allowed_idents = ["X"]
+```
+
+## What to lint
+
+For each visited `static` item:
+
+1. Skip items inside external macros
+   (`hir_in_external_macro`).
+2. Extract the item's identifier `Symbol`.
+3. Require `is_single_ascii_letter(symbol.as_str())` (shared with
+   the other `single_letter_*` rules; lives in
+   `src/common.rs`).
+4. Skip if the identifier is in the configured `allowed_idents`
+   set.
+5. Emit `span_lint_and_help` on the identifier's span with the
+   message ``"static item `{ident}` has a single-letter name"`` and
+   the help
+   ``"rename to a descriptive identifier (e.g. `BUFFER`, `CACHE`, `COUNTER`)"``.
+
+No autofix. Renaming a `static` item touches every reference; the
+edit is large and `MachineApplicable` only with a crate-wide
+rename that the lint pass cannot safely emit.
+
+## Implementation notes
+
+- `allowed_idents` parses straight into a `BTreeSet<Symbol>`.
+
+### Difficulty
+
+**Easy.** The trigger is a four-step predicate over one HIR node
+kind; the configuration is a single `BTreeSet<Symbol>`.
+
+## Default state
+
+Active by default. Empty `allowed_idents`.
+
+## Interaction with sibling rules
+
+- [`single-letter-const-item`](./single-letter-const-item.md) —
+  the const-item counterpart. Disjoint trigger
+  (`ItemKind::Static` vs. `ItemKind::Const`); a single site
+  cannot fire both.


### PR DESCRIPTION
Adds three planning files extending the `single_letter_*` family to positions the current rules don't touch:

- `planned-rules/single-letter-const-item.md` — `const NAME: T = ...;` items (free, `impl`-associated, `trait`-associated, and block-level inside function bodies).
- `planned-rules/single-letter-static-item.md` — `static NAME: T = ...;` items (free and block-level).
- `planned-rules/single-letter-const-generic.md` — `<const N: usize>` parameter declarations.

All three rules ship with the same minimal shape: a single `allowed_idents: BTreeSet<Symbol>` knob, empty by default, no test-code exemption, no autofix, `Warn` severity, active by default.

Plus the three corresponding entries in `planned-rules/README.md`'s "Naming" section.

## Why three separate rules instead of one

`single_letter_generic` already scopes itself to `GenericParamKind::Type` (`src/rules/single_letter_generic.rs:97`) and its rationale and examples are written for type parameters; folding const generics in would silently broaden it. Const items, static items, and const generics in turn have disjoint triggers (`ItemKind::Const`, `ItemKind::Static`, `GenericParamKind::Const`) and disjoint diagnostics — the same split criteria PR #43 applied when separating the original `single_letter_names` into four rules.

No code changes; planning only.