### PR TITLE
fix(single-letter-let-binding)!: drop test code exemption

### DIFF
--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -9,7 +9,7 @@
 
 ## What it does
 Flags `let x = ...;` bindings whose identifier is one ASCII
-letter, outside `#[cfg(test)]` code.
+letter.
 
 ## Why restrict this?
 This is a stylistic preference, not a correctness issue.
@@ -17,10 +17,7 @@ A descriptive `let` binding documents what the right-hand
 side computed; a single-letter name does not. The rule
 allows `let n = ...` and other names in a configurable
 set of exempt identifiers for the well-worn cases
-(unsigned counts), and switches off entirely under
-`#[cfg(test)]` where fixtures such as `let a = ...;
-let b = ...;` for interchangeable specimens are a
-recognised idiom.
+(unsigned counts).
 
 ## Example
 ```rust,ignore
@@ -37,11 +34,11 @@ Configure via `dylint.toml` under `["perfectionist::single_letter_let_binding"]`
 
 ### `extra_allowed_idents`: `[string]` (optional)
 
-Additional identifiers to allow as `let` binding names,
-even outside `#[cfg(test)]` code. Merged with the built-in
-defaults (`["n"]`); empty by default. Use this to
-whitelist project-specific conventional names without
-having to re-state the standard ones.
+Additional identifiers to allow as `let` binding names.
+Merged with the built-in defaults (`["n"]`); empty by
+default. Use this to whitelist project-specific
+conventional names without having to re-state the
+standard ones.
 
 ### `ignore_allowed_idents`: `[string]` (optional)
 

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
 
 use clippy_utils::diagnostics::span_lint_and_help;
-use clippy_utils::is_in_test;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -15,7 +14,7 @@ use crate::common::{
 declare_tool_lint! {
     /// ### What it does
     /// Flags `let x = ...;` bindings whose identifier is one ASCII
-    /// letter, outside `#[cfg(test)]` code.
+    /// letter.
     ///
     /// ### Why restrict this?
     /// This is a stylistic preference, not a correctness issue.
@@ -23,10 +22,7 @@ declare_tool_lint! {
     /// side computed; a single-letter name does not. The rule
     /// allows `let n = ...` and other names in a configurable
     /// set of exempt identifiers for the well-worn cases
-    /// (unsigned counts), and switches off entirely under
-    /// `#[cfg(test)]` where fixtures such as `let a = ...;
-    /// let b = ...;` for interchangeable specimens are a
-    /// recognised idiom.
+    /// (unsigned counts).
     ///
     /// ### Example
     /// ```rust,ignore
@@ -44,19 +40,18 @@ declare_tool_lint! {
 
 const CONFIG_KEY: &str = "perfectionist::single_letter_let_binding";
 
-/// Default exempt identifiers for `let` bindings, applied on top
-/// of the `#[cfg(test)]` exemption. A short unsigned count (`n`)
-/// is the most common idiom that survives outside test code.
+/// Default exempt identifiers for `let` bindings. A short
+/// unsigned count (`n`) is the most common idiom.
 const DEFAULT_LET_EXEMPTIONS: &[&str] = &["n"];
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
-    /// Additional identifiers to allow as `let` binding names,
-    /// even outside `#[cfg(test)]` code. Merged with the built-in
-    /// defaults (`["n"]`); empty by default. Use this to
-    /// whitelist project-specific conventional names without
-    /// having to re-state the standard ones.
+    /// Additional identifiers to allow as `let` binding names.
+    /// Merged with the built-in defaults (`["n"]`); empty by
+    /// default. Use this to whitelist project-specific
+    /// conventional names without having to re-state the
+    /// standard ones.
     extra_allowed_idents: Vec<String>,
     /// Identifiers to drop from the exempt set, even if they
     /// appear in the built-in defaults or in
@@ -113,9 +108,6 @@ impl<'tcx> LateLintPass<'tcx> for SingleLetterLetBinding {
             return;
         }
         if self.allowed_idents.contains(&ident.name) {
-            return;
-        }
-        if is_in_test(lint_context.tcx, local.hir_id) {
             return;
         }
         span_lint_and_help(

--- a/ui/single_letter_names.rs
+++ b/ui/single_letter_names.rs
@@ -143,15 +143,12 @@ impl std::fmt::Display for DisplayMe {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    // OK: single-letter `let` bindings under `#[cfg(test)]` are exempt.
-    fn fixtures() {
-        let a = 1_u32;
-        let b = 2_u32;
-        let c = a + b;
-        let _ = c;
-    }
+// Bad: single-letter `let` bindings are flagged regardless of context.
+fn fixtures() {
+    let a = 1_u32;
+    let b = 2_u32;
+    let c = a + b;
+    let _ = c;
 }
 
 fn main() {

--- a/ui/single_letter_names.rs
+++ b/ui/single_letter_names.rs
@@ -143,7 +143,7 @@ impl std::fmt::Display for DisplayMe {
     }
 }
 
-// Bad: single-letter `let` bindings are flagged regardless of context.
+// Bad: single-letter `let` bindings outside the default exempt set.
 fn fixtures() {
     let a = 1_u32;
     let b = 2_u32;

--- a/ui/single_letter_names.stderr
+++ b/ui/single_letter_names.stderr
@@ -82,5 +82,29 @@ LL | fn write_label(w: &mut String, t: &str) {
    |
    = help: rename to a descriptive identifier
 
-warning: 10 warnings emitted
+warning: `let` binding `a` has a single-letter name
+  --> $DIR/single_letter_names.rs:148:9
+   |
+LL |     let a = 1_u32;
+   |         ^
+   |
+   = help: rename to a descriptive identifier
+
+warning: `let` binding `b` has a single-letter name
+  --> $DIR/single_letter_names.rs:149:9
+   |
+LL |     let b = 2_u32;
+   |         ^
+   |
+   = help: rename to a descriptive identifier
+
+warning: `let` binding `c` has a single-letter name
+  --> $DIR/single_letter_names.rs:150:9
+   |
+LL |     let c = a + b;
+   |         ^
+   |
+   = help: rename to a descriptive identifier
+
+warning: 13 warnings emitted
 


### PR DESCRIPTION
`single_letter_let_binding` bailed via `clippy_utils::is_in_test` for any `let` inside `#[cfg(test)]` code or a `#[test]` function. The rustdoc justified it as accommodating "interchangeable specimens" fixtures.

Tracing the history: the exemption was present in the very first draft of the planning doc (PR #3, `37ba921`), carried straight through implementation (PR #29, `acb6003`), and never requested or defended in any review on either PR. It was an AI-generated guess, not a considered design decision — a descriptive `let` name is just as useful inside a test as outside, and `extra_allowed_idents` already handles project-specific conventional names.

## Changes

- Drop the `is_in_test` call and its supporting prose (rustdoc rationale, `extra_allowed_idents` field doc, default-exemptions comment).
- Replace the UI fixture. The previous one lived under `#[cfg(test)] mod tests` and was a no-op all along — compiletest does not pass `--cfg test`, so the module was always stripped before the lint could see it. The new fixture is a plain `fn` whose `let a`/`let b`/`let c` bindings now warn, and the expected stderr is extended accordingly.
- Regenerate `rules/single_letter_let_binding.md` to match the new rustdoc.

## Breaking change

Projects with single-letter `let` bindings inside test code will see new warnings. The escape hatch is `extra_allowed_idents = ["a", "b", "c", …]` under `[perfectionist::single_letter_let_binding]`.

## Test plan

- [x] `just all` (fmt / build / doc / lint / test / self-lint) green locally.
- [x] UI test exercises the new behaviour: `let a`/`let b`/`let c` at module scope now produce three warnings (13 total in `ui/single_letter_names.rs`).