### PR TITLE
refactor(unknown-perfectionist-lints): narrow the type of `suggestion_distance`

### DIFF
--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -48,7 +48,7 @@ struct Config {
     /// catches single-character typos and short transpositions
     /// without producing wild guesses. Set to `0` to disable
     /// suggestions entirely.
-    suggestion_distance: usize,
+    suggestion_distance: u8,
 }
 
 impl Default for Config {
@@ -60,7 +60,7 @@ impl Default for Config {
 }
 
 pub struct UnknownPerfectionistLints {
-    suggestion_distance: usize,
+    suggestion_distance: u8,
     registered_lints: Vec<String>,
 }
 
@@ -197,10 +197,11 @@ impl UnknownPerfectionistLints {
         if self.suggestion_distance == 0 {
             return None;
         }
+        let max_distance = usize::from(self.suggestion_distance);
         let mut closest: Option<(&str, usize)> = None;
         for registered in &self.registered_lints {
             let distance = levenshtein(candidate, registered);
-            if distance <= self.suggestion_distance
+            if distance <= max_distance
                 && closest.is_none_or(|(_, closest_distance)| distance < closest_distance)
             {
                 closest = Some((registered.as_str(), distance));

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -197,11 +197,10 @@ impl UnknownPerfectionistLints {
         if self.suggestion_distance == 0 {
             return None;
         }
-        let max_distance = usize::from(self.suggestion_distance);
         let mut closest: Option<(&str, usize)> = None;
         for registered in &self.registered_lints {
             let distance = levenshtein(candidate, registered);
-            if distance <= max_distance
+            if distance <= self.suggestion_distance as usize
                 && closest.is_none_or(|(_, closest_distance)| distance < closest_distance)
             {
                 closest = Some((registered.as_str(), distance));


### PR DESCRIPTION
A Levenshtein edit distance over short lint names is bounded by a tiny constant in practice (defaults to 2; values above ~5 already produce wild guesses). `usize` over-advertised the range and silently accepted nonsense TOML values like `suggestion_distance = 1000000`; `u8` makes serde reject them at config load time with a clear out-of-range error.