### PR TITLE
refactor(config)!: use `char` for single-letter types

### DIFF
--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -55,7 +55,7 @@ filter by enclosing item kind.
 allowed_idents = []   # default empty
 ```
 
-### `allowed_idents`: `[single-letter string]` (optional)
+### `allowed_idents`: `[single-character string]` (optional)
 
 Identifiers the rule will not flag. Each entry is a single ASCII
 letter (deserialised as `char`, rejected with a config-parse

--- a/planned-rules/single-letter-const-generic.md
+++ b/planned-rules/single-letter-const-generic.md
@@ -55,9 +55,12 @@ filter by enclosing item kind.
 allowed_idents = []   # default empty
 ```
 
-### `allowed_idents`: `[string]` (optional)
+### `allowed_idents`: `[single-letter string]` (optional)
 
-Identifiers the rule will not flag. Empty by default. Example:
+Identifiers the rule will not flag. Each entry is a single ASCII
+letter (deserialised as `char`, rejected with a config-parse
+error otherwise — a typo like `["xy"]` or `["1"]` does not pass
+through silently). Empty by default. Example:
 
 ```toml
 [single_letter_const_generic]
@@ -90,7 +93,9 @@ declaration.
 
 ## Implementation notes
 
-- `allowed_idents` deserialises as `Vec<String>` and is interned
+- `allowed_idents` deserialises as `Vec<char>` (via the shared
+  `common::deserialize_ascii_letters` helper that rejects any
+  non-ASCII-letter entry at config-parse time) and is interned
   into a `BTreeSet<Symbol>`.
 
 ### Difficulty

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -66,9 +66,12 @@ project-specific conventional names; the default is empty.
 allowed_idents = []   # default empty
 ```
 
-### `allowed_idents`: `[string]` (optional)
+### `allowed_idents`: `[single-letter string]` (optional)
 
-Identifiers the rule will not flag. Empty by default. Example:
+Identifiers the rule will not flag. Each entry is a single ASCII
+letter (deserialised as `char`, rejected with a config-parse
+error otherwise — a typo like `["xy"]` or `["1"]` does not pass
+through silently). Empty by default. Example:
 
 ```toml
 [single_letter_const_item]
@@ -98,7 +101,9 @@ rename that the lint pass cannot safely emit.
 
 ## Implementation notes
 
-- `allowed_idents` deserialises as `Vec<String>` and is interned
+- `allowed_idents` deserialises as `Vec<char>` (via the shared
+  `common::deserialize_ascii_letters` helper that rejects any
+  non-ASCII-letter entry at config-parse time) and is interned
   into a `BTreeSet<Symbol>`.
 
 ### Difficulty

--- a/planned-rules/single-letter-const-item.md
+++ b/planned-rules/single-letter-const-item.md
@@ -66,7 +66,7 @@ project-specific conventional names; the default is empty.
 allowed_idents = []   # default empty
 ```
 
-### `allowed_idents`: `[single-letter string]` (optional)
+### `allowed_idents`: `[single-character string]` (optional)
 
 Identifiers the rule will not flag. Each entry is a single ASCII
 letter (deserialised as `char`, rejected with a config-parse

--- a/planned-rules/single-letter-static-item.md
+++ b/planned-rules/single-letter-static-item.md
@@ -54,9 +54,12 @@ specific conventional names; the default is empty.
 allowed_idents = []   # default empty
 ```
 
-### `allowed_idents`: `[string]` (optional)
+### `allowed_idents`: `[single-letter string]` (optional)
 
-Identifiers the rule will not flag. Empty by default. Example:
+Identifiers the rule will not flag. Each entry is a single ASCII
+letter (deserialised as `char`, rejected with a config-parse
+error otherwise — a typo like `["xy"]` or `["1"]` does not pass
+through silently). Empty by default. Example:
 
 ```toml
 [single_letter_static_item]
@@ -86,7 +89,9 @@ rename that the lint pass cannot safely emit.
 
 ## Implementation notes
 
-- `allowed_idents` deserialises as `Vec<String>` and is interned
+- `allowed_idents` deserialises as `Vec<char>` (via the shared
+  `common::deserialize_ascii_letters` helper that rejects any
+  non-ASCII-letter entry at config-parse time) and is interned
   into a `BTreeSet<Symbol>`.
 
 ### Difficulty

--- a/planned-rules/single-letter-static-item.md
+++ b/planned-rules/single-letter-static-item.md
@@ -54,7 +54,7 @@ specific conventional names; the default is empty.
 allowed_idents = []   # default empty
 ```
 
-### `allowed_idents`: `[single-letter string]` (optional)
+### `allowed_idents`: `[single-character string]` (optional)
 
 Identifiers the rule will not flag. Each entry is a single ASCII
 letter (deserialised as `char`, rejected with a config-parse

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -95,7 +95,7 @@ after the merge with the built-ins, so this knob always
 wins. Useful for opting back into linting on a default
 entry the project does not consider trivial.
 
-### `extra_allowed_idents`: `[single-letter string]` (optional)
+### `extra_allowed_idents`: `[single-character string]` (optional)
 
 Additional identifiers to allow as closure parameter names.
 Merged with the built-in defaults
@@ -103,7 +103,7 @@ Merged with the built-in defaults
 to whitelist project-specific conventional names without
 having to re-state the standard ones.
 
-### `ignore_allowed_idents`: `[single-letter string]` (optional)
+### `ignore_allowed_idents`: `[single-character string]` (optional)
 
 Identifiers to drop from the exempt set, even if they
 appear in the built-in defaults or in

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -95,7 +95,7 @@ after the merge with the built-ins, so this knob always
 wins. Useful for opting back into linting on a default
 entry the project does not consider trivial.
 
-### `extra_allowed_idents`: `[string]` (optional)
+### `extra_allowed_idents`: `[single-letter string]` (optional)
 
 Additional identifiers to allow as closure parameter names.
 Merged with the built-in defaults
@@ -103,7 +103,7 @@ Merged with the built-in defaults
 to whitelist project-specific conventional names without
 having to re-state the standard ones.
 
-### `ignore_allowed_idents`: `[string]` (optional)
+### `ignore_allowed_idents`: `[single-letter string]` (optional)
 
 Identifiers to drop from the exempt set, even if they
 appear in the built-in defaults or in

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -101,7 +101,9 @@ Additional identifiers to allow as closure parameter names.
 Merged with the built-in defaults
 (`["n", "f", "i", "j", "k"]`); empty by default. Use this
 to whitelist project-specific conventional names without
-having to re-state the standard ones.
+having to re-state the standard ones. Each entry is a
+single ASCII letter (`a`-`z`, `A`-`Z`); any other
+character is rejected at config-parse time.
 
 ### `ignore_allowed_idents`: `[single-character string]` (optional)
 
@@ -109,3 +111,5 @@ Identifiers to drop from the exempt set, even if they
 appear in the built-in defaults or in
 `extra_allowed_idents`. Empty by default; checked after
 the merge with the built-ins, so this knob always wins.
+Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
+any other character is rejected at config-parse time.

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -33,7 +33,7 @@ fn write_row(writer: &mut Writer, tree_row: &TreeRow) -> io::Result<()> { ... }
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_function_param"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_allowed_idents`: `[string]` (optional)
+### `extra_allowed_idents`: `[single-letter string]` (optional)
 
 Additional identifiers to allow as function or method
 parameter names. Merged with the built-in defaults
@@ -41,7 +41,7 @@ parameter names. Merged with the built-in defaults
 to whitelist project-specific conventional names without
 having to re-state the standard ones.
 
-### `ignore_allowed_idents`: `[string]` (optional)
+### `ignore_allowed_idents`: `[single-letter string]` (optional)
 
 Identifiers to drop from the exempt set, even if they
 appear in the built-in defaults or in

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -39,7 +39,9 @@ Additional identifiers to allow as function or method
 parameter names. Merged with the built-in defaults
 (`["n", "f", "i", "j", "k"]`); empty by default. Use this
 to whitelist project-specific conventional names without
-having to re-state the standard ones.
+having to re-state the standard ones. Each entry is a
+single ASCII letter (`a`-`z`, `A`-`Z`); any other
+character is rejected at config-parse time.
 
 ### `ignore_allowed_idents`: `[single-character string]` (optional)
 
@@ -47,3 +49,5 @@ Identifiers to drop from the exempt set, even if they
 appear in the built-in defaults or in
 `extra_allowed_idents`. Empty by default; checked after
 the merge with the built-ins, so this knob always wins.
+Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
+any other character is rejected at config-parse time.

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -33,7 +33,7 @@ fn write_row(writer: &mut Writer, tree_row: &TreeRow) -> io::Result<()> { ... }
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_function_param"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_allowed_idents`: `[single-letter string]` (optional)
+### `extra_allowed_idents`: `[single-character string]` (optional)
 
 Additional identifiers to allow as function or method
 parameter names. Merged with the built-in defaults
@@ -41,7 +41,7 @@ parameter names. Merged with the built-in defaults
 to whitelist project-specific conventional names without
 having to re-state the standard ones.
 
-### `ignore_allowed_idents`: `[single-letter string]` (optional)
+### `ignore_allowed_idents`: `[single-character string]` (optional)
 
 Identifiers to drop from the exempt set, even if they
 appear in the built-in defaults or in

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -32,7 +32,7 @@ let metadata = entry.metadata()?;
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_let_binding"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_allowed_idents`: `[string]` (optional)
+### `extra_allowed_idents`: `[single-letter string]` (optional)
 
 Additional identifiers to allow as `let` binding names.
 Merged with the built-in defaults (`["n"]`); empty by
@@ -40,7 +40,7 @@ default. Use this to whitelist project-specific
 conventional names without having to re-state the
 standard ones.
 
-### `ignore_allowed_idents`: `[string]` (optional)
+### `ignore_allowed_idents`: `[single-letter string]` (optional)
 
 Identifiers to drop from the exempt set, even if they
 appear in the built-in defaults or in

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -38,7 +38,9 @@ Additional identifiers to allow as `let` binding names.
 Merged with the built-in defaults (`["n"]`); empty by
 default. Use this to whitelist project-specific
 conventional names without having to re-state the
-standard ones.
+standard ones. Each entry is a single ASCII letter
+(`a`-`z`, `A`-`Z`); any other character is rejected at
+config-parse time.
 
 ### `ignore_allowed_idents`: `[single-character string]` (optional)
 
@@ -46,3 +48,5 @@ Identifiers to drop from the exempt set, even if they
 appear in the built-in defaults or in
 `extra_allowed_idents`. Empty by default; checked after
 the merge with the built-ins, so this knob always wins.
+Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
+any other character is rejected at config-parse time.

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -32,7 +32,7 @@ let metadata = entry.metadata()?;
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_let_binding"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_allowed_idents`: `[single-letter string]` (optional)
+### `extra_allowed_idents`: `[single-character string]` (optional)
 
 Additional identifiers to allow as `let` binding names.
 Merged with the built-in defaults (`["n"]`); empty by
@@ -40,7 +40,7 @@ default. Use this to whitelist project-specific
 conventional names without having to re-state the
 standard ones.
 
-### `ignore_allowed_idents`: `[single-letter string]` (optional)
+### `ignore_allowed_idents`: `[single-character string]` (optional)
 
 Identifiers to drop from the exempt set, even if they
 appear in the built-in defaults or in

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -32,7 +32,7 @@ Use instead:
 
 Configure via `dylint.toml` under `["perfectionist::unicode_ellipsis_in_comments"]`. Every field is optional; the per-field prose below states the default.
 
-### `also_flag`: `[string]` (optional)
+### `also_flag`: `[single-letter string]` (optional)
 
 Extra characters to flag alongside U+2026. Useful for catching
 near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -32,7 +32,7 @@ Use instead:
 
 Configure via `dylint.toml` under `["perfectionist::unicode_ellipsis_in_comments"]`. Every field is optional; the per-field prose below states the default.
 
-### `also_flag`: `[single-letter string]` (optional)
+### `also_flag`: `[single-character string]` (optional)
 
 Extra characters to flag alongside U+2026. Useful for catching
 near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -80,7 +80,7 @@ in the built-in defaults or in `extra_methods`. Empty by
 default; checked after the merge with the built-ins, so
 this knob always wins.
 
-### `also_flag`: `[string]` (optional)
+### `also_flag`: `[single-letter string]` (optional)
 
 Extra characters to flag alongside U+2026, in the same spirit
 as `unicode_ellipsis_in_comments.also_flag`. Empty by default.

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -80,7 +80,7 @@ in the built-in defaults or in `extra_methods`. Empty by
 default; checked after the merge with the built-ins, so
 this knob always wins.
 
-### `also_flag`: `[single-letter string]` (optional)
+### `also_flag`: `[single-character string]` (optional)
 
 Extra characters to flag alongside U+2026, in the same spirit
 as `unicode_ellipsis_in_comments.also_flag`. Empty by default.

--- a/src/common.rs
+++ b/src/common.rs
@@ -298,10 +298,13 @@ pub(crate) fn resolve_symbol_set(
 
 /// Sibling of [`resolve_symbol_set`] keyed on [`char`] instead of
 /// `String`, for the `single_letter_*` rules' `extra_allowed_idents`
-/// and `ignore_allowed_idents` knobs. Every entry is guaranteed to
-/// be a single ASCII letter by [`deserialize_ascii_letters`], so
-/// `char::encode_utf8` always produces a one-byte buffer that
-/// [`Symbol::intern`] can take as `&str`.
+/// and `ignore_allowed_idents` knobs. `char::encode_utf8` writes
+/// into a small stack buffer and hands [`Symbol::intern`] the
+/// resulting `&str`, so the function works for any `char`; callers
+/// that want the entries restricted to ASCII letters route the
+/// `extras` / `ignore` lists through [`deserialize_ascii_letters`]
+/// at the serde layer, and pick hand-written defaults that obey
+/// the same invariant.
 ///
 /// Must be called inside a rustc session.
 pub(crate) fn resolve_symbol_set_from_chars(
@@ -344,4 +347,62 @@ where
         }
     }
     Ok(chars)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deserialize_ascii_letters;
+
+    /// Driver that pipes a TOML array through
+    /// [`deserialize_ascii_letters`] via a synthetic struct,
+    /// mirroring how the real rule `Config`s use it. Returns the
+    /// deserialised letters on success or the serde error message
+    /// on failure, so the tests can pin both the happy and the
+    /// rejection paths.
+    fn parse(toml_text: &str) -> Result<Vec<char>, String> {
+        #[derive(serde::Deserialize)]
+        struct Wrap {
+            #[serde(deserialize_with = "deserialize_ascii_letters")]
+            letters: Vec<char>,
+        }
+        toml::from_str::<Wrap>(toml_text)
+            .map(|wrap| wrap.letters)
+            .map_err(|err| err.to_string())
+    }
+
+    #[test]
+    fn empty_list_is_accepted() {
+        assert_eq!(parse("letters = []").unwrap(), Vec::<char>::new());
+    }
+
+    #[test]
+    fn ascii_letters_are_accepted() {
+        assert_eq!(parse(r#"letters = ["x", "Y"]"#).unwrap(), vec!['x', 'Y']);
+    }
+
+    #[test]
+    fn multi_character_string_is_rejected_at_parse_time() {
+        // serde-toml rejects a multi-codepoint string before our
+        // validator gets a chance to run; the error message
+        // doesn't matter as long as the TOML fails to parse.
+        assert!(parse(r#"letters = ["xy"]"#).is_err());
+    }
+
+    #[test]
+    fn ascii_digit_is_rejected_with_our_message() {
+        let error = parse(r#"letters = ["1"]"#).unwrap_err();
+        assert!(
+            error.contains("expected a single ASCII letter"),
+            "unexpected error message: {error}",
+        );
+    }
+
+    #[test]
+    fn non_ascii_letter_is_rejected_with_our_message() {
+        let error = parse(r#"letters = ["é"]"#).unwrap_err();
+        assert!(
+            error.contains("expected a single ASCII letter"),
+            "unexpected error message: {error}",
+        );
+    }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -275,9 +275,10 @@ pub(crate) fn resolve_string_set(
 /// a [`Symbol`] in one pass — skipping the intermediate
 /// `BTreeSet<String>` of the string-shaped variant. Used by rules
 /// whose late-pass lookup key is already a `Symbol`
-/// (`unicode_ellipsis_in_panic_messages`, the three `single_letter_*`
-/// rules), so that membership checks reduce to integer compares
-/// instead of `Symbol::as_str` → `String` round-trips.
+/// (`unicode_ellipsis_in_panic_messages`, `single_letter_closure_param`'s
+/// trivial-callback list), so that membership checks reduce to
+/// integer compares instead of `Symbol::as_str` → `String`
+/// round-trips.
 ///
 /// Must be called inside a rustc session, since [`Symbol::intern`]
 /// reaches into the per-session symbol table.
@@ -293,4 +294,54 @@ pub(crate) fn resolve_symbol_set(
         .chain(extras.iter().map(|name| Symbol::intern(name)))
         .filter(|sym| !ignore.contains(sym))
         .collect()
+}
+
+/// Sibling of [`resolve_symbol_set`] keyed on [`char`] instead of
+/// `String`, for the `single_letter_*` rules' `extra_allowed_idents`
+/// and `ignore_allowed_idents` knobs. Every entry is guaranteed to
+/// be a single ASCII letter by [`deserialize_ascii_letters`], so
+/// `char::encode_utf8` always produces a one-byte buffer that
+/// [`Symbol::intern`] can take as `&str`.
+///
+/// Must be called inside a rustc session.
+pub(crate) fn resolve_symbol_set_from_chars(
+    defaults: &[char],
+    extras: Vec<char>,
+    ignore: Vec<char>,
+) -> BTreeSet<Symbol> {
+    let intern = |ch: char| {
+        let mut buf = [0u8; 4];
+        Symbol::intern(ch.encode_utf8(&mut buf))
+    };
+    let ignore: BTreeSet<Symbol> = ignore.iter().copied().map(intern).collect();
+    defaults
+        .iter()
+        .copied()
+        .chain(extras)
+        .map(intern)
+        .filter(|sym| !ignore.contains(sym))
+        .collect()
+}
+
+/// Deserialise a TOML array of single-character strings into a
+/// `Vec<char>`, rejecting any entry that is not a single ASCII
+/// letter. Used by the `single_letter_*` rules so that a typo like
+/// `["xy"]` or `["1"]` in `dylint.toml` surfaces as a clean
+/// deserialisation error instead of silently never matching.
+pub(crate) fn deserialize_ascii_letters<'de, Deserializer>(
+    deserializer: Deserializer,
+) -> Result<Vec<char>, Deserializer::Error>
+where
+    Deserializer: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    let chars = Vec::<char>::deserialize(deserializer)?;
+    for ch in &chars {
+        if !ch.is_ascii_alphabetic() {
+            return Err(serde::de::Error::custom(format!(
+                "expected a single ASCII letter (a-z, A-Z), got {ch:?}",
+            )));
+        }
+    }
+    Ok(chars)
 }

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -16,8 +16,8 @@ use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Symbol;
 
 use crate::common::{
-    DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set,
-    resolved_state,
+    DefaultState, binding_ident, deserialize_ascii_letters, hir_in_external_macro,
+    is_single_ascii_letter, resolve_symbol_set, resolve_symbol_set_from_chars, resolved_state,
 };
 
 mod triviality;
@@ -104,7 +104,7 @@ const CONFIG_KEY: &str = "perfectionist::single_letter_closure_param";
 /// `|i| &hex[i..i + 2]` indexing closure is just as canonical as
 /// a `fn step(i: usize)` signature, and is not covered by the
 /// structural trivial-wrapper shapes.
-const DEFAULT_CLOSURE_PARAM_EXEMPTIONS: &[&str] = &["n", "f", "i", "j", "k"];
+const DEFAULT_CLOSURE_PARAM_EXEMPTIONS: &[char] = &['n', 'f', 'i', 'j', 'k'];
 
 /// Default trivial-callback method names whose closure argument
 /// may use single-letter parameters when the body is a single
@@ -193,12 +193,14 @@ struct Config {
     /// (`["n", "f", "i", "j", "k"]`); empty by default. Use this
     /// to whitelist project-specific conventional names without
     /// having to re-state the standard ones.
-    extra_allowed_idents: Vec<String>,
+    #[serde(deserialize_with = "deserialize_ascii_letters")]
+    extra_allowed_idents: Vec<char>,
     /// Identifiers to drop from the exempt set, even if they
     /// appear in the built-in defaults or in
     /// `extra_allowed_idents`. Empty by default; checked after
     /// the merge with the built-ins, so this knob always wins.
-    ignore_allowed_idents: Vec<String>,
+    #[serde(deserialize_with = "deserialize_ascii_letters")]
+    ignore_allowed_idents: Vec<char>,
 }
 
 pub struct SingleLetterClosureParam {
@@ -214,7 +216,7 @@ impl SingleLetterClosureParam {
             config.extra_trivial_callback_methods,
             config.ignore_trivial_callback_methods,
         );
-        let allowed_idents = resolve_symbol_set(
+        let allowed_idents = resolve_symbol_set_from_chars(
             DEFAULT_CLOSURE_PARAM_EXEMPTIONS,
             config.extra_allowed_idents,
             config.ignore_allowed_idents,

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -192,13 +192,17 @@ struct Config {
     /// Merged with the built-in defaults
     /// (`["n", "f", "i", "j", "k"]`); empty by default. Use this
     /// to whitelist project-specific conventional names without
-    /// having to re-state the standard ones.
+    /// having to re-state the standard ones. Each entry is a
+    /// single ASCII letter (`a`-`z`, `A`-`Z`); any other
+    /// character is rejected at config-parse time.
     #[serde(deserialize_with = "deserialize_ascii_letters")]
     extra_allowed_idents: Vec<char>,
     /// Identifiers to drop from the exempt set, even if they
     /// appear in the built-in defaults or in
     /// `extra_allowed_idents`. Empty by default; checked after
     /// the merge with the built-ins, so this knob always wins.
+    /// Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
+    /// any other character is rejected at config-parse time.
     #[serde(deserialize_with = "deserialize_ascii_letters")]
     ignore_allowed_idents: Vec<char>,
 }

--- a/src/rules/single_letter_function_param.rs
+++ b/src/rules/single_letter_function_param.rs
@@ -55,13 +55,17 @@ struct Config {
     /// parameter names. Merged with the built-in defaults
     /// (`["n", "f", "i", "j", "k"]`); empty by default. Use this
     /// to whitelist project-specific conventional names without
-    /// having to re-state the standard ones.
+    /// having to re-state the standard ones. Each entry is a
+    /// single ASCII letter (`a`-`z`, `A`-`Z`); any other
+    /// character is rejected at config-parse time.
     #[serde(deserialize_with = "deserialize_ascii_letters")]
     extra_allowed_idents: Vec<char>,
     /// Identifiers to drop from the exempt set, even if they
     /// appear in the built-in defaults or in
     /// `extra_allowed_idents`. Empty by default; checked after
     /// the merge with the built-ins, so this knob always wins.
+    /// Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
+    /// any other character is rejected at config-parse time.
     #[serde(deserialize_with = "deserialize_ascii_letters")]
     ignore_allowed_idents: Vec<char>,
 }

--- a/src/rules/single_letter_function_param.rs
+++ b/src/rules/single_letter_function_param.rs
@@ -8,8 +8,8 @@ use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::{Span, Symbol};
 
 use crate::common::{
-    DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set,
-    resolved_state,
+    DefaultState, binding_ident, deserialize_ascii_letters, hir_in_external_macro,
+    is_single_ascii_letter, resolve_symbol_set_from_chars, resolved_state,
 };
 
 declare_tool_lint! {
@@ -46,7 +46,7 @@ const CONFIG_KEY: &str = "perfectionist::single_letter_function_param";
 /// parameters: the canonical names from both source documents
 /// (`n` for an unsigned count, `f` for `fmt::Formatter`, `i` /
 /// `j` / `k` for indices).
-const DEFAULT_FN_PARAM_EXEMPTIONS: &[&str] = &["n", "f", "i", "j", "k"];
+const DEFAULT_FN_PARAM_EXEMPTIONS: &[char] = &['n', 'f', 'i', 'j', 'k'];
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
@@ -56,12 +56,14 @@ struct Config {
     /// (`["n", "f", "i", "j", "k"]`); empty by default. Use this
     /// to whitelist project-specific conventional names without
     /// having to re-state the standard ones.
-    extra_allowed_idents: Vec<String>,
+    #[serde(deserialize_with = "deserialize_ascii_letters")]
+    extra_allowed_idents: Vec<char>,
     /// Identifiers to drop from the exempt set, even if they
     /// appear in the built-in defaults or in
     /// `extra_allowed_idents`. Empty by default; checked after
     /// the merge with the built-ins, so this knob always wins.
-    ignore_allowed_idents: Vec<String>,
+    #[serde(deserialize_with = "deserialize_ascii_letters")]
+    ignore_allowed_idents: Vec<char>,
 }
 
 pub struct SingleLetterFunctionParam {
@@ -71,7 +73,7 @@ pub struct SingleLetterFunctionParam {
 impl SingleLetterFunctionParam {
     fn new() -> Self {
         let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-        let allowed_idents = resolve_symbol_set(
+        let allowed_idents = resolve_symbol_set_from_chars(
             DEFAULT_FN_PARAM_EXEMPTIONS,
             config.extra_allowed_idents,
             config.ignore_allowed_idents,

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -7,8 +7,8 @@ use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Symbol;
 
 use crate::common::{
-    DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set,
-    resolved_state,
+    DefaultState, binding_ident, deserialize_ascii_letters, hir_in_external_macro,
+    is_single_ascii_letter, resolve_symbol_set_from_chars, resolved_state,
 };
 
 declare_tool_lint! {
@@ -42,7 +42,7 @@ const CONFIG_KEY: &str = "perfectionist::single_letter_let_binding";
 
 /// Default exempt identifiers for `let` bindings. A short
 /// unsigned count (`n`) is the most common idiom.
-const DEFAULT_LET_EXEMPTIONS: &[&str] = &["n"];
+const DEFAULT_LET_EXEMPTIONS: &[char] = &['n'];
 
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
@@ -52,12 +52,14 @@ struct Config {
     /// default. Use this to whitelist project-specific
     /// conventional names without having to re-state the
     /// standard ones.
-    extra_allowed_idents: Vec<String>,
+    #[serde(deserialize_with = "deserialize_ascii_letters")]
+    extra_allowed_idents: Vec<char>,
     /// Identifiers to drop from the exempt set, even if they
     /// appear in the built-in defaults or in
     /// `extra_allowed_idents`. Empty by default; checked after
     /// the merge with the built-ins, so this knob always wins.
-    ignore_allowed_idents: Vec<String>,
+    #[serde(deserialize_with = "deserialize_ascii_letters")]
+    ignore_allowed_idents: Vec<char>,
 }
 
 pub struct SingleLetterLetBinding {
@@ -67,7 +69,7 @@ pub struct SingleLetterLetBinding {
 impl SingleLetterLetBinding {
     fn new() -> Self {
         let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-        let allowed_idents = resolve_symbol_set(
+        let allowed_idents = resolve_symbol_set_from_chars(
             DEFAULT_LET_EXEMPTIONS,
             config.extra_allowed_idents,
             config.ignore_allowed_idents,

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -51,13 +51,17 @@ struct Config {
     /// Merged with the built-in defaults (`["n"]`); empty by
     /// default. Use this to whitelist project-specific
     /// conventional names without having to re-state the
-    /// standard ones.
+    /// standard ones. Each entry is a single ASCII letter
+    /// (`a`-`z`, `A`-`Z`); any other character is rejected at
+    /// config-parse time.
     #[serde(deserialize_with = "deserialize_ascii_letters")]
     extra_allowed_idents: Vec<char>,
     /// Identifiers to drop from the exempt set, even if they
     /// appear in the built-in defaults or in
     /// `extra_allowed_idents`. Empty by default; checked after
     /// the merge with the built-ins, so this knob always wins.
+    /// Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
+    /// any other character is rejected at config-parse time.
     #[serde(deserialize_with = "deserialize_ascii_letters")]
     ignore_allowed_idents: Vec<char>,
 }

--- a/tests/single_letter_closure_param.rs
+++ b/tests/single_letter_closure_param.rs
@@ -28,9 +28,9 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     ignore_trivial_callback_methods: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    extra_allowed_idents: Option<Vec<String>>,
+    extra_allowed_idents: Option<Vec<char>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ignore_allowed_idents: Option<Vec<String>>,
+    ignore_allowed_idents: Option<Vec<char>>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {

--- a/tests/single_letter_function_param.rs
+++ b/tests/single_letter_function_param.rs
@@ -24,9 +24,9 @@ static SERIAL: Mutex<()> = Mutex::new(());
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    extra_allowed_idents: Option<Vec<String>>,
+    extra_allowed_idents: Option<Vec<char>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ignore_allowed_idents: Option<Vec<String>>,
+    ignore_allowed_idents: Option<Vec<char>>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -46,8 +46,8 @@ fn custom_allowed_idents_extend_and_subtract_the_default_list() {
     run(
         "ui-toml/single_letter_function_param/custom_allowed_idents",
         RuleConfig {
-            extra_allowed_idents: Some(vec!["x".into()]),
-            ignore_allowed_idents: Some(vec!["n".into()]),
+            extra_allowed_idents: Some(vec!['x']),
+            ignore_allowed_idents: Some(vec!['n']),
         },
     );
 }

--- a/tests/single_letter_let_binding.rs
+++ b/tests/single_letter_let_binding.rs
@@ -24,9 +24,9 @@ static SERIAL: Mutex<()> = Mutex::new(());
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    extra_allowed_idents: Option<Vec<String>>,
+    extra_allowed_idents: Option<Vec<char>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ignore_allowed_idents: Option<Vec<String>>,
+    ignore_allowed_idents: Option<Vec<char>>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -46,8 +46,8 @@ fn custom_allowed_idents_extend_and_subtract_the_default_list() {
     run(
         "ui-toml/single_letter_let_binding/custom_allowed_idents",
         RuleConfig {
-            extra_allowed_idents: Some(vec!["x".into()]),
-            ignore_allowed_idents: Some(vec!["n".into()]),
+            extra_allowed_idents: Some(vec!['x']),
+            ignore_allowed_idents: Some(vec!['n']),
         },
     );
 }

--- a/tools/gen-docs/src/extract/ty.rs
+++ b/tools/gen-docs/src/extract/ty.rs
@@ -209,7 +209,11 @@ pub(crate) fn find_type_doc(file: &syn::File, ident: &str) -> Option<TypeDoc> {
 /// - `NonZeroU*` / `NonZeroUsize` → `non-zero unsigned integer`
 /// - `NonZeroI*` / `NonZeroIsize` → `non-zero integer`
 /// - `f32` / `f64` → `float`
-/// - `String` / `&str` / `char` / `OsString` / `PathBuf` / `Cow<…>` → `string`
+/// - `char` → `single-letter string` (TOML's one-byte-string idiom
+///   for a Rust `char`; rendered distinctly from the multi-character
+///   string family because the `single_letter_*` rules' allow-lists
+///   reject any entry that isn't a single ASCII letter)
+/// - `String` / `&str` / `OsString` / `PathBuf` / `Cow<…>` → `string`
 /// - `Vec<T>` / `HashSet<T>` / `BTreeSet<T>` / `VecDeque<T>` /
 ///   `LinkedList<T>` → `[label-of-T]`
 /// - `HashMap<_, V>` / `BTreeMap<_, V>` → `table of label-of-V`
@@ -245,7 +249,8 @@ pub(crate) fn toml_type_label(ty: &Type) -> String {
             };
             match ident.as_str() {
                 "bool" => "boolean".to_owned(),
-                "String" | "str" | "char" | "OsString" | "OsStr" | "Path" | "PathBuf" | "Cow" => {
+                "char" => "single-letter string".to_owned(),
+                "String" | "str" | "OsString" | "OsStr" | "Path" | "PathBuf" | "Cow" => {
                     "string".to_owned()
                 }
                 "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => "unsigned integer".to_owned(),
@@ -315,12 +320,15 @@ mod tests {
         );
         assert_eq!(toml_type_label(&parse_type("f64")), "float");
         assert_eq!(toml_type_label(&parse_type("String")), "string");
-        assert_eq!(toml_type_label(&parse_type("char")), "string");
+        assert_eq!(toml_type_label(&parse_type("char")), "single-letter string");
     }
 
     #[test]
     fn toml_type_label_arrays_and_maps() {
-        assert_eq!(toml_type_label(&parse_type("Vec<char>")), "[string]");
+        assert_eq!(
+            toml_type_label(&parse_type("Vec<char>")),
+            "[single-letter string]"
+        );
         assert_eq!(
             toml_type_label(&parse_type("Vec<Vec<u8>>")),
             "[[unsigned integer]]"

--- a/tools/gen-docs/src/extract/ty.rs
+++ b/tools/gen-docs/src/extract/ty.rs
@@ -209,15 +209,11 @@ pub(crate) fn find_type_doc(file: &syn::File, ident: &str) -> Option<TypeDoc> {
 /// - `NonZeroU*` / `NonZeroUsize` → `non-zero unsigned integer`
 /// - `NonZeroI*` / `NonZeroIsize` → `non-zero integer`
 /// - `f32` / `f64` → `float`
-/// - `char` → `single-letter string` (strictly a lie: `char` is a
-///   Unicode scalar value, so the honest label is
-///   `single-codepoint string`. We get away with the narrower
-///   "letter" wording because every `Vec<char>` field in this
-///   catalogue today happens to be a letter-shaped allow-list
-///   (`single_letter_*::*_allowed_idents`) or a near-letter
-///   ellipsis-relative (`unicode_ellipsis_*::also_flag`). Tracked
-///   for replacement by an `AsciiLetter(char)` newtype at
-///   <https://github.com/KSXGitHub/perfectionist/issues/120>.)
+/// - `char` → `single-character string` (a TOML string of length
+///   one, which is what `serde-toml` accepts for `char`). A
+///   tighter `single-letter string` label is reserved for an
+///   eventual `AsciiLetter(char)` newtype — see
+///   <https://github.com/KSXGitHub/perfectionist/issues/120>.
 /// - `String` / `&str` / `OsString` / `PathBuf` / `Cow<…>` → `string`
 /// - `Vec<T>` / `HashSet<T>` / `BTreeSet<T>` / `VecDeque<T>` /
 ///   `LinkedList<T>` → `[label-of-T]`
@@ -254,9 +250,10 @@ pub(crate) fn toml_type_label(ty: &Type) -> String {
             };
             match ident.as_str() {
                 "bool" => "boolean".to_owned(),
-                // The "letter" framing is narrower than `char` itself; see the
-                // rustdoc above and <https://github.com/KSXGitHub/perfectionist/issues/120>.
-                "char" => "single-letter string".to_owned(),
+                // A tighter `single-letter string` label is reserved for an
+                // eventual `AsciiLetter(char)` newtype; see the rustdoc above
+                // and <https://github.com/KSXGitHub/perfectionist/issues/120>.
+                "char" => "single-character string".to_owned(),
                 "String" | "str" | "OsString" | "OsStr" | "Path" | "PathBuf" | "Cow" => {
                     "string".to_owned()
                 }
@@ -327,14 +324,17 @@ mod tests {
         );
         assert_eq!(toml_type_label(&parse_type("f64")), "float");
         assert_eq!(toml_type_label(&parse_type("String")), "string");
-        assert_eq!(toml_type_label(&parse_type("char")), "single-letter string");
+        assert_eq!(
+            toml_type_label(&parse_type("char")),
+            "single-character string"
+        );
     }
 
     #[test]
     fn toml_type_label_arrays_and_maps() {
         assert_eq!(
             toml_type_label(&parse_type("Vec<char>")),
-            "[single-letter string]"
+            "[single-character string]"
         );
         assert_eq!(
             toml_type_label(&parse_type("Vec<Vec<u8>>")),

--- a/tools/gen-docs/src/extract/ty.rs
+++ b/tools/gen-docs/src/extract/ty.rs
@@ -209,10 +209,15 @@ pub(crate) fn find_type_doc(file: &syn::File, ident: &str) -> Option<TypeDoc> {
 /// - `NonZeroU*` / `NonZeroUsize` → `non-zero unsigned integer`
 /// - `NonZeroI*` / `NonZeroIsize` → `non-zero integer`
 /// - `f32` / `f64` → `float`
-/// - `char` → `single-letter string` (TOML's one-byte-string idiom
-///   for a Rust `char`; rendered distinctly from the multi-character
-///   string family because the `single_letter_*` rules' allow-lists
-///   reject any entry that isn't a single ASCII letter)
+/// - `char` → `single-letter string` (strictly a lie: `char` is a
+///   Unicode scalar value, so the honest label is
+///   `single-codepoint string`. We get away with the narrower
+///   "letter" wording because every `Vec<char>` field in this
+///   catalogue today happens to be a letter-shaped allow-list
+///   (`single_letter_*::*_allowed_idents`) or a near-letter
+///   ellipsis-relative (`unicode_ellipsis_*::also_flag`). Tracked
+///   for replacement by an `AsciiLetter(char)` newtype at
+///   <https://github.com/KSXGitHub/perfectionist/issues/120>.)
 /// - `String` / `&str` / `OsString` / `PathBuf` / `Cow<…>` → `string`
 /// - `Vec<T>` / `HashSet<T>` / `BTreeSet<T>` / `VecDeque<T>` /
 ///   `LinkedList<T>` → `[label-of-T]`
@@ -249,6 +254,8 @@ pub(crate) fn toml_type_label(ty: &Type) -> String {
             };
             match ident.as_str() {
                 "bool" => "boolean".to_owned(),
+                // The "letter" framing is narrower than `char` itself; see the
+                // rustdoc above and <https://github.com/KSXGitHub/perfectionist/issues/120>.
                 "char" => "single-letter string".to_owned(),
                 "String" | "str" | "OsString" | "OsStr" | "Path" | "PathBuf" | "Cow" => {
                     "string".to_owned()


### PR DESCRIPTION
## Summary

The `single_letter_*` rules' `extra_allowed_idents` / `ignore_allowed_idents` knobs were typed as `Vec<String>`, but `is_single_ascii_letter` gates the match, so any multi-character or non-letter entry silently never fired.

## Changes

- `src/rules/single_letter_{let_binding,function_param,closure_param}.rs`:
  - retype `extra_allowed_idents` / `ignore_allowed_idents` as `Vec<char>`; defaults from `&[&str]` to `&[char]`.
  - field docstrings now state the `[A-Za-z]` constraint and the config-parse-time failure mode so the generated `rules/*.md` is accurate.
- `src/common.rs`:
  - add `deserialize_ascii_letters` (rejects any entry that isn't a single ASCII letter at TOML-parse time, so `["xy"]` or `["1"]` produces a config-parse error instead of a silent no-op) and `resolve_symbol_set_from_chars` (intern a `Vec<char>` to `BTreeSet<Symbol>`); the three rules wire their config through both.
  - add a `#[cfg(test)] mod tests` block pinning the deserializer's contract: empty list and ASCII letters succeed, a multi-codepoint string fails at serde-toml's `char` parser, ASCII digits and non-ASCII letters surface our custom error message.
- `tests/single_letter_{let_binding,function_param,closure_param}.rs`: mirror the new `Vec<char>` shape.
- `tools/gen-docs/src/extract/ty.rs`: split `char` out of the multi-character `string` family; it now renders as `single-character string` (honest for every current `Vec<char>` field, since serde-toml only accepts one-character TOML strings for `char`). A tighter `single-letter string` label is reserved for the planned `AsciiLetter(char)` newtype tracked in #120.
- `planned-rules/single-letter-{const-item,static-item,const-generic}.md`: documentation update — restate the planned `allowed_idents` knob as `[single-character string]` / `Vec<char>` so future implementations match.
- `rules/*.md`: regenerated by `just gen-rules-md`. The new label also surfaces on `unicode_ellipsis_in_{comments,panic_messages}.also_flag`, which already used `Vec<char>`.

## Breaking change

`dylint.toml` configurations that wrote multi-character strings in `extra_allowed_idents` / `ignore_allowed_idents` will now fail to deserialise instead of being silently ignored.