### PR TITLE
docs(plan): remove mention of regex

### DIFF
--- a/planned-rules/bare-email.md
+++ b/planned-rules/bare-email.md
@@ -20,10 +20,12 @@ are:
 
 ## What to lint
 
-Scan every doc comment and regular comment for the regex equivalent of
-`(?<![<:\w])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b` (a
-local-part / `@` / domain pattern not already preceded by `<`, `:`,
-or a word character).
+Scan every doc comment and regular comment for a local-part / `@` /
+domain pattern not already preceded by `<`, `:`, or a word
+character. The local-part is one or more characters from
+`A-Za-z0-9._%+-`. The domain is one or more characters from
+`A-Za-z0-9.-`, followed by a `.` and at least two ASCII letters,
+ending at a word boundary.
 
 For each match outside a code span / code block, emit a diagnostic
 at the email span.

--- a/planned-rules/bare-email.md
+++ b/planned-rules/bare-email.md
@@ -22,10 +22,10 @@ are:
 
 Scan every doc comment and regular comment for a local-part / `@` /
 domain pattern not already preceded by `<`, `:`, or a word
-character. The local-part is one or more characters from
-`A-Za-z0-9._%+-`. The domain is one or more characters from
-`A-Za-z0-9.-`, followed by a `.` and at least two ASCII letters,
-ending at a word boundary.
+character. The local-part is one or more ASCII letters, ASCII
+digits, or any of `.`, `_`, `%`, `+`, `-`. The domain is one or
+more ASCII letters, ASCII digits, `.`, or `-`, followed by a `.`
+and at least two ASCII letters, ending at a word boundary.
 
 For each match outside a code span / code block, emit a diagnostic
 at the email span.

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -16,11 +16,11 @@ out of scope (they don't render anywhere) and are not linked anyway.
 
 ## What to lint
 
-Scan every `///` and `//!` comment for the regex equivalent of
-`(?<![\w\[])#\d+\b` (a `#` followed by digits, not already preceded
-by a word character or an opening bracket). For each match outside
-a code span / code block, emit a diagnostic at the bare-reference
-span.
+Scan every `///` and `//!` comment for a `#` followed by one or
+more ASCII digits, ending at a word boundary, and not already
+preceded by a word character or an opening bracket. For each match
+outside a code span / code block, emit a diagnostic at the
+bare-reference span.
 
 Skip:
 

--- a/planned-rules/bare-url.md
+++ b/planned-rules/bare-url.md
@@ -18,9 +18,10 @@ portable form and signals the author's intent explicitly.
 
 ## What to lint
 
-Scan every doc comment and regular comment for the regex equivalent of
-`(?<![<\[(])\bhttps?://\S+` (an `http://` or `https://` followed by
-non-whitespace, not already preceded by `<`, `[`, or `(`).
+Scan every doc comment and regular comment for an `http://` or
+`https://` (starting at a word boundary) followed by one or more
+non-whitespace characters, not already preceded by `<`, `[`, or
+`(`.
 
 For each match outside a code span / code block, emit a diagnostic at
 the URL span.


### PR DESCRIPTION
## Summary

The "What to lint" sections of three planning files (`bare-issue-reference.md`, `bare-email.md`, `bare-url.md`) opened with "the regex equivalent of `<pattern>`", which contradicts the repo-wide convention in [`IMPLEMENTATION_CONVENTIONS.md`](../blob/master/planned-rules/IMPLEMENTATION_CONVENTIONS.md) forbidding the `regex` crate and mandating parser combinators. The regex framing risked nudging future implementers toward a regex-shaped solution.

Each paragraph is reworded to describe the pattern in plain prose — character classes spelled out as "ASCII letters, ASCII digits, or any of `.`, `_`, `%`, `+`, `-`" instead of `[A-Za-z0-9._%+-]`, etc. — preserving the precision of the spec without invoking regex syntax.

Other regex mentions in the repo were audited and left as-is: they are either the no-regex convention itself or design rationale that intentionally contrasts combinators against regex.

## Test plan

- [ ] Docs-only change; no code paths touched.
- [ ] `grep -rn "regex equivalent" planned-rules/` returns no matches.