### PR TITLE
docs(plan/bare-issue-reference): change the specs

### DIFF
--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -208,7 +208,9 @@ pattern that several rules call out by reference — live in
 - [`unicode-ellipsis-in-docs.md`](./unicode-ellipsis-in-docs.md) — flag
   U+2026 (`…`) in `///` and `//!` doc comments; prefer `...`.
 - [`bare-issue-reference.md`](./bare-issue-reference.md) — require
-  `#123` issue / PR references in doc comments to be markdown links.
+  `#123` issue / PR references in doc comments to be markdown
+  links; optionally extend to plain `//` comments with a
+  URL-substitution autofix.
 - [`bare-url.md`](./bare-url.md) — require bare URLs in doc comments
   and regular comments to be wrapped in `<...>` or labelled
   `[text](url)`.

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -133,9 +133,10 @@ form = "inline"
 # `repo_base_url` is unset), plain-comment diagnostics are still
 # emitted help-only; no URL substitution is attempted.
 # Plain *block* comments (`/* ... */`) are out of scope for this
-# lint regardless of this setting. The sibling `bare_url` scans
-# block comments by default (via the shared
-# `unicode_ellipsis_in_comments` retokenizer); this rule
+# lint regardless of this setting. The sibling `bare_url`'s plan
+# is to scan block comments by reusing the regular-comment
+# retokenizer of the already-implemented
+# `perfectionist::unicode_ellipsis_in_comments`; this rule
 # deliberately doesn't, because the working assumption is that
 # `#NNN` references in Rust code live in `//` and `///` comments.
 # If a real codebase surfaces block-comment references, revisit.
@@ -172,17 +173,21 @@ plain_comment_form = "bare"
   pre-expansion source-text walk over each file's comment tokens).
   The markdown scanner is not invoked here; instead reuse the
   same `take_*` token scanner over the raw comment text.
-- **URL-fragment detection.** For each `#N` candidate (in either
-  target, and at the same step as the markdown scanner's skip
-  decisions for the doc-comment target — not after them — so
-  bare URLs in doc text are recognised too), walk backward from
-  the `#`, within the current comment line's text content, for
-  a `<ASCII letters>://` prefix with no intervening whitespace.
-  If found, skip the match. The check therefore covers `http`,
-  `https`, `ftp`, `git`, `ssh`, and any other URL scheme that
-  happens to land in source comments.
-  [`perfectionist::bare_url`](./bare-url.md) commits forward from
-  the scheme to do its URL discovery; the two scanners walk in
+- **URL-fragment detection.** Run this check in the same pass as
+  the markdown scanner's structural classification (the bare URL
+  it protects is plain markdown text the structural scanner
+  doesn't classify as a skip region — so a post-filter ordering
+  would miss it). For each `#N` candidate in either target, walk
+  backward from the `#` — bounded to the current comment line's
+  text content — for a `<ASCII letters>://` prefix with no
+  intervening whitespace. If found, skip the match. The check
+  covers `http`, `https`, `ftp`, `git`, `ssh`, and any other
+  scheme that lands in source comments. A `#NNN` on the line
+  after a URL that wrapped across `//` lines is flagged (the
+  rule treats line breaks as URL terminators, deliberately giving
+  up on wrapped-URL fragments).
+  [`perfectionist::bare_url`](./bare-url.md)'s planned scanner
+  commits forward from the scheme; the two scanners walk in
   opposite directions but agree on what counts as a URL run. If
   either rule grows past the trivial "scheme + non-whitespace"
   check, factor URL discovery into a crate-internal helper
@@ -206,10 +211,10 @@ plain_comment_form = "bare"
 - **Parser style.** Decompose the bare-reference scanner into
   parser-combinator-style `take_*` functions per
   [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md):
-  `take_token_prefix` (`#`, `GH-`, `gh-`, or any user-configured
-  alternative), `take_digits`, and a left-context check that the
-  preceding byte is not a word character or a `[`. Each
-  `extra_tokens` entry becomes one alternative in the
+  `take_token_prefix` (`#`, `GH-`, `gh-`, `pr#`, or any
+  user-configured alternative), `take_digits`, and a left-context
+  check that the preceding byte is not a word character or a `[`.
+  Each `extra_tokens` entry becomes one alternative in the
   `take_token_prefix` step.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -58,11 +58,12 @@ left-context guard (no word character, no `[` before the `#`)
 and the URL-fragment skip still do. The `[` half of the guard
 deserves a note: in plain comments, `[#123]` isn't a markdown
 link, so the guard's doc-comment rationale doesn't transfer.
-Skipping it anyway is deliberate — the brackets in plain text
-read as the author's manual emphasis or quotation, and
-rewriting `[#123]` to a URL form would damage that authorial
-choice. Users who want the URL form should drop the brackets
-themselves.
+Skipping it anyway is deliberate — the bracketed token in plain
+text could be the author's deliberate styling (emphasis, a
+citation marker, a Markdown habit carried over) and the lint
+can't disambiguate, so leaving the span alone respects the
+explicit input. Users who want the URL form should drop the
+brackets themselves.
 
 ## Examples
 
@@ -145,13 +146,14 @@ form = "inline"
 # emitted help-only; no URL substitution is attempted.
 # Plain *block* comments (`/* ... */`) are out of scope for this
 # lint regardless of this setting. The sibling `bare_url`'s plan
-# is to scan block comments by reusing the regular-comment
-# retokenizer that `perfectionist::unicode_ellipsis_in_comments`
-# would expose if factored out (it currently inlines that walk);
-# this rule deliberately doesn't scan block comments at all,
-# because the working assumption is that `#NNN` references in
-# Rust code live in `//` and `///` comments. If a real codebase
-# surfaces block-comment references, revisit.
+# is to scan block comments via the same `rustc_lexer::tokenize`
+# walk that `perfectionist::unicode_ellipsis_in_comments` uses
+# inline (matching on `TokenKind::LineComment { doc_style: None }`
+# and `TokenKind::BlockComment { doc_style: None }`); this rule
+# deliberately doesn't scan block comments at all, because the
+# working assumption is that `#NNN` references in Rust code live
+# in `//` and `///` comments. If a real codebase surfaces
+# block-comment references, revisit.
 include_plain_comments = false
 
 # Replacement form used inside plain `//` comments when
@@ -174,8 +176,12 @@ plain_comment_form = "bare"
 #               recognise it, and the brackets give the URL a
 #               clear boundary when it abuts surrounding
 #               punctuation. `perfectionist::bare_url` accepts
-#               the same form for its own checks, so the two
-#               rules don't ping-pong.
+#               this form by default (`accept` includes
+#               `"angle_brackets"`); a project that has narrowed
+#               `bare_url.accept = ["labelled"]` would still see
+#               a `bare_url` violation on the autofix output and
+#               should pick one of the broader relaxations from
+#               the Interaction-with-sibling-rules section.
 ```
 
 ## Implementation notes
@@ -221,7 +227,12 @@ plain_comment_form = "bare"
     not implement the same redirect; the spec defaults
     conservatively to `MaybeIncorrect` on those and emits a
     note explaining why. The forge is detected by parsing the
-    host out of `repo_base_url`; no extra config knob.
+    host out of `repo_base_url`; no extra config knob. (Future
+    work: if self-hosted-GHE support becomes a real adopter
+    need, align with
+    [`unpinned-repo-ref`](./unpinned-repo-ref.md)'s
+    `hosts = [{ hostname, kind }]` pattern so users can
+    register an instance as `kind = "github"`.)
   - `suggestion_mode = "both"` → two `MaybeIncorrect` suggestions.
     `cargo clippy --fix` will not apply either; the author picks
     manually.

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -37,10 +37,17 @@ Skip:
   (`[#123]`, `[#123](...)`, `[label](#123)`).
 - Inside a markdown reference-link definition trailing target
   (`[#123]: https://...`).
-- When the match is the fragment of a written-out URL (e.g., the
-  `#123` in `https://example.com/article#123`) — applies whether
-  the URL appears as a bare URL in doc text or wrapped as a
-  markdown link.
+- When the match is the fragment of a written-out URL — applies
+  whether the URL appears as a bare URL in doc text or wrapped
+  as a markdown link. Note that the left-context guard already
+  catches the common case where the `#` is preceded by a word
+  character (e.g., `https://example.com/article#123` — the `e`
+  before `#` is a word char, so the bare match never fires); the
+  URL-fragment skip exists for fragments whose `#` is preceded
+  by a non-word character that the left-context guard alone
+  would let through, e.g.
+  `https://example.com/issues/#123`,
+  `https://example.com/path?ref=#123`.
 
 When `include_plain_comments = true`, the same token-shape match
 runs over `//` comment text as well. Markdown-specific skips

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -16,9 +16,10 @@ comments are not processed as markdown, so the standard
 `[#N](url)` suggestion would appear there as literal syntax
 rather than a link — there is no useful fix to offer in
 labelled-link form. Opt in via `include_plain_comments` to lint
-plain comments too; the autofix in that mode substitutes an
-autolink (bare URL, or angle-bracketed URL) instead of a
-labelled markdown link. See `plain_comment_form` below.
+plain comments too; the autofix in that mode substitutes the URL
+itself (bare, or wrapped in angle brackets), relying on the
+editor / code-viewer's URL autolinkification rather than markdown
+rendering. See `plain_comment_form` below.
 
 ## What to lint
 
@@ -112,11 +113,13 @@ extra_tokens = []                # e.g., ["GH-", "gh-", "pr#"]
 # `[#N] / [#N]: <url>` two-piece form instead of `[#N](<url>)`.
 form = "inline"
 
-# When true, also lint plain `//` comments. The autofix in plain
-# comments cannot use markdown `[#N](url)` syntax (plain comments
-# aren't markdown-rendered), so the substitution uses the URL form
-# selected by `plain_comment_form` instead. `form` only governs
-# doc-comment fixes and is ignored for plain comments.
+# When true, also lint plain `//` line comments. The autofix in
+# plain comments cannot use markdown `[#N](url)` syntax (plain
+# comments aren't markdown-rendered), so the substitution uses
+# the URL form selected by `plain_comment_form` instead. `form`
+# only governs doc-comment fixes and is ignored for plain
+# comments. Plain *block* comments (`/* ... */`) are out of
+# scope for this lint regardless of this setting.
 include_plain_comments = false
 
 # Replacement form used inside plain `//` comments when

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -91,7 +91,7 @@ With `include_plain_comments = true`:
 [bare_issue_reference]
 # Base URL used to construct the suggested target. Required for
 # `MachineApplicable` autofix. When unset, every `suggestion_mode`
-# degrades to help-text-only output (no URL can be constructed),
+# degrades to help-only output (no URL can be constructed),
 # so the lint stays usable with zero configuration — it just
 # flags bare references for manual triage.
 repo_base_url = "https://github.com/owner/repo"
@@ -112,11 +112,10 @@ suggestion_mode = "issue_url"
 # "help_only"  — emit no Suggestion, only help text. Use when
 #                `repo_base_url` cannot be configured statically
 #                (e.g., a workspace with multiple repositories).
-#                Selecting this mode explicitly is independent of
-#                the unset-`repo_base_url` degradation described
-#                above — the explicit form is portable across
-#                configurations where `repo_base_url` happens to
-#                be set.
+#                Distinct from the unset-`repo_base_url`
+#                degradation described above: setting this mode
+#                explicitly keeps the lint help-only even when
+#                `repo_base_url` is configured.
 
 # Additional bare-reference tokens to recognise. Default empty.
 extra_tokens = []                # e.g., ["GH-", "gh-", "pr#"]
@@ -132,12 +131,14 @@ form = "inline"
 # only governs doc-comment fixes and is ignored for plain
 # comments. Under `suggestion_mode = "help_only"` (or whenever
 # `repo_base_url` is unset), plain-comment diagnostics are still
-# emitted help-text-only; no URL substitution is attempted.
+# emitted help-only; no URL substitution is attempted.
 # Plain *block* comments (`/* ... */`) are out of scope for this
-# lint regardless of this setting — issue references appear in
-# `//` and `///` comments in practice, not `/* ... */` ones, and
-# narrowing the scope avoids speculative scope growth without a
-# real adopter need.
+# lint regardless of this setting. The sibling `bare_url` scans
+# block comments by default (via the shared
+# `unicode_ellipsis_in_comments` retokenizer); this rule
+# deliberately doesn't, because the working assumption is that
+# `#NNN` references in Rust code live in `//` and `///` comments.
+# If a real codebase surfaces block-comment references, revisit.
 include_plain_comments = false
 
 # Replacement form used inside plain `//` comments when
@@ -175,13 +176,17 @@ plain_comment_form = "bare"
   target, and at the same step as the markdown scanner's skip
   decisions for the doc-comment target — not after them — so
   bare URLs in doc text are recognised too), walk backward from
-  the `#` looking for `https://` or `http://` with no intervening
-  whitespace. If the candidate sits inside that contiguous run,
-  skip the match. [`perfectionist::bare_url`](./bare-url.md)
-  already needs a forward URL scanner; if either rule grows past
-  the trivial "backward to scheme, no whitespace" check, factor
-  URL discovery into a crate-internal helper shared by the two
-  rules rather than duplicating the scanner.
+  the `#`, within the current comment line's text content, for
+  a `<ASCII letters>://` prefix with no intervening whitespace.
+  If found, skip the match. The check therefore covers `http`,
+  `https`, `ftp`, `git`, `ssh`, and any other URL scheme that
+  happens to land in source comments.
+  [`perfectionist::bare_url`](./bare-url.md) commits forward from
+  the scheme to do its URL discovery; the two scanners walk in
+  opposite directions but agree on what counts as a URL run. If
+  either rule grows past the trivial "scheme + non-whitespace"
+  check, factor URL discovery into a crate-internal helper
+  shared by the two rules rather than duplicating the scanner.
 - The autofix substitutes the bare span with the rendered link.
   Suggestion applicability:
   - `suggestion_mode = "issue_url"` → `MachineApplicable`. The
@@ -226,17 +231,15 @@ re-lints will see a `bare_url` violation on the intermediate
 output and fail.
 
 Set `plain_comment_form = "bracketed"` to make the first fix
-already produce `<https://...>`, which both rules accept. Per-
-project relaxations are available too — narrowing `bare_url`'s
-`targets` or adding the URL to its `skip_hosts` — but those
-disable `bare_url` checking beyond just this rule's autofix
-output and are usually the wrong knob.
-
-The two rules' planning files also disagree on plain `/* ... */`
-block-comment scope: `bare_url` scans block comments by default;
-this rule does not (see the `include_plain_comments` knob for
-the rationale).
+already produce `<https://...>`, which both rules accept. A
+project that has consciously decided bare URLs in comments are
+fine can instead narrow `bare_url`'s `targets` or add the issue
+host to its `skip_hosts` — those choices are valid project
+postures, just broader in effect than the `"bracketed"` swap.
 
 ## Default state
 
-Active by default.
+Active by default. With `repo_base_url` unset, every
+`suggestion_mode` degrades to help-only output, so the lint is
+adoptable with zero configuration (see `repo_base_url` in
+Configuration).

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -49,8 +49,8 @@ don't apply there — plain comments aren't markdown — but the
 left-context guard (no word character, no `[` before the `#`)
 and the URL-fragment skip still do.
 
-The match is case-insensitive when alternative tokens like `GH-`,
-`gh-`, or `pr#` are configured.
+In both targets, the match is case-insensitive when alternative
+tokens like `GH-`, `gh-`, or `pr#` are configured.
 
 ## Examples
 
@@ -124,8 +124,13 @@ form = "inline"
 # comments aren't markdown-rendered), so the substitution uses
 # the URL form selected by `plain_comment_form` instead. `form`
 # only governs doc-comment fixes and is ignored for plain
-# comments. Plain *block* comments (`/* ... */`) are out of
-# scope for this lint regardless of this setting.
+# comments. Under `suggestion_mode = "help_only"` (or whenever
+# `repo_base_url` is unset), plain-comment diagnostics are still
+# emitted informationally; no URL substitution is attempted.
+# Plain *block* comments (`/* ... */`) are out of scope for this
+# lint regardless of this setting — issue references appear in
+# line and doc comments in practice, and excluding block comments
+# keeps the comment scanner free of `/* ... */` boundary handling.
 include_plain_comments = false
 
 # Replacement form used inside plain `//` comments when
@@ -156,9 +161,15 @@ plain_comment_form = "bare"
   `//` comments via an `EarlyLintPass` over the source map (or a
   pre-expansion source-text walk over each file's comment tokens).
   The markdown scanner is not invoked here; instead reuse the
-  same `take_*` token scanner over the raw comment text. The
-  URL-fragment skip (described in "What to lint" above) applies
-  to both targets.
+  same `take_*` token scanner over the raw comment text.
+- **URL-fragment detection.** For each candidate match in either
+  target, run a small URL-recognition pass (recognise
+  `http://` / `https://` followed by a non-whitespace run) and
+  skip the match when it lies inside that run. The combinators
+  for URL discovery (`take_scheme`, `take_authority`, `take_path`)
+  are the same ones [`perfectionist::bare_url`](./bare-url.md)
+  uses; factor them into a crate-internal helper shared by the
+  two rules rather than duplicating the scanner.
 - The autofix substitutes the bare span with the rendered link.
   Suggestion applicability:
   - `suggestion_mode = "issue_url"` → `MachineApplicable`. The
@@ -194,12 +205,19 @@ plain_comment_form = "bare"
 When `include_plain_comments = true` and `plain_comment_form = "bare"`,
 the autofix produces a bare URL inside a plain comment — exactly
 what [`perfectionist::bare_url`](./bare-url.md) is designed to
-flag. With both rules enabled and `bare_url`'s `targets` including
-`"comment"`, the rewrite chain is `#123 → https://... → <https://...>`
-across two passes. To avoid the second pass, set
-`plain_comment_form = "bracketed"`, which produces the
-`<https://...>` form directly.
+flag. Since `bare_url`'s default `targets = ["doc", "comment"]`
+includes the `"comment"` target, the rewrite chain
+`#123 → https://... → <https://...>` materialises iteratively
+across `cargo dylint --fix` invocations (the second hop only
+fires on a re-run, after the first autofix lands). Either set
+`plain_comment_form = "bracketed"` so the first fix already
+produces `<https://...>`, or drop `"comment"` from `bare_url`'s
+`targets` if bare URLs in comments are acceptable in the
+project.
 
 ## Default state
 
-Active by default.
+Active by default. With `repo_base_url` unset and
+`suggestion_mode = "help_only"`, the lint runs informationally
+(diagnostic-only, no autofix) and can be adopted without further
+configuration.

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -25,9 +25,10 @@ rendering. See `plain_comment_form` below.
 
 Scan every `///` and `//!` comment for a `#` followed by one or
 more ASCII digits, ending at a word boundary, and not already
-preceded by a word character or an opening bracket. For each match
-outside a code span / code block, emit a diagnostic at the
-bare-reference span.
+preceded by a word character or by the `[` character (the
+opening of an existing markdown link). For each match outside a
+code span / code block, emit a diagnostic at the bare-reference
+span.
 
 Skip:
 
@@ -36,15 +37,17 @@ Skip:
   (`[#123]`, `[#123](...)`, `[label](#123)`).
 - Inside a markdown reference-link definition trailing target
   (`[#123]: https://...`).
+- When the match is the fragment of a written-out URL (e.g., the
+  `#123` in `https://example.com/article#123`) — applies whether
+  the URL appears as a bare URL in doc text or wrapped as a
+  markdown link.
 
 When `include_plain_comments = true`, the same token-shape match
 runs over `//` comment text as well. Markdown-specific skips
 (code spans, existing markdown links, reference-link definitions)
 don't apply there — plain comments aren't markdown — but the
-scanner still skips a `#NNN` span that occurs as the fragment of
-an existing URL (e.g., the `#123` in
-`https://example.com/article#123`), so a URL fragment the author
-already wrote isn't mistaken for a bare reference.
+left-context guard (no word character, no `[` before the `#`)
+and the URL-fragment skip still do.
 
 The match is case-insensitive when alternative tokens like `GH-`,
 `gh-`, or `pr#` are configured.
@@ -105,6 +108,9 @@ suggestion_mode = "issue_url"
 # "help_only"  — emit no Suggestion, only help text. Use when
 #                `repo_base_url` cannot be configured statically
 #                (e.g., a workspace with multiple repositories).
+#                With `repo_base_url` unset, this mode runs the
+#                lint informationally to flag bare references for
+#                manual triage with no further configuration.
 
 # Additional bare-reference tokens to recognise. Default empty.
 extra_tokens = []                # e.g., ["GH-", "gh-", "pr#"]
@@ -127,7 +133,10 @@ include_plain_comments = false
 plain_comment_form = "bare"
 # "bare"      — substitute the bare URL (https://...). Many editors
 #               and code-view UIs auto-detect bare URLs as
-#               clickable.
+#               clickable, but they disagree on whether trailing
+#               punctuation (`;`, `,`, `.`) belongs to the URL;
+#               pick "bracketed" if the surrounding prose tends to
+#               put punctuation immediately after the reference.
 # "bracketed" — substitute <https://...>. A pre-markdown convention
 #               for delimiting a URL inside prose; the angle
 #               brackets give the URL a clear boundary when it
@@ -146,11 +155,10 @@ plain_comment_form = "bare"
 - When `include_plain_comments = true`, additionally walk plain
   `//` comments via an `EarlyLintPass` over the source map (or a
   pre-expansion source-text walk over each file's comment tokens).
-  The markdown scanner is not invoked here; instead reuse the same
-  `take_*` token scanner over the raw comment text, plus a small
-  "is the match a URL fragment?" check to avoid re-reporting an
-  `#N` that already lives inside a written-out URL (e.g., the
-  `#123` in `https://example.com/article#123`).
+  The markdown scanner is not invoked here; instead reuse the
+  same `take_*` token scanner over the raw comment text. The
+  URL-fragment skip (described in "What to lint" above) applies
+  to both targets.
 - The autofix substitutes the bare span with the rendered link.
   Suggestion applicability:
   - `suggestion_mode = "issue_url"` → `MachineApplicable`. The
@@ -172,8 +180,8 @@ plain_comment_form = "bare"
   [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md):
   `take_token_prefix` (`#`, `GH-`, `gh-`, or any user-configured
   alternative), `take_digits`, and a left-context check that the
-  preceding byte is not a word character or an opening bracket.
-  Each `extra_tokens` entry becomes one alternative in the
+  preceding byte is not a word character or a `[`. Each
+  `extra_tokens` entry becomes one alternative in the
   `take_token_prefix` step.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
@@ -181,9 +189,17 @@ plain_comment_form = "bare"
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)
   that every registered lint follows.
 
+## Interaction with sibling rules
+
+When `include_plain_comments = true` and `plain_comment_form = "bare"`,
+the autofix produces a bare URL inside a plain comment — exactly
+what [`perfectionist::bare_url`](./bare-url.md) is designed to
+flag. With both rules enabled and `bare_url`'s `targets` including
+`"comment"`, the rewrite chain is `#123 → https://... → <https://...>`
+across two passes. To avoid the second pass, set
+`plain_comment_form = "bracketed"`, which produces the
+`<https://...>` form directly.
+
 ## Default state
 
-Active by default. With `repo_base_url` unset and
-`suggestion_mode = "help_only"`, the lint becomes informational
-and a project can run it without further configuration to flag
-the bare references for manual triage.
+Active by default.

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -122,8 +122,9 @@ suggestion_mode = "issue_url"
 #                `repo_base_url` is configured.
 
 # Doc-comment fix form. Defaults to "inline". When set to
-# "reference", the lint emits the `[#N] / [#N]: <url>` two-piece
-# form instead of `[#N](<url>)`. Ignored for plain-comment fixes,
+# "reference", the lint emits the `[#N] / [#N]: URL` two-piece
+# form instead of `[#N](URL)` (where `URL` is the substituted
+# target, not literal text). Ignored for plain-comment fixes,
 # which use `plain_comment_form` instead.
 form = "inline"
 
@@ -138,15 +139,17 @@ form = "inline"
 # Plain *block* comments (`/* ... */`) are out of scope for this
 # lint regardless of this setting. The sibling `bare_url`'s plan
 # is to scan block comments by reusing the regular-comment
-# retokenizer of the already-implemented
-# `perfectionist::unicode_ellipsis_in_comments`; this rule
-# deliberately doesn't, because the working assumption is that
-# `#NNN` references in Rust code live in `//` and `///` comments.
-# If a real codebase surfaces block-comment references, revisit.
+# retokenizer that `perfectionist::unicode_ellipsis_in_comments`
+# would expose if factored out (it currently inlines that walk);
+# this rule deliberately doesn't scan block comments at all,
+# because the working assumption is that `#NNN` references in
+# Rust code live in `//` and `///` comments. If a real codebase
+# surfaces block-comment references, revisit.
 include_plain_comments = false
 
 # Replacement form used inside plain `//` comments when
-# `include_plain_comments = true`. Ignored for doc comments and
+# `include_plain_comments = true`. Counterpart to `form` above,
+# which governs doc-comment fixes. Ignored for doc comments, and
 # ignored whenever no URL can be substituted (see the unset-
 # `repo_base_url` / `help_only` notes above).
 plain_comment_form = "bare"
@@ -156,12 +159,16 @@ plain_comment_form = "bare"
 #               punctuation (`;`, `,`, `.`) belongs to the URL;
 #               pick "bracketed" if the surrounding prose tends to
 #               put punctuation immediately after the reference.
-# "bracketed" — substitute <https://...>. This is CommonMark's
-#               autolink syntax (which plain comments don't
-#               render, but the brackets still give the URL a
-#               clear textual boundary when it abuts surrounding
-#               punctuation). `perfectionist::bare_url` accepts
-#               the same form for its own checks.
+# "bracketed" — substitute <https://...>. The angle-bracket
+#               delimiter predates markdown as a URL-in-prose
+#               convention (RFC-style "<URL>" wrapping) and is
+#               what CommonMark later codified as autolink
+#               syntax. Editors that auto-link URLs typically
+#               recognise it, and the brackets give the URL a
+#               clear boundary when it abuts surrounding
+#               punctuation. `perfectionist::bare_url` accepts
+#               the same form for its own checks, so the two
+#               rules don't ping-pong.
 ```
 
 ## Implementation notes
@@ -193,16 +200,20 @@ plain_comment_form = "bare"
   up on wrapped-URL fragments).
   [`perfectionist::bare_url`](./bare-url.md)'s planned scanner
   commits forward from the scheme; the two scanners walk in
-  opposite directions but agree on what counts as a URL run. If
+  opposite directions but agree on what counts as a URL span. If
   either rule grows past the trivial "scheme + non-whitespace"
   check, factor URL discovery into a crate-internal helper
   shared by the two rules rather than duplicating the scanner.
 - The autofix substitutes the bare span with the rendered link.
   Suggestion applicability:
-  - `suggestion_mode = "issue_url"` → `MachineApplicable`. The
-    `/issues/<n>` URL works for both issues and PRs on GitHub thanks
-    to redirect; on configured non-GitHub forges, mark this mode as
-    `MaybeIncorrect` and emit a note explaining why.
+  - `suggestion_mode = "issue_url"` → `MachineApplicable` when
+    `repo_base_url`'s host is `github.com` (or `*.github.com`),
+    because GitHub redirects `/issues/<n>` to `/pull/<n>` when
+    the number names a PR. Otherwise (the URL points at a
+    self-hosted forge that may not redirect) downgrade to
+    `MaybeIncorrect` and emit a note explaining why. The forge
+    is detected by parsing the host out of `repo_base_url`; no
+    extra config knob.
   - `suggestion_mode = "both"` → two `MaybeIncorrect` suggestions.
     `cargo clippy --fix` will not apply either; the author picks
     manually.

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -55,7 +55,14 @@ runs over `//` comment text as well. Markdown-specific skips
 (code spans, existing markdown links, reference-link definitions)
 don't apply there — plain comments aren't markdown — but the
 left-context guard (no word character, no `[` before the `#`)
-and the URL-fragment skip still do.
+and the URL-fragment skip still do. The `[` half of the guard
+deserves a note: in plain comments, `[#123]` isn't a markdown
+link, so the guard's doc-comment rationale doesn't transfer.
+Skipping it anyway is deliberate — the brackets in plain text
+read as the author's manual emphasis or quotation, and
+rewriting `[#123]` to a URL form would damage that authorial
+choice. Users who want the URL form should drop the brackets
+themselves.
 
 ## Examples
 
@@ -207,13 +214,14 @@ plain_comment_form = "bare"
 - The autofix substitutes the bare span with the rendered link.
   Suggestion applicability:
   - `suggestion_mode = "issue_url"` → `MachineApplicable` when
-    `repo_base_url`'s host is `github.com` (or `*.github.com`),
-    because GitHub redirects `/issues/<n>` to `/pull/<n>` when
-    the number names a PR. Otherwise (the URL points at a
-    self-hosted forge that may not redirect) downgrade to
-    `MaybeIncorrect` and emit a note explaining why. The forge
-    is detected by parsing the host out of `repo_base_url`; no
-    extra config knob.
+    `repo_base_url`'s host is exactly `github.com`, because
+    public GitHub redirects `/issues/<n>` to `/pull/<n>` when
+    the number names a PR. Other hosts — GitHub Enterprise
+    Server (custom hostnames), GitLab, Gitea, etc. — may or may
+    not implement the same redirect; the spec defaults
+    conservatively to `MaybeIncorrect` on those and emits a
+    note explaining why. The forge is detected by parsing the
+    host out of `repo_base_url`; no extra config knob.
   - `suggestion_mode = "both"` → two `MaybeIncorrect` suggestions.
     `cargo clippy --fix` will not apply either; the author picks
     manually.
@@ -252,9 +260,10 @@ output and fail.
 Set `plain_comment_form = "bracketed"` to make the first fix
 already produce `<https://...>`, which both rules accept. A
 project that has consciously decided bare URLs in comments are
-fine can instead narrow `bare_url`'s `targets` or add the issue
-host to its `skip_hosts` — those choices are valid project
-postures, just broader in effect than the `"bracketed"` swap.
+fine can instead narrow `bare_url`'s `targets` (universally
+valid) or — when `repo_base_url` is set — add the issue host to
+`bare_url`'s `skip_hosts`. Both are broader in effect than the
+`"bracketed"` swap.
 
 ## Default state
 

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -49,8 +49,9 @@ don't apply there — plain comments aren't markdown — but the
 left-context guard (no word character, no `[` before the `#`)
 and the URL-fragment skip still do.
 
-In both targets, the match is case-insensitive when alternative
-tokens like `GH-`, `gh-`, or `pr#` are configured.
+In both doc and plain comments, the match is case-insensitive
+when alternative tokens like `GH-`, `gh-`, or `pr#` are
+configured.
 
 ## Examples
 
@@ -89,7 +90,10 @@ With `include_plain_comments = true`:
 ```toml
 [bare_issue_reference]
 # Base URL used to construct the suggested target. Required for
-# `MachineApplicable` autofix.
+# `MachineApplicable` autofix. When unset, every `suggestion_mode`
+# degrades to help-text-only output (no URL can be constructed),
+# so the lint stays usable with zero configuration — it just
+# flags bare references for manual triage.
 repo_base_url = "https://github.com/owner/repo"
 
 # Templates for the suggested URL. `{number}` is substituted.
@@ -108,9 +112,11 @@ suggestion_mode = "issue_url"
 # "help_only"  — emit no Suggestion, only help text. Use when
 #                `repo_base_url` cannot be configured statically
 #                (e.g., a workspace with multiple repositories).
-#                With `repo_base_url` unset, this mode runs the
-#                lint informationally to flag bare references for
-#                manual triage with no further configuration.
+#                Selecting this mode explicitly is independent of
+#                the unset-`repo_base_url` degradation described
+#                above — the explicit form is portable across
+#                configurations where `repo_base_url` happens to
+#                be set.
 
 # Additional bare-reference tokens to recognise. Default empty.
 extra_tokens = []                # e.g., ["GH-", "gh-", "pr#"]
@@ -126,15 +132,18 @@ form = "inline"
 # only governs doc-comment fixes and is ignored for plain
 # comments. Under `suggestion_mode = "help_only"` (or whenever
 # `repo_base_url` is unset), plain-comment diagnostics are still
-# emitted informationally; no URL substitution is attempted.
+# emitted help-text-only; no URL substitution is attempted.
 # Plain *block* comments (`/* ... */`) are out of scope for this
 # lint regardless of this setting — issue references appear in
-# line and doc comments in practice, and excluding block comments
-# keeps the comment scanner free of `/* ... */` boundary handling.
+# `//` and `///` comments in practice, not `/* ... */` ones, and
+# narrowing the scope avoids speculative scope growth without a
+# real adopter need.
 include_plain_comments = false
 
 # Replacement form used inside plain `//` comments when
-# `include_plain_comments = true`. Ignored for doc comments.
+# `include_plain_comments = true`. Ignored for doc comments and
+# ignored whenever no URL can be substituted (see the unset-
+# `repo_base_url` / `help_only` notes above).
 plain_comment_form = "bare"
 # "bare"      — substitute the bare URL (https://...). Many editors
 #               and code-view UIs auto-detect bare URLs as
@@ -162,14 +171,17 @@ plain_comment_form = "bare"
   pre-expansion source-text walk over each file's comment tokens).
   The markdown scanner is not invoked here; instead reuse the
   same `take_*` token scanner over the raw comment text.
-- **URL-fragment detection.** For each candidate match in either
-  target, run a small URL-recognition pass (recognise
-  `http://` / `https://` followed by a non-whitespace run) and
-  skip the match when it lies inside that run. The combinators
-  for URL discovery (`take_scheme`, `take_authority`, `take_path`)
-  are the same ones [`perfectionist::bare_url`](./bare-url.md)
-  uses; factor them into a crate-internal helper shared by the
-  two rules rather than duplicating the scanner.
+- **URL-fragment detection.** For each `#N` candidate (in either
+  target, and at the same step as the markdown scanner's skip
+  decisions for the doc-comment target — not after them — so
+  bare URLs in doc text are recognised too), walk backward from
+  the `#` looking for `https://` or `http://` with no intervening
+  whitespace. If the candidate sits inside that contiguous run,
+  skip the match. [`perfectionist::bare_url`](./bare-url.md)
+  already needs a forward URL scanner; if either rule grows past
+  the trivial "backward to scheme, no whitespace" check, factor
+  URL discovery into a crate-internal helper shared by the two
+  rules rather than duplicating the scanner.
 - The autofix substitutes the bare span with the rendered link.
   Suggestion applicability:
   - `suggestion_mode = "issue_url"` → `MachineApplicable`. The
@@ -209,15 +221,22 @@ flag. Since `bare_url`'s default `targets = ["doc", "comment"]`
 includes the `"comment"` target, the rewrite chain
 `#123 → https://... → <https://...>` materialises iteratively
 across `cargo dylint --fix` invocations (the second hop only
-fires on a re-run, after the first autofix lands). Either set
-`plain_comment_form = "bracketed"` so the first fix already
-produces `<https://...>`, or drop `"comment"` from `bare_url`'s
-`targets` if bare URLs in comments are acceptable in the
-project.
+fires on a re-run). A CI that runs `--fix` once and immediately
+re-lints will see a `bare_url` violation on the intermediate
+output and fail.
+
+Set `plain_comment_form = "bracketed"` to make the first fix
+already produce `<https://...>`, which both rules accept. Per-
+project relaxations are available too — narrowing `bare_url`'s
+`targets` or adding the URL to its `skip_hosts` — but those
+disable `bare_url` checking beyond just this rule's autofix
+output and are usually the wrong knob.
+
+The two rules' planning files also disagree on plain `/* ... */`
+block-comment scope: `bare_url` scans block comments by default;
+this rule does not (see the `include_plain_comments` knob for
+the rationale).
 
 ## Default state
 
-Active by default. With `repo_base_url` unset and
-`suggestion_mode = "help_only"`, the lint runs informationally
-(diagnostic-only, no autofix) and can be adopted without further
-configuration.
+Active by default.

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -41,10 +41,10 @@ When `include_plain_comments = true`, the same token-shape match
 runs over `//` comment text as well. Markdown-specific skips
 (code spans, existing markdown links, reference-link definitions)
 don't apply there — plain comments aren't markdown — but the
-scanner still skips a `#NNN` that appears inside an existing URL
-(i.e., the bare span sits within a contiguous URL-shaped run such
-as `https://github.com/owner/repo/issues/123`), so a URL the
-author already wrote isn't reported as a bare reference.
+scanner still skips a `#NNN` span that occurs as the fragment of
+an existing URL (e.g., the `#123` in
+`https://example.com/article#123`), so a URL fragment the author
+already wrote isn't mistaken for a bare reference.
 
 The match is case-insensitive when alternative tokens like `GH-`,
 `gh-`, or `pr#` are configured.
@@ -148,9 +148,9 @@ plain_comment_form = "bare"
   pre-expansion source-text walk over each file's comment tokens).
   The markdown scanner is not invoked here; instead reuse the same
   `take_*` token scanner over the raw comment text, plus a small
-  "is the match inside a contiguous URL run?" check to avoid
-  re-reporting an `#N` token that already lives inside a
-  written-out URL.
+  "is the match a URL fragment?" check to avoid re-reporting an
+  `#N` that already lives inside a written-out URL (e.g., the
+  `#123` in `https://example.com/article#123`).
 - The autofix substitutes the bare span with the rendered link.
   Suggestion applicability:
   - `suggestion_mode = "issue_url"` → `MachineApplicable`. The

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -4,9 +4,9 @@
 
 ## Statement
 
-In doc comments (`///`, `//!`), references to issues or pull requests
-written as the bare token `#<digits>` (or a configured equivalent like
-`GH-123`) must be rendered as markdown links. Two acceptable forms:
+In doc comments (`///`, `//!`), references to issues or pull
+requests written as the bare token `#<digits>` must be rendered
+as markdown links. Two acceptable forms:
 
 - Inline: `[#123](https://github.com/owner/repo/issues/123)`.
 - Reference: `[#123]` paired with `[#123]: https://github.com/owner/repo/issues/123`.
@@ -55,10 +55,6 @@ runs over `//` comment text as well. Markdown-specific skips
 don't apply there — plain comments aren't markdown — but the
 left-context guard (no word character, no `[` before the `#`)
 and the URL-fragment skip still do.
-
-In both doc and plain comments, the match is case-insensitive
-when alternative tokens like `GH-`, `gh-`, or `pr#` are
-configured.
 
 ## Examples
 
@@ -123,9 +119,6 @@ suggestion_mode = "issue_url"
 #                degradation described above: setting this mode
 #                explicitly keeps the lint help-only even when
 #                `repo_base_url` is configured.
-
-# Additional bare-reference tokens to recognise. Default empty.
-extra_tokens = []                # e.g., ["GH-", "gh-", "pr#"]
 
 # Defaults to "inline". When set to "reference", the lint emits the
 # `[#N] / [#N]: <url>` two-piece form instead of `[#N](<url>)`.
@@ -218,11 +211,8 @@ plain_comment_form = "bare"
 - **Parser style.** Decompose the bare-reference scanner into
   parser-combinator-style `take_*` functions per
   [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md):
-  `take_token_prefix` (`#`, `GH-`, `gh-`, `pr#`, or any
-  user-configured alternative), `take_digits`, and a left-context
+  `take_hash` (the literal `#`), `take_digits`, and a left-context
   check that the preceding byte is not a word character or a `[`.
-  Each `extra_tokens` entry becomes one alternative in the
-  `take_token_prefix` step.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
   for cross-cutting conventions that apply to every rule in this

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -121,8 +121,10 @@ suggestion_mode = "issue_url"
 #                explicitly keeps the lint help-only even when
 #                `repo_base_url` is configured.
 
-# Defaults to "inline". When set to "reference", the lint emits the
-# `[#N] / [#N]: <url>` two-piece form instead of `[#N](<url>)`.
+# Doc-comment fix form. Defaults to "inline". When set to
+# "reference", the lint emits the `[#N] / [#N]: <url>` two-piece
+# form instead of `[#N](<url>)`. Ignored for plain-comment fixes,
+# which use `plain_comment_form` instead.
 form = "inline"
 
 # When true, also lint plain `//` line comments. The autofix in
@@ -154,10 +156,12 @@ plain_comment_form = "bare"
 #               punctuation (`;`, `,`, `.`) belongs to the URL;
 #               pick "bracketed" if the surrounding prose tends to
 #               put punctuation immediately after the reference.
-# "bracketed" — substitute <https://...>. A pre-markdown convention
-#               for delimiting a URL inside prose; the angle
-#               brackets give the URL a clear boundary when it
-#               abuts surrounding punctuation.
+# "bracketed" — substitute <https://...>. This is CommonMark's
+#               autolink syntax (which plain comments don't
+#               render, but the brackets still give the URL a
+#               clear textual boundary when it abuts surrounding
+#               punctuation). `perfectionist::bare_url` accepts
+#               the same form for its own checks.
 ```
 
 ## Implementation notes

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -146,8 +146,8 @@ plain_comment_form = "bare"
   The markdown scanner is not invoked here; instead reuse the same
   `take_*` token scanner over the raw comment text, plus a small
   "is the match inside a contiguous URL run?" check to avoid
-  re-reporting `#123` that already lives inside a written-out
-  URL.
+  re-reporting an `#N` token that already lives inside a
+  written-out URL.
 - The autofix substitutes the bare span with the rendered link.
   Suggestion applicability:
   - `suggestion_mode = "issue_url"` → `MachineApplicable`. The

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -23,12 +23,13 @@ rendering. See `plain_comment_form` below.
 
 ## What to lint
 
-Scan every `///` and `//!` comment for a `#` followed by one or
-more ASCII digits, ending at a word boundary, and not already
-preceded by a word character or by the `[` character (the
-opening of an existing markdown link). For each match outside a
-code span / code block, emit a diagnostic at the bare-reference
-span.
+Scan every `///` and `//!` doc comment — and, when
+`include_plain_comments = true`, every plain `//` comment too —
+for a `#` followed by one or more ASCII digits, ending at a word
+boundary, and not already preceded by a word character or by the
+`[` character (the opening of an existing markdown link). For
+each match outside a code span / code block, emit a diagnostic
+at the bare-reference span.
 
 Skip:
 
@@ -208,12 +209,13 @@ plain_comment_form = "bare"
   arbitrary files). Document the pattern of duplicating the URL in
   `dylint.toml`, and offer a small build-script snippet in the
   project's README that synchronises the two.
-- **Parser style.** Decompose the bare-reference scanner into
-  parser-combinator-style `take_*` functions per
-  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md):
-  `take_hash` (the literal `#`), `take_digits`, and a left-context
-  check that the preceding byte is not a word character or a `[`.
-
+- The bare-reference scanner itself is trivial enough (a literal
+  `#`, a digit run, and a one-byte left-context check) that the
+  parser-combinator scaffolding called out in
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  is not required. The URL-fragment backward walk and the
+  markdown structural classifier are the parts of this rule that
+  do follow the combinator convention.
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
   for cross-cutting conventions that apply to every rule in this
   catalogue, in particular the lint-name namespacing (`perfectionist::*`)

--- a/planned-rules/bare-issue-reference.md
+++ b/planned-rules/bare-issue-reference.md
@@ -11,8 +11,14 @@ written as the bare token `#<digits>` (or a configured equivalent like
 - Inline: `[#123](https://github.com/owner/repo/issues/123)`.
 - Reference: `[#123]` paired with `[#123]: https://github.com/owner/repo/issues/123`.
 
-The rule applies only to *doc comments*. Plain `//` comments are
-out of scope (they don't render anywhere) and are not linked anyway.
+By default the rule applies only to *doc comments*. Plain `//`
+comments are not processed as markdown, so the standard
+`[#N](url)` suggestion would appear there as literal syntax
+rather than a link — there is no useful fix to offer in
+labelled-link form. Opt in via `include_plain_comments` to lint
+plain comments too; the autofix in that mode substitutes an
+autolink (bare URL, or angle-bracketed URL) instead of a
+labelled markdown link. See `plain_comment_form` below.
 
 ## What to lint
 
@@ -29,6 +35,15 @@ Skip:
   (`[#123]`, `[#123](...)`, `[label](#123)`).
 - Inside a markdown reference-link definition trailing target
   (`[#123]: https://...`).
+
+When `include_plain_comments = true`, the same token-shape match
+runs over `//` comment text as well. Markdown-specific skips
+(code spans, existing markdown links, reference-link definitions)
+don't apply there — plain comments aren't markdown — but the
+scanner still skips a `#NNN` that appears inside an existing URL
+(i.e., the bare span sits within a contiguous URL-shaped run such
+as `https://github.com/owner/repo/issues/123`), so a URL the
+author already wrote isn't reported as a bare reference.
 
 The match is case-insensitive when alternative tokens like `GH-`,
 `gh-`, or `pr#` are configured.
@@ -48,6 +63,21 @@ The match is case-insensitive when alternative tokens like `GH-`,
 ///
 /// [#123]: https://github.com/owner/repo/issues/123
 /// [#124]: https://github.com/owner/repo/issues/124
+```
+
+With `include_plain_comments = true`:
+
+```rust
+// Bad
+// Workaround for #123; revisit once upstream lands #124.
+
+// Good (plain_comment_form = "bare")
+// Workaround for https://github.com/owner/repo/issues/123; revisit
+// once upstream lands https://github.com/owner/repo/issues/124.
+
+// Good (plain_comment_form = "bracketed")
+// Workaround for <https://github.com/owner/repo/issues/123>; revisit
+// once upstream lands <https://github.com/owner/repo/issues/124>.
 ```
 
 ## Configuration
@@ -81,6 +111,24 @@ extra_tokens = []                # e.g., ["GH-", "gh-", "pr#"]
 # Defaults to "inline". When set to "reference", the lint emits the
 # `[#N] / [#N]: <url>` two-piece form instead of `[#N](<url>)`.
 form = "inline"
+
+# When true, also lint plain `//` comments. The autofix in plain
+# comments cannot use markdown `[#N](url)` syntax (plain comments
+# aren't markdown-rendered), so the substitution uses the URL form
+# selected by `plain_comment_form` instead. `form` only governs
+# doc-comment fixes and is ignored for plain comments.
+include_plain_comments = false
+
+# Replacement form used inside plain `//` comments when
+# `include_plain_comments = true`. Ignored for doc comments.
+plain_comment_form = "bare"
+# "bare"      — substitute the bare URL (https://...). Many editors
+#               and code-view UIs auto-detect bare URLs as
+#               clickable.
+# "bracketed" — substitute <https://...>. A pre-markdown convention
+#               for delimiting a URL inside prose; the angle
+#               brackets give the URL a clear boundary when it
+#               abuts surrounding punctuation.
 ```
 
 ## Implementation notes
@@ -92,6 +140,14 @@ form = "inline"
   [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md#markdown-parsing)
   to skip code regions, existing links, and reference-link
   definitions.
+- When `include_plain_comments = true`, additionally walk plain
+  `//` comments via an `EarlyLintPass` over the source map (or a
+  pre-expansion source-text walk over each file's comment tokens).
+  The markdown scanner is not invoked here; instead reuse the same
+  `take_*` token scanner over the raw comment text, plus a small
+  "is the match inside a contiguous URL run?" check to avoid
+  re-reporting `#123` that already lives inside a written-out
+  URL.
 - The autofix substitutes the bare span with the rendered link.
   Suggestion applicability:
   - `suggestion_mode = "issue_url"` → `MachineApplicable`. The


### PR DESCRIPTION
Updates `planned-rules/bare-issue-reference.md` and its index entry in `planned-rules/README.md`.

## Rationale fix

The old reasoning for restricting the rule to doc comments —
"plain `//` comments don't render anywhere and are not linked
anyway" — was hand-wavy: `//` comments do render as source, and
"not linked anyway" is the very condition the rule exists to flag.
The actual reason is that plain comments aren't markdown-processed,
so a `[#N](url)` suggestion would appear as literal syntax rather
than a link. Rewritten to say that.

## Plain-comment opt-in

Add config knobs that let a project lint plain `//` comments too:

- `include_plain_comments` (default `false`).
- `plain_comment_form` (`bare` | `bracketed`) — autofix shape in
  plain comments. `bare` substitutes `https://...`; `bracketed`
  substitutes `<https://...>`. Labelled markdown links aren't
  offered there.

Plain `/* ... */` block comments stay out of scope, with the
rationale documented at the knob.

## Spec tightening (multi-round self-review)

A self-review loop tightened several rough edges:

- **URL-fragment skip**: spec a backward scan from `#` for
  `<scheme>://` (any ASCII-letter scheme), runs alongside the
  markdown structural pass so bare URLs in doc text are
  recognised. Bounded to the current comment line. Cross-
  references `bare_url`'s planned forward scanner; defers a
  shared-helper extraction.
- **Zero-config affordance**: when `repo_base_url` is unset,
  every `suggestion_mode` degrades to help-only output, so the
  lint is adoptable with zero configuration. Documented at
  `repo_base_url` and surfaced in `## Default state`.
- **Interaction with sibling rules**: new section. `bare_url`
  would re-flag the bare-URL output of `plain_comment_form = "bare"`;
  the iterative-fix chain and CI-single-`--fix` caveat are
  spelled out, with `bracketed` as the simplest fix and
  `targets` / `skip_hosts` narrowing legitimised as broader
  project postures.
- **Terminology**: "help-only" throughout (catalogue convention);
  `#N` placeholder consistently; "the `[` character" instead of
  the ambiguous "opening bracket"; "doc and plain comments"
  instead of `targets` jargon.
- **Trailing-punctuation pitfall** of `plain_comment_form = "bare"`
  noted in the knob comment.
- **README index entry** broadened.

## Deferred (out of scope for this PR)

`bare-url` and `bare-email` configure their doc-vs-comment scope
via `targets = ["doc", "comment"]` (covering both `//` and
`/* */`) and reuse the `unicode_ellipsis_in_comments`
retokenizer with `LateLintPass`. This rule's spec uses a boolean
knob, `//` only, and a separate `EarlyLintPass`. Alignment to the
sibling shape would substantially reshape the PR and is left for
a separate discussion.