### PR TITLE
refactor(config)!: rename `ignore_allowed_idents` and `also_flag`

### DIFF
--- a/planned-rules/unicode-ellipsis-in-docs.md
+++ b/planned-rules/unicode-ellipsis-in-docs.md
@@ -75,7 +75,7 @@ Replace `…` with `...`. `Applicability::MachineApplicable`.
 
 ## Configuration
 
-- `unicode_ellipsis_in_docs.also_flag = ["\u{22EF}", "\u{2025}"]` —
+- `unicode_ellipsis_in_docs.extra_flagged_chars = ["\u{22EF}", "\u{2025}"]` —
   empty by default. Lets a project extend the rule to midline
   ellipsis (`⋯`) or two-dot leader (`‥`).
 - `unicode_ellipsis_in_docs.allow_in_code_spans = true` — defaults to

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -105,11 +105,11 @@ having to re-state the standard ones. Each entry is a
 single ASCII letter (`a`-`z`, `A`-`Z`); any other
 character is rejected at config-parse time.
 
-### `ignore_allowed_idents`: `[single-letter string]` (optional)
+### `extra_denied_idents`: `[single-letter string]` (optional)
 
-Identifiers to drop from the exempt set, even if they
-appear in the built-in defaults or in
-`extra_allowed_idents`. Empty by default; checked after
+Identifiers to deny (always flag), removing them from the
+exempt set even if they appear in the built-in defaults or
+in `extra_allowed_idents`. Empty by default; checked after
 the merge with the built-ins, so this knob always wins.
 Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
 any other character is rejected at config-parse time.

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -43,11 +43,11 @@ having to re-state the standard ones. Each entry is a
 single ASCII letter (`a`-`z`, `A`-`Z`); any other
 character is rejected at config-parse time.
 
-### `ignore_allowed_idents`: `[single-letter string]` (optional)
+### `extra_denied_idents`: `[single-letter string]` (optional)
 
-Identifiers to drop from the exempt set, even if they
-appear in the built-in defaults or in
-`extra_allowed_idents`. Empty by default; checked after
+Identifiers to deny (always flag), removing them from the
+exempt set even if they appear in the built-in defaults or
+in `extra_allowed_idents`. Empty by default; checked after
 the merge with the built-ins, so this knob always wins.
 Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
 any other character is rejected at config-parse time.

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -42,11 +42,11 @@ standard ones. Each entry is a single ASCII letter
 (`a`-`z`, `A`-`Z`); any other character is rejected at
 config-parse time.
 
-### `ignore_allowed_idents`: `[single-letter string]` (optional)
+### `extra_denied_idents`: `[single-letter string]` (optional)
 
-Identifiers to drop from the exempt set, even if they
-appear in the built-in defaults or in
-`extra_allowed_idents`. Empty by default; checked after
+Identifiers to deny (always flag), removing them from the
+exempt set even if they appear in the built-in defaults or
+in `extra_allowed_idents`. Empty by default; checked after
 the merge with the built-ins, so this knob always wins.
 Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
 any other character is rejected at config-parse time.

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -32,7 +32,7 @@ Use instead:
 
 Configure via `dylint.toml` under `["perfectionist::unicode_ellipsis_in_comments"]`. Every field is optional; the per-field prose below states the default.
 
-### `also_flag`: `[single-character string]` (optional)
+### `extra_flagged_chars`: `[single-character string]` (optional)
 
 Extra characters to flag alongside U+2026. Useful for catching
 near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -80,7 +80,8 @@ in the built-in defaults or in `extra_methods`. Empty by
 default; checked after the merge with the built-ins, so
 this knob always wins.
 
-### `also_flag`: `[single-character string]` (optional)
+### `extra_flagged_chars`: `[single-character string]` (optional)
 
 Extra characters to flag alongside U+2026, in the same spirit
-as `unicode_ellipsis_in_comments.also_flag`. Empty by default.
+as `unicode_ellipsis_in_comments.extra_flagged_chars`. Empty by
+default.

--- a/src/ascii_letter.rs
+++ b/src/ascii_letter.rs
@@ -11,7 +11,7 @@
 ///
 /// `char` keeps the broader `single-character string` label for the
 /// codepoint-shaped fields that genuinely accept any Unicode
-/// character (`unicode_ellipsis_*::also_flag`); `AsciiLetter`'s
+/// character (`unicode_ellipsis_*::extra_flagged_chars`); `AsciiLetter`'s
 /// label is strictly narrower because every value satisfies
 /// `char::is_ascii_alphabetic`.
 #[expect(
@@ -26,7 +26,7 @@ pub(crate) const TOML_LABEL: &str = "single-letter string";
 /// non-alphabetic codepoint with a clear error message at
 /// config-parse time. The `single_letter_*` rules use
 /// `Vec<AsciiLetter>` for their `extra_allowed_idents` /
-/// `ignore_allowed_idents` knobs so the invariant the rule
+/// `extra_denied_idents` knobs so the invariant the rule
 /// documentation advertises ("each entry is a single ASCII letter,
 /// `a`-`z`, `A`-`Z`") is part of the type rather than carried by a
 /// `#[serde(deserialize_with = "...")]` attribute by convention.

--- a/src/common.rs
+++ b/src/common.rs
@@ -298,7 +298,7 @@ pub(crate) fn resolve_symbol_set(
 
 /// Sibling of [`resolve_symbol_set`] keyed on [`char`] instead of
 /// `String`, for the `single_letter_*` rules' `extra_allowed_idents`
-/// and `ignore_allowed_idents` knobs. `char::encode_utf8` writes
+/// and `extra_denied_idents` knobs. `char::encode_utf8` writes
 /// into a small stack buffer and hands [`Symbol::intern`] the
 /// resulting `&str`. `extras` and `ignore` accept anything that
 /// iterates into `char` — notably the rules'

--- a/src/literal_scan.rs
+++ b/src/literal_scan.rs
@@ -34,8 +34,9 @@ use rustc_span::Span;
 ///
 /// Applicability is [`MachineApplicable`] for U+2026 (the rule's
 /// primary target, which always maps cleanly to `...`) and
-/// [`MaybeIncorrect`] for any user-configured `also_flag` characters
-/// (whose visual equivalence to `...` is up to the project to assert).
+/// [`MaybeIncorrect`] for any user-configured `extra_flagged_chars`
+/// entries (whose visual equivalence to `...` is up to the project to
+/// assert).
 ///
 /// [`MachineApplicable`]: Applicability::MachineApplicable
 /// [`MaybeIncorrect`]: Applicability::MaybeIncorrect

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -197,13 +197,13 @@ struct Config {
     /// single ASCII letter (`a`-`z`, `A`-`Z`); any other
     /// character is rejected at config-parse time.
     extra_allowed_idents: Vec<AsciiLetter>,
-    /// Identifiers to drop from the exempt set, even if they
-    /// appear in the built-in defaults or in
-    /// `extra_allowed_idents`. Empty by default; checked after
+    /// Identifiers to deny (always flag), removing them from the
+    /// exempt set even if they appear in the built-in defaults or
+    /// in `extra_allowed_idents`. Empty by default; checked after
     /// the merge with the built-ins, so this knob always wins.
     /// Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
     /// any other character is rejected at config-parse time.
-    ignore_allowed_idents: Vec<AsciiLetter>,
+    extra_denied_idents: Vec<AsciiLetter>,
 }
 
 pub struct SingleLetterClosureParam {
@@ -222,7 +222,7 @@ impl SingleLetterClosureParam {
         let allowed_idents = resolve_symbol_set_from_chars(
             DEFAULT_CLOSURE_PARAM_EXEMPTIONS,
             config.extra_allowed_idents,
-            config.ignore_allowed_idents,
+            config.extra_denied_idents,
         );
         Self {
             trivial_callback_methods,

--- a/src/rules/single_letter_function_param.rs
+++ b/src/rules/single_letter_function_param.rs
@@ -60,13 +60,13 @@ struct Config {
     /// single ASCII letter (`a`-`z`, `A`-`Z`); any other
     /// character is rejected at config-parse time.
     extra_allowed_idents: Vec<AsciiLetter>,
-    /// Identifiers to drop from the exempt set, even if they
-    /// appear in the built-in defaults or in
-    /// `extra_allowed_idents`. Empty by default; checked after
+    /// Identifiers to deny (always flag), removing them from the
+    /// exempt set even if they appear in the built-in defaults or
+    /// in `extra_allowed_idents`. Empty by default; checked after
     /// the merge with the built-ins, so this knob always wins.
     /// Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
     /// any other character is rejected at config-parse time.
-    ignore_allowed_idents: Vec<AsciiLetter>,
+    extra_denied_idents: Vec<AsciiLetter>,
 }
 
 pub struct SingleLetterFunctionParam {
@@ -79,7 +79,7 @@ impl SingleLetterFunctionParam {
         let allowed_idents = resolve_symbol_set_from_chars(
             DEFAULT_FN_PARAM_EXEMPTIONS,
             config.extra_allowed_idents,
-            config.ignore_allowed_idents,
+            config.extra_denied_idents,
         );
         Self { allowed_idents }
     }

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -56,13 +56,13 @@ struct Config {
     /// (`a`-`z`, `A`-`Z`); any other character is rejected at
     /// config-parse time.
     extra_allowed_idents: Vec<AsciiLetter>,
-    /// Identifiers to drop from the exempt set, even if they
-    /// appear in the built-in defaults or in
-    /// `extra_allowed_idents`. Empty by default; checked after
+    /// Identifiers to deny (always flag), removing them from the
+    /// exempt set even if they appear in the built-in defaults or
+    /// in `extra_allowed_idents`. Empty by default; checked after
     /// the merge with the built-ins, so this knob always wins.
     /// Each entry is a single ASCII letter (`a`-`z`, `A`-`Z`);
     /// any other character is rejected at config-parse time.
-    ignore_allowed_idents: Vec<AsciiLetter>,
+    extra_denied_idents: Vec<AsciiLetter>,
 }
 
 pub struct SingleLetterLetBinding {
@@ -75,7 +75,7 @@ impl SingleLetterLetBinding {
         let allowed_idents = resolve_symbol_set_from_chars(
             DEFAULT_LET_EXEMPTIONS,
             config.extra_allowed_idents,
-            config.ignore_allowed_idents,
+            config.extra_denied_idents,
         );
         Self { allowed_idents }
     }

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -47,7 +47,7 @@ struct Config {
     /// near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)
     /// or U+2025 TWO DOT LEADER (`‥`) that the same autocorrect
     /// pipelines occasionally insert. Empty by default.
-    also_flag: Vec<char>,
+    extra_flagged_chars: Vec<char>,
     /// Which comment forms to scan. Defaults to both `line` (`//`)
     /// and `block` (`/* */`). Narrow this if a project intentionally
     /// uses one form for prose and wants the lint to ignore it.
@@ -57,7 +57,7 @@ struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            also_flag: Vec::new(),
+            extra_flagged_chars: Vec::new(),
             scope: vec![Scope::Line, Scope::Block],
         }
     }
@@ -83,7 +83,7 @@ impl UnicodeEllipsisInComments {
     fn new() -> Self {
         let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
         let mut flagged_chars = vec!['\u{2026}'];
-        for character in config.also_flag {
+        for character in config.extra_flagged_chars {
             if !flagged_chars.contains(&character) {
                 flagged_chars.push(character);
             }

--- a/src/rules/unicode_ellipsis_in_panic_messages/config.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages/config.rs
@@ -56,8 +56,9 @@ struct Config {
     /// this knob always wins.
     ignore_methods: Vec<String>,
     /// Extra characters to flag alongside U+2026, in the same spirit
-    /// as `unicode_ellipsis_in_comments.also_flag`. Empty by default.
-    also_flag: Vec<char>,
+    /// as `unicode_ellipsis_in_comments.extra_flagged_chars`. Empty by
+    /// default.
+    extra_flagged_chars: Vec<char>,
 }
 
 pub(super) struct UnicodeEllipsisInPanicMessages {
@@ -70,7 +71,7 @@ impl UnicodeEllipsisInPanicMessages {
     pub(super) fn new() -> Self {
         let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
         let mut flagged_chars = vec!['\u{2026}'];
-        for character in config.also_flag {
+        for character in config.extra_flagged_chars {
             if !flagged_chars.contains(&character) {
                 flagged_chars.push(character);
             }

--- a/tests/single_letter_closure_param.rs
+++ b/tests/single_letter_closure_param.rs
@@ -30,7 +30,7 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     extra_allowed_idents: Option<Vec<char>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ignore_allowed_idents: Option<Vec<char>>,
+    extra_denied_idents: Option<Vec<char>>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {

--- a/tests/single_letter_function_param.rs
+++ b/tests/single_letter_function_param.rs
@@ -26,7 +26,7 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     extra_allowed_idents: Option<Vec<char>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ignore_allowed_idents: Option<Vec<char>>,
+    extra_denied_idents: Option<Vec<char>>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -47,7 +47,7 @@ fn custom_allowed_idents_extend_and_subtract_the_default_list() {
         "ui-toml/single_letter_function_param/custom_allowed_idents",
         RuleConfig {
             extra_allowed_idents: Some(vec!['x']),
-            ignore_allowed_idents: Some(vec!['n']),
+            extra_denied_idents: Some(vec!['n']),
         },
     );
 }

--- a/tests/single_letter_let_binding.rs
+++ b/tests/single_letter_let_binding.rs
@@ -26,7 +26,7 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     extra_allowed_idents: Option<Vec<char>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ignore_allowed_idents: Option<Vec<char>>,
+    extra_denied_idents: Option<Vec<char>>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -47,7 +47,7 @@ fn custom_allowed_idents_extend_and_subtract_the_default_list() {
         "ui-toml/single_letter_let_binding/custom_allowed_idents",
         RuleConfig {
             extra_allowed_idents: Some(vec!['x']),
-            ignore_allowed_idents: Some(vec!['n']),
+            extra_denied_idents: Some(vec!['n']),
         },
     );
 }

--- a/ui-toml/single_letter_function_param/custom_allowed_idents/fixture.rs
+++ b/ui-toml/single_letter_function_param/custom_allowed_idents/fixture.rs
@@ -5,11 +5,11 @@
 #![warn(perfectionist::single_letter_function_param)]
 
 // `extra_allowed_idents = ["x"]` adds to the built-in
-// `["n", "f", "i", "j", "k"]` list, and `ignore_allowed_idents = ["n"]`
+// `["n", "f", "i", "j", "k"]` list, and `extra_denied_idents = ["n"]`
 // drops the default back out. After the merge `n` is no longer
 // allowed and `x` is.
 
-// `n` is dropped from the allowlist by `ignore_allowed_idents`: fires.
+// `n` is dropped from the allowlist by `extra_denied_idents`: fires.
 fn count(n: usize) -> usize {
     n + 1
 }

--- a/ui-toml/single_letter_let_binding/custom_allowed_idents/fixture.rs
+++ b/ui-toml/single_letter_let_binding/custom_allowed_idents/fixture.rs
@@ -5,11 +5,11 @@
 #![warn(perfectionist::single_letter_let_binding)]
 
 // `extra_allowed_idents = ["x"]` adds to the built-in `["n"]` list,
-// and `ignore_allowed_idents = ["n"]` drops the default back out.
+// and `extra_denied_idents = ["n"]` drops the default back out.
 // After the merge `n` is no longer allowed and `x` is.
 
 fn run() {
-    // `n` is dropped from the allowlist by `ignore_allowed_idents`: fires.
+    // `n` is dropped from the allowlist by `extra_denied_idents`: fires.
     let n = 5_u32;
     // `x` is added to the allowlist by `extra_allowed_idents`: quiet.
     let x = 10_u32;


### PR DESCRIPTION
`ignore_allowed_idents` read as a contradiction: it removes an identifier from the exempt set so it *is* flagged, the opposite of what "ignore" means in the sibling `ignore_macros` / `ignore_methods` knobs. Rename it to `extra_denied_idents`, mirroring the existing `extra_allowed_idents` and the allow/deny vocabulary already used by `macro_argument_binding`.

`also_flag` was an imperative verb phrase among otherwise noun-phrase config keys (`extra_macros`, `extra_allowed_idents`, `scope`). Rename it to `extra_flagged_chars`, a noun phrase parallel to `extra_allowed_idents`.

Both are breaking config-key changes; `deny_unknown_fields` rejects the old names.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/134>.

https://claude.ai/code/session_0147zVbyDukANsFBbNy4Sdt7