### PR TITLE
fix(gen-docs): one representation for "no configuration"

### DIFF
--- a/tools/gen-docs/src/check_md.rs
+++ b/tools/gen-docs/src/check_md.rs
@@ -235,7 +235,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::model::DefaultState;
+    use crate::model::{ConfigDoc, DefaultState};
 
     fn fake_rule(name: &str) -> Rule {
         Rule {
@@ -244,7 +244,11 @@ mod tests {
             short_desc: format!("{name} short desc"),
             doc_markdown: "Body.".to_owned(),
             relative_source: PathBuf::from(format!("src/rules/{name}.rs")),
-            config: None,
+            config: ConfigDoc {
+                key: format!("perfectionist::{name}"),
+                fields: Vec::new(),
+                custom_types: Vec::new(),
+            },
         }
     }
 

--- a/tools/gen-docs/src/extract.rs
+++ b/tools/gen-docs/src/extract.rs
@@ -413,10 +413,7 @@ mod tests {
 
         let rules = collect_rules(&rules_dir);
         assert_eq!(rules.len(), 1, "exactly one rule should be discovered");
-        let config = rules[0]
-            .config
-            .as_ref()
-            .expect("config in submodule should be merged into the rule's ConfigDoc");
+        let config = &rules[0].config;
         assert_eq!(config.key, "perfectionist::demo_rule");
         let names: Vec<&str> = config.fields.iter().map(|f| f.name.as_str()).collect();
         assert_eq!(names, vec!["knob"]);

--- a/tools/gen-docs/src/extract/config.rs
+++ b/tools/gen-docs/src/extract/config.rs
@@ -17,16 +17,9 @@ use crate::model::{ConfigDoc, ConfigField};
 /// and bundle them — along with any project-local types the fields
 /// reference — into a `ConfigDoc`.
 ///
-/// Every rule must declare *both* halves; a rule with no configurable
-/// knobs uses an empty `Config {}` (e.g. `flat_module_pattern`) rather
-/// than omitting the pair. This keeps "no configuration" to a single
-/// representation across the catalogue — an empty `ConfigDoc` that
-/// both output modes render as "Configuration: none." — instead of
-/// the silently-divergent "empty struct vs. no struct" the docs used
-/// to allow. Any rule file that drops one or both halves is therefore
-/// a convention violation, and this function panics (naming the file)
-/// rather than returning, just as the level / `DEFAULT_STATE` checks
-/// in `extract.rs` do.
+/// Every rule must declare both halves; a rule with no configurable
+/// knobs uses an empty `Config {}`. Panics, naming the file, when a
+/// rule declares neither half or only one of them.
 pub(crate) fn extract_config(
     source_path: &Path,
     file: &syn::File,
@@ -51,9 +44,7 @@ pub(crate) fn extract_config(
         (None, None) => panic!(
             "{}: a rule must declare both a `CONFIG_KEY` constant and a \
              `Config` struct. A rule with no configurable knobs uses an \
-             empty `Config {{}}` (e.g. `flat_module_pattern`) so that \
-             \"no configuration\" has a single representation across the \
-             catalogue and always renders as \"Configuration: none.\".",
+             empty `Config {{}}`.",
             source_path.display(),
         ),
         (Some(_), None) => panic!(
@@ -173,9 +164,7 @@ mod tests {
         // as an empty `Config {}`, never as an absent pair. The
         // extractor panics so a doc regeneration catches it instead of
         // silently dropping the configuration section.
-        let source = r#"
-            pub struct SomeRule;
-        "#;
+        let source = "pub struct SomeRule;";
         let file = syn::parse_file(source).unwrap();
         let _ = extract_config(Path::new("no_config.rs"), &file, &SharedTypes::default());
     }
@@ -185,9 +174,7 @@ mod tests {
     fn extract_config_rejects_a_half_defined_config_key_only() {
         // Declaring `CONFIG_KEY` without a `Config` struct is the
         // usual shape of an author having dropped one half; reject it.
-        let source = r#"
-            const CONFIG_KEY: &str = "perfectionist::demo";
-        "#;
+        let source = r#"const CONFIG_KEY: &str = "perfectionist::demo";"#;
         let file = syn::parse_file(source).unwrap();
         let _ = extract_config(Path::new("half.rs"), &file, &SharedTypes::default());
     }
@@ -195,10 +182,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "no `CONFIG_KEY` const")]
     fn extract_config_rejects_a_half_defined_struct_only() {
-        let source = r#"
-            #[derive(serde::Deserialize)]
-            struct Config {}
-        "#;
+        let source = "struct Config {}";
         let file = syn::parse_file(source).unwrap();
         let _ = extract_config(Path::new("half.rs"), &file, &SharedTypes::default());
     }

--- a/tools/gen-docs/src/extract/config.rs
+++ b/tools/gen-docs/src/extract/config.rs
@@ -15,17 +15,23 @@ use crate::model::{ConfigDoc, ConfigField};
 
 /// Locate the rule's `Config` struct and its `CONFIG_KEY` constant
 /// and bundle them — along with any project-local types the fields
-/// reference — into a `ConfigDoc`. Returns `None` when *both* the
-/// constant and the struct are missing (a rule with no configuration
-/// concept at all). Defining only one of the two prints a warning
-/// and still returns `None`: the convention in this repo is that
-/// every rule has both, and a half-defined Config is almost always
-/// the author having dropped the other half.
+/// reference — into a `ConfigDoc`.
+///
+/// Every rule must declare *both* halves; a rule with no configurable
+/// knobs uses an empty `Config {}` (e.g. `flat_module_pattern`) rather
+/// than omitting the pair. This keeps "no configuration" to a single
+/// representation across the catalogue — an empty `ConfigDoc` that
+/// both output modes render as "Configuration: none." — instead of
+/// the silently-divergent "empty struct vs. no struct" the docs used
+/// to allow. Any rule file that drops one or both halves is therefore
+/// a convention violation, and this function panics (naming the file)
+/// rather than returning, just as the level / `DEFAULT_STATE` checks
+/// in `extract.rs` do.
 pub(crate) fn extract_config(
     source_path: &Path,
     file: &syn::File,
     shared: &SharedTypes,
-) -> Option<ConfigDoc> {
+) -> ConfigDoc {
     let key = file.items.iter().find_map(|item| match item {
         Item::Const(item_const) if item_const.ident == "CONFIG_KEY" => match &*item_const.expr {
             Expr::Lit(ExprLit {
@@ -42,23 +48,25 @@ pub(crate) fn extract_config(
     });
     let (key, config_struct) = match (key, config_struct) {
         (Some(key), Some(config_struct)) => (key, config_struct),
-        (None, None) => return None,
-        (Some(_), None) => {
-            eprintln!(
-                "warning: {} declares CONFIG_KEY but no `Config` struct; \
-                 skipping its configuration section",
-                source_path.display(),
-            );
-            return None;
-        }
-        (None, Some(_)) => {
-            eprintln!(
-                "warning: {} declares a `Config` struct but no CONFIG_KEY const; \
-                 skipping its configuration section",
-                source_path.display(),
-            );
-            return None;
-        }
+        (None, None) => panic!(
+            "{}: a rule must declare both a `CONFIG_KEY` constant and a \
+             `Config` struct. A rule with no configurable knobs uses an \
+             empty `Config {{}}` (e.g. `flat_module_pattern`) so that \
+             \"no configuration\" has a single representation across the \
+             catalogue and always renders as \"Configuration: none.\".",
+            source_path.display(),
+        ),
+        (Some(_), None) => panic!(
+            "{}: declares `CONFIG_KEY` but no `Config` struct. Every rule \
+             must declare both; add the `Config` struct (an empty \
+             `Config {{}}` if the rule has no knobs).",
+            source_path.display(),
+        ),
+        (None, Some(_)) => panic!(
+            "{}: declares a `Config` struct but no `CONFIG_KEY` const. \
+             Every rule must declare both; add the `CONFIG_KEY` constant.",
+            source_path.display(),
+        ),
     };
     let rename_all = serde_str_attr(&config_struct.attrs, "rename_all");
 
@@ -101,11 +109,11 @@ pub(crate) fn extract_config(
         .filter_map(|ident| find_type_doc(file, &ident, shared))
         .collect();
 
-    Some(ConfigDoc {
+    ConfigDoc {
         key,
         fields,
         custom_types,
-    })
+    }
 }
 
 #[cfg(test)]
@@ -129,8 +137,7 @@ mod tests {
             }
         "#;
         let file = syn::parse_file(source).unwrap();
-        let config = extract_config(Path::new("synthetic.rs"), &file, &SharedTypes::default())
-            .expect("demo file declares CONFIG_KEY and Config");
+        let config = extract_config(Path::new("synthetic.rs"), &file, &SharedTypes::default());
         let names: Vec<&str> = config.fields.iter().map(|f| f.name.as_str()).collect();
         assert_eq!(names, vec!["renamed-key", "plain_name"]);
     }
@@ -153,9 +160,46 @@ mod tests {
             }
         "#;
         let file = syn::parse_file(source).unwrap();
-        let config = extract_config(Path::new("synthetic.rs"), &file, &SharedTypes::default())
-            .expect("demo file declares CONFIG_KEY and Config");
+        let config = extract_config(Path::new("synthetic.rs"), &file, &SharedTypes::default());
         let names: Vec<&str> = config.fields.iter().map(|f| f.name.as_str()).collect();
         assert_eq!(names, vec!["also-flag", "some-other-key", "explicit"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "must declare both")]
+    fn extract_config_rejects_a_rule_with_no_config() {
+        // A rule file that declares neither `CONFIG_KEY` nor `Config`
+        // is a convention violation: "no configuration" must be spelt
+        // as an empty `Config {}`, never as an absent pair. The
+        // extractor panics so a doc regeneration catches it instead of
+        // silently dropping the configuration section.
+        let source = r#"
+            pub struct SomeRule;
+        "#;
+        let file = syn::parse_file(source).unwrap();
+        let _ = extract_config(Path::new("no_config.rs"), &file, &SharedTypes::default());
+    }
+
+    #[test]
+    #[should_panic(expected = "no `Config` struct")]
+    fn extract_config_rejects_a_half_defined_config_key_only() {
+        // Declaring `CONFIG_KEY` without a `Config` struct is the
+        // usual shape of an author having dropped one half; reject it.
+        let source = r#"
+            const CONFIG_KEY: &str = "perfectionist::demo";
+        "#;
+        let file = syn::parse_file(source).unwrap();
+        let _ = extract_config(Path::new("half.rs"), &file, &SharedTypes::default());
+    }
+
+    #[test]
+    #[should_panic(expected = "no `CONFIG_KEY` const")]
+    fn extract_config_rejects_a_half_defined_struct_only() {
+        let source = r#"
+            #[derive(serde::Deserialize)]
+            struct Config {}
+        "#;
+        let file = syn::parse_file(source).unwrap();
+        let _ = extract_config(Path::new("half.rs"), &file, &SharedTypes::default());
     }
 }

--- a/tools/gen-docs/src/model.rs
+++ b/tools/gen-docs/src/model.rs
@@ -63,9 +63,15 @@ pub(crate) struct Rule {
     pub(crate) doc_markdown: String,
     /// Source path relative to the repo root, for cross-linking.
     pub(crate) relative_source: PathBuf,
-    /// `Config` struct contents when the rule declares one. `None`
-    /// means the rule file has no `Config` / `CONFIG_KEY` pair.
-    pub(crate) config: Option<ConfigDoc>,
+    /// The rule's configuration surface. Every rule declares both a
+    /// `CONFIG_KEY` constant and a `Config` struct; a rule with no
+    /// knobs uses an empty `Config {}` (e.g. `flat_module_pattern`).
+    /// "No configuration" therefore has a single representation —
+    /// an empty `ConfigDoc` — that both output modes render as
+    /// "Configuration: none." The extractor enforces this, panicking
+    /// on any rule file that omits either half, so the field is never
+    /// absent here.
+    pub(crate) config: ConfigDoc,
 }
 
 /// Whether a rule's pass is installed by default. Mirrors the

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -187,9 +187,7 @@ fn rule_article(rule: &Rule, context: &RenderContext<'_>) -> Markup {
                 (PreEscaped(markdown_inline_to_html(&rule.short_desc)))
             }
             (PreEscaped(markdown_to_html(&rule.doc_markdown)))
-            @if let Some(config) = &rule.config {
-                (config_section(config))
-            }
+            (config_section(&rule.config))
             p.source {
                 "Source: "
                 a href=(source_url) { code { (source_path) } }
@@ -217,6 +215,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+    use crate::model::ConfigDoc;
 
     fn fake_rule(name: &str) -> Rule {
         Rule {
@@ -225,7 +224,11 @@ mod tests {
             short_desc: format!("demo rule {name}"),
             doc_markdown: "### What it does\nDoes a demo.".to_owned(),
             relative_source: PathBuf::from(format!("src/rules/{name}.rs")),
-            config: None,
+            config: ConfigDoc {
+                key: format!("perfectionist::{name}"),
+                fields: Vec::new(),
+                custom_types: Vec::new(),
+            },
         }
     }
 

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -88,19 +88,7 @@ pub(crate) fn render_rule_md(rule: &Rule, source_link_prefix: &str) -> String {
         }
         out.push('\n');
     }
-    if let Some(config) = &rule.config {
-        render_config_section(config, &mut out);
-    } else {
-        // Rules without a `Config`/`CONFIG_KEY` pair (in practice,
-        // only `unknown_perfectionist_lints` today) get the same
-        // "Configuration: none." stub the HTML renderer emits, for
-        // the same reason: silence about configurability is
-        // ambiguous; an explicit "none" is not.
-        let _ = writeln!(out, "## Configuration");
-        out.push('\n');
-        let _ = writeln!(out, "None.");
-        out.push('\n');
-    }
+    render_config_section(&rule.config, &mut out);
     trim_trailing_blank_lines(&mut out);
     out
 }
@@ -422,7 +410,11 @@ mod tests {
             short_desc: "demo rule used in tests".to_owned(),
             doc_markdown: "### What it does\nDoes a demo.".to_owned(),
             relative_source: PathBuf::from("src/rules/demo_rule.rs"),
-            config: None,
+            config: ConfigDoc {
+                key: "perfectionist::demo_rule".to_owned(),
+                fields: Vec::new(),
+                custom_types: Vec::new(),
+            },
         }
     }
 
@@ -460,7 +452,7 @@ mod tests {
     #[test]
     fn rule_md_with_config_lists_fields_and_types() {
         let mut rule = fake_rule();
-        rule.config = Some(ConfigDoc {
+        rule.config = ConfigDoc {
             key: "perfectionist::demo_rule".to_owned(),
             fields: vec![ConfigField {
                 name: "style".to_owned(),
@@ -485,7 +477,7 @@ mod tests {
                     ],
                 },
             }],
-        });
+        };
         let md = render_rule_md(&rule, "../");
         assert!(md.contains("### `style`: `Style` (optional)"));
         assert!(md.contains("Pick a style."));


### PR DESCRIPTION
Resolves <https://github.com/KSXGitHub/perfectionist/issues/135>.

`gen-docs` rendered "no configuration" two different ways: an empty `Config {}` produced "Configuration: none.", while a rule that omitted the `Config`/`CONFIG_KEY` pair entirely produced no configuration section at all in the HTML catalogue. (The markdown renderer already handled both, so the two output modes also disagreed.)

This PR settles on a single representation: every rule declares both a `CONFIG_KEY` constant and a `Config` struct — a rule with no knobs uses an empty `Config {}` — so "no configuration" is always an empty `ConfigDoc` that both renderers turn into "Configuration: none."

- `Rule.config` is now `ConfigDoc` instead of `Option<ConfigDoc>`.
- `extract_config` panics, naming the file, when a rule drops `CONFIG_KEY`, `Config`, or both — `gen-docs` now enforces the convention, matching how it already rejects level / `DEFAULT_STATE` drift.
- Removed the now-dead absent-config branches in both renderers.
- Added `#[should_panic]` tests for the no-config and half-defined cases; updated existing fixtures.

No existing rule changes shape (all 22 already declare a `Config`, 3 of them empty), so the generated catalogue output is unchanged. Validated with the full `just all` gate.