### PR TITLE
docs(unicode-ellipsis-in-panic-messages): make `also_flag` doc self-contained

### DIFF
--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -82,5 +82,7 @@ this knob always wins.
 
 ### `also_flag`: `[single-character string]` (optional)
 
-Extra characters to flag alongside U+2026, in the same spirit
-as `unicode_ellipsis_in_comments.also_flag`. Empty by default.
+Extra characters to flag alongside U+2026. Useful for catching
+near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)
+or U+2025 TWO DOT LEADER (`‥`) that the same autocorrect
+pipelines occasionally insert. Empty by default.

--- a/src/rules/unicode_ellipsis_in_panic_messages/config.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages/config.rs
@@ -55,8 +55,10 @@ struct Config {
     /// default; checked after the merge with the built-ins, so
     /// this knob always wins.
     ignore_methods: Vec<String>,
-    /// Extra characters to flag alongside U+2026, in the same spirit
-    /// as `unicode_ellipsis_in_comments.also_flag`. Empty by default.
+    /// Extra characters to flag alongside U+2026. Useful for catching
+    /// near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)
+    /// or U+2025 TWO DOT LEADER (`‥`) that the same autocorrect
+    /// pipelines occasionally insert. Empty by default.
     also_flag: Vec<char>,
 }
 


### PR DESCRIPTION
The also_flag config field documented itself by pointing the reader at unicode_ellipsis_in_comments.also_flag instead of describing what it does. Replace the cross-rule redirect with the same self-contained prose the sibling rule uses, naming the near-relative characters (U+22EF, U+2025) inline.

https://claude.ai/code/session_01G1czdRu2tYLwZK9JWhYtTb