### PR TITLE
feat(pages): permalink anchors to rule-name headings

### DIFF
--- a/tools/gen-docs/src/assets/rule-anchor.svg
+++ b/tools/gen-docs/src/assets/rule-anchor.svg
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Chain-link "permalink" glyph used by the rule-name heading anchors.
-
-  Source: GitHub Octicons, the `link-16` icon (https://primer.style/octicons/).
-  Licensed under the MIT License, Copyright (c) GitHub Inc.
+  GitHub Octicons `link-16`, MIT License, Copyright (c) GitHub Inc.
   https://github.com/primer/octicons/blob/main/LICENSE
 
-  The path is verbatim from upstream; only the `fill` (the page's
-  muted-grey, matching `.rule-jump-link`) is added so the standalone
-  asset renders in the catalogue's palette when referenced via
-  `background-image` (an external image has no host `currentColor` to
-  inherit, so the colour is baked in here rather than themed in CSS).
+  Path is verbatim from upstream; only `fill` is added, since an
+  external image can't inherit the page's `currentColor`.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="#57606a"><path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"/></svg>

--- a/tools/gen-docs/src/assets/rule-anchor.svg
+++ b/tools/gen-docs/src/assets/rule-anchor.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Chain-link "permalink" glyph used by the rule-name heading anchors.
+
+  Source: GitHub Octicons, the `link-16` icon (https://primer.style/octicons/).
+  Licensed under the MIT License, Copyright (c) GitHub Inc.
+  https://github.com/primer/octicons/blob/main/LICENSE
+
+  The path is verbatim from upstream; only the `fill` (the page's
+  muted-grey, matching `.rule-jump-link`) is added so the standalone
+  asset renders in the catalogue's palette when referenced via
+  `background-image` (an external image has no host `currentColor` to
+  inherit, so the colour is baked in here rather than themed in CSS).
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="#57606a"><path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"/></svg>

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -177,9 +177,8 @@ fn run_html(root: &Path, out_dir: &Path, git_ref: &str) -> ExitCode {
     let index_path = out_dir.join("index.html");
     fs::write(&index_path, html).expect("failed to write index.html");
 
-    // The heading-anchor chain-link glyph is referenced by the
-    // stylesheet's `url(...)`, not inlined into the page, so it has to
-    // land beside `index.html` for that relative URL to resolve.
+    // Lands beside index.html so the stylesheet's relative `url(...)`
+    // resolves.
     let icon_path = out_dir.join(RULE_ANCHOR_ICON_FILENAME);
     fs::write(&icon_path, RULE_ANCHOR_ICON).expect("failed to write rule-anchor icon");
 

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -42,7 +42,7 @@ use pipe_trait::Pipe;
 use crate::check_md::{CheckOutcome, check_rules_dir, write_rules_dir};
 use crate::extract::collect_rules;
 use crate::model::{RenderContext, Rule};
-use crate::render::render_page;
+use crate::render::{RULE_ANCHOR_ICON, RULE_ANCHOR_ICON_FILENAME, render_page};
 
 #[derive(Parser)]
 #[clap(about = "Render perfectionist's lint catalogue")]
@@ -176,6 +176,12 @@ fn run_html(root: &Path, out_dir: &Path, git_ref: &str) -> ExitCode {
     let html = render_page(&rules, &context);
     let index_path = out_dir.join("index.html");
     fs::write(&index_path, html).expect("failed to write index.html");
+
+    // The heading-anchor chain-link glyph is referenced by the
+    // stylesheet's `url(...)`, not inlined into the page, so it has to
+    // land beside `index.html` for that relative URL to resolve.
+    let icon_path = out_dir.join(RULE_ANCHOR_ICON_FILENAME);
+    fs::write(&icon_path, RULE_ANCHOR_ICON).expect("failed to write rule-anchor icon");
 
     eprintln!("wrote {} rule(s) to {}", rules.len(), index_path.display());
     ExitCode::SUCCESS

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -184,8 +184,8 @@ fn rule_article(rule: &Rule, context: &RenderContext<'_>) -> Markup {
     html! {
         article.rule id=(anchor_for(&rule.namespaced)) {
             h2 {
-                a.rule-anchor href={ "#" (anchor_for(&rule.namespaced)) } aria-label="Permalink to this rule" {}
                 code {
+                    a.rule-anchor href={ "#" (anchor_for(&rule.namespaced)) } aria-label="Permalink to this rule" {}
                     span.lint-prefix { (NAMESPACE) }
                     span.lint-name { (unnamespaced(&rule.namespaced)) }
                 }
@@ -397,10 +397,10 @@ mod tests {
             ),
             "rule heading must emit a left-side permalink anchor to its own id",
         );
-        let heading = "<h2><a class=\"rule-anchor\"";
+        let heading = "<h2><code><a class=\"rule-anchor\"";
         assert!(
             html.contains(heading),
-            "the permalink anchor must be the first child of the rule <h2> (left side)",
+            "the permalink anchor must be the first child of the rule heading's <code> (left side)",
         );
         // Tag-prefixed needles: the inlined stylesheet mentions these
         // as bare selectors, so a class-only search would match the CSS

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -22,17 +22,12 @@ const STYLE: &str = concat!(
 );
 const NAV_TOGGLE_SCRIPT: &str = include_str!("nav_toggle.js");
 
-/// The chain-link glyph rendered beside each rule-name heading. It is
-/// shipped as a standalone file alongside `index.html` and referenced
-/// from the stylesheet by [`RULE_ANCHOR_ICON_FILENAME`] rather than
-/// inlined into the page, so the SVG markup stays out of every served
-/// byte of HTML.
+/// The chain-link glyph for the rule-name heading anchors, shipped as
+/// a standalone file beside `index.html` rather than inlined.
 pub(crate) const RULE_ANCHOR_ICON: &str = include_str!("assets/rule-anchor.svg");
 
-/// File name the [`RULE_ANCHOR_ICON`] is written under in the output
-/// directory. `rules.css` references the same name in a relative
-/// `url(...)`, so the two must agree; `style_references_rule_anchor_icon`
-/// pins that.
+/// File name [`RULE_ANCHOR_ICON`] is written under. `rules.css`
+/// references the same name in a relative `url(...)`, so they must agree.
 pub(crate) const RULE_ANCHOR_ICON_FILENAME: &str = "rule-anchor.svg";
 
 pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String {
@@ -395,11 +390,6 @@ mod tests {
     #[test]
     fn rule_heading_emits_left_side_permalink_anchor() {
         let html = render_page(&[fake_rule("alpha")], &fake_context());
-        // The rule-name heading carries a self-link whose href is the
-        // article's own id, placed *before* the <code> (left side) and
-        // before the "↑ top" jump link. The CSS parks it in the left
-        // gutter and hides it until hover; the markup just has to emit
-        // the empty, labelled anchor pointing at the rule's anchor.
         assert!(
             html.contains(
                 "<a class=\"rule-anchor\" href=\"#perfectionist-alpha\" \
@@ -412,10 +402,9 @@ mod tests {
             html.contains(heading),
             "the permalink anchor must be the first child of the rule <h2> (left side)",
         );
-        // Use tag-prefixed needles: the inlined stylesheet mentions
-        // `.rule-anchor` / `.rule-jump-link` as bare selectors, so a
-        // class-only search would match the CSS in <head> long before
-        // the body markup and scramble the ordering check.
+        // Tag-prefixed needles: the inlined stylesheet mentions these
+        // as bare selectors, so a class-only search would match the CSS
+        // in <head> before the body markup and scramble the ordering.
         let anchor_pos = html
             .find("<a class=\"rule-anchor\"")
             .expect("rule-anchor missing");
@@ -433,10 +422,6 @@ mod tests {
 
     #[test]
     fn page_does_not_inline_the_anchor_icon_svg() {
-        // The chain-link glyph is shipped as an external file referenced
-        // by the stylesheet's `url(...)`; per the design it must never
-        // be inlined into the served HTML. No `<svg` should appear
-        // anywhere on the page.
         let html = render_page(&[fake_rule("alpha")], &fake_context());
         assert!(
             !html.contains("<svg"),
@@ -446,15 +431,13 @@ mod tests {
 
     #[test]
     fn style_references_rule_anchor_icon() {
-        // `rules.css` pulls the glyph in via a relative `url(...)`, and
-        // `run_html` writes the file under RULE_ANCHOR_ICON_FILENAME
-        // beside index.html. The two names must agree or the icon 404s.
+        // The CSS `url(...)` and the written filename must agree, or the
+        // icon 404s.
         let expected = format!("url(\"{RULE_ANCHOR_ICON_FILENAME}\")");
         assert!(
             STYLE.contains(&expected),
             "rules.css must reference the anchor icon as {expected}",
         );
-        // The vendored asset must keep its Octicons MIT attribution.
         assert!(
             RULE_ANCHOR_ICON.contains("Octicons") && RULE_ANCHOR_ICON.contains("MIT"),
             "the bundled rule-anchor.svg must retain its Octicons MIT attribution",

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -22,6 +22,19 @@ const STYLE: &str = concat!(
 );
 const NAV_TOGGLE_SCRIPT: &str = include_str!("nav_toggle.js");
 
+/// The chain-link glyph rendered beside each rule-name heading. It is
+/// shipped as a standalone file alongside `index.html` and referenced
+/// from the stylesheet by [`RULE_ANCHOR_ICON_FILENAME`] rather than
+/// inlined into the page, so the SVG markup stays out of every served
+/// byte of HTML.
+pub(crate) const RULE_ANCHOR_ICON: &str = include_str!("assets/rule-anchor.svg");
+
+/// File name the [`RULE_ANCHOR_ICON`] is written under in the output
+/// directory. `rules.css` references the same name in a relative
+/// `url(...)`, so the two must agree; `style_references_rule_anchor_icon`
+/// pins that.
+pub(crate) const RULE_ANCHOR_ICON_FILENAME: &str = "rule-anchor.svg";
+
 pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String {
     let RenderContext {
         crate_version,
@@ -176,6 +189,7 @@ fn rule_article(rule: &Rule, context: &RenderContext<'_>) -> Markup {
     html! {
         article.rule id=(anchor_for(&rule.namespaced)) {
             h2 {
+                a.rule-anchor href={ "#" (anchor_for(&rule.namespaced)) } aria-label="Permalink to this rule" {}
                 code {
                     span.lint-prefix { (NAMESPACE) }
                     span.lint-name { (unnamespaced(&rule.namespaced)) }
@@ -375,6 +389,75 @@ mod tests {
             STYLE.contains("[hidden]") && STYLE.contains("display: none !important"),
             "style/base.css must keep the `[hidden] {{ display: none !important }}` reset; \
              without it the JS-driven toggle's `hidden`-by-default fallback is broken",
+        );
+    }
+
+    #[test]
+    fn rule_heading_emits_left_side_permalink_anchor() {
+        let html = render_page(&[fake_rule("alpha")], &fake_context());
+        // The rule-name heading carries a self-link whose href is the
+        // article's own id, placed *before* the <code> (left side) and
+        // before the "↑ top" jump link. The CSS parks it in the left
+        // gutter and hides it until hover; the markup just has to emit
+        // the empty, labelled anchor pointing at the rule's anchor.
+        assert!(
+            html.contains(
+                "<a class=\"rule-anchor\" href=\"#perfectionist-alpha\" \
+                 aria-label=\"Permalink to this rule\"></a>"
+            ),
+            "rule heading must emit a left-side permalink anchor to its own id",
+        );
+        let heading = "<h2><a class=\"rule-anchor\"";
+        assert!(
+            html.contains(heading),
+            "the permalink anchor must be the first child of the rule <h2> (left side)",
+        );
+        // Use tag-prefixed needles: the inlined stylesheet mentions
+        // `.rule-anchor` / `.rule-jump-link` as bare selectors, so a
+        // class-only search would match the CSS in <head> long before
+        // the body markup and scramble the ordering check.
+        let anchor_pos = html
+            .find("<a class=\"rule-anchor\"")
+            .expect("rule-anchor missing");
+        let code_pos = html
+            .find("<span class=\"lint-prefix\"")
+            .expect("lint-prefix missing");
+        let jump_pos = html
+            .find("<a class=\"rule-jump-link\"")
+            .expect("jump link missing");
+        assert!(
+            anchor_pos < code_pos && code_pos < jump_pos,
+            "permalink anchor must precede the rule name, which precedes the jump link",
+        );
+    }
+
+    #[test]
+    fn page_does_not_inline_the_anchor_icon_svg() {
+        // The chain-link glyph is shipped as an external file referenced
+        // by the stylesheet's `url(...)`; per the design it must never
+        // be inlined into the served HTML. No `<svg` should appear
+        // anywhere on the page.
+        let html = render_page(&[fake_rule("alpha")], &fake_context());
+        assert!(
+            !html.contains("<svg"),
+            "the heading-anchor icon must stay an external resource, not inlined SVG",
+        );
+    }
+
+    #[test]
+    fn style_references_rule_anchor_icon() {
+        // `rules.css` pulls the glyph in via a relative `url(...)`, and
+        // `run_html` writes the file under RULE_ANCHOR_ICON_FILENAME
+        // beside index.html. The two names must agree or the icon 404s.
+        let expected = format!("url(\"{RULE_ANCHOR_ICON_FILENAME}\")");
+        assert!(
+            STYLE.contains(&expected),
+            "rules.css must reference the anchor icon as {expected}",
+        );
+        // The vendored asset must keep its Octicons MIT attribution.
+        assert!(
+            RULE_ANCHOR_ICON.contains("Octicons") && RULE_ANCHOR_ICON.contains("MIT"),
+            "the bundled rule-anchor.svg must retain its Octicons MIT attribution",
         );
     }
 

--- a/tools/gen-docs/src/style/rules.css
+++ b/tools/gen-docs/src/style/rules.css
@@ -86,13 +86,11 @@ article.rule h2 {
   font-family: ui-monospace, SFMono-Regular, monospace;
 }
 
-/* The glyph is positioned against the heading's <code> box, not the
-   whole <h2>: `right: 100%` parks it entirely left of <code> (so the
-   rule name stays aligned with the body's paragraphs), and spanning the
-   <code> box with `top`/`bottom: 0` centres it on the text rather than
-   the taller line box. The combined width + margin reach (~0.95rem)
-   stays inside the body's 1rem side padding, so it never forces
-   horizontal scrolling on phones. */
+/* `right: 100%` parks the glyph left of the heading's <code>, so the
+   rule name stays aligned with body paragraphs; spanning <code> with
+   `top`/`bottom: 0` centres it on the text, not the taller line box.
+   The ~0.95rem reach stays within the body's 1rem padding to avoid
+   horizontal scroll on phones. */
 article.rule h2 code {
   position: relative;
 }

--- a/tools/gen-docs/src/style/rules.css
+++ b/tools/gen-docs/src/style/rules.css
@@ -87,17 +87,10 @@ article.rule h2 {
   font-family: ui-monospace, SFMono-Regular, monospace;
 }
 
-/* GitHub-style heading permalink: a chain-link glyph in the left
-   gutter of each rule-name heading, hidden until the heading is
-   hovered or the link itself is focused. Taking it out of flow with
-   `position: absolute` + `right: 100%` parks it entirely to the left
-   of the heading box, so the rule name stays aligned with the body's
-   paragraphs and the link is "pushed off" into the gutter. The icon
-   is an external `rule-anchor.svg` (Octicons, MIT) pulled in via
-   `background-image` — never inlined into the page. The combined
-   `width` + `margin-right` reach (~0.95rem) stays inside the body's
-   1rem side padding, so the glyph never spills past the viewport edge
-   to force horizontal scrolling on phones. */
+/* `right: 100%` parks the glyph entirely left of the heading box, so
+   the rule name stays aligned with the body's paragraphs. The combined
+   width + margin reach (~0.95rem) stays inside the body's 1rem side
+   padding, so it never forces horizontal scrolling on phones. */
 article.rule h2 .rule-anchor {
   position: absolute;
   right: 100%;

--- a/tools/gen-docs/src/style/rules.css
+++ b/tools/gen-docs/src/style/rules.css
@@ -83,19 +83,25 @@ article.rule {
 }
 
 article.rule h2 {
-  position: relative;
   font-family: ui-monospace, SFMono-Regular, monospace;
 }
 
-/* `right: 100%` parks the glyph entirely left of the heading box, so
-   the rule name stays aligned with the body's paragraphs. The combined
-   width + margin reach (~0.95rem) stays inside the body's 1rem side
-   padding, so it never forces horizontal scrolling on phones. */
+/* The glyph is positioned against the heading's <code> box, not the
+   whole <h2>: `right: 100%` parks it entirely left of <code> (so the
+   rule name stays aligned with the body's paragraphs), and spanning the
+   <code> box with `top`/`bottom: 0` centres it on the text rather than
+   the taller line box. The combined width + margin reach (~0.95rem)
+   stays inside the body's 1rem side padding, so it never forces
+   horizontal scrolling on phones. */
+article.rule h2 code {
+  position: relative;
+}
+
 article.rule h2 .rule-anchor {
   position: absolute;
   right: 100%;
   top: 0;
-  height: 1.55em;
+  bottom: 0;
   width: 0.8rem;
   margin-right: 0.15rem;
   background: url("rule-anchor.svg") no-repeat center / 0.8rem;

--- a/tools/gen-docs/src/style/rules.css
+++ b/tools/gen-docs/src/style/rules.css
@@ -83,7 +83,36 @@ article.rule {
 }
 
 article.rule h2 {
+  position: relative;
   font-family: ui-monospace, SFMono-Regular, monospace;
+}
+
+/* GitHub-style heading permalink: a chain-link glyph in the left
+   gutter of each rule-name heading, hidden until the heading is
+   hovered or the link itself is focused. Taking it out of flow with
+   `position: absolute` + `right: 100%` parks it entirely to the left
+   of the heading box, so the rule name stays aligned with the body's
+   paragraphs and the link is "pushed off" into the gutter. The icon
+   is an external `rule-anchor.svg` (Octicons, MIT) pulled in via
+   `background-image` — never inlined into the page. The combined
+   `width` + `margin-right` reach (~0.95rem) stays inside the body's
+   1rem side padding, so the glyph never spills past the viewport edge
+   to force horizontal scrolling on phones. */
+article.rule h2 .rule-anchor {
+  position: absolute;
+  right: 100%;
+  top: 0;
+  height: 1.55em;
+  width: 0.8rem;
+  margin-right: 0.15rem;
+  background: url("rule-anchor.svg") no-repeat center / 0.8rem;
+  opacity: 0;
+  transition: opacity 0.12s ease-in-out;
+}
+
+article.rule h2:hover .rule-anchor,
+article.rule h2 .rule-anchor:focus {
+  opacity: 1;
 }
 
 article.rule h2 .lint-prefix {


### PR DESCRIPTION
Adds GitHub-style permalink anchors to the rule-name headings on the generated catalogue page. Each rule heading gets a chain-link glyph in its left gutter, hidden until the heading is hovered (or the link is focused for keyboard users), and parked off to the left so the rule name stays aligned with the body text. Only rule-name headings get one — headings from rendered rustdoc do not.

The glyph is GitHub's Octicons `link-16` (MIT), vendored under `tools/gen-docs/src/assets/rule-anchor.svg` and shipped beside `index.html` as an external `background-image` rather than inlined into the page.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/132>.