### PR TITLE
docs(macro-argument-binding): remove irrelevant information

### DIFF
--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -164,11 +164,7 @@ Checked after the merge, so this knob always wins.
 
 #### `Mode` (enum)
 
-Eligibility mode. The default is `AllowAndDeny`. The matcher-based
-mode described in `planned-rules/macro-argument-binding.md` is not
-yet implemented and is therefore not exposed as a value here; a
-`dylint.toml` that names it will fail to deserialise with a
-useful error.
+Eligibility mode. The default is `AllowAndDeny`.
 
 ##### `"deny_only"` (Rust: `DenyOnly`)
 

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -183,11 +183,7 @@ const BUILTIN_PURE_METHODS: &[&str] = &[
     "as_bytes", "as_deref", "as_mut", "as_ref", "as_slice", "as_str", "is_empty", "len",
 ];
 
-/// Eligibility mode. The default is `AllowAndDeny`. The matcher-based
-/// mode described in `planned-rules/macro-argument-binding.md` is not
-/// yet implemented and is therefore not exposed as a value here; a
-/// `dylint.toml` that names it will fail to deserialise with a
-/// useful error.
+/// Eligibility mode. The default is `AllowAndDeny`.
 #[derive(Debug, Clone, Copy, Default, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum Mode {


### PR DESCRIPTION
The `Mode` config reference enumerates the values an end-user can set; the matcher-based mode is not one of them. Its unimplemented status (and the deserialise-failure behaviour) is already recorded in the planning file's Status section, so the note only advertised a value that cannot be selected and pointed end-users at an internal planning doc.

https://claude.ai/code/session_01Wa8sG1LrTPAHXZUeTAmf8A