### PR TITLE
docs(plan/unit-test-file-layout): use float fraction for relative inline test cap

### DIFF
--- a/planned-rules/unit-test-file-layout.md
+++ b/planned-rules/unit-test-file-layout.md
@@ -44,24 +44,31 @@ inline_style = "preserve"
 #                        (matching parallel-disk-usage's guidance).
 # "preserve"           — no preference about inline vs external.
 
-# Threshold for `external_when_long`. The lint sums the line spans of
+# Thresholds for `external_when_long`. The lint sums the line spans of
 # every inline test item in a file (the fixed set defined under
-# "What to lint" below) and compares the total against both limits. The lint fires when either
-# is exceeded. The fraction is `inline_test_lines / file_lines`, where
-# `file_lines` is the total line count of the parent source file — a
-# dimensionless ratio in `[0.0, 1.0)`.
+# "What to lint" below) and compares the total against both limits,
+# firing when either is exceeded.
 #
-# The measured fraction is always strictly below 1.0 for any file the
-# check applies to: a file whose top-level items are *entirely*
-# `#[cfg(test)]`-gated is exempt (see "What to lint"), so every checked
-# file has at least one production line. A cap of `1.0` therefore can
-# never be tripped and disables the relative limit.
-#
-# Defaults are set so that `inline_max_lines` is the active constraint
-# in typical projects; drop `inline_max_fraction_of_file` below 1.0 to
-# add the relative cap.
+# `inline_max_lines` is the absolute cap and is always active.
 inline_max_lines = 50
-inline_max_fraction_of_file = 1.0   # 1.0 = effectively disabled
+
+# `inline_max_fraction_of_file` is the optional relative cap: a
+# fraction `inline_test_lines / file_lines`, where `file_lines` is the
+# parent source file's total line count. It is stored internally as an
+# optional float (`Option<f32>`) and is unset (`None`) by default,
+# which disables the relative limit and leaves `inline_max_lines` as
+# the active constraint in typical projects.
+#
+# Accepted values are `0.0 <= x < 1.0`. A value `>= 1.0` or `< 0.0` is
+# a configuration error — the lint refuses to start rather than
+# silently clamping. Disabling the relative cap is expressed by
+# *omitting* the key, never by a sentinel value: the measured fraction
+# is always strictly below 1.0 for any checked file (a file whose
+# top-level items are *entirely* `#[cfg(test)]`-gated is exempt — see
+# "What to lint"), so `1.0` could never fire anyway and is rejected so
+# that "disabled" and "cap at the ceiling" cannot share a value.
+#
+# inline_max_fraction_of_file = 0.5
 
 # How external test files must be laid out on disk.
 external_layout = "nested"
@@ -128,8 +135,9 @@ toward the footprint.
      inline test item in the file, then compute the sum's share of
      the parent file's total line count. Emit a single per-file
      diagnostic when *either* the absolute total exceeds
-     `inline_max_lines` *or* the share exceeds
-     `inline_max_fraction_of_file`. The diagnostic spans the contiguous
+     `inline_max_lines` *or* — when `inline_max_fraction_of_file` is
+     set — the share exceeds it. With the fraction left unset only the
+     absolute cap applies. The diagnostic spans the contiguous
      run of inline test items (or the union of their spans, if they
      are not contiguous), names which limit was tripped, and points
      at the canonical extraction target. A file that has only one or

--- a/planned-rules/unit-test-file-layout.md
+++ b/planned-rules/unit-test-file-layout.md
@@ -47,15 +47,21 @@ inline_style = "preserve"
 # Threshold for `external_when_long`. The lint sums the line spans of
 # every inline test item in a file (the fixed set defined under
 # "What to lint" below) and compares the total against both limits. The lint fires when either
-# is exceeded. The percentage is `(inline_test_lines / file_lines) *
-# 100`, where `file_lines` is the total line count of the parent
-# source file.
+# is exceeded. The fraction is `inline_test_lines / file_lines`, where
+# `file_lines` is the total line count of the parent source file — a
+# dimensionless ratio in `[0.0, 1.0)`.
+#
+# The measured fraction is always strictly below 1.0 for any file the
+# check applies to: a file whose top-level items are *entirely*
+# `#[cfg(test)]`-gated is exempt (see "What to lint"), so every checked
+# file has at least one production line. A cap of `1.0` therefore can
+# never be tripped and disables the relative limit.
 #
 # Defaults are set so that `inline_max_lines` is the active constraint
-# in typical projects; bump or drop `inline_max_percent_of_file` to
+# in typical projects; drop `inline_max_fraction_of_file` below 1.0 to
 # add the relative cap.
 inline_max_lines = 50
-inline_max_percent_of_file = 100   # 100 = effectively disabled
+inline_max_fraction_of_file = 1.0   # 1.0 = effectively disabled
 
 # How external test files must be laid out on disk.
 external_layout = "nested"
@@ -123,7 +129,7 @@ toward the footprint.
      the parent file's total line count. Emit a single per-file
      diagnostic when *either* the absolute total exceeds
      `inline_max_lines` *or* the share exceeds
-     `inline_max_percent_of_file`. The diagnostic spans the contiguous
+     `inline_max_fraction_of_file`. The diagnostic spans the contiguous
      run of inline test items (or the union of their spans, if they
      are not contiguous), names which limit was tripped, and points
      at the canonical extraction target. A file that has only one or
@@ -257,7 +263,7 @@ file's position relative to its parent matters.
   `cx.sess().source_map().span_to_lines(span)`; the
   `FileLines.lines.len()` is its line count. Sum across items. Use
   `SourceFile::count_lines()` on the parent file for the denominator
-  of the percentage check. Cache the per-file total per crate to
+  of the fraction check. Cache the per-file total per crate to
   avoid recounting.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)


### PR DESCRIPTION
Docs-only change to the planning file for the (unimplemented) `unit_test_file_layout` rule.

Reworks the relative cap on inline-test footprint:

- **Renames** `inline_max_percent_of_file` (integer 0–100) → `inline_max_fraction_of_file` (float). The quantity is a dimensionless line ratio (`inline_test_lines / file_lines`); the integer percent only added a cosmetic `*100` and pinned granularity at 1%.
- **Specifies validation.** The field is optional (`Option<f32>`, `None` by default), accepting `0.0 <= x < 1.0`. Values `>= 1.0` or `< 0.0` are configuration errors, not silently-clamped no-ops.
- **Disable by omission.** The relative cap is turned off by leaving the key unset, not by a sentinel. The measured fraction is always strictly below 1.0 for any checked file (all-test files are exempt), so `1.0` could never fire and is rejected — keeping "disabled" and "cap at the ceiling" from sharing a value.

`inline_max_lines = 50` (the absolute cap) is unchanged and remains the active default constraint.