### PR TITLE
docs(plan): remove redundant no-op `preserve` style values

### DIFF
--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -320,14 +320,14 @@ shows:
 
 ```toml
 [qualified_paths]
-style = "preserve"
+style = "unqualified"
 ```
 
 The actual `dylint.toml` reads:
 
 ```toml
 [perfectionist::qualified_paths]
-style = "preserve"
+style = "unqualified"
 ```
 
 A user-side suppression reads:
@@ -378,6 +378,28 @@ gated behind a "are you sure?" knob, or rules whose preferred
 configuration genuinely varies per project to the point that
 shipping a baseline policy would be presumptuous. Everything
 else is `Active by default`.
+
+### Mandatory configuration on opt-in rules
+
+A handful of `Inactive by default` rules express a *direction*
+with no neutral baseline — `core_or_std` (`prefer_core` vs.
+`prefer_std`), `qualified_paths` (`unqualified` vs. `qualified`),
+`self_import` (`forbid` vs. `combined`), and `serde_wrapper_style`
+(`transparent` vs. `from_into`). These rules deliberately do **not**
+offer a `preserve`/no-op `style` value. "I don't want this rule" is
+already expressed by leaving it out of `[perfectionist].enable`, so
+a do-nothing `style` would only duplicate that — and a no-op enum
+variant that shadows the activation mechanism is exactly the
+redundancy this convention forbids.
+
+The consequence is that `style` is **mandatory whenever the rule is
+enabled** and has no default value. The validation is scoped to
+activation: a rule reads and validates its `style` only when it
+appears in `[perfectionist].enable`. A rule that is *not* enabled
+never reads its configuration block, so omitting `style` for a
+disabled direction rule is harmless and does not fail the run. Only
+an *enabled* rule with a missing or invalid `style` is a
+configuration error.
 
 Severity escalation (`Warn → Deny → Forbid`) is the consumer's
 prerogative and lives entirely outside the planning file. The

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -38,14 +38,14 @@ pattern that several rules call out by reference — live in
   configurable).
 - [`self-import.md`](./self-import.md) — decide how `self` in `use`
   statements is handled. Configurable as `forbid` (always prefer the
-  bare `use foo::bar;`), `combined` (fold adjacent module + item
-  imports into `use foo::bar::{self, X};`), or `preserve` (default
-  no-op).
+  bare `use foo::bar;`) or `combined` (fold adjacent module + item
+  imports into `use foo::bar::{self, X};`). Inactive by default; opt
+  in and pick a direction.
 - [`core-or-std.md`](./core-or-std.md) — decide whether items that
   exist in both `core`/`alloc` and `std` should be named through the
   narrower or wider path. Configurable as `prefer_core` (matches
-  `clippy::std_instead_of_core` + `std_instead_of_alloc`),
-  `prefer_std`, or `preserve` (default).
+  `clippy::std_instead_of_core` + `std_instead_of_alloc`) or
+  `prefer_std`. Inactive by default; opt in and pick a direction.
 - [`no-star-imports.md`](./no-star-imports.md) — forbid `use foo::*` inside
   module bodies. Two exceptions are enabled by default and individually
   configurable: the prelude form (`use foo::prelude::*`) and root-of-
@@ -61,8 +61,8 @@ pattern that several rules call out by reference — live in
   outside the current scope are named by their full path
   (`std::fs::create_dir_all`, `#[derive(clap::Parser)]`) or imported
   via `use` and called by the simple identifier. AI tends to produce
-  the former; parallel-disk-usage prefers the latter. Configurable
-  per project.
+  the former; parallel-disk-usage prefers the latter. Inactive by
+  default; opt in and pick `unqualified` or `qualified`.
 
 ### Trait bounds and signatures
 - [`where-clause-bounds.md`](./where-clause-bounds.md) — prefer `where` clauses
@@ -169,8 +169,8 @@ pattern that several rules call out by reference — live in
   `#[serde(transparent)]` and `#[serde(from = "T", into = "T")]`
   produce the same wire format. The lint enforces a project-wide
   choice between the two (`transparent` for zero-cost,
-  `from_into` to keep a validation hook ready). Default
-  `preserve`.
+  `from_into` to keep a validation hook ready). Inactive by
+  default; opt in and choose `transparent` or `from_into`.
 
 ### Documentation
 - [`intra-doc-links.md`](./intra-doc-links.md) — backticked identifiers in

--- a/planned-rules/core-or-std.md
+++ b/planned-rules/core-or-std.md
@@ -5,7 +5,7 @@
 ## Statement
 
 A project picks one style for naming items that exist in both `core` (or
-`alloc`) and `std`, and enforces it consistently. The three styles
+`alloc`) and `std`, and enforces it consistently. The two styles
 supported by this lint are:
 
 - **`prefer_core`** — flag any `std::` path that names an item canonically
@@ -14,8 +14,6 @@ supported by this lint are:
   both of which live in clippy's `restriction` group (off by default).
 - **`prefer_std`** — flag any `core::` or `alloc::` path that names an
   item also reachable through `std::`. Suggest the `std::` path.
-- **`preserve`** (default) — no-op. Useful as a project-wide
-  acknowledgement that the rule exists but neither extreme is enforced.
 
 The choice is project-driven:
 
@@ -30,8 +28,12 @@ The choice is project-driven:
 
 ```toml
 # dylint.toml
+#
+# Inactive by default. Enable in `[perfectionist].enable`, then set
+# `style` — it is mandatory and has no default. The value below is an
+# example, not a default.
 [core_or_std]
-style = "preserve"   # or "prefer_core" or "prefer_std"
+style = "prefer_core"   # or "prefer_std"
 ```
 
 Optional knobs:
@@ -84,10 +86,6 @@ The lint should *not* fire inside a module gated by `#![no_std]` or
 Detect via `tcx.sess.contains_name(.., sym::no_std)` on the crate's
 attributes for the global case, and by walking enclosing items for the
 `cfg`-gated case.
-
-## Style: `preserve`
-
-The lint emits nothing. Default.
 
 ## Examples across both styles
 
@@ -149,6 +147,8 @@ The lint emits nothing. Default.
 
 ## Default state
 
-Active by default, but the default `style = "preserve"` keeps the
-pass a no-op until the project opts into `prefer_core` or
-`prefer_std`.
+Inactive by default. `prefer_core` vs. `prefer_std` genuinely varies
+per project, so the rule ships no baseline; enable it in
+`[perfectionist].enable` and set `style`. `style` is mandatory once
+enabled — see
+[Mandatory configuration on opt-in rules](./IMPLEMENTATION_CONVENTIONS.md#mandatory-configuration-on-opt-in-rules).

--- a/planned-rules/print-macro-split.md
+++ b/planned-rules/print-macro-split.md
@@ -80,7 +80,6 @@ For every invocation of a target macro:
      `\n\<newline><indent>` where `<indent>` matches the source
      indentation of the original literal. Wrap the macro
      invocation across multiple lines if needed.
-   - `preserve`: emit nothing.
 
 ## Examples
 
@@ -138,7 +137,7 @@ println!("a\nb");
 
 ```toml
 [print_macro_split]
-style = "multiple_calls"   # or "line_continuation" or "preserve"
+style = "multiple_calls"   # or "line_continuation"
 
 # Source-line width that triggers the rule. Default 100 matches
 # rustfmt's column default. Common alternatives are 80 (terminal)

--- a/planned-rules/qualified-paths.md
+++ b/planned-rules/qualified-paths.md
@@ -57,8 +57,10 @@ external module.
 
 ```toml
 [qualified_paths]
-style = "preserve"
-# "preserve"     — no-op (default).
+# Inactive by default. Enable in `[perfectionist].enable`, then set
+# `style` — it is mandatory and has no default. The value below is an
+# example, not a default.
+style = "unqualified"
 # "unqualified"  — flag any module-qualified path; suggest a `use`
 #                  for the leaf and replace with the simple ident.
 # "qualified"    — flag any simple-ident path that resolves to an
@@ -254,9 +256,11 @@ For each path:
 
 ## Default state
 
-Active by default, but the default `style = "preserve"` keeps the
-pass a no-op until the project opts into `prefer_imported` or
-`prefer_qualified`.
+Inactive by default. `unqualified` vs. `qualified` is a per-project
+preference, so the rule ships no baseline; enable it in
+`[perfectionist].enable` and set `style`. `style` is mandatory once
+enabled — see
+[Mandatory configuration on opt-in rules](./IMPLEMENTATION_CONVENTIONS.md#mandatory-configuration-on-opt-in-rules).
 
 ## Why one rule instead of two
 

--- a/planned-rules/self-import.md
+++ b/planned-rules/self-import.md
@@ -7,7 +7,7 @@ defers all `self`-import decisions here.
 ## Statement
 
 A project picks one style for handling `self` in `use` statements and
-enforces it consistently. The three styles supported by this lint are:
+enforces it consistently. The two styles supported by this lint are:
 
 - **`forbid`** — every form that imports a module via `self` is bad.
   Prefer the simpler bare form.
@@ -19,19 +19,21 @@ enforces it consistently. The three styles supported by this lint are:
     `use foo::bar;` and `use foo::bar::Baz;`.
 - **`combined`** — adjacent `use foo::bar; use foo::bar::Baz;` should
   fold into a single `use foo::bar::{self, Baz};`.
-- **`preserve`** (default) — no-op. Existing forms are accepted as
-  written.
 
-The default is `preserve` so the lint is zero-friction to adopt; a
-project that has a preference enables `forbid` or `combined`
-explicitly.
+The rule is inactive by default, so it is zero-friction to adopt; a
+project that has a preference enables it and sets `style` to `forbid`
+or `combined`.
 
 ## Configuration
 
 ```toml
 # dylint.toml
+#
+# Inactive by default. Enable in `[perfectionist].enable`, then set
+# `style` — it is mandatory and has no default. The value below is an
+# example, not a default.
 [self_import]
-style = "preserve"   # or "forbid" or "combined"
+style = "forbid"   # or "combined"
 ```
 
 ## Style: `forbid`
@@ -87,11 +89,6 @@ source is a bare `use foo::bar;` (the same namespace caveat applies in
 reverse — the combined form *narrows* the import to the module
 namespace).
 
-## Style: `preserve`
-
-The lint emits nothing. Useful as a project-wide acknowledgement that
-`self_import` exists but neither extreme is enforced. Default.
-
 ## What to lint
 
 - `EarlyLintPass::check_mod`. Walk `ItemKind::Use` items in source
@@ -112,7 +109,6 @@ The lint emits nothing. Useful as a project-wide acknowledgement that
     and visibility. If statement A imports `foo::bar` (or
     `foo::bar::{self}`) and statement B imports `foo::bar::Baz`, fold
     them into `foo::bar::{self, Baz}`.
-- Under `preserve`: nothing.
 
 ## Implementation notes
 
@@ -136,8 +132,11 @@ The lint emits nothing. Useful as a project-wide acknowledgement that
 
 ## Default state
 
-Active by default, but the default `style = "preserve"` keeps the
-pass a no-op until the project opts into `forbid` or `combined`.
+Inactive by default. `forbid` vs. `combined` is a per-project
+preference, so the rule ships no baseline; enable it in
+`[perfectionist].enable` and set `style`. `style` is mandatory once
+enabled — see
+[Mandatory configuration on opt-in rules](./IMPLEMENTATION_CONVENTIONS.md#mandatory-configuration-on-opt-in-rules).
 
 ## Why a separate lint from `import-granularity`
 

--- a/planned-rules/serde-wrapper-style.md
+++ b/planned-rules/serde-wrapper-style.md
@@ -44,8 +44,10 @@ two forms would produce identical behaviour.
 
 ```toml
 [serde_wrapper_style]
-style = "preserve"
-# "preserve"          — no-op (default).
+# Inactive by default. Enable in `[perfectionist].enable`, then set
+# `style` — it is mandatory and has no default. The value below is an
+# example, not a default.
+style = "transparent"
 # "transparent"       — flag trivial `#[serde(from, into)]` and
 #                       suggest `#[serde(transparent)]`. Existing
 #                       non-trivial `from`/`into` (where the
@@ -253,10 +255,13 @@ apply it without manual review.
 
 ## Default state
 
-Active by default, but the default `style = "preserve"` keeps the
-pass a no-op so the rule is zero-friction to adopt. A project
-that has audited the trivial-impl recogniser on its codebase opts
-in by setting `style` to `transparent` or `from_into`.
+Inactive by default — also the safe choice given the high
+false-positive risk noted above. `transparent` vs. `from_into` is a
+per-project preference, so the rule ships no baseline; a project that
+has audited the trivial-impl recogniser on its codebase enables it in
+`[perfectionist].enable` and sets `style`. `style` is mandatory once
+enabled — see
+[Mandatory configuration on opt-in rules](./IMPLEMENTATION_CONVENTIONS.md#mandatory-configuration-on-opt-in-rules).
 
 ## Why a single rule instead of two
 

--- a/planned-rules/unit-test-file-layout.md
+++ b/planned-rules/unit-test-file-layout.md
@@ -35,14 +35,13 @@ layout rules apply to whatever name the project picks.
 # dylint.toml
 [unit_test_file_layout]
 
-# How inline test modules are handled.
-inline_style = "preserve"
+# How inline test modules are handled. Defaults to `external_when_long`.
+inline_style = "external_when_long"
 # "external_only"      — every `#[cfg(test)] mod X;` must be external
 #                        (matching pacquet's strict policy).
-# "external_when_long" — inline allowed up to the configured threshold;
-#                        beyond that, must be moved to a file
+# "external_when_long" — (default) inline allowed up to the configured
+#                        threshold; beyond that, must be moved to a file
 #                        (matching parallel-disk-usage's guidance).
-# "preserve"           — no preference about inline vs external.
 
 # Threshold for `external_when_long`. The lint sums the line spans of
 # every inline test item in a file (the fixed set defined under
@@ -129,7 +128,6 @@ toward the footprint.
      at the canonical extraction target. A file that has only one or
      two short tests stays under the budget and is not flagged, even
      when it has no `mod tests { ... }` block at all.
-   - `preserve`: emit nothing.
 
 A file that contains **only** test items — for example, the
 `src/foo/tests.rs` that a parent file's `mod tests;` resolves to,
@@ -148,9 +146,8 @@ configured `external_layout` pattern.
 ```rust
 // src/foo.rs
 //
-// Acceptable when `inline_style = "preserve"` or
-// `inline_style = "external_when_long"` and the inline-test footprint
-// is small.
+// Acceptable when `inline_style = "external_when_long"` and the
+// inline-test footprint is small.
 #[cfg(test)]
 mod tests {
     use super::parse;


### PR DESCRIPTION
A `style = "preserve"` (and `inline_style = "preserve"`) variant whose only effect is to emit nothing duplicates the global `[perfectionist].disable` (or, for opt-in rules, simply not enabling them). Remove every such no-op value:

- core_or_std, qualified_paths, self_import, serde_wrapper_style: these express a project-specific direction with no neutral baseline, so make them Inactive by default with a mandatory `style` (no default). Document the "mandatory-when-enabled, harmless-when-disabled" rule as a new convention so a disabled rule never errors over an absent `style`.
- print_macro_split, unit_test_file_layout: keep them Active by default and drop only the surplus `preserve`; their real active defaults (`multiple_calls`, `external_when_long`) remain.

Per-axis "no preference" controls that skip only one axis of a multi-axis rule (external_layout = "any", pipe_style "allow") are kept — they are selective controls, not whole-rule no-ops.

https://claude.ai/code/session_01M8qmn35VpQXEahqVnzPtMA