### PR TITLE
test: remove needless owned `String`

### DIFF
--- a/tests/bare_email.rs
+++ b/tests/bare_email.rs
@@ -13,7 +13,7 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     style: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    skip_domains: Option<Vec<String>>,
+    skip_domains: Option<Vec<&'static str>>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -43,7 +43,7 @@ fn skip_domains_matches_case_insensitively() {
     run(
         "ui-toml/bare_email/skip_domains_case_insensitive",
         RuleConfig {
-            skip_domains: Some(vec!["EXAMPLE.COM".to_owned()]),
+            skip_domains: Some(vec!["EXAMPLE.COM"]),
             ..Default::default()
         },
     );

--- a/tests/bare_url.rs
+++ b/tests/bare_url.rs
@@ -24,7 +24,7 @@ static SERIAL: Mutex<()> = Mutex::new(());
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    skip_hosts: Option<Vec<String>>,
+    skip_hosts: Option<Vec<&'static str>>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -55,7 +55,7 @@ fn custom_skip_hosts_replaces_the_default_list() {
     run(
         "ui-toml/bare_url/custom_skip_hosts",
         RuleConfig {
-            skip_hosts: Some(vec!["example.net".to_owned()]),
+            skip_hosts: Some(vec!["example.net"]),
         },
     );
 }

--- a/tests/lint_silence_reason.rs
+++ b/tests/lint_silence_reason.rs
@@ -28,7 +28,7 @@ static SERIAL: Mutex<()> = Mutex::new(());
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    exempt_lints: Option<Vec<String>>,
+    exempt_lints: Option<Vec<&'static str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     min_reason_length: Option<NonZeroUsize>,
 }
@@ -38,7 +38,7 @@ fn dylint_toml(config: RuleConfig) -> String {
     toml::to_string(&table).expect("serialise rule config as dylint.toml")
 }
 
-fn run(src_base: &str, contents: String) {
+fn run(src_base: &str, contents: &str) {
     let _serial = SERIAL.lock().unwrap_or_else(|err| err.into_inner());
     dylint_testing::ui::Test::src_base(env!("CARGO_PKG_NAME"), src_base)
         .dylint_toml(contents)
@@ -49,8 +49,8 @@ fn run(src_base: &str, contents: String) {
 fn exempt_lints_skips_attributes_whose_every_lint_is_exempt() {
     run(
         "ui-toml/lint_silence_reason/exempt_lints",
-        dylint_toml(RuleConfig {
-            exempt_lints: Some(vec!["clippy::module_name_repetitions".into()]),
+        &dylint_toml(RuleConfig {
+            exempt_lints: Some(vec!["clippy::module_name_repetitions"]),
             ..Default::default()
         }),
     );
@@ -60,7 +60,7 @@ fn exempt_lints_skips_attributes_whose_every_lint_is_exempt() {
 fn min_reason_length_one_accepts_any_non_blank_reason() {
     run(
         "ui-toml/lint_silence_reason/min_reason_length_one",
-        dylint_toml(RuleConfig {
+        &dylint_toml(RuleConfig {
             min_reason_length: 1.pipe(NonZeroUsize::new).unwrap().pipe(Some),
             ..Default::default()
         }),
@@ -71,7 +71,7 @@ fn min_reason_length_one_accepts_any_non_blank_reason() {
 fn min_reason_length_eight_raises_the_floor() {
     run(
         "ui-toml/lint_silence_reason/min_reason_length_eight",
-        dylint_toml(RuleConfig {
+        &dylint_toml(RuleConfig {
             min_reason_length: 8.pipe(NonZeroUsize::new).unwrap().pipe(Some),
             ..Default::default()
         }),
@@ -88,7 +88,6 @@ fn disable_in_global_table_suppresses_the_rule() {
         text_block_fnl! {
             "[perfectionist]"
             r#"disable = ["lint_silence_reason"]"#
-        }
-        .to_owned(),
+        },
     );
 }

--- a/tests/macro_argument_binding.rs
+++ b/tests/macro_argument_binding.rs
@@ -20,19 +20,19 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     mode: Option<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    deny_extra: Vec<String>,
+    deny_extra: Vec<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    allow_extra: Vec<String>,
+    allow_extra: Vec<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    ignore: Vec<String>,
+    ignore: Vec<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    extra_pure_methods: Vec<String>,
+    extra_pure_methods: Vec<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    ignore_pure_methods: Vec<String>,
+    ignore_pure_methods: Vec<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    extra_pure_macros: Vec<String>,
+    extra_pure_macros: Vec<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    ignore_pure_macros: Vec<String>,
+    ignore_pure_macros: Vec<&'static str>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -74,7 +74,7 @@ fn deny_extra_adds_a_qualified_macro_to_the_deny_set() {
     run(
         "ui-toml/macro_argument_binding/deny_extra",
         RuleConfig {
-            deny_extra: vec!["inner::their_macro".into()],
+            deny_extra: vec!["inner::their_macro"],
             ..Default::default()
         },
     );
@@ -85,7 +85,7 @@ fn allow_extra_silences_an_uncatalogued_macro() {
     run(
         "ui-toml/macro_argument_binding/allow_extra",
         RuleConfig {
-            allow_extra: vec!["my_macro".into()],
+            allow_extra: vec!["my_macro"],
             ..Default::default()
         },
     );
@@ -96,7 +96,7 @@ fn extra_pure_methods_adds_a_pure_getter_to_the_postfix_set() {
     run(
         "ui-toml/macro_argument_binding/extra_pure_methods",
         RuleConfig {
-            extra_pure_methods: vec!["cached_size".into()],
+            extra_pure_methods: vec!["cached_size"],
             ..Default::default()
         },
     );
@@ -107,7 +107,7 @@ fn ignore_pure_methods_drops_a_built_in_pure_getter() {
     run(
         "ui-toml/macro_argument_binding/ignore_pure_methods",
         RuleConfig {
-            ignore_pure_methods: vec!["as_ref".into()],
+            ignore_pure_methods: vec!["as_ref"],
             ..Default::default()
         },
     );
@@ -118,7 +118,7 @@ fn extra_pure_macros_adds_a_compile_time_macro_to_the_atom_set() {
     run(
         "ui-toml/macro_argument_binding/extra_pure_macros",
         RuleConfig {
-            extra_pure_macros: vec!["literal_table".into()],
+            extra_pure_macros: vec!["literal_table"],
             ..Default::default()
         },
     );
@@ -129,7 +129,7 @@ fn ignore_pure_macros_drops_a_built_in_compile_time_macro() {
     run(
         "ui-toml/macro_argument_binding/ignore_pure_macros",
         RuleConfig {
-            ignore_pure_macros: vec!["cfg".into()],
+            ignore_pure_macros: vec!["cfg"],
             ..Default::default()
         },
     );
@@ -140,7 +140,7 @@ fn ignore_suppresses_a_built_in_deny_set_macro() {
     run(
         "ui-toml/macro_argument_binding/ignore",
         RuleConfig {
-            ignore: vec!["debug_assert_eq".into()],
+            ignore: vec!["debug_assert_eq"],
             ..Default::default()
         },
     );
@@ -151,8 +151,8 @@ fn ignore_wins_over_deny_extra_for_the_same_macro() {
     run(
         "ui-toml/macro_argument_binding/ignore_overrides_deny_extra",
         RuleConfig {
-            deny_extra: vec!["my_macro".into()],
-            ignore: vec!["my_macro".into()],
+            deny_extra: vec!["my_macro"],
+            ignore: vec!["my_macro"],
             ..Default::default()
         },
     );

--- a/tests/macro_trailing_comma.rs
+++ b/tests/macro_trailing_comma.rs
@@ -24,9 +24,9 @@ static SERIAL: Mutex<()> = Mutex::new(());
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    extra_macros: Vec<String>,
+    extra_macros: Vec<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    ignore: Vec<String>,
+    ignore: Vec<&'static str>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -52,7 +52,7 @@ fn extra_macros_enables_a_macro_by_bare_name() {
     run(
         "ui-toml/macro_trailing_comma/extra_macros",
         RuleConfig {
-            extra_macros: vec!["my_macro".into()],
+            extra_macros: vec!["my_macro"],
             ..Default::default()
         },
     );
@@ -66,7 +66,7 @@ fn extra_macros_enables_a_macro_by_qualified_path() {
     run(
         "ui-toml/macro_trailing_comma/extra_macros_qualified",
         RuleConfig {
-            extra_macros: vec!["inner::their_macro".into()],
+            extra_macros: vec!["inner::their_macro"],
             ..Default::default()
         },
     );
@@ -77,7 +77,7 @@ fn ignore_suppresses_a_built_in_curated_macro() {
     run(
         "ui-toml/macro_trailing_comma/ignore",
         RuleConfig {
-            ignore: vec!["vec".into()],
+            ignore: vec!["vec"],
             ..Default::default()
         },
     );
@@ -88,8 +88,8 @@ fn ignore_wins_over_extra_macros_for_the_same_macro() {
     run(
         "ui-toml/macro_trailing_comma/ignore_overrides_extra",
         RuleConfig {
-            extra_macros: vec!["my_macro".into()],
-            ignore: vec!["my_macro".into()],
+            extra_macros: vec!["my_macro"],
+            ignore: vec!["my_macro"],
         },
     );
 }
@@ -104,7 +104,7 @@ fn ignore_supports_qualified_path_and_whitespace_padding() {
     run(
         "ui-toml/macro_trailing_comma/ignore_qualified_with_whitespace",
         RuleConfig {
-            ignore: vec!["  std::vec  ".into()],
+            ignore: vec!["  std::vec  "],
             ..Default::default()
         },
     );

--- a/tests/non_exhaustive_error.rs
+++ b/tests/non_exhaustive_error.rs
@@ -26,9 +26,9 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     require_for: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    extra_suffixes: Option<Vec<String>>,
+    extra_suffixes: Option<Vec<&'static str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ignore_suffixes: Option<Vec<String>>,
+    ignore_suffixes: Option<Vec<&'static str>>,
 }
 
 /// The `[perfectionist]` table, kept minimal so every fixture below
@@ -110,8 +110,8 @@ fn custom_suffixes_extend_and_subtract_the_default_list() {
     run(
         "ui-toml/non_exhaustive_error/custom_suffixes",
         RuleConfig {
-            extra_suffixes: Some(vec!["Failure".into()]),
-            ignore_suffixes: Some(vec!["Error".into()]),
+            extra_suffixes: Some(vec!["Failure"]),
+            ignore_suffixes: Some(vec!["Error"]),
             ..Default::default()
         },
     );

--- a/tests/prefer_raw_string.rs
+++ b/tests/prefer_raw_string.rs
@@ -29,7 +29,7 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     min_escapes_to_trigger: Option<NonZeroUsize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    eligible_escapes: Option<Vec<String>>,
+    eligible_escapes: Option<Vec<&'static str>>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -68,7 +68,7 @@ fn eligible_escapes_subset_narrows_what_counts_as_eliminable() {
     run(
         "ui-toml/prefer_raw_string/eligible_escapes_subset",
         RuleConfig {
-            eligible_escapes: Some(vec![r#"\""#.into()]),
+            eligible_escapes: Some(vec![r#"\""#]),
             ..Default::default()
         },
     );
@@ -85,7 +85,7 @@ fn eligible_escapes_rejects_non_self_decoding_entries() {
     run(
         "ui-toml/prefer_raw_string/eligible_escapes_rejects_non_self_decoding",
         RuleConfig {
-            eligible_escapes: Some(vec![r"\n".into()]),
+            eligible_escapes: Some(vec![r"\n"]),
             ..Default::default()
         },
     );

--- a/tests/single_letter_closure_param.rs
+++ b/tests/single_letter_closure_param.rs
@@ -24,9 +24,9 @@ static SERIAL: Mutex<()> = Mutex::new(());
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    extra_trivial_callback_methods: Option<Vec<String>>,
+    extra_trivial_callback_methods: Option<Vec<&'static str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ignore_trivial_callback_methods: Option<Vec<String>>,
+    ignore_trivial_callback_methods: Option<Vec<&'static str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     extra_allowed_idents: Option<Vec<char>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -50,8 +50,8 @@ fn custom_trivial_callback_methods_extend_and_subtract_the_default_list() {
     run(
         "ui-toml/single_letter_closure_param/custom_trivial_callback_methods",
         RuleConfig {
-            extra_trivial_callback_methods: Some(vec!["when".into()]),
-            ignore_trivial_callback_methods: Some(vec!["sort_by".into()]),
+            extra_trivial_callback_methods: Some(vec!["when"]),
+            ignore_trivial_callback_methods: Some(vec!["sort_by"]),
             ..Default::default()
         },
     );

--- a/tests/unicode_ellipsis_in_panic_messages.rs
+++ b/tests/unicode_ellipsis_in_panic_messages.rs
@@ -25,13 +25,13 @@ static SERIAL: Mutex<()> = Mutex::new(());
 #[derive(Default, serde::Serialize)]
 struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
-    extra_macros: Option<Vec<String>>,
+    extra_macros: Option<Vec<&'static str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ignore_macros: Option<Vec<String>>,
+    ignore_macros: Option<Vec<&'static str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    extra_methods: Option<Vec<String>>,
+    extra_methods: Option<Vec<&'static str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ignore_methods: Option<Vec<String>>,
+    ignore_methods: Option<Vec<&'static str>>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -51,10 +51,10 @@ fn custom_macros_and_methods_extend_and_subtract_the_default_lists() {
     run(
         "ui-toml/unicode_ellipsis_in_panic_messages/custom_macros_and_methods",
         RuleConfig {
-            extra_macros: Some(vec!["my_panic".into()]),
-            ignore_macros: Some(vec!["panic".into()]),
-            extra_methods: Some(vec!["expect_with".into()]),
-            ignore_methods: Some(vec!["expect".into()]),
+            extra_macros: Some(vec!["my_panic"]),
+            ignore_macros: Some(vec!["panic"]),
+            extra_methods: Some(vec!["expect_with"]),
+            ignore_methods: Some(vec!["expect"]),
         },
     );
 }


### PR DESCRIPTION
`dylint_testing::ui::Test::dylint_toml` takes `impl AsRef<str>` and clones internally, and `text_block_fnl!` expands to a `&'static str`, so neither the `run` helper nor the per-rule `RuleConfig` mirrors ever need to own their strings.

- `lint_silence_reason`'s `run` helper now takes `&str`, dropping the `text_block_fnl! { … }.to_owned()` at the call site.
- The serialize-only `RuleConfig` mirrors declare their list fields as `Vec<&'static str>` instead of `Vec<String>`, so the literals drop their `.to_owned()` / `.into()`.

Tests only; no behavior change.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/148>.