### PR TITLE
refactor(config/unicode-ellipsis-in-comments)!: split `scope` into 2 booleans

### DIFF
--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -41,12 +41,8 @@ pipelines occasionally insert. Empty by default.
 
 ### `scan_line_comments`: `boolean` (optional)
 
-Scan `//` line comments, including consecutive runs that rustc
-treats as a single logical comment. Defaults to `true`. Narrow
-this if a project intentionally uses one comment form for prose
-and wants the lint to ignore it.
+Scan `//` line comments. Defaults to `true`.
 
 ### `scan_block_comments`: `boolean` (optional)
 
-Scan `/* ... */` block comments, including nested ones.
-Defaults to `true`.
+Scan `/* ... */` block comments. Defaults to `true`.

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -39,23 +39,14 @@ near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)
 or U+2025 TWO DOT LEADER (`‥`) that the same autocorrect
 pipelines occasionally insert. Empty by default.
 
-### `scope`: `[Scope]` (optional)
+### `scan_line_comments`: `boolean` (optional)
 
-Which comment forms to scan. Defaults to both `line` (`//`)
-and `block` (`/* */`). Narrow this if a project intentionally
-uses one form for prose and wants the lint to ignore it.
+Scan `//` line comments, including consecutive runs that rustc
+treats as a single logical comment. Defaults to `true`. Narrow
+this if a project intentionally uses one comment form for prose
+and wants the lint to ignore it.
 
-### Types
+### `scan_block_comments`: `boolean` (optional)
 
-#### `Scope` (enum)
-
-Selector for which comment syntaxes the rule scans.
-
-##### `"line"` (Rust: `Line`)
-
-`//`-prefixed line comments, including consecutive runs that
-rustc treats as a single logical comment.
-
-##### `"block"` (Rust: `Block`)
-
-`/* ... */` block comments, including nested ones.
+Scan `/* ... */` block comments, including nested ones.
+Defaults to `true`.

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -46,13 +46,9 @@ struct Config {
     /// or U+2025 TWO DOT LEADER (`‥`) that the same autocorrect
     /// pipelines occasionally insert. Empty by default.
     extra_flagged_chars: Vec<char>,
-    /// Scan `//` line comments, including consecutive runs that rustc
-    /// treats as a single logical comment. Defaults to `true`. Narrow
-    /// this if a project intentionally uses one comment form for prose
-    /// and wants the lint to ignore it.
+    /// Scan `//` line comments. Defaults to `true`.
     scan_line_comments: bool,
-    /// Scan `/* ... */` block comments, including nested ones.
-    /// Defaults to `true`.
+    /// Scan `/* ... */` block comments. Defaults to `true`.
     scan_block_comments: bool,
 }
 

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use rustc_ast::Crate;
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
@@ -48,35 +46,30 @@ struct Config {
     /// or U+2025 TWO DOT LEADER (`‥`) that the same autocorrect
     /// pipelines occasionally insert. Empty by default.
     extra_flagged_chars: Vec<char>,
-    /// Which comment forms to scan. Defaults to both `line` (`//`)
-    /// and `block` (`/* */`). Narrow this if a project intentionally
-    /// uses one form for prose and wants the lint to ignore it.
-    scope: Vec<Scope>,
+    /// Scan `//` line comments, including consecutive runs that rustc
+    /// treats as a single logical comment. Defaults to `true`. Narrow
+    /// this if a project intentionally uses one comment form for prose
+    /// and wants the lint to ignore it.
+    scan_line_comments: bool,
+    /// Scan `/* ... */` block comments, including nested ones.
+    /// Defaults to `true`.
+    scan_block_comments: bool,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             extra_flagged_chars: Vec::new(),
-            scope: vec![Scope::Line, Scope::Block],
+            scan_line_comments: true,
+            scan_block_comments: true,
         }
     }
 }
 
-/// Selector for which comment syntaxes the rule scans.
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-enum Scope {
-    /// `//`-prefixed line comments, including consecutive runs that
-    /// rustc treats as a single logical comment.
-    Line,
-    /// `/* ... */` block comments, including nested ones.
-    Block,
-}
-
 pub struct UnicodeEllipsisInComments {
     flagged_chars: Vec<char>,
-    scopes: BTreeSet<Scope>,
+    scan_line_comments: bool,
+    scan_block_comments: bool,
 }
 
 impl UnicodeEllipsisInComments {
@@ -90,7 +83,8 @@ impl UnicodeEllipsisInComments {
         }
         Self {
             flagged_chars,
-            scopes: config.scope.into_iter().collect(),
+            scan_line_comments: config.scan_line_comments,
+            scan_block_comments: config.scan_block_comments,
         }
     }
 }
@@ -113,9 +107,7 @@ pub fn register_pass(lint_store: &mut LintStore) {
 impl EarlyLintPass for UnicodeEllipsisInComments {
     fn check_crate(&mut self, lint_context: &EarlyContext<'_>, _: &Crate) {
         let source_map = lint_context.sess().source_map();
-        let scan_line_comments = self.scopes.contains(&Scope::Line);
-        let scan_block_comments = self.scopes.contains(&Scope::Block);
-        if !(scan_line_comments || scan_block_comments) {
+        if !(self.scan_line_comments || self.scan_block_comments) {
             return;
         }
         for source_file in source_map.files().iter() {
@@ -129,10 +121,10 @@ impl EarlyLintPass for UnicodeEllipsisInComments {
             for token in tokenize(source_text, FrontmatterAllowed::Yes) {
                 let token_len = token.len;
                 let should_scan_token = match token.kind {
-                    TokenKind::LineComment { doc_style: None } => scan_line_comments,
+                    TokenKind::LineComment { doc_style: None } => self.scan_line_comments,
                     TokenKind::BlockComment {
                         doc_style: None, ..
-                    } => scan_block_comments,
+                    } => self.scan_block_comments,
                     _ => false,
                 };
                 if should_scan_token {

--- a/tests/unicode_ellipsis_in_comments.rs
+++ b/tests/unicode_ellipsis_in_comments.rs
@@ -41,3 +41,31 @@ fn comment_rule_does_not_intrude_into_doc_comments() {
         },
     );
 }
+
+/// `scan_block_comments = false` narrows the rule to `//` line
+/// comments: the line comment fires while the `/* */` block comment
+/// is left untouched.
+#[test]
+fn scan_line_only() {
+    run(
+        "ui-toml/unicode_ellipsis_in_comments/scan_line_only",
+        text_block_fnl! {
+            r#"["perfectionist::unicode_ellipsis_in_comments"]"#
+            "scan_block_comments = false"
+        },
+    );
+}
+
+/// `scan_line_comments = false` narrows the rule to `/* */` block
+/// comments: the block comment fires while the `//` line comment is
+/// left untouched.
+#[test]
+fn scan_block_only() {
+    run(
+        "ui-toml/unicode_ellipsis_in_comments/scan_block_only",
+        text_block_fnl! {
+            r#"["perfectionist::unicode_ellipsis_in_comments"]"#
+            "scan_line_comments = false"
+        },
+    );
+}

--- a/ui-toml/unicode_ellipsis_in_comments/scan_block_only/fixture.rs
+++ b/ui-toml/unicode_ellipsis_in_comments/scan_block_only/fixture.rs
@@ -1,0 +1,4 @@
+// Line comment with ellipsis…
+/* Block comment with ellipsis… */
+
+fn main() {}

--- a/ui-toml/unicode_ellipsis_in_comments/scan_block_only/fixture.stderr
+++ b/ui-toml/unicode_ellipsis_in_comments/scan_block_only/fixture.stderr
@@ -1,0 +1,10 @@
+warning: Unicode `…` (U+2026) in comment
+  --> $DIR/fixture.rs:2:31
+   |
+LL | /* Block comment with ellipsis… */
+   |                               ^ help: use ASCII `...` instead: `...`
+   |
+   = note: `#[warn(perfectionist::unicode_ellipsis_in_comments)]` on by default
+
+warning: 1 warning emitted
+

--- a/ui-toml/unicode_ellipsis_in_comments/scan_line_only/fixture.rs
+++ b/ui-toml/unicode_ellipsis_in_comments/scan_line_only/fixture.rs
@@ -1,0 +1,4 @@
+// Line comment with ellipsis…
+/* Block comment with ellipsis… */
+
+fn main() {}

--- a/ui-toml/unicode_ellipsis_in_comments/scan_line_only/fixture.stderr
+++ b/ui-toml/unicode_ellipsis_in_comments/scan_line_only/fixture.stderr
@@ -1,0 +1,10 @@
+warning: Unicode `…` (U+2026) in comment
+  --> $DIR/fixture.rs:1:30
+   |
+LL | // Line comment with ellipsis…
+   |                              ^ help: use ASCII `...` instead: `...`
+   |
+   = note: `#[warn(perfectionist::unicode_ellipsis_in_comments)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Replace `unicode_ellipsis_in_comments`'s `scope: Vec<Scope>` multi-select with two boolean fields, `scan_line_comments` and `scan_block_comments` (both default `true`), and delete the `Scope` enum and the runtime `BTreeSet`. A fixed two-variant multi-select reads more directly as a pair of per-surface booleans: no redundant-input dedup, and the catalogue docs surface a clear per-surface default.

Also regenerates the rule's markdown doc and adds `ui-toml/` fixtures (`scan_line_only`, `scan_block_only`) exercising each per-surface knob.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/131>.