### PR TITLE
refactor(config/prefer-derive-more-over-thiserror): remove `thiserror_paths`

### DIFF
--- a/rules/prefer_derive_more_over_thiserror.md
+++ b/rules/prefer_derive_more_over_thiserror.md
@@ -23,7 +23,7 @@ the consumer crate. Three syntactic shapes trigger the lint:
    `#[cfg_attr(_, error(...))]` is unwrapped symmetrically
    with the derive side.
 3. **Imports.** Every `use` or `extern crate` statement that
-   brings a configured `thiserror` path into scope:
+   brings a `thiserror` path into scope:
    `use thiserror::*`, `use thiserror::Error`,
    `use thiserror::Error as MyError;`,
    `use thiserror::{self as te};`, `use thiserror as te;`,
@@ -82,12 +82,4 @@ pub enum MyError {
 
 ## Configuration
 
-Configure via `dylint.toml` under `["perfectionist::prefer_derive_more_over_thiserror"]`. Every field is optional; the per-field prose below states the default.
-
-### `thiserror_paths`: `[string]` (optional)
-
-Paths whose presence in a `#[derive(...)]` list (or whose
-crate's presence in a `use` statement) flags the site. Each
-entry is a `::`-separated path string. Replaces the default
-`["thiserror::Error"]` when supplied; the empty list `[]`
-disables the rule.
+None.

--- a/src/rules/prefer_derive_more_over_thiserror.rs
+++ b/src/rules/prefer_derive_more_over_thiserror.rs
@@ -42,7 +42,7 @@ declare_tool_lint! {
     ///    `#[cfg_attr(_, error(...))]` is unwrapped symmetrically
     ///    with the derive side.
     /// 3. **Imports.** Every `use` or `extern crate` statement that
-    ///    brings a configured `thiserror` path into scope:
+    ///    brings a `thiserror` path into scope:
     ///    `use thiserror::*`, `use thiserror::Error`,
     ///    `use thiserror::Error as MyError;`,
     ///    `use thiserror::{self as te};`, `use thiserror as te;`,
@@ -130,20 +130,10 @@ pub fn register_pass(lint_store: &mut LintStore) {
 
 impl EarlyLintPass for PreferDeriveMoreOverThiserror {
     fn check_crate(&mut self, _cx: &EarlyContext<'_>, krate: &Crate) {
-        // `thiserror_paths` is empty when the user opts out via
-        // `thiserror_paths = []` in `dylint.toml`. Skip the
-        // crate-wide alias scan and short-circuit every per-item
-        // check below — there is nothing to match against.
-        if self.thiserror_paths.is_empty() {
-            return;
-        }
         scan::collect_aliases(self, krate);
     }
 
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
-        if self.thiserror_paths.is_empty() {
-            return;
-        }
         match &item.kind {
             ItemKind::Use(use_tree) => self.check_use(cx, item, use_tree),
             ItemKind::ExternCrate(orig, ident) => {

--- a/src/rules/prefer_derive_more_over_thiserror.rs
+++ b/src/rules/prefer_derive_more_over_thiserror.rs
@@ -6,7 +6,7 @@
 //! and the pre-expansion `EarlyLintPass` driver. The work is split
 //! across submodules:
 //! - [`config`] — `Config`, the `PreferDeriveMoreOverThiserror` pass
-//!   state, and the configured-path matcher.
+//!   state, and the path matcher.
 //! - [`scan`] — crate-wide `use` / `extern crate` alias collection.
 //! - [`detect`] — per-item derive / attribute / import matching and
 //!   diagnostic dispatch.

--- a/src/rules/prefer_derive_more_over_thiserror/config.rs
+++ b/src/rules/prefer_derive_more_over_thiserror/config.rs
@@ -14,11 +14,10 @@ const CONFIG_KEY: &str = "perfectionist::prefer_derive_more_over_thiserror";
 const THISERROR_PATHS: &[&str] = &["thiserror::Error"];
 
 /// Configuration is reserved for future knobs; the lint currently
-/// has no options. The empty struct still exists so that an empty
+/// has no options. The empty struct still exists so that a stray
 /// `[perfectionist::prefer_derive_more_over_thiserror]` table in
 /// `dylint.toml` deserialises rather than producing a confusing
-/// parse error. `deny_unknown_fields` is kept deliberately: an
-/// unrecognised key is rejected loudly instead of silently ignored.
+/// parse error.
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {}

--- a/src/rules/prefer_derive_more_over_thiserror/config.rs
+++ b/src/rules/prefer_derive_more_over_thiserror/config.rs
@@ -1,7 +1,7 @@
 //! Configuration and in-memory state for
-//! `prefer_derive_more_over_thiserror`: the user-facing `Config`
-//! shape, the default path list, the `PreferDeriveMoreOverThiserror`
-//! pass state, and the configured-path matcher shared by the
+//! `prefer_derive_more_over_thiserror`: the empty `Config` shape, the
+//! recognised path list, the `PreferDeriveMoreOverThiserror` pass
+//! state, and the path matcher shared by the
 //! [`scan`](super::scan) and [`detect`](super::detect) submodules.
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -10,42 +10,38 @@ use rustc_span::Symbol;
 
 const CONFIG_KEY: &str = "perfectionist::prefer_derive_more_over_thiserror";
 
-/// Recognised `thiserror` derive paths. The default covers the
-/// canonical crate; a project that re-publishes the derive under a
-/// different crate name can extend the list.
-const DEFAULT_THISERROR_PATHS: &[&str] = &["thiserror::Error"];
+/// The `thiserror` derive paths the rule recognises.
+const THISERROR_PATHS: &[&str] = &["thiserror::Error"];
 
+/// Configuration is reserved for future knobs; the lint currently
+/// has no options. The empty struct still exists so that a stray
+/// `[perfectionist::prefer_derive_more_over_thiserror]` table in
+/// `dylint.toml` deserialises rather than producing a confusing
+/// parse error.
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
-struct Config {
-    /// Paths whose presence in a `#[derive(...)]` list (or whose
-    /// crate's presence in a `use` statement) flags the site. Each
-    /// entry is a `::`-separated path string. Replaces the default
-    /// `["thiserror::Error"]` when supplied; the empty list `[]`
-    /// disables the rule.
-    thiserror_paths: Option<Vec<String>>,
-}
+struct Config {}
 
-/// Parsed configuration plus the crate-wide alias maps the pass
-/// accumulates in its pre-expansion `check_crate` scan. Fields are
+/// The recognised thiserror paths plus the crate-wide alias maps the
+/// pass accumulates in its pre-expansion `check_crate` scan. Fields are
 /// `pub(super)` so the sibling `scan` and `detect` submodules (both
 /// descendants of the rule's entry module) can read and, in the
 /// scan's case, populate them.
 pub(super) struct PreferDeriveMoreOverThiserror {
-    /// Configured paths split into segment lists (e.g.
+    /// Recognised paths split into segment lists (e.g.
     /// `[[thiserror, Error]]`).
     pub(super) thiserror_paths: Vec<Vec<Symbol>>,
-    /// First segments of every configured path — the crate names a
+    /// First segments of every recognised path — the crate names a
     /// `use` statement must start with to be flagged.
     pub(super) thiserror_crates: BTreeSet<Symbol>,
-    /// Identifiers that, anywhere in the crate, name a configured
+    /// Identifiers that, anywhere in the crate, name a recognised
     /// path's terminal item. A bare `#[derive(X)]` where `X` is in
     /// this set is treated as thiserror-derived. Populated by the
     /// alias-collection visitor (`scan` submodule) from the
     /// `EarlyLintPass::check_crate` hook, before any `check_item`
     /// callback runs.
     pub(super) aliases: BTreeSet<Symbol>,
-    /// Local names that alias a configured thiserror *crate*.
+    /// Local names that alias a recognised thiserror *crate*.
     /// Populated from `use thiserror as te;` and
     /// `extern crate thiserror as te;`. The value is the original
     /// crate name (e.g. `thiserror`) so that a derive path
@@ -56,14 +52,8 @@ pub(super) struct PreferDeriveMoreOverThiserror {
 
 impl PreferDeriveMoreOverThiserror {
     pub(super) fn new() -> Self {
-        let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-        let configured = config.thiserror_paths.unwrap_or_else(|| {
-            DEFAULT_THISERROR_PATHS
-                .iter()
-                .map(|path| (*path).to_owned())
-                .collect()
-        });
-        let thiserror_paths: Vec<Vec<Symbol>> = configured
+        let _config: Config = dylint_linting::config_or_default(CONFIG_KEY);
+        let thiserror_paths: Vec<Vec<Symbol>> = THISERROR_PATHS
             .iter()
             .map(|path| {
                 path.split("::")
@@ -87,8 +77,8 @@ impl PreferDeriveMoreOverThiserror {
 }
 
 /// Whether `path` (a sequence of bare segment symbols) exactly equals
-/// one of the configured thiserror paths. Shared by the scan's
+/// one of the recognised thiserror paths. Shared by the scan's
 /// alias collection and the detection pass's derive matching.
-pub(super) fn path_matches_thiserror(configured: &[Vec<Symbol>], path: &[Symbol]) -> bool {
-    configured.iter().any(|cfg| cfg.as_slice() == path)
+pub(super) fn path_matches_thiserror(recognised: &[Vec<Symbol>], path: &[Symbol]) -> bool {
+    recognised.iter().any(|known| known.as_slice() == path)
 }

--- a/src/rules/prefer_derive_more_over_thiserror/config.rs
+++ b/src/rules/prefer_derive_more_over_thiserror/config.rs
@@ -1,7 +1,7 @@
 //! Configuration and in-memory state for
 //! `prefer_derive_more_over_thiserror`: the empty `Config` shape, the
-//! recognised path list, the `PreferDeriveMoreOverThiserror` pass
-//! state, and the path matcher shared by the
+//! recognised `thiserror` paths, the `PreferDeriveMoreOverThiserror`
+//! pass state, and the path matcher shared by the
 //! [`scan`](super::scan) and [`detect`](super::detect) submodules.
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/src/rules/prefer_derive_more_over_thiserror/config.rs
+++ b/src/rules/prefer_derive_more_over_thiserror/config.rs
@@ -14,10 +14,11 @@ const CONFIG_KEY: &str = "perfectionist::prefer_derive_more_over_thiserror";
 const THISERROR_PATHS: &[&str] = &["thiserror::Error"];
 
 /// Configuration is reserved for future knobs; the lint currently
-/// has no options. The empty struct still exists so that a stray
+/// has no options. The empty struct still exists so that an empty
 /// `[perfectionist::prefer_derive_more_over_thiserror]` table in
 /// `dylint.toml` deserialises rather than producing a confusing
-/// parse error.
+/// parse error. `deny_unknown_fields` is kept deliberately: an
+/// unrecognised key is rejected loudly instead of silently ignored.
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {}

--- a/src/rules/prefer_derive_more_over_thiserror/detect.rs
+++ b/src/rules/prefer_derive_more_over_thiserror/detect.rs
@@ -34,7 +34,7 @@ impl PreferDeriveMoreOverThiserror {
         flag_enum_error_attrs(cx, def);
     }
 
-    /// Emit on every `use` statement whose tree touches a configured
+    /// Emit on every `use` statement whose tree touches a recognised
     /// thiserror crate at any depth. Handles the three common shapes
     /// in one pass:
     ///
@@ -80,7 +80,7 @@ impl PreferDeriveMoreOverThiserror {
 
     /// Walk a struct or enum's outer attributes and emit a
     /// diagnostic on every derive entry that resolves to a
-    /// configured thiserror path. Recurses through `#[cfg_attr]`
+    /// recognised thiserror path. Recurses through `#[cfg_attr]`
     /// wrappers so that conditional derives are not silently
     /// missed. Returns `true` when at least one entry matched,
     /// signalling that the caller should also flag `#[error(...)]`
@@ -163,7 +163,7 @@ impl PreferDeriveMoreOverThiserror {
         }
         // Crate-aliased derive entry (`#[derive(te::Error)]` paired
         // with `use thiserror as te;`): expand the first segment to
-        // the original crate name and re-match against configured
+        // the original crate name and re-match against the recognised
         // paths.
         if let [first, rest @ ..] = segments
             && let Some(&expanded_first) = self.crate_aliases.get(first)

--- a/src/rules/prefer_derive_more_over_thiserror/scan.rs
+++ b/src/rules/prefer_derive_more_over_thiserror/scan.rs
@@ -168,15 +168,14 @@ fn walk_use_tree_for_aliases(
                 return;
             }
             // `use a::b::*;` brings the *direct* children of `a::b`
-            // into scope, so the glob exposes the configured leaf
-            // only when the configured path is exactly one segment
-            // deeper than the glob's path. For default config
-            // `[[thiserror, Error]]` plus `use thiserror::*;` the
-            // check is `2 == 1 + 1` and `Error` is inserted; for a
-            // hypothetical multi-segment config like
-            // `["foo::bar::Error"]` plus `use foo::*;` it is
-            // `3 == 1 + 1 ⇒ false` and the rule does not falsely
-            // claim `Error` is in scope.
+            // into scope, so the glob exposes a recognised leaf
+            // only when the recognised path is exactly one segment
+            // deeper than the glob's path. For `[[thiserror, Error]]`
+            // plus `use thiserror::*;` the check is `2 == 1 + 1` and
+            // `Error` is inserted; a glob that stops more than one
+            // segment short of the leaf (e.g. a one-segment glob
+            // against a three-segment path) fails the `+ 1` check, so
+            // the rule does not falsely claim the leaf is in scope.
             //
             // The glob's path is also expanded through `crate_aliases`
             // so `use te::*;` after `use thiserror as te;` behaves

--- a/ui/prefer_derive_more_over_thiserror.rs
+++ b/ui/prefer_derive_more_over_thiserror.rs
@@ -33,7 +33,7 @@ mod thiserror {
 use thiserror::Error;
 
 // Bad: `use thiserror::*` glob form. Even more aggressive — adds
-// every configured path's last segment to the alias set.
+// each recognised path's last segment to the alias set.
 use thiserror::*;
 
 // Bad: aliased import. Still flagged — the rule keys on the use


### PR DESCRIPTION
The rule now always recognises `thiserror::Error` instead of reading a configurable path list. The knob exposed arbitrary-path configurability that made no sense against the rule's thiserror-specific diagnostics (`#[error(...)]` -> `#[display(...)]`, the `thiserror` wording), and its empty-list opt-out duplicated the standard rule-state mechanism. With the knob gone, `deny_unknown_fields` now rejects a stray `thiserror_paths` entry in `dylint.toml`; disable the rule via its activation state instead.

This is **not** a breaking change as the rule hasn't been released yet.

https://claude.ai/code/session_01Riw4zcehZbHTgpBztnKUNq