### PR TITLE
fix(pages): actually render `mandatory` badge

### DIFF
--- a/tools/gen-docs/src/extract/config.rs
+++ b/tools/gen-docs/src/extract/config.rs
@@ -13,7 +13,7 @@ use crate::extract::serde_attrs::{
 };
 use crate::extract::shared::SharedTypes;
 use crate::extract::ty::{collect_referenced_idents, find_type_doc, is_option, toml_type_label};
-use crate::model::{ConfigDoc, ConfigField};
+use crate::model::{ConfigDoc, ConfigField, Optionality};
 
 /// Locate the rule's `Config` struct and its `CONFIG_KEY` constant
 /// and bundle them — along with any project-local types the fields
@@ -90,12 +90,18 @@ pub(crate) fn extract_config(
                     .map(|style| apply_rename_all(style, &rust_name))
                     .unwrap_or(rust_name)
             });
-            let required =
-                !container_default && !serde_has_default(&field.attrs) && !is_option(&field.ty);
+            let optionality = if !container_default
+                && !serde_has_default(&field.attrs)
+                && !is_option(&field.ty)
+            {
+                Optionality::Mandatory
+            } else {
+                Optionality::Optional
+            };
             ConfigField {
                 name,
                 type_label: toml_type_label(&field.ty, shared),
-                required,
+                optionality,
                 doc_markdown: doc_attrs_to_markdown(&field.attrs),
             }
         })
@@ -142,14 +148,18 @@ mod tests {
         "#;
         let file = syn::parse_file(source).unwrap();
         let config = extract_config(Path::new("synthetic.rs"), &file, &SharedTypes::default());
-        let required: Vec<(&str, bool)> = config
+        let optionality: Vec<(&str, Optionality)> = config
             .fields
             .iter()
-            .map(|f| (f.name.as_str(), f.required))
+            .map(|f| (f.name.as_str(), f.optionality))
             .collect();
         assert_eq!(
-            required,
-            vec![("style", true), ("maybe", false), ("with_default", false)],
+            optionality,
+            vec![
+                ("style", Optionality::Mandatory),
+                ("maybe", Optionality::Optional),
+                ("with_default", Optionality::Optional),
+            ],
         );
     }
 
@@ -168,7 +178,7 @@ mod tests {
         "#;
         let file = syn::parse_file(source).unwrap();
         let config = extract_config(Path::new("synthetic.rs"), &file, &SharedTypes::default());
-        assert!(!config.fields[0].required);
+        assert_eq!(config.fields[0].optionality, Optionality::Optional);
     }
 
     #[test]

--- a/tools/gen-docs/src/extract/config.rs
+++ b/tools/gen-docs/src/extract/config.rs
@@ -8,9 +8,11 @@ use std::path::Path;
 
 use syn::{Expr, ExprLit, Item, Lit};
 
-use crate::extract::serde_attrs::{apply_rename_all, doc_attrs_to_markdown, serde_str_attr};
+use crate::extract::serde_attrs::{
+    apply_rename_all, doc_attrs_to_markdown, serde_has_default, serde_str_attr,
+};
 use crate::extract::shared::SharedTypes;
-use crate::extract::ty::{collect_referenced_idents, find_type_doc, toml_type_label};
+use crate::extract::ty::{collect_referenced_idents, find_type_doc, is_option, toml_type_label};
 use crate::model::{ConfigDoc, ConfigField};
 
 /// Locate the rule's `Config` struct and its `CONFIG_KEY` constant
@@ -60,6 +62,12 @@ pub(crate) fn extract_config(
         ),
     };
     let rename_all = serde_str_attr(&config_struct.attrs, "rename_all");
+    // A container `#[serde(default)]` fills every missing field from a
+    // default, so all the struct's fields are optional. Without it, a
+    // field that is neither `Option<…>` nor individually defaulted is
+    // required — the syntactic signal for a "Mandatory configuration on
+    // opt-in rules" direction field such as `self_import`'s `style`.
+    let container_default = serde_has_default(&config_struct.attrs);
 
     let named_fields = match &config_struct.fields {
         syn::Fields::Named(named) => named.named.iter().collect::<Vec<_>>(),
@@ -82,9 +90,12 @@ pub(crate) fn extract_config(
                     .map(|style| apply_rename_all(style, &rust_name))
                     .unwrap_or(rust_name)
             });
+            let required =
+                !container_default && !serde_has_default(&field.attrs) && !is_option(&field.ty);
             ConfigField {
                 name,
                 type_label: toml_type_label(&field.ty, shared),
+                required,
                 doc_markdown: doc_attrs_to_markdown(&field.attrs),
             }
         })
@@ -110,6 +121,55 @@ pub(crate) fn extract_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn required_field_is_detected_syntactically() {
+        // A `Config` without a container `#[serde(default)]` makes a
+        // non-`Option`, non-defaulted field required — the signal for a
+        // mandatory direction field. `Option` fields and defaulted
+        // fields stay optional.
+        let source = r#"
+            const CONFIG_KEY: &str = "perfectionist::demo";
+
+            #[derive(serde::Deserialize)]
+            #[serde(deny_unknown_fields, rename_all = "snake_case")]
+            struct Config {
+                style: Style,
+                maybe: Option<Style>,
+                #[serde(default)]
+                with_default: Style,
+            }
+        "#;
+        let file = syn::parse_file(source).unwrap();
+        let config = extract_config(Path::new("synthetic.rs"), &file, &SharedTypes::default());
+        let required: Vec<(&str, bool)> = config
+            .fields
+            .iter()
+            .map(|f| (f.name.as_str(), f.required))
+            .collect();
+        assert_eq!(
+            required,
+            vec![("style", true), ("maybe", false), ("with_default", false)],
+        );
+    }
+
+    #[test]
+    fn container_default_makes_all_fields_optional() {
+        // With a container `#[serde(default)]`, even a non-`Option`
+        // field is optional (filled from the struct's default).
+        let source = r#"
+            const CONFIG_KEY: &str = "perfectionist::demo";
+
+            #[derive(Default, serde::Deserialize)]
+            #[serde(default, rename_all = "snake_case")]
+            struct Config {
+                count: usize,
+            }
+        "#;
+        let file = syn::parse_file(source).unwrap();
+        let config = extract_config(Path::new("synthetic.rs"), &file, &SharedTypes::default());
+        assert!(!config.fields[0].required);
+    }
 
     #[test]
     fn config_field_honours_serde_rename() {

--- a/tools/gen-docs/src/extract/serde_attrs.rs
+++ b/tools/gen-docs/src/extract/serde_attrs.rs
@@ -35,6 +35,35 @@ pub(crate) fn serde_str_attr(attrs: &[Attribute], key: &str) -> Option<String> {
     None
 }
 
+/// Whether the item carries a serde `default` directive — the bare
+/// flag `#[serde(default)]` or `#[serde(default = "path")]`. On a
+/// container it means any missing field is filled from a default; on a
+/// field it means that one field is. Used to tell a required config
+/// field (no default, not `Option`) from an optional one.
+pub(crate) fn serde_has_default(attrs: &[Attribute]) -> bool {
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        let Ok(items) =
+            attr.parse_args_with(syn::punctuated::Punctuated::<Meta, Token![,]>::parse_terminated)
+        else {
+            continue;
+        };
+        for item in items {
+            let path = match &item {
+                Meta::Path(path) => path,
+                Meta::NameValue(name_value) => &name_value.path,
+                Meta::List(list) => &list.path,
+            };
+            if path.is_ident("default") {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Apply one of serde's `rename_all` styles to a Rust identifier.
 /// Covers the styles serde itself documents: `snake_case`,
 /// `kebab-case`, their SCREAMING variants, `lowercase`, `UPPERCASE`,
@@ -174,6 +203,23 @@ mod tests {
         // Non-string value is rejected (only `Lit::Str` is accepted).
         let attrs = parse_attrs(r#"#[serde(skip = true)] struct S;"#);
         assert_eq!(serde_str_attr(&attrs, "skip"), None);
+    }
+
+    #[test]
+    fn serde_has_default_detects_flag_and_path_forms() {
+        // Bare flag.
+        let attrs = parse_attrs(r#"#[serde(default, rename_all = "snake_case")] struct S;"#);
+        assert!(serde_has_default(&attrs));
+        // `default = "path"` form.
+        let attrs = parse_attrs(r#"#[serde(default = "make")] struct S;"#);
+        assert!(serde_has_default(&attrs));
+        // No default directive.
+        let attrs =
+            parse_attrs(r#"#[serde(deny_unknown_fields, rename_all = "snake_case")] struct S;"#);
+        assert!(!serde_has_default(&attrs));
+        // Non-`serde` attributes are ignored.
+        let attrs = parse_attrs(r#"#[other(default)] struct S;"#);
+        assert!(!serde_has_default(&attrs));
     }
 
     #[test]

--- a/tools/gen-docs/src/extract/ty.rs
+++ b/tools/gen-docs/src/extract/ty.rs
@@ -243,6 +243,18 @@ pub(crate) fn find_type_doc(
 /// **Keep in sync with [`is_builtin_type`].** Both functions must
 /// recognise the same set of identifiers; see the note on
 /// `is_builtin_type` for why.
+/// Whether `ty` is `Option<...>` (matched on the final path segment,
+/// so `Option<T>` and `std::option::Option<T>` both count). An
+/// `Option<T>` config field is optional regardless of any serde
+/// `default`; a non-`Option` field with no default is required.
+pub(crate) fn is_option(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::Path(type_path)
+            if type_path.path.segments.last().is_some_and(|segment| segment.ident == "Option"),
+    )
+}
+
 pub(crate) fn toml_type_label(ty: &Type, shared: &SharedTypes) -> String {
     match ty {
         Type::Path(type_path) => {

--- a/tools/gen-docs/src/extract/ty.rs
+++ b/tools/gen-docs/src/extract/ty.rs
@@ -243,11 +243,11 @@ pub(crate) fn is_option(ty: &Type) -> bool {
 /// - `Vec<T>` / `HashSet<T>` / `BTreeSet<T>` / `VecDeque<T>` /
 ///   `LinkedList<T>` → `[label-of-T]`
 /// - `HashMap<_, V>` / `BTreeMap<_, V>` → `table of label-of-V`
-/// - `Option<T>` → `label-of-T` (every config field is already
-///   marked optional, so the wrapper would just add noise)
-/// - `Option<T>` / `Box<T>` / `Rc<T>` / `Arc<T>` → `label-of-T`
-///   (every config field is already marked optional, and the
-///   smart-pointer wrappers are transparent at the serde layer)
+/// - `Option<T>` → `label-of-T` (an `Option<T>` field is optional and
+///   its badge already conveys that, so the wrapper would only add
+///   noise to the label)
+/// - `Box<T>` / `Rc<T>` / `Arc<T>` → `label-of-T` (the smart-pointer
+///   wrappers are transparent at the serde layer)
 /// - Anything else (project-local enums and structs) → the Rust
 ///   identifier verbatim, since those names appear in the per-rule
 ///   Types subsection below and the reader can scan to them.

--- a/tools/gen-docs/src/extract/ty.rs
+++ b/tools/gen-docs/src/extract/ty.rs
@@ -206,6 +206,18 @@ pub(crate) fn find_type_doc(
     None
 }
 
+/// Whether `ty` is `Option<...>` (matched on the final path segment,
+/// so `Option<T>` and `std::option::Option<T>` both count). An
+/// `Option<T>` config field is optional regardless of any serde
+/// `default`; a non-`Option` field with no default is required.
+pub(crate) fn is_option(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::Path(type_path)
+            if type_path.path.segments.last().is_some_and(|segment| segment.ident == "Option"),
+    )
+}
+
 /// Translate a `syn::Type` into a TOML-flavoured type label. The
 /// renderer never shows Rust syntax to the reader; TOML authors
 /// write arrays as `[a, b]`, integers without sign annotations, and
@@ -243,18 +255,6 @@ pub(crate) fn find_type_doc(
 /// **Keep in sync with [`is_builtin_type`].** Both functions must
 /// recognise the same set of identifiers; see the note on
 /// `is_builtin_type` for why.
-/// Whether `ty` is `Option<...>` (matched on the final path segment,
-/// so `Option<T>` and `std::option::Option<T>` both count). An
-/// `Option<T>` config field is optional regardless of any serde
-/// `default`; a non-`Option` field with no default is required.
-pub(crate) fn is_option(ty: &Type) -> bool {
-    matches!(
-        ty,
-        Type::Path(type_path)
-            if type_path.path.segments.last().is_some_and(|segment| segment.ident == "Option"),
-    )
-}
-
 pub(crate) fn toml_type_label(ty: &Type, shared: &SharedTypes) -> String {
     match ty {
         Type::Path(type_path) => {

--- a/tools/gen-docs/src/model.rs
+++ b/tools/gen-docs/src/model.rs
@@ -4,7 +4,7 @@
 
 use std::path::PathBuf;
 
-use strum::{Display, EnumString};
+use strum::{AsRefStr, Display, EnumString};
 
 /// The tool namespace every `perfectionist` lint registers under,
 /// including the trailing `::`. Shared between the extractor (which
@@ -131,8 +131,8 @@ pub(crate) struct ConfigDoc {
 /// states the default in human-readable form. The exception is the
 /// "Mandatory configuration on opt-in rules" direction fields (e.g.
 /// `self_import`'s `style`), which are a bare type with no default;
-/// those carry [`ConfigField::required`] and render a `mandatory`
-/// badge instead.
+/// those carry [`ConfigField::optionality`] set to
+/// [`Optionality::Mandatory`] and render a `mandatory` badge instead.
 #[derive(Clone)]
 pub(crate) struct ConfigField {
     /// The TOML key a reader writes in `dylint.toml`. Resolved in
@@ -150,8 +150,20 @@ pub(crate) struct ConfigField {
     pub(crate) type_label: String,
     /// Per-field `///` doc comment, in markdown form.
     pub(crate) doc_markdown: String,
-    /// Whether the field is mandatory rather than optional.
-    pub(crate) required: bool,
+    /// Whether the field is optional or mandatory in TOML.
+    pub(crate) optionality: Optionality,
+}
+
+/// Whether a [`ConfigField`] is optional or mandatory in TOML. Its
+/// string form (`"optional"` / `"mandatory"`) doubles as the rendered
+/// badge label and — prefixed with `badge-` — the badge's CSS class, so
+/// the renderers read it off the `strum`-derived `AsRef<str>` rather
+/// than hand-writing the two words.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, AsRefStr)]
+#[strum(serialize_all = "snake_case")]
+pub(crate) enum Optionality {
+    Optional,
+    Mandatory,
 }
 
 /// A non-built-in type that one of the `Config` fields references.

--- a/tools/gen-docs/src/model.rs
+++ b/tools/gen-docs/src/model.rs
@@ -150,11 +150,7 @@ pub(crate) struct ConfigField {
     pub(crate) type_label: String,
     /// Per-field `///` doc comment, in markdown form.
     pub(crate) doc_markdown: String,
-    /// Whether the field is mandatory rather than optional. Detected
-    /// syntactically (see `extract::config`): a field that is neither
-    /// `Option<…>` nor covered by a serde `default` (container or field)
-    /// has no default and so must be set. Drives a `mandatory` badge in
-    /// place of the default `optional` one.
+    /// Whether the field is mandatory rather than optional.
     pub(crate) required: bool,
 }
 

--- a/tools/gen-docs/src/model.rs
+++ b/tools/gen-docs/src/model.rs
@@ -124,11 +124,15 @@ pub(crate) struct ConfigDoc {
     pub(crate) custom_types: Vec<TypeDoc>,
 }
 
-/// One configurable knob. Each rule's `Config` derives
-/// `#[serde(default)]`, so every field is optional in TOML; the
-/// renderer marks them with an `optional` badge rather than
+/// One configurable knob. Most rules' `Config` derives
+/// `#[serde(default)]`, so their fields are optional in TOML; the
+/// renderer marks those with an `optional` badge rather than
 /// reproducing the Rust default expression — the prose doc comment
-/// states the default in human-readable form.
+/// states the default in human-readable form. The exception is the
+/// "Mandatory configuration on opt-in rules" direction fields (e.g.
+/// `self_import`'s `style`), which are a bare type with no default;
+/// those carry [`ConfigField::required`] and render a `mandatory`
+/// badge instead.
 #[derive(Clone)]
 pub(crate) struct ConfigField {
     /// The TOML key a reader writes in `dylint.toml`. Resolved in
@@ -146,6 +150,12 @@ pub(crate) struct ConfigField {
     pub(crate) type_label: String,
     /// Per-field `///` doc comment, in markdown form.
     pub(crate) doc_markdown: String,
+    /// Whether the field is mandatory rather than optional. Detected
+    /// syntactically (see `extract::config`): a field that is neither
+    /// `Option<…>` nor covered by a serde `default` (container or field)
+    /// has no default and so must be set. Drives a `mandatory` badge in
+    /// place of the default `optional` one.
+    pub(crate) required: bool,
 }
 
 /// A non-built-in type that one of the `Config` fields references.

--- a/tools/gen-docs/src/render/config.rs
+++ b/tools/gen-docs/src/render/config.rs
@@ -47,7 +47,11 @@ pub(crate) fn config_section(config: &ConfigDoc) -> Markup {
                         " : "
                         code.config-type { (field.type_label) }
                         " "
-                        span.badge.badge-optional { "optional" }
+                        @if field.required {
+                            span.badge.badge-mandatory { "mandatory" }
+                        } @else {
+                            span.badge.badge-optional { "optional" }
+                        }
                     }
                     dd {
                         @if field.doc_markdown.is_empty() {

--- a/tools/gen-docs/src/render/config.rs
+++ b/tools/gen-docs/src/render/config.rs
@@ -47,10 +47,8 @@ pub(crate) fn config_section(config: &ConfigDoc) -> Markup {
                         " : "
                         code.config-type { (field.type_label) }
                         " "
-                        @if field.required {
-                            span.badge.badge-mandatory { "mandatory" }
-                        } @else {
-                            span.badge.badge-optional { "optional" }
+                        span class={ "badge badge-" (field.optionality.as_ref()) } {
+                            (field.optionality.as_ref())
                         }
                     }
                     dd {
@@ -144,11 +142,11 @@ fn custom_type_block(ty: &TypeDoc) -> Markup {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::ConfigField;
+    use crate::model::{ConfigField, Optionality};
 
     #[test]
     fn config_section_badges_mandatory_and_optional_fields() {
-        // A `required` field renders the `mandatory` badge; an ordinary
+        // A mandatory field renders the `mandatory` badge; an ordinary
         // field keeps `optional`. Guards the HTML path the way
         // `render_md`'s test guards the markdown path.
         let config = ConfigDoc {
@@ -158,21 +156,20 @@ mod tests {
                     name: "style".to_owned(),
                     type_label: "Style".to_owned(),
                     doc_markdown: "Pick a style.".to_owned(),
-                    required: true,
+                    optionality: Optionality::Mandatory,
                 },
                 ConfigField {
                     name: "extras".to_owned(),
                     type_label: "[string]".to_owned(),
                     doc_markdown: "Extra entries.".to_owned(),
-                    required: false,
+                    optionality: Optionality::Optional,
                 },
             ],
             custom_types: Vec::new(),
         };
         let html = config_section(&config).into_string();
-        // Tie each badge to its field so an inverted `field.required`
-        // branch (mandatory <-> optional) is caught, not just badge
-        // presence.
+        // Tie each badge to its field so a mis-mapping (mandatory <->
+        // optional) is caught, not just badge presence.
         assert!(
             html.contains(
                 r#"<code class="config-key">style</code> : <code class="config-type">Style</code> <span class="badge badge-mandatory">mandatory</span>"#

--- a/tools/gen-docs/src/render/config.rs
+++ b/tools/gen-docs/src/render/config.rs
@@ -170,13 +170,20 @@ mod tests {
             custom_types: Vec::new(),
         };
         let html = config_section(&config).into_string();
+        // Tie each badge to its field so an inverted `field.required`
+        // branch (mandatory <-> optional) is caught, not just badge
+        // presence.
         assert!(
-            html.contains(r#"<span class="badge badge-mandatory">mandatory</span>"#),
-            "mandatory field should render the mandatory badge: {html}"
+            html.contains(
+                r#"<code class="config-key">style</code> : <code class="config-type">Style</code> <span class="badge badge-mandatory">mandatory</span>"#
+            ),
+            "the required field `style` should render the mandatory badge: {html}"
         );
         assert!(
-            html.contains(r#"<span class="badge badge-optional">optional</span>"#),
-            "optional field should render the optional badge: {html}"
+            html.contains(
+                r#"<code class="config-key">extras</code> : <code class="config-type">[string]</code> <span class="badge badge-optional">optional</span>"#
+            ),
+            "the optional field `extras` should render the optional badge: {html}"
         );
     }
 }

--- a/tools/gen-docs/src/render/config.rs
+++ b/tools/gen-docs/src/render/config.rs
@@ -140,3 +140,43 @@ fn custom_type_block(ty: &TypeDoc) -> Markup {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::ConfigField;
+
+    #[test]
+    fn config_section_badges_mandatory_and_optional_fields() {
+        // A `required` field renders the `mandatory` badge; an ordinary
+        // field keeps `optional`. Guards the HTML path the way
+        // `render_md`'s test guards the markdown path.
+        let config = ConfigDoc {
+            key: "perfectionist::demo_rule".to_owned(),
+            fields: vec![
+                ConfigField {
+                    name: "style".to_owned(),
+                    type_label: "Style".to_owned(),
+                    doc_markdown: "Pick a style.".to_owned(),
+                    required: true,
+                },
+                ConfigField {
+                    name: "extras".to_owned(),
+                    type_label: "[string]".to_owned(),
+                    doc_markdown: "Extra entries.".to_owned(),
+                    required: false,
+                },
+            ],
+            custom_types: Vec::new(),
+        };
+        let html = config_section(&config).into_string();
+        assert!(
+            html.contains(r#"<span class="badge badge-mandatory">mandatory</span>"#),
+            "mandatory field should render the mandatory badge: {html}"
+        );
+        assert!(
+            html.contains(r#"<span class="badge badge-optional">optional</span>"#),
+            "optional field should render the optional badge: {html}"
+        );
+    }
+}

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -18,7 +18,8 @@
 use std::fmt::Write as _;
 
 use crate::model::{
-    ConfigDoc, ConfigField, EnumVariant, NAMESPACE, Rule, StructField, TypeDoc, TypeKind,
+    ConfigDoc, ConfigField, EnumVariant, NAMESPACE, Optionality, Rule, StructField, TypeDoc,
+    TypeKind,
 };
 
 /// Per-rule markdown filename. Mirrors the source layout
@@ -159,7 +160,11 @@ fn render_config_section(config: &ConfigDoc, out: &mut String) {
     // wording (and unchanged output). A mandatory field has no default,
     // so the "states the default" clause is scoped to optional fields
     // once any field is mandatory.
-    let optionality_note = if config.fields.iter().any(|field| field.required) {
+    let optionality_note = if config
+        .fields
+        .iter()
+        .any(|field| field.optionality == Optionality::Mandatory)
+    {
         "A field marked mandatory must be set; an optional field can be omitted and the per-field \
          prose below states its default"
     } else {
@@ -192,11 +197,7 @@ fn render_field(field: &ConfigField, out: &mut String) {
         "### `{name}`: `{ty}` ({optionality})",
         name = field.name,
         ty = field.type_label,
-        optionality = if field.required {
-            "mandatory"
-        } else {
-            "optional"
-        },
+        optionality = field.optionality.as_ref(),
     );
     out.push('\n');
     append_doc(&field.doc_markdown, out);
@@ -416,7 +417,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::model::{ConfigField, DefaultState, EnumVariant, TypeDoc, TypeKind};
+    use crate::model::{ConfigField, DefaultState, EnumVariant, Optionality, TypeDoc, TypeKind};
 
     fn fake_rule() -> Rule {
         Rule {
@@ -470,20 +471,20 @@ mod tests {
         rule.config = ConfigDoc {
             key: "perfectionist::demo_rule".to_owned(),
             fields: vec![
-                // `required` is set directly on these fixtures; the real
-                // extractor derives it syntactically from each field's
-                // type and serde attributes (see `extract::config`).
+                // `optionality` is set directly on these fixtures; the
+                // real extractor derives it syntactically from each
+                // field's type and serde attributes (see `extract::config`).
                 ConfigField {
                     name: "style".to_owned(),
                     type_label: "Style".to_owned(),
                     doc_markdown: "Pick a style.".to_owned(),
-                    required: true,
+                    optionality: Optionality::Mandatory,
                 },
                 ConfigField {
                     name: "extras".to_owned(),
                     type_label: "[string]".to_owned(),
                     doc_markdown: "Extra entries.".to_owned(),
-                    required: false,
+                    optionality: Optionality::Optional,
                 },
             ],
             custom_types: vec![TypeDoc {

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -156,16 +156,18 @@ fn render_config_section(config: &ConfigDoc, out: &mut String) {
     }
     // Only nuance the optionality note when a field is actually
     // mandatory; rules whose fields are all optional keep the simpler
-    // wording (and unchanged output).
+    // wording (and unchanged output). A mandatory field has no default,
+    // so the "states the default" clause is scoped to optional fields
+    // once any field is mandatory.
     let optionality_note = if config.fields.iter().any(|field| field.required) {
-        "Each field is optional unless marked mandatory"
+        "Each field is optional unless marked mandatory; the per-field prose below states each \
+         optional field's default"
     } else {
-        "Every field is optional"
+        "Every field is optional; the per-field prose below states the default"
     };
     let _ = writeln!(
         out,
-        "Configure via `dylint.toml` under `[\"{}\"]`. {optionality_note}; the per-field prose \
-         below states the default.",
+        "Configure via `dylint.toml` under `[\"{}\"]`. {optionality_note}.",
         config.key,
     );
     out.push('\n');

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -506,6 +506,12 @@ mod tests {
             }],
         };
         let md = render_rule_md(&rule, "../");
+        // The intro note uses the mandatory-branch wording because a
+        // required field is present.
+        assert!(
+            md.contains("A field marked mandatory must be set;"),
+            "got:\n{md}"
+        );
         // A `required` field renders the `mandatory` marker, not `optional`.
         assert!(md.contains("### `style`: `Style` (mandatory)"));
         assert!(!md.contains("### `style`: `Style` (optional)"));

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -154,10 +154,18 @@ fn render_config_section(config: &ConfigDoc, out: &mut String) {
         out.push('\n');
         return;
     }
+    // Only nuance the optionality note when a field is actually
+    // mandatory; rules whose fields are all optional keep the simpler
+    // wording (and unchanged output).
+    let optionality_note = if config.fields.iter().any(|field| field.required) {
+        "Each field is optional unless marked mandatory"
+    } else {
+        "Every field is optional"
+    };
     let _ = writeln!(
         out,
-        "Configure via `dylint.toml` under `[\"{}\"]`. Every field is optional; the \
-         per-field prose below states the default.",
+        "Configure via `dylint.toml` under `[\"{}\"]`. {optionality_note}; the per-field prose \
+         below states the default.",
         config.key,
     );
     out.push('\n');
@@ -179,9 +187,14 @@ fn render_field(field: &ConfigField, out: &mut String) {
     // prose. The HTML renderer uses `:` for the same reason.
     let _ = writeln!(
         out,
-        "### `{name}`: `{ty}` (optional)",
+        "### `{name}`: `{ty}` ({optionality})",
         name = field.name,
         ty = field.type_label,
+        optionality = if field.required {
+            "mandatory"
+        } else {
+            "optional"
+        },
     );
     out.push('\n');
     append_doc(&field.doc_markdown, out);
@@ -454,11 +467,23 @@ mod tests {
         let mut rule = fake_rule();
         rule.config = ConfigDoc {
             key: "perfectionist::demo_rule".to_owned(),
-            fields: vec![ConfigField {
-                name: "style".to_owned(),
-                type_label: "Style".to_owned(),
-                doc_markdown: "Pick a style.".to_owned(),
-            }],
+            fields: vec![
+                // `doc_markdown` is post-extraction: the `**Mandatory.**`
+                // sentinel has already been stripped (see
+                // `extract::config::split_mandatory_sentinel`).
+                ConfigField {
+                    name: "style".to_owned(),
+                    type_label: "Style".to_owned(),
+                    doc_markdown: "Pick a style.".to_owned(),
+                    required: true,
+                },
+                ConfigField {
+                    name: "extras".to_owned(),
+                    type_label: "[string]".to_owned(),
+                    doc_markdown: "Extra entries.".to_owned(),
+                    required: false,
+                },
+            ],
             custom_types: vec![TypeDoc {
                 name: "Style".to_owned(),
                 doc_markdown: "Style enum.".to_owned(),
@@ -479,7 +504,11 @@ mod tests {
             }],
         };
         let md = render_rule_md(&rule, "../");
-        assert!(md.contains("### `style`: `Style` (optional)"));
+        // A `required` field renders the `mandatory` marker, not `optional`.
+        assert!(md.contains("### `style`: `Style` (mandatory)"));
+        assert!(!md.contains("### `style`: `Style` (optional)"));
+        // An ordinary field still renders `optional`.
+        assert!(md.contains("### `extras`: `[string]` (optional)"));
         assert!(md.contains("Pick a style."));
         assert!(md.contains("#### `Style` (enum)"));
         // Renamed variant carries the Rust-side annotation.

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -468,9 +468,9 @@ mod tests {
         rule.config = ConfigDoc {
             key: "perfectionist::demo_rule".to_owned(),
             fields: vec![
-                // `doc_markdown` is post-extraction: the `**Mandatory.**`
-                // sentinel has already been stripped (see
-                // `extract::config::split_mandatory_sentinel`).
+                // `required` is set directly on these fixtures; the real
+                // extractor derives it syntactically from each field's
+                // type and serde attributes (see `extract::config`).
                 ConfigField {
                     name: "style".to_owned(),
                     type_label: "Style".to_owned(),

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -160,8 +160,8 @@ fn render_config_section(config: &ConfigDoc, out: &mut String) {
     // so the "states the default" clause is scoped to optional fields
     // once any field is mandatory.
     let optionality_note = if config.fields.iter().any(|field| field.required) {
-        "Each field is optional unless marked mandatory; the per-field prose below states each \
-         optional field's default"
+        "A field marked mandatory must be set; an optional field can be omitted and the per-field \
+         prose below states its default"
     } else {
         "Every field is optional; the per-field prose below states the default"
     };

--- a/tools/gen-docs/src/style/rules.css
+++ b/tools/gen-docs/src/style/rules.css
@@ -227,6 +227,11 @@ dl.config dd p {
   color: #57606a;
 }
 
+.badge-mandatory {
+  background: #ffebe9;
+  color: #cf222e;
+}
+
 article.rule h4 {
   margin-top: 1.25rem;
   margin-bottom: 0.4rem;


### PR DESCRIPTION
gen-docs badged every `Config` field `optional`, which is wrong for a field that has no default and must be set (a "Mandatory configuration on opt-in rules" direction field).

This renders a `mandatory` badge for such a field instead. A field is detected as mandatory when it is neither `Option<…>` nor covered by a serde `default` (container-level or per-field) — a purely syntactic signal (new `serde_has_default` / `is_option` helpers), so the field's doc prose stays clean and no doc-comment convention is needed. A field's optionality is modelled as an `Optionality` enum, so both renderers read the badge label off one value.

Only the reusable gen-docs mechanism lands here; it's inert until a rule declares such a field. The first is `self_import`'s `style`, which lands with #152 (this adopts that PR's approach).

Resolves <https://github.com/KSXGitHub/perfectionist/issues/157>.