### PR TITLE
fix(task/warmup): correct dylint time measurement

### DIFF
--- a/justfile
+++ b/justfile
@@ -57,7 +57,7 @@ self-lint:
 
 # Pre-warm `target/integration-fixtures`
 warmup-integration-tests:
-  time cargo run {{locked}} --package _utils --bin warmup -- "$(pwd)"
+  cargo run {{locked}} --package _utils --bin warmup -- "$(pwd)"
 
 # Install cargo-dylint and dylint-link into `.dev-tools/`
 install-dev-tools:

--- a/utils/cli/warmup.rs
+++ b/utils/cli/warmup.rs
@@ -14,6 +14,7 @@
 use clap::Parser;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::time::Instant;
 
 #[derive(Parser)]
 #[clap(about = "Pre-warm the shared integration-test target dir")]
@@ -52,11 +53,14 @@ fn main() -> ExitCode {
         &[("src/lib.rs", "")],
     );
 
+    let started = Instant::now();
     let (stderr, success) = _utils::run_dylint(&warmup_project_dir, &shared_target_dir);
+    let elapsed = started.elapsed();
     if !success {
         eprintln!("{stderr}");
         return ExitCode::FAILURE;
     }
+    eprintln!("warmup: cargo dylint --all took {elapsed:.2?}");
 
     ExitCode::SUCCESS
 }


### PR DESCRIPTION
The `time` shell builtin in `warmup-integration-tests` also folded in compiling `_utils` and linking the `warmup` binary. Measure the `cargo dylint --all` invocation directly from the warmup code instead.

https://claude.ai/code/session_01J5WRyJ5KWFamgZvnTbbqdc