### PR TITLE
style(docs/rules): separate rule index entries with a blank line

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -9,78 +9,103 @@ Lint-control attributes use the `perfectionist::` namespace.
 - [`bare_email`](./bare_email.md) (default: `active`).
 
   bare email address in comment or doc comment; wrap in `<...>` or prefix with `mailto:`
+
 - [`bare_issue_reference`](./bare_issue_reference.md) (default: `active`).
 
   ambiguous bare `#NNN` issue / PR reference in comment
+
 - [`bare_url`](./bare_url.md) (default: `active`).
 
   bare URL in comment or doc comment; wrap in `<...>` or use a labelled markdown link
+
 - [`derive_ordering`](./derive_ordering.md) (default: `inactive`).
 
   trait names in a `#[derive(...)]` list are not in the configured order
+
 - [`flat_module_pattern`](./flat_module_pattern.md) (default: `active`).
 
   submodule defined as `module/mod.rs`; prefer the flat `module.rs` layout
+
 - [`import_granularity`](./import_granularity.md) (default: `active`).
 
   import granularity does not match the configured `import_granularity.style`
+
 - [`lint_reason_from_comment`](./lint_reason_from_comment.md) (default: `active`).
 
   trailing comment on a lint-level attribute should be lifted into a `reason = "..."` field
+
 - [`lint_silence_reason`](./lint_silence_reason.md) (default: `active`).
 
   `#[allow]` / `#[expect]` attribute lacks an explanatory `reason = "..."` field
+
 - [`macro_argument_binding`](./macro_argument_binding.md) (default: `active`).
 
   macro invocation passes an impure expression that should be bound to a `let` first
+
 - [`macro_trailing_comma`](./macro_trailing_comma.md) (default: `active`).
 
   macro invocation does not follow rustfmt's vertical trailing-comma policy
+
 - [`non_exhaustive_error`](./non_exhaustive_error.md) (default: `inactive`).
 
   error-shaped type is missing `#[non_exhaustive]`
+
 - [`prefer_derive_more_over_thiserror`](./prefer_derive_more_over_thiserror.md) (default: `active`).
 
   `thiserror` import, derive, or attribute; this catalogue prefers `derive_more::{Display, Error}`
+
 - [`prefer_raw_string`](./prefer_raw_string.md) (default: `active`).
 
   string literal contains only raw-expressible escapes; prefer the raw-string form
+
 - [`print_macro_split`](./print_macro_split.md) (default: `active`).
 
   splittable print macro with an embedded-newline template exceeds the configured line width
+
 - [`single_letter_closure_param`](./single_letter_closure_param.md) (default: `active`).
 
   closure parameter has a single-letter name
+
 - [`single_letter_const_generic`](./single_letter_const_generic.md) (default: `active`).
 
   const generic parameter has a single-letter name
+
 - [`single_letter_const_item`](./single_letter_const_item.md) (default: `active`).
 
   const item has a single-letter name
+
 - [`single_letter_function_param`](./single_letter_function_param.md) (default: `active`).
 
   function parameter has a single-letter name
+
 - [`single_letter_generic`](./single_letter_generic.md) (default: `active`).
 
   generic type parameter has a single-letter name
+
 - [`single_letter_let_binding`](./single_letter_let_binding.md) (default: `active`).
 
   `let` binding has a single-letter name
+
 - [`single_letter_static_item`](./single_letter_static_item.md) (default: `active`).
 
   static item has a single-letter name
+
 - [`unicode_ellipsis_in_comments`](./unicode_ellipsis_in_comments.md) (default: `active`).
 
   U+2026 HORIZONTAL ELLIPSIS in non-doc comments; prefer `...`
+
 - [`unicode_ellipsis_in_docs`](./unicode_ellipsis_in_docs.md) (default: `active`).
 
   U+2026 HORIZONTAL ELLIPSIS in doc comments; prefer `...`
+
 - [`unicode_ellipsis_in_panic_messages`](./unicode_ellipsis_in_panic_messages.md) (default: `active`).
 
   U+2026 HORIZONTAL ELLIPSIS in panic / assertion / expect messages; prefer `...`
+
 - [`unit_test_file_layout`](./unit_test_file_layout.md) (default: `active`).
 
   unit-test code is in the wrong file or exceeds the inline-test budget
+
 - [`unknown_perfectionist_lints`](./unknown_perfectionist_lints.md) (default: `active`).
 
   lint-control attribute references a `perfectionist::*` lint that this plugin does not register

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -138,6 +138,11 @@ pub(crate) fn render_index_md(rules: &[Rule]) -> String {
         );
         let _ = writeln!(out);
         let _ = writeln!(out, "  {desc}", desc = rule.short_desc);
+        // Blank line between entries so each rule's link-and-
+        // description pair reads as its own block in the raw
+        // source. The trailing blank after the final entry is
+        // stripped by `trim_trailing_blank_lines` below.
+        let _ = writeln!(out);
     }
     trim_trailing_blank_lines(&mut out);
     out

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -138,10 +138,6 @@ pub(crate) fn render_index_md(rules: &[Rule]) -> String {
         );
         let _ = writeln!(out);
         let _ = writeln!(out, "  {desc}", desc = rule.short_desc);
-        // Blank line between entries so each rule's link-and-
-        // description pair reads as its own block in the raw
-        // source. The trailing blank after the final entry is
-        // stripped by `trim_trailing_blank_lines` below.
         let _ = writeln!(out);
     }
     trim_trailing_blank_lines(&mut out);


### PR DESCRIPTION
Render a blank line between consecutive entries in the rules catalogue index so each link-and-description pair reads as its own block in the raw markdown source.

https://claude.ai/code/session_01CBJkP8XES4L4f3b84SE8ze