### PR TITLE
fix(unit-test-file-layout): integration tests false positives

### DIFF
--- a/rules/unit_test_file_layout.md
+++ b/rules/unit_test_file_layout.md
@@ -36,6 +36,12 @@ axes are checked:
 The module identifier is irrelevant to the layout rule; only the
 file's position relative to its parent matters.
 
+Only the library or binary crate is checked. Integration tests
+(`tests/`), benchmarks (`benches/`), and examples (`examples/`)
+are separate crates whose top-level `#[test]` functions *are*
+the target rather than unit tests misplaced in a production
+file, so they are left untouched.
+
 ## Why restrict this?
 This is a stylistic preference, not a correctness issue. Both
 source projects keep large test suites out of the production

--- a/rules/unit_test_file_layout.md
+++ b/rules/unit_test_file_layout.md
@@ -38,9 +38,11 @@ file's position relative to its parent matters.
 
 Only the library or binary crate is checked. Integration tests
 (`tests/`), benchmarks (`benches/`), and examples (`examples/`)
-are separate crates whose top-level `#[test]` functions *are*
-the target rather than unit tests misplaced in a production
-file, so they are left untouched.
+are separate targets, not the library or binary whose unit-test
+layout this rule governs; for those compiled under `cfg(test)`
+their top-level `#[test]` functions *are* the target rather than
+unit tests misplaced in a production file, so they are left
+untouched.
 
 ## Why restrict this?
 This is a stylistic preference, not a correctness issue. Both

--- a/src/rules/unit_test_file_layout.rs
+++ b/src/rules/unit_test_file_layout.rs
@@ -60,6 +60,12 @@ declare_tool_lint! {
     /// The module identifier is irrelevant to the layout rule; only the
     /// file's position relative to its parent matters.
     ///
+    /// Only the library or binary crate is checked. Integration tests
+    /// (`tests/`), benchmarks (`benches/`), and examples (`examples/`)
+    /// are separate crates whose top-level `#[test]` functions *are*
+    /// the target rather than unit tests misplaced in a production
+    /// file, so they are left untouched.
+    ///
     /// ### Why restrict this?
     /// This is a stylistic preference, not a correctness issue. Both
     /// source projects keep large test suites out of the production

--- a/src/rules/unit_test_file_layout.rs
+++ b/src/rules/unit_test_file_layout.rs
@@ -62,9 +62,11 @@ declare_tool_lint! {
     ///
     /// Only the library or binary crate is checked. Integration tests
     /// (`tests/`), benchmarks (`benches/`), and examples (`examples/`)
-    /// are separate crates whose top-level `#[test]` functions *are*
-    /// the target rather than unit tests misplaced in a production
-    /// file, so they are left untouched.
+    /// are separate targets, not the library or binary whose unit-test
+    /// layout this rule governs; for those compiled under `cfg(test)`
+    /// their top-level `#[test]` functions *are* the target rather than
+    /// unit tests misplaced in a production file, so they are left
+    /// untouched.
     ///
     /// ### Why restrict this?
     /// This is a stylistic preference, not a correctness issue. Both

--- a/src/rules/unit_test_file_layout/layout.rs
+++ b/src/rules/unit_test_file_layout/layout.rs
@@ -126,6 +126,13 @@ pub(super) fn is_separate_test_target(cx: &LateContext<'_>) -> bool {
     let Some(path) = root.local_path() else {
         return false;
     };
+    is_separate_target_path(path)
+}
+
+/// The crate-root-path predicate behind [`is_separate_test_target`],
+/// split out as a pure function so the path arithmetic can be
+/// unit-tested without a compiler context.
+fn is_separate_target_path(path: &Path) -> bool {
     let parent = path.parent();
     // Flat form `<dir>/<name>.rs` — including `<dir>/main.rs`, a target
     // literally named `main` — roots directly in the target directory,
@@ -235,4 +242,53 @@ fn normalize(path: &Path) -> PathBuf {
     path.components()
         .filter(|component| !matches!(component, Component::CurDir))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::is_separate_target_path;
+
+    #[test]
+    fn separate_targets_are_recognised() {
+        // Flat `<dir>/<name>.rs`, the `<dir>/main.rs` named-`main` case,
+        // the `<dir>/<name>/main.rs` subdirectory form, and an absolute
+        // integration-test root — for tests, benches, and examples alike.
+        for path in [
+            "tests/integration.rs",
+            "tests/main.rs",
+            "tests/suite/main.rs",
+            "benches/bench.rs",
+            "benches/suite/main.rs",
+            "examples/demo.rs",
+            "examples/demo/main.rs",
+            "/abs/tests/integration.rs",
+        ] {
+            assert!(
+                is_separate_target_path(Path::new(path)),
+                "`{path}` should be treated as a separate test target",
+            );
+        }
+    }
+
+    #[test]
+    fn library_and_binary_roots_are_checked() {
+        // Library, default binary, extra binaries (flat and the
+        // `src/bin/<name>/main.rs` multi-file form), and a nested module
+        // file all stay in scope.
+        for path in [
+            "src/lib.rs",
+            "src/main.rs",
+            "src/bin/cli.rs",
+            "src/bin/cli/main.rs",
+            "src/rules/unit_test_file_layout/layout.rs",
+            "lib.rs",
+        ] {
+            assert!(
+                !is_separate_target_path(Path::new(path)),
+                "`{path}` should be checked, not skipped",
+            );
+        }
+    }
 }

--- a/src/rules/unit_test_file_layout/layout.rs
+++ b/src/rules/unit_test_file_layout/layout.rs
@@ -108,13 +108,13 @@ pub(super) fn check_external_mod(
 /// every such file would be flagged. The rule only speaks to where a
 /// library or binary keeps its unit tests, so skip these crates whole.
 ///
-/// Detection keys off the crate root's *own* directory: Cargo roots
-/// these targets at `<dir>/<name>.rs` or `<dir>/<name>/main.rs`, where
-/// `<dir>` is `tests`, `benches`, or `examples`, while a library/binary
-/// roots under `src/` (`lib.rs`, `main.rs`, `bin/<name>.rs`). Matching
-/// the immediate directory rather than any ancestor keeps a library
-/// that merely lives below such a directory — a workspace member at
-/// `tests/<crate>/src/lib.rs`, say — in scope.
+/// Detection keys off the crate root's directory: Cargo roots these
+/// targets at `<dir>/<name>.rs` or `<dir>/<name>/main.rs`, where `<dir>`
+/// is `tests`, `benches`, or `examples`, while a library/binary roots
+/// under `src/` (`lib.rs`, `main.rs`, `bin/<name>.rs`). Matching the
+/// target directory itself — not some farther ancestor — keeps a
+/// library that merely lives below such a directory (a workspace member
+/// at `tests/<crate>/src/lib.rs`, say) in scope.
 pub(super) fn is_separate_test_target(cx: &LateContext<'_>) -> bool {
     let Some(root) = cx.sess().local_crate_source_file() else {
         return false;
@@ -122,17 +122,24 @@ pub(super) fn is_separate_test_target(cx: &LateContext<'_>) -> bool {
     let Some(path) = root.local_path() else {
         return false;
     };
-    // `<dir>/<name>/main.rs` puts the discriminating directory one level
-    // further up than the flat `<dir>/<name>.rs` form.
-    let target_dir = if path.file_name().and_then(|name| name.to_str()) == Some("main.rs") {
-        path.parent().and_then(Path::parent)
-    } else {
-        path.parent()
-    };
+    let parent = path.parent();
+    // Flat form `<dir>/<name>.rs` — including `<dir>/main.rs`, a target
+    // literally named `main` — roots directly in the target directory,
+    // so check the immediate parent first. The subdirectory form
+    // `<dir>/<name>/main.rs` roots one level deeper, so for a `main.rs`
+    // leaf also accept the grandparent. Checking the parent first is
+    // what keeps `tests/main.rs` matched instead of walking past `tests`
+    // to nothing.
+    is_target_directory(parent)
+        || (path.file_name().and_then(|name| name.to_str()) == Some("main.rs")
+            && is_target_directory(parent.and_then(Path::parent)))
+}
+
+/// Whether `dir`'s final component is one of Cargo's separate-target
+/// directories (`tests`, `benches`, `examples`).
+fn is_target_directory(dir: Option<&Path>) -> bool {
     matches!(
-        target_dir
-            .and_then(Path::file_name)
-            .and_then(|name| name.to_str()),
+        dir.and_then(Path::file_name).and_then(|name| name.to_str()),
         Some("tests" | "benches" | "examples"),
     )
 }

--- a/src/rules/unit_test_file_layout/layout.rs
+++ b/src/rules/unit_test_file_layout/layout.rs
@@ -95,6 +95,38 @@ pub(super) fn check_external_mod(
     }
 }
 
+/// Whether the crate currently being compiled is a *separate*
+/// non-library target — an integration test (`tests/`), benchmark
+/// (`benches/`), or example (`examples/`) crate — rather than the
+/// library or binary whose unit-test layout this rule governs.
+///
+/// Cargo compiles each of those as its own crate, so a `--all-targets`
+/// run hands them to the rule too. But an integration test's top-level
+/// `#[test]` functions *are the target*, not unit tests misplaced
+/// inside a production file; they routinely sit beside ordinary helper
+/// `fn`s that this rule would otherwise miscount as production, so
+/// every such file would be flagged. The rule only speaks to where a
+/// library or binary keeps its unit tests, so skip these crates whole.
+///
+/// Detection keys off the crate root's path: Cargo always roots these
+/// targets under a `tests/`, `benches/`, or `examples/` directory,
+/// while a library/binary roots under `src/` (`lib.rs`, `main.rs`,
+/// `bin/<name>.rs`).
+pub(super) fn is_separate_test_target(cx: &LateContext<'_>) -> bool {
+    let Some(root) = cx.sess().local_crate_source_file() else {
+        return false;
+    };
+    let Some(path) = root.local_path() else {
+        return false;
+    };
+    path.components().any(|component| {
+        let Component::Normal(name) = component else {
+            return false;
+        };
+        matches!(name.to_str(), Some("tests" | "benches" | "examples"))
+    })
+}
+
 fn source_file_path(cx: &LateContext<'_>, span: Span) -> Option<PathBuf> {
     let file = cx.sess().source_map().lookup_source_file(span.lo());
     real_path(&file)

--- a/src/rules/unit_test_file_layout/layout.rs
+++ b/src/rules/unit_test_file_layout/layout.rs
@@ -101,12 +101,16 @@ pub(super) fn check_external_mod(
 /// library or binary whose unit-test layout this rule governs.
 ///
 /// Cargo compiles each of those as its own crate, so a `--all-targets`
-/// run hands them to the rule too. But an integration test's top-level
-/// `#[test]` functions *are the target*, not unit tests misplaced
-/// inside a production file; they routinely sit beside ordinary helper
-/// `fn`s that this rule would otherwise miscount as production, so
-/// every such file would be flagged. The rule only speaks to where a
-/// library or binary keeps its unit tests, so skip these crates whole.
+/// run hands them to the rule too. For the ones built under `cfg(test)`
+/// — integration tests, benchmarks, and `test = true` examples — the
+/// top-level `#[test]` functions *are the target*, not unit tests
+/// misplaced inside a production file; sitting beside ordinary helper
+/// `fn`s the rule counts as production, they would otherwise be
+/// flagged. (A plain example builds without `cfg(test)`, so the rule
+/// sees no test items there regardless, but it is skipped for the same
+/// reason and to cover the `test = true` case.) The rule only governs
+/// where a library or binary keeps its unit tests, so skip these
+/// targets whole.
 ///
 /// Detection keys off the crate root's directory: Cargo roots these
 /// targets at `<dir>/<name>.rs` or `<dir>/<name>/main.rs`, where `<dir>`

--- a/src/rules/unit_test_file_layout/layout.rs
+++ b/src/rules/unit_test_file_layout/layout.rs
@@ -108,10 +108,13 @@ pub(super) fn check_external_mod(
 /// every such file would be flagged. The rule only speaks to where a
 /// library or binary keeps its unit tests, so skip these crates whole.
 ///
-/// Detection keys off the crate root's path: Cargo always roots these
-/// targets under a `tests/`, `benches/`, or `examples/` directory,
-/// while a library/binary roots under `src/` (`lib.rs`, `main.rs`,
-/// `bin/<name>.rs`).
+/// Detection keys off the crate root's *own* directory: Cargo roots
+/// these targets at `<dir>/<name>.rs` or `<dir>/<name>/main.rs`, where
+/// `<dir>` is `tests`, `benches`, or `examples`, while a library/binary
+/// roots under `src/` (`lib.rs`, `main.rs`, `bin/<name>.rs`). Matching
+/// the immediate directory rather than any ancestor keeps a library
+/// that merely lives below such a directory — a workspace member at
+/// `tests/<crate>/src/lib.rs`, say — in scope.
 pub(super) fn is_separate_test_target(cx: &LateContext<'_>) -> bool {
     let Some(root) = cx.sess().local_crate_source_file() else {
         return false;
@@ -119,12 +122,19 @@ pub(super) fn is_separate_test_target(cx: &LateContext<'_>) -> bool {
     let Some(path) = root.local_path() else {
         return false;
     };
-    path.components().any(|component| {
-        let Component::Normal(name) = component else {
-            return false;
-        };
-        matches!(name.to_str(), Some("tests" | "benches" | "examples"))
-    })
+    // `<dir>/<name>/main.rs` puts the discriminating directory one level
+    // further up than the flat `<dir>/<name>.rs` form.
+    let target_dir = if path.file_name().and_then(|name| name.to_str()) == Some("main.rs") {
+        path.parent().and_then(Path::parent)
+    } else {
+        path.parent()
+    };
+    matches!(
+        target_dir
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str()),
+        Some("tests" | "benches" | "examples"),
+    )
 }
 
 fn source_file_path(cx: &LateContext<'_>, span: Span) -> Option<PathBuf> {

--- a/src/rules/unit_test_file_layout/scan.rs
+++ b/src/rules/unit_test_file_layout/scan.rs
@@ -45,6 +45,12 @@ struct FileAcc {
 }
 
 pub(super) fn run(state: &UnitTestFileLayout, cx: &LateContext<'_>) {
+    // Integration tests, benchmarks, and examples are separate crates
+    // Cargo hands the rule under `--all-targets`; their test code is the
+    // target itself, not misplaced unit tests, so leave them untouched.
+    if layout::is_separate_test_target(cx) {
+        return;
+    }
     let mut files: HashMap<BytePos, FileAcc> = HashMap::new();
     walk(state, cx, cx.tcx.hir_root_module(), &mut files);
     for acc in files.values() {

--- a/tests/unit_test_file_layout.rs
+++ b/tests/unit_test_file_layout.rs
@@ -310,28 +310,36 @@ fn help_names_the_actual_inline_module() {
     );
 }
 
+/// A small integration-test body with a top-level `use` and helper
+/// `fn` (both counted as production, which defeats the all-test-file
+/// exemption) followed by 60 `#[test] fn`s — well over the inline
+/// budget. Reused by the flat and subdirectory layout tests below.
+fn integration_test_body() -> String {
+    let mut body = String::from("use std::cmp::max;\n\nfn helper() -> i32 {\n    max(1, 0)\n}\n\n");
+    for index in 0..60 {
+        body.push_str(&format!(
+            "#[test]\nfn case_{index}() {{ assert_eq!(helper(), 1); }}\n",
+        ));
+    }
+    body
+}
+
 /// Integration tests live in their own crate under `tests/`, which a
 /// `--all-targets` run hands the rule too. Their top-level `#[test]`
 /// functions are the target itself, not unit tests misplaced inside a
 /// production file, so the rule must not flag them — even when the
 /// test footprint dwarfs the inline budget and the file also carries
-/// an ordinary helper `fn` (which would otherwise count as production
-/// and defeat the all-test-file exemption).
+/// top-level `use`s and helper `fn`s the rule would otherwise count as
+/// production.
 #[test]
 fn does_not_flag_integration_tests() {
-    let mut integration = String::from("fn helper() -> i32 {\n    1\n}\n\n");
-    for index in 0..60 {
-        integration.push_str(&format!(
-            "#[test]\nfn case_{index}() {{ assert_eq!(helper(), 1); }}\n",
-        ));
-    }
     let (_temp, stderr, success) = run_project_with_config(
         "fixture_utfl_integration_tests",
         cargo_manifest_dir(),
         &shared_target_dir(),
         &[
             ("src/lib.rs", "pub fn calculate() -> i32 {\n    1\n}\n"),
-            ("tests/integration.rs", &integration),
+            ("tests/integration.rs", &integration_test_body()),
         ],
         "",
     );
@@ -339,6 +347,29 @@ fn does_not_flag_integration_tests() {
     assert!(
         !stderr.contains(LINT),
         "integration tests under `tests/` must not be flagged; stderr was:\n{stderr}",
+    );
+}
+
+/// Cargo also auto-discovers the subdirectory form `tests/<name>/main.rs`
+/// as an integration-test crate. Its discriminating `tests` directory is
+/// one level further up than the flat form, so this guards the path
+/// arithmetic that walks past the `main.rs` stem.
+#[test]
+fn does_not_flag_integration_test_subdir_main() {
+    let (_temp, stderr, success) = run_project_with_config(
+        "fixture_utfl_integration_subdir",
+        cargo_manifest_dir(),
+        &shared_target_dir(),
+        &[
+            ("src/lib.rs", "pub fn calculate() -> i32 {\n    1\n}\n"),
+            ("tests/suite/main.rs", &integration_test_body()),
+        ],
+        "",
+    );
+    assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");
+    assert!(
+        !stderr.contains(LINT),
+        "the `tests/<name>/main.rs` form must not be flagged; stderr was:\n{stderr}",
     );
 }
 

--- a/tests/unit_test_file_layout.rs
+++ b/tests/unit_test_file_layout.rs
@@ -414,7 +414,7 @@ fn flags_equivalent_body_in_src_module() {
     );
     assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");
     assert!(
-        stderr.contains("inline test code spans") && stderr.contains("src/thing"),
+        stderr.contains("inline test code spans") && stderr.contains("src/thing/tests.rs"),
         "the same over-budget body in a `src/` module must be flagged with the inline-footprint \
          diagnostic; stderr was:\n{stderr}",
     );

--- a/tests/unit_test_file_layout.rs
+++ b/tests/unit_test_file_layout.rs
@@ -373,6 +373,52 @@ fn does_not_flag_integration_test_subdir_main() {
     );
 }
 
+/// A flat integration test may be named `main` (`tests/main.rs`),
+/// which is *not* the `tests/<name>/main.rs` subdirectory form: its
+/// discriminating `tests` directory is the immediate parent, not two
+/// levels up. It must still be recognised as a separate target.
+#[test]
+fn does_not_flag_integration_test_named_main() {
+    let (_temp, stderr, success) = run_project_with_config(
+        "fixture_utfl_integration_named_main",
+        cargo_manifest_dir(),
+        &shared_target_dir(),
+        &[
+            ("src/lib.rs", "pub fn calculate() -> i32 {\n    1\n}\n"),
+            ("tests/main.rs", &integration_test_body()),
+        ],
+        "",
+    );
+    assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");
+    assert!(
+        !stderr.contains(LINT),
+        "an integration test named `main` must not be flagged; stderr was:\n{stderr}",
+    );
+}
+
+/// Positive control for the integration-test cases above: the same body
+/// in a `src/`-rooted module *is* over budget and flagged. Without it,
+/// those negatives could pass vacuously — a missing warning is otherwise
+/// indistinguishable from the rule never running on the crate.
+#[test]
+fn flags_equivalent_body_in_src_module() {
+    let (_temp, stderr, success) = run_project_with_config(
+        "fixture_utfl_src_body_positive_control",
+        cargo_manifest_dir(),
+        &shared_target_dir(),
+        &[
+            ("src/lib.rs", "pub mod thing;\n"),
+            ("src/thing.rs", &integration_test_body()),
+        ],
+        "",
+    );
+    assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");
+    assert!(
+        stderr.contains(LINT),
+        "the same over-budget body in a `src/` module must be flagged; stderr was:\n{stderr}",
+    );
+}
+
 #[test]
 fn external_only_flags_inline_tests() {
     let (_temp, stderr, success) = run_project_with_config(

--- a/tests/unit_test_file_layout.rs
+++ b/tests/unit_test_file_layout.rs
@@ -310,6 +310,38 @@ fn help_names_the_actual_inline_module() {
     );
 }
 
+/// Integration tests live in their own crate under `tests/`, which a
+/// `--all-targets` run hands the rule too. Their top-level `#[test]`
+/// functions are the target itself, not unit tests misplaced inside a
+/// production file, so the rule must not flag them — even when the
+/// test footprint dwarfs the inline budget and the file also carries
+/// an ordinary helper `fn` (which would otherwise count as production
+/// and defeat the all-test-file exemption).
+#[test]
+fn does_not_flag_integration_tests() {
+    let mut integration = String::from("fn helper() -> i32 {\n    1\n}\n\n");
+    for index in 0..60 {
+        integration.push_str(&format!(
+            "#[test]\nfn case_{index}() {{ assert_eq!(helper(), 1); }}\n",
+        ));
+    }
+    let (_temp, stderr, success) = run_project_with_config(
+        "fixture_utfl_integration_tests",
+        cargo_manifest_dir(),
+        &shared_target_dir(),
+        &[
+            ("src/lib.rs", "pub fn calculate() -> i32 {\n    1\n}\n"),
+            ("tests/integration.rs", &integration),
+        ],
+        "",
+    );
+    assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");
+    assert!(
+        !stderr.contains(LINT),
+        "integration tests under `tests/` must not be flagged; stderr was:\n{stderr}",
+    );
+}
+
 #[test]
 fn external_only_flags_inline_tests() {
     let (_temp, stderr, success) = run_project_with_config(

--- a/tests/unit_test_file_layout.rs
+++ b/tests/unit_test_file_layout.rs
@@ -414,8 +414,32 @@ fn flags_equivalent_body_in_src_module() {
     );
     assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");
     assert!(
-        stderr.contains(LINT),
-        "the same over-budget body in a `src/` module must be flagged; stderr was:\n{stderr}",
+        stderr.contains("inline test code spans") && stderr.contains("src/thing"),
+        "the same over-budget body in a `src/` module must be flagged with the inline-footprint \
+         diagnostic; stderr was:\n{stderr}",
+    );
+}
+
+/// Benchmarks are their own crate compiled under `cfg(test)`, like
+/// integration tests, so without the separate-target skip the same
+/// over-budget body would be flagged. This is the one load-bearing
+/// separate-target branch besides `tests/`, so guard it directly.
+#[test]
+fn does_not_flag_benchmarks() {
+    let (_temp, stderr, success) = run_project_with_config(
+        "fixture_utfl_benchmarks",
+        cargo_manifest_dir(),
+        &shared_target_dir(),
+        &[
+            ("src/lib.rs", "pub fn calculate() -> i32 {\n    1\n}\n"),
+            ("benches/bench.rs", &integration_test_body()),
+        ],
+        "",
+    );
+    assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");
+    assert!(
+        !stderr.contains(LINT),
+        "benchmarks under `benches/` must not be flagged; stderr was:\n{stderr}",
     );
 }
 


### PR DESCRIPTION
## Summary

`unit_test_file_layout` runs on every crate `cargo dylint -- --all-targets` compiles, including the integration tests, benchmarks, and examples Cargo builds as their own crates. There, top-level `#[test]` functions are the target itself (not `#[cfg(test)]`-gated unit tests inside a production file), and they sit beside ordinary helper `fn`s. The rule counted those helpers as production and the test functions as an oversized inline footprint, so it flagged the file — e.g. `tests/foo.rs` reported *"inline test code spans N lines, over the limit of 50"*.

## Fix

- `layout::is_separate_test_target` returns true when the crate root lives under a `tests/`, `benches/`, or `examples/` directory (via `local_crate_source_file()`, as `flat_module_pattern` already does); `scan::run` bails out early for those crates. The rule now governs only the library/binary that actually hosts unit tests.
- Updated the rule's rustdoc and regenerated `rules/unit_test_file_layout.md`.

## Test plan

- [x] New regression test `does_not_flag_integration_tests` (a `tests/` file with a helper `fn` + 60 test fns); confirmed it fails before the fix with the exact over-budget diagnostic and passes after.
- [x] Full `just all` green locally — `fmt`, `build`, `doc`, `lint`, `test`, `self-lint`.

https://claude.ai/code/session_01RYcvmsT8LTHmcQSxNgMCTP