### PR TITLE
ci: don't trigger on irrelevant changes

### DIFF
--- a/.github/workflows/pages-preview.yaml
+++ b/.github/workflows/pages-preview.yaml
@@ -1,8 +1,23 @@
 name: Pages preview
 
 on:
+  # Mirror the production Pages deploy's path filter (see pages.yaml): a
+  # preview is only worth building when the PR changes something the
+  # rendered site is derived from (rule sources under `src/`, the
+  # gen-docs renderer + assets, `Cargo.toml`) or a build input (lockfile,
+  # toolchain, linker config in `.cargo/`). PRs that only touch
+  # `planned-rules/`, the generated `rules/` markdown mirror, or
+  # `README.md` don't change the page, so they skip the Cloudflare deploy.
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'tools/gen-docs/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain'
+      - '.cargo/**'
+      - '.github/workflows/pages-preview.yaml'
 
 permissions:
   contents: read

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,9 +1,28 @@
 name: Pages
 
 on:
+  # Only rebuild + redeploy the public catalogue when an input to the
+  # rendered site actually changes. gen-docs reads the rule sources
+  # under `src/`, its own renderer + assets under `tools/gen-docs/`, and
+  # `Cargo.toml` (crate version + repo URL); the build additionally
+  # depends on the pinned toolchain, the lockfile, and the linker config
+  # in `.cargo/`. Pure docs that never reach the page — `planned-rules/`,
+  # the generated `rules/` markdown mirror, `README.md` — are excluded.
+  # An allow-list fits a deploy workflow: a path missed here just leaves
+  # the live site untouched (the previous deploy stands), never broken.
+  # `workflow_dispatch` stays available for manual redeploys regardless
+  # of which paths changed.
   push:
     branches:
       - master
+    paths:
+      - 'src/**'
+      - 'tools/gen-docs/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain'
+      - '.cargo/**'
+      - '.github/workflows/pages.yaml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,9 +3,46 @@ name: Test
 on:
   # Branch pushes only — tag pushes are covered by the deploy workflow,
   # which invokes this workflow via `workflow_call` before publishing.
+  #
+  # `paths-ignore` is a deny-list of pure-documentation files that never
+  # feed `just all` (fmt / build / doc / lint / test / self-lint). A push
+  # or PR that touches *only* these paths skips the suite; touching even
+  # one other file still runs it. A deny-list is the safe shape here: an
+  # unlisted source path merely runs CI needlessly, whereas an incomplete
+  # *allow*-list would silently skip CI on code that needs it. The two
+  # lists are kept identical by hand. `workflow_call` is left unfiltered
+  # — path filters don't apply to it, and deploy.yaml relies on the suite
+  # always running before publish.
+  #
+  # Note: if "Test" is a required status check in branch protection, a
+  # docs-only PR will never report it and can't merge until the rule is
+  # relaxed (e.g. drop the check from "required", or merge docs-only PRs
+  # via a path that doesn't demand it).
   push:
     branches: ['**']
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE.md'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
+      - '.github/copilot-instructions.md'
+      - 'CONFIGURATION.md'
+      - 'CONTROLLING_RULES.md'
+      - 'planned-rules/**'
+      - '.vscode.template/**'
+      - '.github/dependabot.yml'
   pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE.md'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
+      - '.github/copilot-instructions.md'
+      - 'CONFIGURATION.md'
+      - 'CONTROLLING_RULES.md'
+      - 'planned-rules/**'
+      - '.vscode.template/**'
+      - '.github/dependabot.yml'
   workflow_call:
 
 # `actions/checkout` plus the cargo build / test commands only need


### PR DESCRIPTION
Every workflow fired unconditionally, wasting CI on changes that can't affect the result. This scopes each to its real inputs.

- **`test.yaml`** — `paths-ignore` skips the suite (`just all`) when a push/PR touches *only* docs (`README.md`, `planned-rules/**`, `CLAUDE.md` + symlinks, `LICENSE.md`, `CONFIGURATION.md`, `CONTROLLING_RULES.md`, `.vscode.template/**`, `dependabot.yml`). A deny-list is the safe shape: a missed source path just runs CI needlessly, whereas a missed allow-list entry would silently skip CI on real code. `workflow_call` stays unfiltered so `deploy.yaml` always tests before publishing.
- **`pages.yaml` / `pages-preview.yaml`** — `paths` allow-list restricts the build + deploy to inputs the rendered site is actually derived from: `src/**`, `tools/gen-docs/**`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain`, `.cargo/**`, and the workflow file itself. gen-docs reads `src/rules/` at runtime and never touches `planned-rules/` or the generated `rules/` markdown mirror, so edits there no longer trigger a deploy. An allow-list fits a deploy: a missed path leaves the live site untouched, never broken.

**Caveat:** if "Test" is a required status check, a docs-only PR won't report it and can't merge until that's relaxed — GitHub treats a path-skipped run as "never reported," not "passed."

https://claude.ai/code/session_0146GNrmF83vKqTauuRjpBXW