### PR TITLE
fix: resolve comment-walking lint levels at the enclosing HIR node

### DIFF
--- a/src/comment_walk.rs
+++ b/src/comment_walk.rs
@@ -1,7 +1,8 @@
-//! Comment-stream walker shared by `bare_url`, `bare_email`, and
-//! `bare_issue_reference`.
+//! Comment-stream walker shared by `bare_url`, `bare_email`,
+//! `bare_issue_reference`, and `unicode_ellipsis_in_docs`.
 //!
-//! Each of these rules needs to scan two distinct surfaces:
+//! Each of these rules needs to scan one or both of two distinct
+//! surfaces:
 //!
 //! - **Doc-comment blocks** — `///` / `//!` line runs and `/** ... */`
 //!   block doc comments, each block treated as a single markdown

--- a/src/comment_walk.rs
+++ b/src/comment_walk.rs
@@ -17,7 +17,7 @@
 //! into the source map.
 
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
-use rustc_lint::{EarlyContext, LintContext};
+use rustc_session::Session;
 use rustc_span::def_id::LOCAL_CRATE;
 use rustc_span::{BytePos, Pos, RelativeBytePos, SourceFile, Span, SyntaxContext};
 
@@ -97,13 +97,13 @@ impl CommentChunk<'_> {
 
 /// Walk every comment in the local crate's source files, handing each
 /// chunk to `callback`. The callback receives a borrowed
-/// [`CommentChunk`] together with the lint context's session
-/// information.
-pub(crate) fn walk_local_comments(
-    lint_context: &EarlyContext<'_>,
-    mut callback: impl FnMut(&CommentChunk<'_>),
-) {
-    let source_map = lint_context.sess().source_map();
+/// [`CommentChunk`]. Takes the session directly rather than a lint
+/// context so it can run from either an early or a late pass — the
+/// comment-walking rules emit from a late pass (see
+/// [`crate::enclosing_hir::emit_at_enclosing_hir`]) so per-site
+/// `#[allow]` / `#[expect]` resolve at the comment's enclosing item.
+pub(crate) fn walk_local_comments(sess: &Session, mut callback: impl FnMut(&CommentChunk<'_>)) {
+    let source_map = sess.source_map();
     for source_file in source_map.files().iter() {
         if source_file.cnum != LOCAL_CRATE {
             continue;

--- a/src/enclosing_hir.rs
+++ b/src/enclosing_hir.rs
@@ -61,10 +61,12 @@ fn find_comment_anchor_hir_ids(tcx: TyCtxt<'_>, target_spans: &[Span]) -> Vec<hi
 
 fn walk(tcx: TyCtxt<'_>, target_spans: &[Span], include_attr_spans: bool) -> Vec<hir::HirId> {
     let mut best: Vec<hir::HirId> = vec![hir::CRATE_HIR_ID; target_spans.len()];
+    let mut best_width: Vec<u32> = vec![u32::MAX; target_spans.len()];
     let mut finder = EnclosingHirFinder {
         tcx,
         targets: target_spans,
         best: &mut best,
+        best_width: &mut best_width,
         include_attr_spans,
     };
     tcx.hir_walk_toplevel_module(&mut finder);
@@ -104,6 +106,10 @@ struct EnclosingHirFinder<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     targets: &'a [Span],
     best: &'a mut [hir::HirId],
+    /// Byte width of the span that elected each `best[i]`, used only in
+    /// comment-anchoring mode to keep the *tightest* containing node
+    /// (see [`Self::update`]). `u32::MAX` until the first match.
+    best_width: &'a mut [u32],
     /// When set, a documentable node's `#[doc]` attribute spans (what
     /// `///` / `//!` / `/** */` lower to) count toward containment
     /// alongside its own span, and enum variants / struct fields are
@@ -141,13 +147,44 @@ impl<'a, 'tcx> EnclosingHirFinder<'a, 'tcx> {
 
     fn update(&mut self, hir_id: hir::HirId, span: Span) {
         for (index, &target) in self.targets.iter().enumerate() {
-            if !contains(span, target) {
-                continue;
+            if self.include_attr_spans {
+                // Comment-anchoring mode. The target is a pristine,
+                // root-context source span (a comment), so a strict
+                // byte-containment check identifies every node that
+                // lexically encloses it — no macro-hygiene fallback is
+                // wanted here (see the `else` branch for why that
+                // matters elsewhere).
+                if !span.contains(target) {
+                    continue;
+                }
+                // Keep the *tightest* enclosing node, not the
+                // last-visited one. A proc-macro `#[derive]`
+                // (e.g. `serde::Deserialize`) generates HIR nodes —
+                // `visit_map` / `visit_seq` bodies — whose root-context
+                // spans cover the whole field list and are visited
+                // *after* the struct's fields. With a depth/order tie-
+                // break those wider generated nodes would steal the
+                // anchor from the documented field, so the field-level
+                // `#[expect]` would neither suppress nor be fulfilled
+                // (issue #165 follow-up). Preferring the narrowest span
+                // keeps the field's own one-line `#[doc]` span.
+                let width = span.hi().0.saturating_sub(span.lo().0);
+                if width >= self.best_width[index] {
+                    continue;
+                }
+                self.best_width[index] = width;
+                self.best[index] = hir_id;
+            } else {
+                // Macro-call mode. Targets here are pre-expansion call
+                // sites, so [`contains`] resolves macro hygiene before
+                // comparing byte ranges. The walk is depth-first, so a
+                // parent is visited before its children and the last
+                // successful update lands on the deepest node seen.
+                if !contains(span, target) {
+                    continue;
+                }
+                self.best[index] = hir_id;
             }
-            // The walk is depth-first: a parent is visited before its
-            // children, so each successful containment update lands on
-            // the deepest node seen so far.
-            self.best[index] = hir_id;
         }
     }
 }

--- a/src/enclosing_hir.rs
+++ b/src/enclosing_hir.rs
@@ -1,12 +1,20 @@
-//! Shared helper for the pre-expansion → late-pass split that
-//! `macro_trailing_comma` and `macro_argument_binding` both use.
-//!
-//! Both rules emit their diagnostics from a late pass, after parking
-//! violation spans during a pre-expansion pass. The late pass then
-//! anchors each pending span at the deepest enclosing HIR node so
+//! Shared helper for rules that discover violation spans outside the
+//! HIR walk and need to emit them at the enclosing HIR node so
 //! `cfg_attr`-wrapped `#[expect]` / `#[allow]` attributes resolve
-//! correctly. The walk shape is identical between the two rules; this
-//! module provides the generic walker.
+//! correctly.
+//!
+//! Two families of rules use it:
+//!
+//! - The pre-expansion → late-pass split of `macro_trailing_comma` and
+//!   `macro_argument_binding`. They park macro-call spans during a
+//!   pre-expansion pass and, in a late pass, anchor each at the deepest
+//!   enclosing HIR node via [`find_enclosing_hir_ids`].
+//! - The comment-walking rules (`bare_url`, `bare_email`,
+//!   `bare_issue_reference`, `unicode_ellipsis_in_comments`,
+//!   `unicode_ellipsis_in_docs`). They scan source text in a late pass
+//!   and emit through [`emit_at_enclosing_hir`], which uses the
+//!   attribute-aware [`find_comment_anchor_hir_ids`] so a doc comment
+//!   resolves to the item it documents.
 //!
 //! Callers feed in the spans they care about and get back, for each
 //! one, the deepest HIR node whose span contains it (or
@@ -28,23 +36,105 @@ use rustc_span::Span;
 /// enclosing item's span does not cover the call site — maps to
 /// [`hir::CRATE_HIR_ID`].
 pub(crate) fn find_enclosing_hir_ids(tcx: TyCtxt<'_>, target_spans: &[Span]) -> Vec<hir::HirId> {
+    walk(tcx, target_spans, false)
+}
+
+/// Like [`find_enclosing_hir_ids`], but a node's outer attributes —
+/// including the `#[doc]` attributes that `///` / `//!` / `/** */` doc
+/// comments lower to — count toward containment alongside the node's
+/// own span.
+///
+/// This is what the comment-walking rules need. An item's own span
+/// starts at the item keyword, *after* its leading doc comment, so a
+/// `…` inside `/// …` is not contained by the documented item's span
+/// and plain [`find_enclosing_hir_ids`] would resolve it to the
+/// enclosing module / crate. Folding each node's attribute spans in
+/// re-attaches the doc comment to the item it documents, so a per-item
+/// / per-field / per-variant `#[allow]` / `#[expect]` resolves. A plain
+/// `//` / `/* */` comment carries no attribute, so it still anchors at
+/// the deepest node whose body span contains it (the enclosing block /
+/// item), which is the same place a user puts the suppressing
+/// attribute.
+fn find_comment_anchor_hir_ids(tcx: TyCtxt<'_>, target_spans: &[Span]) -> Vec<hir::HirId> {
+    walk(tcx, target_spans, true)
+}
+
+fn walk(tcx: TyCtxt<'_>, target_spans: &[Span], include_attr_spans: bool) -> Vec<hir::HirId> {
     let mut best: Vec<hir::HirId> = vec![hir::CRATE_HIR_ID; target_spans.len()];
     let mut finder = EnclosingHirFinder {
         tcx,
         targets: target_spans,
         best: &mut best,
+        include_attr_spans,
     };
     tcx.hir_walk_toplevel_module(&mut finder);
     best
+}
+
+/// Resolve each violation's primary span to its deepest enclosing HIR
+/// node — in a single [`find_comment_anchor_hir_ids`] walk — then hand
+/// that node id, the span, and the payload to `emit`.
+///
+/// The companion to [`find_enclosing_hir_ids`] for the comment-walking
+/// rules (`bare_url`, `bare_email`, `bare_issue_reference`, the two
+/// `unicode_ellipsis_in_*` rules). Those discover violation spans by
+/// scanning source text in a late pass, outside the HIR walk, so the
+/// early-pass lint-level builder would sit at the crate root at
+/// emission time and only a crate-root `#![allow]` / `#![expect]`
+/// would apply. Anchoring each diagnostic at its enclosing node — and
+/// emitting through `clippy_utils::diagnostics::span_lint_hir_and_then`
+/// from `emit` — is what lets a per-item / per-field / per-module
+/// `#[allow]` / `#[expect]` resolve.
+pub(crate) fn emit_at_enclosing_hir<Payload>(
+    tcx: TyCtxt<'_>,
+    violations: Vec<(Span, Payload)>,
+    mut emit: impl FnMut(hir::HirId, Span, Payload),
+) {
+    if violations.is_empty() {
+        return;
+    }
+    let target_spans: Vec<Span> = violations.iter().map(|(span, _)| *span).collect();
+    let hir_ids = find_comment_anchor_hir_ids(tcx, &target_spans);
+    for ((span, payload), hir_id) in violations.into_iter().zip(hir_ids) {
+        emit(hir_id, span, payload);
+    }
 }
 
 struct EnclosingHirFinder<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     targets: &'a [Span],
     best: &'a mut [hir::HirId],
+    /// When set, a node's outer-attribute spans (the `#[doc]`
+    /// attributes doc comments lower to, plus any other attributes)
+    /// count toward containment alongside its own span. See
+    /// [`find_comment_anchor_hir_ids`].
+    include_attr_spans: bool,
 }
 
 impl<'a, 'tcx> EnclosingHirFinder<'a, 'tcx> {
+    /// Record `hir_id` as the best anchor for every target its `span`
+    /// contains — and, in comment-anchoring mode, every target one of
+    /// its outer-attribute spans contains. The latter is what attaches
+    /// a `///` / `//!` / `/** */` doc comment to the item it documents,
+    /// whose own span begins after the comment.
+    fn visit_node(&mut self, hir_id: hir::HirId, span: Span) {
+        self.update(hir_id, span);
+        if self.include_attr_spans {
+            // Only doc comments are folded in: they are what `///`,
+            // `//!`, and `/** */` lower to, and the comment-walking
+            // rules anchor on them. `is_doc_comment` hands back the
+            // comment's own span; other attributes are skipped, which
+            // also sidesteps `Attribute::span` panicking on parsed
+            // attribute kinds that carry no span (e.g. the synthesised
+            // prelude import).
+            for attr in self.tcx.hir_attrs(hir_id) {
+                if let Some(doc_span) = attr.is_doc_comment() {
+                    self.update(hir_id, doc_span);
+                }
+            }
+        }
+    }
+
     fn update(&mut self, hir_id: hir::HirId, span: Span) {
         for (index, &target) in self.targets.iter().enumerate() {
             if !contains(span, target) {
@@ -98,47 +188,57 @@ impl<'tcx> Visitor<'tcx> for EnclosingHirFinder<'_, 'tcx> {
     }
 
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
-        self.update(item.hir_id(), item.span);
+        self.visit_node(item.hir_id(), item.span);
         intravisit::walk_item(self, item);
     }
 
     fn visit_trait_item(&mut self, item: &'tcx hir::TraitItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
+        self.visit_node(item.hir_id(), item.span);
         intravisit::walk_trait_item(self, item);
     }
 
     fn visit_impl_item(&mut self, item: &'tcx hir::ImplItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
+        self.visit_node(item.hir_id(), item.span);
         intravisit::walk_impl_item(self, item);
     }
 
     fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) {
-        self.update(item.hir_id(), item.span);
+        self.visit_node(item.hir_id(), item.span);
         intravisit::walk_foreign_item(self, item);
     }
 
+    fn visit_variant(&mut self, variant: &'tcx hir::Variant<'tcx>) {
+        self.visit_node(variant.hir_id, variant.span);
+        intravisit::walk_variant(self, variant);
+    }
+
+    fn visit_field_def(&mut self, field: &'tcx hir::FieldDef<'tcx>) {
+        self.visit_node(field.hir_id, field.span);
+        intravisit::walk_field_def(self, field);
+    }
+
     fn visit_block(&mut self, block: &'tcx hir::Block<'tcx>) {
-        self.update(block.hir_id, block.span);
+        self.visit_node(block.hir_id, block.span);
         intravisit::walk_block(self, block);
     }
 
     fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
-        self.update(stmt.hir_id, stmt.span);
+        self.visit_node(stmt.hir_id, stmt.span);
         intravisit::walk_stmt(self, stmt);
     }
 
     fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) {
-        self.update(local.hir_id, local.span);
+        self.visit_node(local.hir_id, local.span);
         intravisit::walk_local(self, local);
     }
 
     fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
-        self.update(expr.hir_id, expr.span);
+        self.visit_node(expr.hir_id, expr.span);
         intravisit::walk_expr(self, expr);
     }
 
     fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
-        self.update(pat.hir_id, pat.span);
+        self.visit_node(pat.hir_id, pat.span);
         intravisit::walk_pat(self, pat);
     }
 }

--- a/src/enclosing_hir.rs
+++ b/src/enclosing_hir.rs
@@ -104,29 +104,33 @@ struct EnclosingHirFinder<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     targets: &'a [Span],
     best: &'a mut [hir::HirId],
-    /// When set, a node's outer-attribute spans (the `#[doc]`
-    /// attributes doc comments lower to, plus any other attributes)
-    /// count toward containment alongside its own span. See
-    /// [`find_comment_anchor_hir_ids`].
+    /// When set, a documentable node's `#[doc]` attribute spans (what
+    /// `///` / `//!` / `/** */` lower to) count toward containment
+    /// alongside its own span, and enum variants / struct fields are
+    /// registered as anchors. See [`find_comment_anchor_hir_ids`].
     include_attr_spans: bool,
 }
 
 impl<'a, 'tcx> EnclosingHirFinder<'a, 'tcx> {
-    /// Record `hir_id` as the best anchor for every target its `span`
-    /// contains — and, in comment-anchoring mode, every target one of
-    /// its outer-attribute spans contains. The latter is what attaches
-    /// a `///` / `//!` / `/** */` doc comment to the item it documents,
-    /// whose own span begins after the comment.
-    fn visit_node(&mut self, hir_id: hir::HirId, span: Span) {
+    /// Record a node that can carry a doc comment: its own `span` and,
+    /// in comment-anchoring mode, the span of each `#[doc]` attribute it
+    /// bears. Folding the attribute spans in is what attaches a `///` /
+    /// `//!` / `/** */` doc comment to the item it documents, whose own
+    /// span begins after the comment.
+    ///
+    /// Only the node kinds a doc comment can actually attach to —
+    /// items, trait / impl / foreign items, enum variants, struct
+    /// fields — route through here. Blocks, statements, locals,
+    /// expressions, and patterns never carry a doc comment, so they
+    /// call [`Self::update`] directly and skip the per-node
+    /// `hir_attrs` lookup.
+    fn register_documentable(&mut self, hir_id: hir::HirId, span: Span) {
         self.update(hir_id, span);
         if self.include_attr_spans {
-            // Only doc comments are folded in: they are what `///`,
-            // `//!`, and `/** */` lower to, and the comment-walking
-            // rules anchor on them. `is_doc_comment` hands back the
-            // comment's own span; other attributes are skipped, which
-            // also sidesteps `Attribute::span` panicking on parsed
-            // attribute kinds that carry no span (e.g. the synthesised
-            // prelude import).
+            // `is_doc_comment` hands back the comment's own span; other
+            // attributes are skipped, which also sidesteps
+            // `Attribute::span` panicking on parsed attribute kinds that
+            // carry no span (e.g. the synthesised prelude import).
             for attr in self.tcx.hir_attrs(hir_id) {
                 if let Some(doc_span) = attr.is_doc_comment() {
                     self.update(hir_id, doc_span);
@@ -188,57 +192,66 @@ impl<'tcx> Visitor<'tcx> for EnclosingHirFinder<'_, 'tcx> {
     }
 
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
-        self.visit_node(item.hir_id(), item.span);
+        self.register_documentable(item.hir_id(), item.span);
         intravisit::walk_item(self, item);
     }
 
     fn visit_trait_item(&mut self, item: &'tcx hir::TraitItem<'tcx>) {
-        self.visit_node(item.hir_id(), item.span);
+        self.register_documentable(item.hir_id(), item.span);
         intravisit::walk_trait_item(self, item);
     }
 
     fn visit_impl_item(&mut self, item: &'tcx hir::ImplItem<'tcx>) {
-        self.visit_node(item.hir_id(), item.span);
+        self.register_documentable(item.hir_id(), item.span);
         intravisit::walk_impl_item(self, item);
     }
 
     fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) {
-        self.visit_node(item.hir_id(), item.span);
+        self.register_documentable(item.hir_id(), item.span);
         intravisit::walk_foreign_item(self, item);
     }
 
+    // Variants and fields are only registered in comment-anchoring mode
+    // (where a doc comment can anchor to them). The macro-call path
+    // (`find_enclosing_hir_ids`) never visited them, so guarding on the
+    // flag keeps that path byte-for-byte unchanged; the walk still
+    // recurses into them either way to reach nested expressions.
     fn visit_variant(&mut self, variant: &'tcx hir::Variant<'tcx>) {
-        self.visit_node(variant.hir_id, variant.span);
+        if self.include_attr_spans {
+            self.register_documentable(variant.hir_id, variant.span);
+        }
         intravisit::walk_variant(self, variant);
     }
 
     fn visit_field_def(&mut self, field: &'tcx hir::FieldDef<'tcx>) {
-        self.visit_node(field.hir_id, field.span);
+        if self.include_attr_spans {
+            self.register_documentable(field.hir_id, field.span);
+        }
         intravisit::walk_field_def(self, field);
     }
 
     fn visit_block(&mut self, block: &'tcx hir::Block<'tcx>) {
-        self.visit_node(block.hir_id, block.span);
+        self.update(block.hir_id, block.span);
         intravisit::walk_block(self, block);
     }
 
     fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
-        self.visit_node(stmt.hir_id, stmt.span);
+        self.update(stmt.hir_id, stmt.span);
         intravisit::walk_stmt(self, stmt);
     }
 
     fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) {
-        self.visit_node(local.hir_id, local.span);
+        self.update(local.hir_id, local.span);
         intravisit::walk_local(self, local);
     }
 
     fn visit_expr(&mut self, expr: &'tcx hir::Expr<'tcx>) {
-        self.visit_node(expr.hir_id, expr.span);
+        self.update(expr.hir_id, expr.span);
         intravisit::walk_expr(self, expr);
     }
 
     fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
-        self.visit_node(pat.hir_id, pat.span);
+        self.update(pat.hir_id, pat.span);
         intravisit::walk_pat(self, pat);
     }
 }

--- a/src/enclosing_hir.rs
+++ b/src/enclosing_hir.rs
@@ -148,27 +148,29 @@ impl<'a, 'tcx> EnclosingHirFinder<'a, 'tcx> {
     fn update(&mut self, hir_id: hir::HirId, span: Span) {
         for (index, &target) in self.targets.iter().enumerate() {
             if self.include_attr_spans {
-                // Comment-anchoring mode. The target is a pristine,
-                // root-context source span (a comment), so a strict
-                // byte-containment check identifies every node that
-                // lexically encloses it — no macro-hygiene fallback is
-                // wanted here (see the `else` branch for why that
-                // matters elsewhere).
-                if !span.contains(target) {
+                // Comment-anchoring mode. Resolve macro hygiene before
+                // comparing: a `///` forwarded through a `macro_rules!`
+                // (`declare_tool_lint!` does this for every lint here)
+                // lands on the generated item with an
+                // expansion-context `#[doc]` span that does not
+                // byte-match the root-context comment the walker
+                // scanned, so a raw `Span::contains` would miss it and
+                // the finding would fall back to the crate root.
+                let Some(width) = comment_enclosure_width(span, target) else {
                     continue;
-                }
-                // Keep the *tightest* enclosing node, not the
-                // last-visited one. A proc-macro `#[derive]`
-                // (e.g. `serde::Deserialize`) generates HIR nodes —
-                // `visit_map` / `visit_seq` bodies — whose root-context
+                };
+                // Keep the *tightest* enclosing node, measured at the
+                // source level (see [`comment_enclosure_width`]), not
+                // the last-visited one. A proc-macro `#[derive]`
+                // (e.g. `serde::Deserialize`) generates root-context
+                // HIR nodes — `visit_map` / `visit_seq` bodies — whose
                 // spans cover the whole field list and are visited
-                // *after* the struct's fields. With a depth/order tie-
-                // break those wider generated nodes would steal the
-                // anchor from the documented field, so the field-level
-                // `#[expect]` would neither suppress nor be fulfilled
-                // (issue #165 follow-up). Preferring the narrowest span
-                // keeps the field's own one-line `#[doc]` span.
-                let width = span.hi().0.saturating_sub(span.lo().0);
+                // *after* the struct's fields. A depth/order tie-break
+                // would let those wider generated nodes steal the
+                // anchor from the documented field, defeating a
+                // field-level `#[expect]` (issue #165 follow-up).
+                // Preferring the narrowest span keeps the field's own
+                // one-line `#[doc]` span.
                 if width >= self.best_width[index] {
                     continue;
                 }
@@ -219,6 +221,36 @@ fn contains(item_span: Span, target: Span) -> bool {
         || item_span
             .source_callsite()
             .contains(target.source_callsite())
+}
+
+/// For comment anchoring: if `candidate` encloses `target`, return the
+/// byte width to tie-break on (smaller = tighter); otherwise `None`.
+///
+/// Containment is checked the same hygiene-resolving way as [`contains`]
+/// — a direct byte check first, then a [`Span::source_callsite`] check
+/// so a `#[doc]` forwarded through a `macro_rules!` (whose span sits in
+/// the macro expansion) still matches the generated item it landed on.
+///
+/// The width is measured at the level the match held: the candidate's
+/// own span for a direct match, or its `source_callsite` for a
+/// hygiene match. Measuring the hygiene case at the resolved source
+/// span is what lets a macro-generated item's `#[doc]` (resolving to
+/// the one-line `///`) win the tightest-node tie-break over the
+/// enclosing module, while a root-context proc-macro-`derive` body
+/// keeps its wide field-list width and loses to the documented field.
+fn comment_enclosure_width(candidate: Span, target: Span) -> Option<u32> {
+    if candidate.contains(target) {
+        return Some(span_width(candidate));
+    }
+    let resolved = candidate.source_callsite();
+    if resolved.contains(target.source_callsite()) {
+        return Some(span_width(resolved));
+    }
+    None
+}
+
+fn span_width(span: Span) -> u32 {
+    span.hi().0.saturating_sub(span.lo().0)
 }
 
 impl<'tcx> Visitor<'tcx> for EnclosingHirFinder<'_, 'tcx> {

--- a/src/literal_scan.rs
+++ b/src/literal_scan.rs
@@ -31,9 +31,10 @@
 //! folds without being fooled by `\\n` (an escaped backslash followed
 //! by the letter `n`, which is *not* a newline).
 
-use clippy_utils::diagnostics::span_lint_and_sugg;
+use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_hir_and_then};
 use rustc_errors::Applicability;
-use rustc_lint::{Lint, LintContext};
+use rustc_hir::HirId;
+use rustc_lint::{LateContext, Lint, LintContext};
 use rustc_span::Span;
 
 /// For each character in `text` that appears in `flagged`, emit a
@@ -98,23 +99,65 @@ pub(crate) fn emit_flagged_char<Cx>(
 ) where
     Cx: LintContext,
 {
-    let applicability = if character == '\u{2026}' {
-        Applicability::MachineApplicable
-    } else {
-        Applicability::MaybeIncorrect
-    };
     span_lint_and_sugg(
         lint_context,
         lint,
         span,
-        format!(
-            "Unicode `{character}` (U+{:04X}) in {context_label}",
-            character as u32,
-        ),
+        flagged_char_message(character, context_label),
         "use ASCII `...` instead",
         "...".to_owned(),
-        applicability,
+        flagged_char_applicability(character),
     );
+}
+
+/// HIR-anchored counterpart of [`emit_flagged_char`] for the
+/// comment-scanning rules (`unicode_ellipsis_in_comments` and
+/// `unicode_ellipsis_in_docs`). They run in a late pass and emit at the
+/// comment's enclosing HIR node — resolved by
+/// [`crate::enclosing_hir::emit_at_enclosing_hir`] — so a per-item /
+/// per-module `#[allow]` / `#[expect]` resolves, not just a crate-root
+/// `#![allow]`. The message, suggestion, and applicability match
+/// [`emit_flagged_char`] exactly.
+pub(crate) fn emit_flagged_char_hir(
+    lint_context: &LateContext<'_>,
+    lint: &'static Lint,
+    hir_id: HirId,
+    character: char,
+    span: Span,
+    context_label: &str,
+) {
+    let applicability = flagged_char_applicability(character);
+    span_lint_hir_and_then(
+        lint_context,
+        lint,
+        hir_id,
+        span,
+        flagged_char_message(character, context_label),
+        |diag| {
+            diag.span_suggestion(span, "use ASCII `...` instead", "...", applicability);
+        },
+    );
+}
+
+/// Diagnostic message for a flagged character, shared by the
+/// current-context [`emit_flagged_char`] and HIR-anchored
+/// [`emit_flagged_char_hir`] emitters so the two stay identical.
+fn flagged_char_message(character: char, context_label: &str) -> String {
+    format!(
+        "Unicode `{character}` (U+{:04X}) in {context_label}",
+        character as u32,
+    )
+}
+
+/// Suggestion applicability for a flagged character: `MachineApplicable`
+/// for U+2026 (always maps cleanly to `...`), `MaybeIncorrect` for any
+/// user-configured `extra_flagged_chars` entry.
+fn flagged_char_applicability(character: char) -> Applicability {
+    if character == '\u{2026}' {
+        Applicability::MachineApplicable
+    } else {
+        Applicability::MaybeIncorrect
+    }
 }
 
 /// Return `(prefix_length, suffix_length)` covering the opening and

--- a/src/rules/bare_email.rs
+++ b/src/rules/bare_email.rs
@@ -4,14 +4,16 @@
 
 use std::collections::BTreeSet;
 
-use clippy_utils::diagnostics::span_lint_and_then;
-use rustc_ast::Crate;
+use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
-use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
+use rustc_hir::HirId;
+use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
+use rustc_span::Span;
 
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
+use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
 
 declare_tool_lint! {
@@ -137,15 +139,19 @@ pub fn register_pass(lint_store: &mut LintStore) {
     if let DefaultState::Inactive = resolved_state("bare_email", DefaultState::Active) {
         return;
     }
-    lint_store.register_early_pass(|| Box::new(BareEmail::new()));
+    lint_store.register_late_pass(|_| Box::new(BareEmail::new()));
 }
 
-impl EarlyLintPass for BareEmail {
-    fn check_crate(&mut self, lint_context: &EarlyContext<'_>, _: &Crate) {
+impl<'tcx> LateLintPass<'tcx> for BareEmail {
+    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
         if !(self.scan_doc_comments || self.scan_regular_comments) {
             return;
         }
-        walk_local_comments(lint_context, |chunk| {
+        // Each parked finding is the bare address text; the required
+        // form (`self.style`) is uniform across the crate, so it's read
+        // once at emission time rather than stored per violation.
+        let mut violations: Vec<(Span, String)> = Vec::new();
+        walk_local_comments(lint_context.sess(), |chunk| {
             let is_doc = matches!(
                 chunk.surface,
                 CommentSurface::DocBlock | CommentSurface::DocBlockBlock,
@@ -161,7 +167,11 @@ impl EarlyLintPass for BareEmail {
             } else {
                 Vec::new()
             };
-            self.scan(lint_context, chunk, &skips);
+            self.scan(chunk, &skips, &mut violations);
+        });
+        let style = self.style;
+        emit_at_enclosing_hir(lint_context.tcx, violations, |hir_id, span, address| {
+            emit_email(lint_context, hir_id, span, style, address);
         });
     }
 }
@@ -169,9 +179,9 @@ impl EarlyLintPass for BareEmail {
 impl BareEmail {
     fn scan(
         &self,
-        lint_context: &EarlyContext<'_>,
         chunk: &CommentChunk<'_>,
         skips: &[std::ops::Range<usize>],
+        out: &mut Vec<(Span, String)>,
     ) {
         let text = &chunk.rendered;
         let bytes = text.as_bytes();
@@ -241,77 +251,79 @@ impl BareEmail {
                 index += address_len;
                 continue;
             }
-            self.emit(lint_context, chunk, index, address);
+            let Some(span) = chunk.span_for(index, address_len as u32) else {
+                index += address_len;
+                continue;
+            };
+            out.push((span, address.to_owned()));
             index += address_len;
         }
     }
+}
 
-    fn emit(
-        &self,
-        lint_context: &EarlyContext<'_>,
-        chunk: &CommentChunk<'_>,
-        rendered_pos: usize,
-        address: &str,
-    ) {
-        let Some(span) = chunk.span_for(rendered_pos, address.len() as u32) else {
-            return;
-        };
-        let style = self.style;
-        let address = address.to_owned();
-        span_lint_and_then(
-            lint_context,
-            BARE_EMAIL,
-            span,
-            format!("bare email address `{address}`"),
-            move |diag| match style {
-                Style::AngleBrackets => {
-                    diag.span_suggestion(
-                        span,
-                        "wrap in `<...>`",
-                        format!("<{address}>"),
-                        Applicability::MachineApplicable,
-                    );
-                }
-                Style::Mailto => {
-                    diag.span_suggestion(
-                        span,
-                        "prefix with `mailto:`",
-                        format!("mailto:{address}"),
-                        Applicability::MachineApplicable,
-                    );
-                }
-                Style::Both => {
-                    diag.span_suggestion(
-                        span,
-                        "wrap in `<mailto:...>`",
-                        format!("<mailto:{address}>"),
-                        Applicability::MachineApplicable,
-                    );
-                }
-                Style::Either => {
-                    diag.span_suggestion(
-                        span,
-                        "wrap in `<...>`",
-                        format!("<{address}>"),
-                        Applicability::MaybeIncorrect,
-                    );
-                    diag.span_suggestion(
-                        span,
-                        "or prefix with `mailto:`",
-                        format!("mailto:{address}"),
-                        Applicability::MaybeIncorrect,
-                    );
-                }
-                Style::Forbid => {
-                    diag.help(
-                        "move the email out of source — e.g. into a \
-                             CONTRIBUTING.md or SECURITY.md — or remove it \
-                             entirely",
-                    );
-                }
-            },
-        );
-    }
+/// Emit one bare-email finding at its enclosing HIR node, with the
+/// suggestion(s) the configured `style` calls for.
+fn emit_email(
+    lint_context: &LateContext<'_>,
+    hir_id: HirId,
+    span: Span,
+    style: Style,
+    address: String,
+) {
+    span_lint_hir_and_then(
+        lint_context,
+        BARE_EMAIL,
+        hir_id,
+        span,
+        format!("bare email address `{address}`"),
+        move |diag| match style {
+            Style::AngleBrackets => {
+                diag.span_suggestion(
+                    span,
+                    "wrap in `<...>`",
+                    format!("<{address}>"),
+                    Applicability::MachineApplicable,
+                );
+            }
+            Style::Mailto => {
+                diag.span_suggestion(
+                    span,
+                    "prefix with `mailto:`",
+                    format!("mailto:{address}"),
+                    Applicability::MachineApplicable,
+                );
+            }
+            Style::Both => {
+                diag.span_suggestion(
+                    span,
+                    "wrap in `<mailto:...>`",
+                    format!("<mailto:{address}>"),
+                    Applicability::MachineApplicable,
+                );
+            }
+            Style::Either => {
+                diag.span_suggestion(
+                    span,
+                    "wrap in `<...>`",
+                    format!("<{address}>"),
+                    Applicability::MaybeIncorrect,
+                );
+                diag.span_suggestion(
+                    span,
+                    "or prefix with `mailto:`",
+                    format!("mailto:{address}"),
+                    Applicability::MaybeIncorrect,
+                );
+            }
+            Style::Forbid => {
+                diag.help(
+                    "move the email out of source — e.g. into a \
+                         CONTRIBUTING.md or SECURITY.md — or remove it \
+                         entirely",
+                );
+            }
+        },
+    );
 }
 
 /// Take an email address from the start of `input`. Returns

--- a/src/rules/bare_issue_reference.rs
+++ b/src/rules/bare_issue_reference.rs
@@ -2,15 +2,16 @@
 //! PR references in doc comments (and optionally plain `//` line
 //! comments), suggesting the markdown-link form.
 
-use clippy_utils::diagnostics::span_lint_and_then;
-use rustc_ast::Crate;
+use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
-use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
+use rustc_hir::HirId;
+use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
 
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
+use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
 use crate::url_scan::back_scan_url_fragment;
 
@@ -348,18 +349,42 @@ pub fn register_pass(lint_store: &mut LintStore) {
     if let DefaultState::Inactive = resolved_state("bare_issue_reference", DefaultState::Active) {
         return;
     }
-    lint_store.register_early_pass(|| Box::new(BareIssueReference::new()));
+    lint_store.register_late_pass(|_| Box::new(BareIssueReference::new()));
 }
 
-impl EarlyLintPass for BareIssueReference {
-    fn check_crate(&mut self, lint_context: &EarlyContext<'_>, _: &Crate) {
-        walk_local_comments(lint_context, |chunk| match chunk.surface {
+/// One bare `#NNN` finding, parked during the comment walk and emitted
+/// later at its enclosing HIR node. Everything the diagnostic needs
+/// that depends on the comment chunk (the link URLs, the
+/// `reference`-form definition site) is precomputed here, since the
+/// chunk is gone by the time the late pass emits.
+struct IssueRefViolation {
+    token: String,
+    issue_url: Option<String>,
+    pr_url: Option<String>,
+    is_doc: bool,
+    ref_site: Option<RefDefinitionSite>,
+}
+
+/// The crate-uniform rendering choices for the bare `#NNN` autofix,
+/// resolved once and shared by every emitted finding.
+#[derive(Clone, Copy)]
+struct EmitOptions {
+    suggest_issue: bool,
+    suggest_pr: bool,
+    doc_form: DocForm,
+    plain_form: PlainForm,
+}
+
+impl<'tcx> LateLintPass<'tcx> for BareIssueReference {
+    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
+        let mut violations: Vec<(Span, IssueRefViolation)> = Vec::new();
+        walk_local_comments(lint_context.sess(), |chunk| match chunk.surface {
             CommentSurface::DocBlock | CommentSurface::DocBlockBlock => {
-                self.scan_doc(lint_context, chunk);
+                self.scan_doc(chunk, &mut violations);
             }
             CommentSurface::PlainLine => {
                 if self.include_plain_comments {
-                    self.scan_plain(lint_context, chunk);
+                    self.scan_plain(chunk, &mut violations);
                 }
             }
             CommentSurface::PlainBlock => {
@@ -367,25 +392,37 @@ impl EarlyLintPass for BareIssueReference {
                 // deliberately doesn't scan plain block comments.
             }
         });
+        let options = EmitOptions {
+            suggest_issue: self.suggest_issue_url,
+            // On GitLab a bare `#NNN` always denotes an issue — merge
+            // requests are written `!NNN` — so the PR suggestion never
+            // applies to it, whatever `suggest_pr_url` says.
+            suggest_pr: self.suggest_pr_url && self.hash_can_mean_pr(),
+            doc_form: self.doc_comment_form,
+            plain_form: self.plain_comment_form,
+        };
+        emit_at_enclosing_hir(lint_context.tcx, violations, |hir_id, span, violation| {
+            emit_issue_ref(lint_context, hir_id, span, violation, options);
+        });
     }
 }
 
 impl BareIssueReference {
-    fn scan_doc(&self, lint_context: &EarlyContext<'_>, chunk: &CommentChunk<'_>) {
+    fn scan_doc(&self, chunk: &CommentChunk<'_>, out: &mut Vec<(Span, IssueRefViolation)>) {
         let skips = scan_skip_regions(&chunk.rendered);
-        self.scan(lint_context, chunk, &skips, true);
+        self.scan(chunk, &skips, true, out);
     }
 
-    fn scan_plain(&self, lint_context: &EarlyContext<'_>, chunk: &CommentChunk<'_>) {
-        self.scan(lint_context, chunk, &[], false);
+    fn scan_plain(&self, chunk: &CommentChunk<'_>, out: &mut Vec<(Span, IssueRefViolation)>) {
+        self.scan(chunk, &[], false, out);
     }
 
     fn scan(
         &self,
-        lint_context: &EarlyContext<'_>,
         chunk: &CommentChunk<'_>,
         skips: &[std::ops::Range<usize>],
         is_doc: bool,
+        out: &mut Vec<(Span, IssueRefViolation)>,
     ) {
         let text = &chunk.rendered;
         let bytes = text.as_bytes();
@@ -435,112 +472,138 @@ impl BareIssueReference {
                 continue;
             }
             let number = &text[digits_start..end];
-            self.emit(lint_context, chunk, index, end - index, number, is_doc);
+            self.collect(chunk, index, end - index, number, is_doc, out);
             index = end;
         }
     }
 
-    fn emit(
+    fn collect(
         &self,
-        lint_context: &EarlyContext<'_>,
         chunk: &CommentChunk<'_>,
         rendered_pos: usize,
         len: usize,
         number: &str,
         is_doc: bool,
+        out: &mut Vec<(Span, IssueRefViolation)>,
     ) {
         let Some(span) = chunk.span_for(rendered_pos, len as u32) else {
             return;
         };
-        let token = format!("#{number}");
-        let issue_url = self.issue_url(number);
-        let pr_url = self.pr_url(number);
-        let suggest_issue = self.suggest_issue_url;
-        // On GitLab a bare `#NNN` always denotes an issue — merge
-        // requests are written `!NNN` — so the PR suggestion never
-        // applies to it, whatever `suggest_pr_url` says.
-        let suggest_pr = self.suggest_pr_url && self.hash_can_mean_pr();
-        let doc_form = self.doc_comment_form;
-        let plain_form = self.plain_comment_form;
         // For the `reference` form, work out where (and with what
         // prefix) to append the `[#N]: URL` definition, so the fix is
         // complete rather than leaving the definition to the author.
         // `None` for other forms, block doc comments, or a block that
         // already defines the reference.
-        let ref_site = (doc_form == DocForm::Reference)
+        let ref_site = (self.doc_comment_form == DocForm::Reference)
             .then(|| reference_definition_site(chunk, rendered_pos, number))
             .flatten();
-        span_lint_and_then(
-            lint_context,
-            BARE_ISSUE_REFERENCE,
+        out.push((
             span,
-            format!(
-                "ambiguous `{token}`; a bare `#NNN` could be an issue or pull request, \
-                 a colour, or any other numbered item",
-            ),
-            move |diag| {
-                // Offer the issue / PR link suggestions when a
-                // repository is configured and at least one knob is
-                // on. These are only ever `MaybeIncorrect`: the token
-                // is ambiguous, so the lint can't be sure it even
-                // names a reference.
-                match issue_url {
-                    None => {
-                        diag.help(
-                            "set `repository` (and `forge`, if its host isn't a recognised \
-                             service) in dylint.toml under \
-                             `[perfectionist::bare_issue_reference]` to enable issue / PR link \
-                             suggestions",
+            IssueRefViolation {
+                token: format!("#{number}"),
+                issue_url: self.issue_url(number),
+                pr_url: self.pr_url(number),
+                is_doc,
+                ref_site,
+            },
+        ));
+    }
+}
+
+/// Emit one bare `#NNN` finding at its enclosing HIR node. The
+/// suggestion shape is driven by `doc_form` / `plain_form`; the issue /
+/// PR link URLs were resolved when the violation was parked.
+fn emit_issue_ref(
+    lint_context: &LateContext<'_>,
+    hir_id: HirId,
+    span: Span,
+    violation: IssueRefViolation,
+    options: EmitOptions,
+) {
+    let IssueRefViolation {
+        token,
+        issue_url,
+        pr_url,
+        is_doc,
+        ref_site,
+    } = violation;
+    let EmitOptions {
+        suggest_issue,
+        suggest_pr,
+        doc_form,
+        plain_form,
+    } = options;
+    span_lint_hir_and_then(
+        lint_context,
+        BARE_ISSUE_REFERENCE,
+        hir_id,
+        span,
+        format!(
+            "ambiguous `{token}`; a bare `#NNN` could be an issue or pull request, \
+             a colour, or any other numbered item",
+        ),
+        move |diag| {
+            // Offer the issue / PR link suggestions when a
+            // repository is configured and at least one knob is
+            // on. These are only ever `MaybeIncorrect`: the token
+            // is ambiguous, so the lint can't be sure it even
+            // names a reference.
+            match issue_url {
+                None => {
+                    diag.help(
+                        "set `repository` (and `forge`, if its host isn't a recognised \
+                         service) in dylint.toml under \
+                         `[perfectionist::bare_issue_reference]` to enable issue / PR link \
+                         suggestions",
+                    );
+                }
+                Some(_) if !(suggest_issue || suggest_pr) => {
+                    diag.help(
+                        "enable `suggest_issue_url` and/or `suggest_pr_url` in dylint.toml \
+                         under `[perfectionist::bare_issue_reference]` to get a link \
+                         suggestion",
+                    );
+                }
+                Some(issue_url) => {
+                    if suggest_issue {
+                        emit_one(
+                            diag,
+                            span,
+                            &token,
+                            &issue_url,
+                            "issue",
+                            is_doc,
+                            doc_form,
+                            plain_form,
+                            ref_site.as_ref(),
                         );
                     }
-                    Some(_) if !(suggest_issue || suggest_pr) => {
-                        diag.help(
-                            "enable `suggest_issue_url` and/or `suggest_pr_url` in dylint.toml \
-                             under `[perfectionist::bare_issue_reference]` to get a link \
-                             suggestion",
+                    if suggest_pr {
+                        let pr_url = pr_url.expect("pr_url renders whenever issue_url does");
+                        emit_one(
+                            diag,
+                            span,
+                            &token,
+                            &pr_url,
+                            "pull request",
+                            is_doc,
+                            doc_form,
+                            plain_form,
+                            ref_site.as_ref(),
                         );
-                    }
-                    Some(issue_url) => {
-                        if suggest_issue {
-                            emit_one(
-                                diag,
-                                span,
-                                &token,
-                                &issue_url,
-                                "issue",
-                                is_doc,
-                                doc_form,
-                                plain_form,
-                                ref_site.as_ref(),
-                            );
-                        }
-                        if suggest_pr {
-                            let pr_url = pr_url.expect("pr_url renders whenever issue_url does");
-                            emit_one(
-                                diag,
-                                span,
-                                &token,
-                                &pr_url,
-                                "pull request",
-                                is_doc,
-                                doc_form,
-                                plain_form,
-                                ref_site.as_ref(),
-                            );
-                        }
                     }
                 }
-                // Two disambiguations that apply whatever the config:
-                // mark the token as not-a-reference, or avoid the
-                // `#NNN` spelling entirely.
-                diag.help(format!(
-                    "if `{token}` is not an issue or pull request, enclose it in backticks \
-                     so it renders as code",
-                ));
-                diag.help("or refer to the numbered item with a spelling that has no leading `#`");
-            },
-        );
-    }
+            }
+            // Two disambiguations that apply whatever the config:
+            // mark the token as not-a-reference, or avoid the
+            // `#NNN` spelling entirely.
+            diag.help(format!(
+                "if `{token}` is not an issue or pull request, enclose it in backticks \
+                 so it renders as code",
+            ));
+            diag.help("or refer to the numbered item with a spelling that has no leading `#`");
+        },
+    );
 }
 
 /// Where to append a `reference`-form `[#N]: URL` definition, so the

--- a/src/rules/bare_url.rs
+++ b/src/rules/bare_url.rs
@@ -4,15 +4,15 @@
 
 use std::collections::BTreeSet;
 
-use clippy_utils::diagnostics::span_lint_and_sugg;
-use rustc_ast::Crate;
+use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
-use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
+use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
 
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
+use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
 use crate::url_scan::{DEFAULT_FORWARD_SCHEMES, TrailingClass, classify_trailing, take_url};
 
@@ -129,48 +129,59 @@ pub fn register_pass(lint_store: &mut LintStore) {
     if let DefaultState::Inactive = resolved_state("bare_url", DefaultState::Active) {
         return;
     }
-    lint_store.register_early_pass(|| Box::new(BareUrl::new()));
+    lint_store.register_late_pass(|_| Box::new(BareUrl::new()));
 }
 
-impl EarlyLintPass for BareUrl {
-    fn check_crate(&mut self, lint_context: &EarlyContext<'_>, _: &Crate) {
+/// One bare-URL finding, parked during the comment walk and emitted
+/// later at its enclosing HIR node.
+struct UrlViolation {
+    url: String,
+    applicability: Applicability,
+}
+
+impl<'tcx> LateLintPass<'tcx> for BareUrl {
+    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
         if !(self.scan_doc_comments || self.scan_regular_comments) {
             return;
         }
-        walk_local_comments(lint_context, |chunk| match chunk.surface {
+        let mut violations: Vec<(Span, UrlViolation)> = Vec::new();
+        walk_local_comments(lint_context.sess(), |chunk| match chunk.surface {
             CommentSurface::DocBlock | CommentSurface::DocBlockBlock => {
                 if self.scan_doc_comments {
-                    self.scan_doc_chunk(lint_context, chunk);
+                    self.scan_doc_chunk(chunk, &mut violations);
                 }
             }
             CommentSurface::PlainLine | CommentSurface::PlainBlock => {
                 if self.scan_regular_comments {
-                    self.scan_plain_chunk(lint_context, chunk);
+                    self.scan_plain_chunk(chunk, &mut violations);
                 }
             }
+        });
+        emit_at_enclosing_hir(lint_context.tcx, violations, |hir_id, span, violation| {
+            emit_diag(lint_context, hir_id, span, &violation);
         });
     }
 }
 
 impl BareUrl {
-    fn scan_doc_chunk(&self, lint_context: &EarlyContext<'_>, chunk: &CommentChunk<'_>) {
+    fn scan_doc_chunk(&self, chunk: &CommentChunk<'_>, out: &mut Vec<(Span, UrlViolation)>) {
         let skips = scan_skip_regions(&chunk.rendered);
-        self.scan(lint_context, chunk, &skips);
+        self.scan(chunk, &skips, out);
     }
 
-    fn scan_plain_chunk(&self, lint_context: &EarlyContext<'_>, chunk: &CommentChunk<'_>) {
+    fn scan_plain_chunk(&self, chunk: &CommentChunk<'_>, out: &mut Vec<(Span, UrlViolation)>) {
         // Plain comments aren't markdown, so no skip-region pass is
         // run; only the left-context guard inside [`Self::scan`]
         // (the `prev_byte` check against `<`, `[`, `(`, `"`, `'`,
         // `` ` ``, and word chars) applies.
-        self.scan(lint_context, chunk, &[]);
+        self.scan(chunk, &[], out);
     }
 
     fn scan(
         &self,
-        lint_context: &EarlyContext<'_>,
         chunk: &CommentChunk<'_>,
         skips: &[std::ops::Range<usize>],
+        out: &mut Vec<(Span, UrlViolation)>,
     ) {
         let text = &chunk.rendered;
         let bytes = text.as_bytes();
@@ -226,17 +237,17 @@ impl BareUrl {
                 index += url_match.consumed;
                 continue;
             }
-            self.emit(lint_context, chunk, index, url_match.url);
+            self.collect(chunk, index, url_match.url, out);
             index += url_match.consumed;
         }
     }
 
-    fn emit(
+    fn collect(
         &self,
-        lint_context: &EarlyContext<'_>,
         chunk: &CommentChunk<'_>,
         rendered_pos: usize,
         url: &str,
+        out: &mut Vec<(Span, UrlViolation)>,
     ) {
         let Some(span) = chunk.span_for(rendered_pos, url.len() as u32) else {
             return;
@@ -245,25 +256,36 @@ impl BareUrl {
             TrailingClass::Safe => Applicability::MachineApplicable,
             TrailingClass::Ambiguous => Applicability::MaybeIncorrect,
         };
-        let suggestion = format!("<{url}>");
-        emit_diag(lint_context, span, url, suggestion, applicability);
+        out.push((
+            span,
+            UrlViolation {
+                url: url.to_owned(),
+                applicability,
+            },
+        ));
     }
 }
 
 fn emit_diag(
-    lint_context: &EarlyContext<'_>,
+    lint_context: &LateContext<'_>,
+    hir_id: rustc_hir::HirId,
     span: Span,
-    url: &str,
-    suggestion: String,
-    applicability: Applicability,
+    violation: &UrlViolation,
 ) {
-    span_lint_and_sugg(
+    let UrlViolation { url, applicability } = violation;
+    span_lint_hir_and_then(
         lint_context,
         BARE_URL,
+        hir_id,
         span,
         format!("bare URL `{url}`; wrap in `<...>` or use a labelled markdown link"),
-        "wrap in `<...>` for portable autolink syntax",
-        suggestion,
-        applicability,
+        |diag| {
+            diag.span_suggestion(
+                span,
+                "wrap in `<...>` for portable autolink syntax",
+                format!("<{url}>"),
+                *applicability,
+            );
+        },
     );
 }

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -1,12 +1,12 @@
-use rustc_ast::Crate;
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
-use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
+use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::def_id::LOCAL_CRATE;
 use rustc_span::{BytePos, Pos, RelativeBytePos, SourceFile, Span, SyntaxContext};
 
 use crate::common::{DefaultState, resolved_state};
-use crate::literal_scan::emit_flagged_chars;
+use crate::enclosing_hir::emit_at_enclosing_hir;
+use crate::literal_scan::emit_flagged_char_hir;
 
 declare_tool_lint! {
     /// ### What it does
@@ -96,15 +96,16 @@ pub fn register_pass(lint_store: &mut LintStore) {
     {
         return;
     }
-    lint_store.register_early_pass(|| Box::new(UnicodeEllipsisInComments::new()));
+    lint_store.register_late_pass(|_| Box::new(UnicodeEllipsisInComments::new()));
 }
 
-impl EarlyLintPass for UnicodeEllipsisInComments {
-    fn check_crate(&mut self, lint_context: &EarlyContext<'_>, _: &Crate) {
-        let source_map = lint_context.sess().source_map();
+impl<'tcx> LateLintPass<'tcx> for UnicodeEllipsisInComments {
+    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
         if !(self.scan_line_comments || self.scan_block_comments) {
             return;
         }
+        let source_map = lint_context.sess().source_map();
+        let mut violations: Vec<(Span, char)> = Vec::new();
         for source_file in source_map.files().iter() {
             if source_file.cnum != LOCAL_CRATE {
                 continue;
@@ -127,37 +128,46 @@ impl EarlyLintPass for UnicodeEllipsisInComments {
                         .checked_add(token_len)
                         .expect("source-file offset overflowed u32");
                     let comment = &source_text[offset as usize..end as usize];
-                    self.scan_comment(lint_context, source_file, offset, comment);
+                    self.collect_comment(source_file, offset, comment, &mut violations);
                 }
                 offset = offset
                     .checked_add(token_len)
                     .expect("source-file offset overflowed u32");
             }
         }
+        emit_at_enclosing_hir(lint_context.tcx, violations, |hir_id, span, character| {
+            emit_flagged_char_hir(
+                lint_context,
+                UNICODE_ELLIPSIS_IN_COMMENTS,
+                hir_id,
+                character,
+                span,
+                "comment",
+            );
+        });
     }
 }
 
 impl UnicodeEllipsisInComments {
-    fn scan_comment(
+    fn collect_comment(
         &self,
-        lint_context: &EarlyContext<'_>,
         source_file: &SourceFile,
         comment_offset: u32,
         comment: &str,
+        out: &mut Vec<(Span, char)>,
     ) {
-        emit_flagged_chars(
-            lint_context,
-            UNICODE_ELLIPSIS_IN_COMMENTS,
-            comment,
-            &self.flagged_chars,
-            "comment",
-            |byte_index, char_len| {
-                let span_start = source_file.absolute_position(RelativeBytePos::from_u32(
-                    comment_offset + byte_index as u32,
-                ));
-                let span_end = BytePos::from_u32(span_start.0 + char_len);
-                Span::new(span_start, span_end, SyntaxContext::root(), None)
-            },
-        );
+        for (byte_index, character) in comment.char_indices() {
+            if !self.flagged_chars.contains(&character) {
+                continue;
+            }
+            let span_start = source_file.absolute_position(RelativeBytePos::from_u32(
+                comment_offset + byte_index as u32,
+            ));
+            let span_end = BytePos::from_u32(span_start.0 + character.len_utf8() as u32);
+            out.push((
+                Span::new(span_start, span_end, SyntaxContext::root(), None),
+                character,
+            ));
+        }
     }
 }

--- a/src/rules/unicode_ellipsis_in_docs.rs
+++ b/src/rules/unicode_ellipsis_in_docs.rs
@@ -1,10 +1,11 @@
-use rustc_ast::Crate;
-use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
+use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
+use rustc_span::Span;
 
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
-use crate::literal_scan::emit_flagged_char;
+use crate::enclosing_hir::emit_at_enclosing_hir;
+use crate::literal_scan::emit_flagged_char_hir;
 use crate::markdown::{position_in_skip, scan_code_regions};
 
 declare_tool_lint! {
@@ -91,22 +92,33 @@ pub fn register_pass(lint_store: &mut LintStore) {
     {
         return;
     }
-    lint_store.register_early_pass(|| Box::new(UnicodeEllipsisInDocs::new()));
+    lint_store.register_late_pass(|_| Box::new(UnicodeEllipsisInDocs::new()));
 }
 
-impl EarlyLintPass for UnicodeEllipsisInDocs {
-    fn check_crate(&mut self, lint_context: &EarlyContext<'_>, _: &Crate) {
-        walk_local_comments(lint_context, |chunk| match chunk.surface {
+impl<'tcx> LateLintPass<'tcx> for UnicodeEllipsisInDocs {
+    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
+        let mut violations: Vec<(Span, char)> = Vec::new();
+        walk_local_comments(lint_context.sess(), |chunk| match chunk.surface {
             CommentSurface::DocBlock | CommentSurface::DocBlockBlock => {
-                self.scan_doc_chunk(lint_context, chunk);
+                self.collect_doc_chunk(chunk, &mut violations);
             }
             CommentSurface::PlainLine | CommentSurface::PlainBlock => {}
+        });
+        emit_at_enclosing_hir(lint_context.tcx, violations, |hir_id, span, character| {
+            emit_flagged_char_hir(
+                lint_context,
+                UNICODE_ELLIPSIS_IN_DOCS,
+                hir_id,
+                character,
+                span,
+                "doc comment",
+            );
         });
     }
 }
 
 impl UnicodeEllipsisInDocs {
-    fn scan_doc_chunk(&self, lint_context: &EarlyContext<'_>, chunk: &CommentChunk<'_>) {
+    fn collect_doc_chunk(&self, chunk: &CommentChunk<'_>, out: &mut Vec<(Span, char)>) {
         // Code spans join the skip mask unless the user opts into
         // scanning them; code blocks are always masked.
         let skips = scan_code_regions(&chunk.rendered, !self.scan_code_spans);
@@ -123,13 +135,7 @@ impl UnicodeEllipsisInDocs {
             let Some(span) = chunk.span_for(byte_offset, character.len_utf8() as u32) else {
                 continue;
             };
-            emit_flagged_char(
-                lint_context,
-                UNICODE_ELLIPSIS_IN_DOCS,
-                character,
-                span,
-                "doc comment",
-            );
+            out.push((span, character));
         }
     }
 }

--- a/tests/bare_email.rs
+++ b/tests/bare_email.rs
@@ -63,3 +63,14 @@ fn mailto_style_emits_single_mailto_suggestion() {
         },
     );
 }
+
+/// Regression test for
+/// <https://github.com/KSXGitHub/perfectionist/issues/165>: a per-item
+/// `#[expect]` on the documented item both suppresses the bare-email
+/// finding in its doc comment and is fulfilled by it. The fixture
+/// produces no diagnostics; before the fix the finding resolved to the
+/// crate root, firing anyway and leaving the expectation unfulfilled.
+#[test]
+fn per_item_expect_fulfils_and_suppresses() {
+    run("ui-toml/bare_email/expect_at_item", RuleConfig::default());
+}

--- a/tests/bare_issue_reference.rs
+++ b/tests/bare_issue_reference.rs
@@ -197,3 +197,17 @@ fn reference_form_skips_existing_definition() {
         }),
     );
 }
+
+/// Regression test for
+/// <https://github.com/KSXGitHub/perfectionist/issues/165>: a per-item
+/// `#[expect]` on the documented item both suppresses the bare `#NNN`
+/// finding in its doc comment and is fulfilled by it. The fixture
+/// produces no diagnostics; before the fix the finding resolved to the
+/// crate root, firing anyway and leaving the expectation unfulfilled.
+#[test]
+fn per_item_expect_fulfils_and_suppresses() {
+    run(
+        "ui-toml/bare_issue_reference/expect_at_item",
+        RuleConfig::default(),
+    );
+}

--- a/tests/bare_url.rs
+++ b/tests/bare_url.rs
@@ -59,3 +59,14 @@ fn custom_skip_hosts_replaces_the_default_list() {
         },
     );
 }
+
+/// Regression test for
+/// <https://github.com/KSXGitHub/perfectionist/issues/165>: a per-item
+/// `#[expect]` on the documented item both suppresses the bare-URL
+/// finding in its doc comment and is fulfilled by it. The fixture
+/// produces no diagnostics; before the fix the finding resolved to the
+/// crate root, firing anyway and leaving the expectation unfulfilled.
+#[test]
+fn per_item_expect_fulfils_and_suppresses() {
+    run("ui-toml/bare_url/expect_at_item", RuleConfig::default());
+}

--- a/tests/unicode_ellipsis_in_comments.rs
+++ b/tests/unicode_ellipsis_in_comments.rs
@@ -69,3 +69,18 @@ fn scan_block_only() {
         },
     );
 }
+
+/// Regression test for
+/// <https://github.com/KSXGitHub/perfectionist/issues/165>: a plain
+/// `//` comment anchors at the function body that lexically contains
+/// it, so a `#[expect]` on the enclosing function both suppresses the
+/// finding and is fulfilled by it. The fixture produces no diagnostics;
+/// before the fix every finding resolved to the crate root, firing
+/// anyway and leaving the expectation unfulfilled.
+#[test]
+fn per_item_expect_fulfils_and_suppresses() {
+    run(
+        "ui-toml/unicode_ellipsis_in_comments/expect_at_item",
+        r#"["perfectionist::unicode_ellipsis_in_comments"]"#,
+    );
+}

--- a/tests/unicode_ellipsis_in_docs.rs
+++ b/tests/unicode_ellipsis_in_docs.rs
@@ -82,3 +82,28 @@ fn docs_rule_does_not_intrude_into_regular_comments() {
         },
     );
 }
+
+/// Regression test for
+/// <https://github.com/KSXGitHub/perfectionist/issues/165>: a per-item
+/// / per-module `#[expect]` both suppresses the doc-comment finding and
+/// is fulfilled by it. The fixture produces no diagnostics; before the
+/// fix it emitted the finding *and* an `unfulfilled_lint_expectations`.
+#[test]
+fn per_item_expect_fulfils_and_suppresses() {
+    run(
+        "ui-toml/unicode_ellipsis_in_docs/expect_at_item",
+        &dylint_toml(RuleConfig::default()),
+    );
+}
+
+/// Companion to [`per_item_expect_fulfils_and_suppresses`]: a per-item
+/// `#[allow]` silences only that item's doc comment, while a sibling
+/// item with no attribute still fires — so per-site control no longer
+/// requires a crate-root `#![allow]` that exempts every doc comment.
+#[test]
+fn per_item_allow_suppresses_only_that_item() {
+    run(
+        "ui-toml/unicode_ellipsis_in_docs/allow_at_item",
+        &dylint_toml(RuleConfig::default()),
+    );
+}

--- a/ui-toml/bare_email/expect_at_item/fixture.rs
+++ b/ui-toml/bare_email/expect_at_item/fixture.rs
@@ -1,0 +1,21 @@
+// Regression for
+// <https://github.com/KSXGitHub/perfectionist/issues/165>: a per-item
+// `#[expect]` on the documented item both suppresses the bare-email
+// finding in its doc comment and is fulfilled by it. The fixture
+// produces no diagnostics; before the fix the finding resolved to the
+// crate root, so it fired anyway and the expectation went unfulfilled.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+
+#[cfg_attr(
+    dylint_lib = "perfectionist",
+    expect(
+        perfectionist::bare_email,
+        reason = "the address is shown verbatim on purpose"
+    )
+)]
+/// Report security issues to security@example.com.
+pub fn documented() {}
+
+fn main() {}

--- a/ui-toml/bare_issue_reference/expect_at_item/fixture.rs
+++ b/ui-toml/bare_issue_reference/expect_at_item/fixture.rs
@@ -1,0 +1,21 @@
+// Regression for
+// <https://github.com/KSXGitHub/perfectionist/issues/165>: a per-item
+// `#[expect]` on the documented item both suppresses the bare `#NNN`
+// finding in its doc comment and is fulfilled by it. The fixture
+// produces no diagnostics; before the fix the finding resolved to the
+// crate root, so it fired anyway and the expectation went unfulfilled.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+
+#[cfg_attr(
+    dylint_lib = "perfectionist",
+    expect(
+        perfectionist::bare_issue_reference,
+        reason = "the reference is written bare on purpose"
+    )
+)]
+/// Closes #123 and supersedes #124.
+pub fn documented() {}
+
+fn main() {}

--- a/ui-toml/bare_url/expect_at_item/fixture.rs
+++ b/ui-toml/bare_url/expect_at_item/fixture.rs
@@ -1,0 +1,21 @@
+// Regression for
+// <https://github.com/KSXGitHub/perfectionist/issues/165>: a per-item
+// `#[expect]` on the documented item both suppresses the bare-URL
+// finding in its doc comment and is fulfilled by it. The fixture
+// produces no diagnostics; before the fix the finding resolved to the
+// crate root, so it fired anyway and the expectation went unfulfilled.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+
+#[cfg_attr(
+    dylint_lib = "perfectionist",
+    expect(
+        perfectionist::bare_url,
+        reason = "the URL is shown verbatim on purpose"
+    )
+)]
+/// See https://example.com/path for details.
+pub fn documented() {}
+
+fn main() {}

--- a/ui-toml/unicode_ellipsis_in_comments/expect_at_item/fixture.rs
+++ b/ui-toml/unicode_ellipsis_in_comments/expect_at_item/fixture.rs
@@ -1,0 +1,26 @@
+// Regression for
+// <https://github.com/KSXGitHub/perfectionist/issues/165>: a plain
+// `//` comment is not an attribute, so it anchors at the deepest HIR
+// node whose body span contains it — here the function body — and a
+// `#[expect]` on the enclosing function both suppresses the finding
+// and is fulfilled by it. The fixture produces no diagnostics; before
+// the fix every finding resolved to the crate root.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+
+#[cfg_attr(
+    dylint_lib = "perfectionist",
+    expect(
+        perfectionist::unicode_ellipsis_in_comments,
+        reason = "the comment names the ellipsis glyph on purpose"
+    )
+)]
+fn documented() {
+    // A plain comment naming the ellipsis … on purpose.
+    let _ = 1;
+}
+
+fn main() {
+    documented();
+}

--- a/ui-toml/unicode_ellipsis_in_docs/allow_at_item/fixture.rs
+++ b/ui-toml/unicode_ellipsis_in_docs/allow_at_item/fixture.rs
@@ -1,0 +1,23 @@
+// A per-item `#[allow]` suppresses only that item's doc-comment
+// finding; a sibling item with no attribute still fires. This pins the
+// fix for <https://github.com/KSXGitHub/perfectionist/issues/165>: the
+// level now resolves at the comment's enclosing item, not the crate
+// root, so per-site control works without exempting the whole crate.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+
+#[cfg_attr(
+    dylint_lib = "perfectionist",
+    allow(
+        perfectionist::unicode_ellipsis_in_docs,
+        reason = "documents the ellipsis glyph on purpose"
+    )
+)]
+/// Allowed here, so this ellipsis … is not flagged.
+pub fn allowed() {}
+
+/// But this ellipsis … is still flagged.
+pub fn flagged() {}
+
+fn main() {}

--- a/ui-toml/unicode_ellipsis_in_docs/allow_at_item/fixture.stderr
+++ b/ui-toml/unicode_ellipsis_in_docs/allow_at_item/fixture.stderr
@@ -1,0 +1,10 @@
+warning: Unicode `…` (U+2026) in doc comment
+  --> $DIR/fixture.rs:20:23
+   |
+LL | /// But this ellipsis … is still flagged.
+   |                       ^ help: use ASCII `...` instead: `...`
+   |
+   = note: `#[warn(perfectionist::unicode_ellipsis_in_docs)]` on by default
+
+warning: 1 warning emitted
+

--- a/ui-toml/unicode_ellipsis_in_docs/expect_at_item/fixture.rs
+++ b/ui-toml/unicode_ellipsis_in_docs/expect_at_item/fixture.rs
@@ -1,0 +1,35 @@
+// A per-item `#[expect]` must both suppress the doc-comment finding
+// and be fulfilled by it. The regression in
+// <https://github.com/KSXGitHub/perfectionist/issues/165> anchored
+// every comment-scanned finding at the crate root, so a per-item
+// attribute was ignored: the finding still fired *and* the
+// expectation was additionally reported as unfulfilled. With the
+// finding now emitted at the comment's enclosing HIR node, this
+// fixture produces no diagnostics at all.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+
+#[cfg_attr(
+    dylint_lib = "perfectionist",
+    expect(
+        perfectionist::unicode_ellipsis_in_docs,
+        reason = "documents the ellipsis glyph on purpose"
+    )
+)]
+/// Mentions the ellipsis … on purpose.
+pub fn documented() {}
+
+mod inner {
+    #![cfg_attr(
+        dylint_lib = "perfectionist",
+        expect(
+            perfectionist::unicode_ellipsis_in_docs,
+            reason = "module-scope expect must fulfil too"
+        )
+    )]
+
+    //! Inner module doc comment with an ellipsis … is suppressed here.
+}
+
+fn main() {}

--- a/ui/auxiliary/proc_macro_synth_binding.rs
+++ b/ui/auxiliary/proc_macro_synth_binding.rs
@@ -271,6 +271,51 @@ pub fn synth_const_generic(input: TokenStream) -> TokenStream {
     wrap_const_block(body)
 }
 
+/// `#[derive(SynthFieldRefBody)]` → emits
+/// `const _: () = { let _ = (); };` whose `let _ = ();` statement is
+/// spanned over the derived type's body `{ ... }` — the span that
+/// covers its field / variant doc comments. The `const _` wrapper is
+/// anonymous, so the derive can be applied to several types in one
+/// crate without name collisions.
+///
+/// This mimics how a real proc-macro derive such as
+/// `serde::Deserialize` lays out its generated `visit_map` / `visit_seq`
+/// bodies: a root-context HIR node whose span spans the whole field
+/// list, lowered *after* the struct itself. The comment-anchor finder
+/// must keep the documented field/variant as the anchor (the tightest
+/// containing node) rather than letting this wider, later-visited
+/// generated node steal it — the bug reported in issue #165's
+/// follow-up. Built-in derives (`Debug`, `Default`, ...) don't produce
+/// such a node, which is why they don't reproduce it.
+#[proc_macro_derive(SynthFieldRefBody)]
+pub fn synth_field_ref_body(input: TokenStream) -> TokenStream {
+    // The body `{ ... }` group span covers the field / variant doc
+    // comments inside it.
+    let body_span = input
+        .into_iter()
+        .find_map(|tree| match tree {
+            TokenTree::Group(group) if group.delimiter() == Delimiter::Brace => Some(group.span()),
+            _ => None,
+        })
+        .unwrap_or_else(Span::call_site);
+    let at_body = |mut tree: TokenTree| {
+        tree.set_span(body_span);
+        tree
+    };
+    let mut body = TokenStream::new();
+    body.extend([
+        at_body(TokenTree::Ident(Ident::new("let", body_span))),
+        at_body(TokenTree::Ident(Ident::new("_", body_span))),
+        at_body(TokenTree::Punct(Punct::new('=', Spacing::Alone))),
+        at_body(TokenTree::Group(Group::new(
+            Delimiter::Parenthesis,
+            TokenStream::new(),
+        ))),
+        at_body(TokenTree::Punct(Punct::new(';', Spacing::Alone))),
+    ]);
+    wrap_const_block(body)
+}
+
 fn wrap_const_block(body: TokenStream) -> TokenStream {
     let call_site = Span::call_site();
     let mut out = TokenStream::new();

--- a/ui/unicode_ellipsis_in_docs_macro_generated.rs
+++ b/ui/unicode_ellipsis_in_docs_macro_generated.rs
@@ -1,0 +1,40 @@
+// Regression test for
+// <https://github.com/KSXGitHub/perfectionist/pull/166#issuecomment-4562112957>:
+// a per-site `#[expect]` forwarded through a `macro_rules!` onto a
+// generated item (the shape `declare_tool_lint!` uses for every lint in
+// this crate) must still resolve. The forwarded `#[doc]` lands on the
+// generated item with a macro-expansion-context span that does not
+// byte-match the root-context comment the walker scans, so the
+// comment-anchor finder must resolve macro hygiene before comparing
+// spans — otherwise the finding falls back to crate-root resolution and
+// the item-level `#[expect]` neither suppresses nor is fulfilled.
+//
+// This fixture produces no diagnostics. The forwarded `#[expect]` is
+// captured by `$(#[$attr:meta])*` and lands on the generated item
+// alongside the `#[doc]`, so it resolves on the same node the finding
+// anchors to.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+#![allow(dead_code, reason = "ui fixture")]
+
+macro_rules! declare_with_docs {
+    ($(#[$attr:meta])* $name:ident) => {
+        $(#[$attr])*
+        pub struct $name;
+    };
+}
+
+declare_with_docs! {
+    #[cfg_attr(
+        dylint_lib = "perfectionist",
+        expect(
+            perfectionist::unicode_ellipsis_in_docs,
+            reason = "documents the ellipsis glyph on purpose"
+        )
+    )]
+    /// Generated item doc comment with an ellipsis … on purpose.
+    Generated
+}
+
+fn main() {}

--- a/ui/unicode_ellipsis_in_docs_proc_macro.rs
+++ b/ui/unicode_ellipsis_in_docs_proc_macro.rs
@@ -1,0 +1,53 @@
+// aux-build:proc_macro_synth_binding.rs
+
+// Regression test for
+// <https://github.com/KSXGitHub/perfectionist/pull/166#issuecomment-4557181827>:
+// a per-field / per-variant `#[expect(perfectionist::unicode_ellipsis_in_docs)]`
+// must be honored even when the field's / variant's enclosing type
+// carries a proc-macro `#[derive(...)]`. A custom derive routes the
+// type's tokens through a proc-macro, giving the field/variant
+// doc-comment spans a proc-macro expansion context; the comment-anchor
+// finder must still resolve each finding to the documented field /
+// variant so the `#[expect]` both suppresses it and is fulfilled.
+//
+// This fixture produces no diagnostics. Before the fix the findings
+// resolved to a coarser node, so they fired anyway and the
+// expectations were reported unfulfilled. Every Config in this crate
+// derives `serde::Deserialize` and documents its fields with an
+// intentional ellipsis, so this is the crate's own primary use case.
+
+#![feature(register_tool)]
+#![cfg_attr(dylint_lib = "perfectionist", register_tool(perfectionist))]
+#![allow(dead_code, reason = "ui fixture")]
+
+extern crate proc_macro_synth_binding;
+
+use proc_macro_synth_binding::SynthFieldRefBody;
+
+#[derive(SynthFieldRefBody)]
+struct DerivedStruct {
+    #[cfg_attr(
+        dylint_lib = "perfectionist",
+        expect(
+            perfectionist::unicode_ellipsis_in_docs,
+            reason = "documents the ellipsis glyph on purpose"
+        )
+    )]
+    /// Field doc comment with an ellipsis … on purpose.
+    field: u32,
+}
+
+#[derive(SynthFieldRefBody)]
+enum DerivedEnum {
+    #[cfg_attr(
+        dylint_lib = "perfectionist",
+        expect(
+            perfectionist::unicode_ellipsis_in_docs,
+            reason = "documents the ellipsis glyph on purpose"
+        )
+    )]
+    /// Variant doc comment with an ellipsis … on purpose.
+    Variant,
+}
+
+fn main() {}


### PR DESCRIPTION
The comment-walking lints (`unicode_ellipsis_in_docs`, `unicode_ellipsis_in_comments`, `bare_url`, `bare_email`, `bare_issue_reference`) ran in `EarlyLintPass::check_crate` and emitted at parent-less spans, so every finding resolved to the **crate-root** lint level. A per-item / per-field / per-module `#[allow]` / `#[expect]` was ignored — the finding still fired, and an `#[expect]` was additionally reported as unfulfilled. Only a crate-root `#[allow/expect]` worked.

## Fix

- Each rule is now a late pass that scans the same comment surfaces, parks the findings, and emits them through `span_lint_hir_and_then` at the comment's enclosing HIR node.
- A new attribute-aware HIR finder folds each documentable node's `#[doc]` attribute spans (what `///` / `//!` / `/** */` lower to) into a hygiene-resolving containment test, and resolves each comment to the **tightest** enclosing node (measured at the source level). This combination handles two awkward shapes:
  - A proc-macro `#[derive(...)]` (e.g. `serde::Deserialize`) generates root-context `visit_map` / `visit_seq` bodies spanning the whole field list; the tightest-node tie-break keeps the documented field/variant rather than letting those wider generated nodes steal the anchor.
  - A `///` forwarded through a `macro_rules!` onto a generated item (the shape `declare_tool_lint!` uses for every lint here) lands with a macro-expansion-context span; `source_callsite` resolution matches it to the generated item so a per-site `#[expect]` there resolves.
  - The macro-call path (`find_enclosing_hir_ids`) is unchanged.
- `walk_local_comments` now takes `&Session` so it runs from a late pass.

Regression fixtures cover per-item / per-module `#[expect]` and per-item `#[allow]` for all five rules, a per-field and per-variant `#[expect]` inside a proc-macro-derived type, and a per-site `#[expect]` on a `macro_rules!`-generated item's doc comment. `just all` passes (fmt, build, doc, lint, test, self-lint).

Resolves <https://github.com/KSXGitHub/perfectionist/issues/165>.