### PR TITLE
feat(macro-argument-binding): exempt `assert_op_expr` by default

### DIFF
--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -447,7 +447,7 @@ group.
 The third part collects third-party macros whose matchers are
 known to evaluate every top-level argument exactly once before
 forwarding it, so the rule's once-vs.-zero hazard does not apply.
-The current entries cover four crates; the group is open-ended
+The current entries cover five crates; the group is open-ended
 and further crates can be added as their matchers are vetted.
 
 - The `insta` snapshot-assertion family: `assert_snapshot!`,
@@ -464,6 +464,12 @@ and further crates can be added as their matchers are vetted.
   captured expression once; `ensure!(cond, args)` matches the
   conditional-arguments shape of `assert!(cond, args)` already
   on group 1.
+- `assert_cmp::assert_op_expr!($left, $op, $right)`. It expands to
+  `match ($left, $right) { (left, right) => assert!(left $op right,
+  ...) }`, moving each operand into the scrutinee tuple exactly
+  once. The sibling `assert_op!` takes only idents / literals and
+  so never carries an impure argument; the `debug_*` variants are
+  omitted because they compile to nothing in release builds.
 - The `maplit::{hashmap, btreemap, hashset, btreeset}!` builders.
   Each expands to one `.insert` call per key/value pair, so every
   captured expression is evaluated exactly once.

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -100,6 +100,16 @@ const BUILTIN_ALLOW: &[&str] = &[
     //   and evaluates each captured expression once; `ensure!(cond,
     //   args)` matches the shape of `assert!(cond, args)` already on
     //   group 1 — `cond` always evaluates, `args` only on failure.
+    // - `assert_cmp::assert_op_expr` asserts a binary comparison
+    //   of two expressions. It expands to `match ($left, $right)
+    //   { (left, right) => assert!(left $op right, ...) }`, moving
+    //   each operand into the scrutinee tuple exactly once (the
+    //   `stringify!` uses are compile-time only). The sibling
+    //   `assert_op!(a $op b)` takes only idents / literals, so it
+    //   never carries an impure argument and needs no entry; the
+    //   `debug_*` variants are deliberately omitted because they
+    //   compile to nothing in release builds (the same conditional-
+    //   evaluation hazard as `debug_assert!`).
     // - `insta`'s snapshot-assertion family. Each variant
     //   evaluates its value argument exactly once before
     //   serialising; `assert_display_snapshot` is deprecated
@@ -130,6 +140,7 @@ const BUILTIN_ALLOW: &[&str] = &[
     "assert_debug_snapshot",
     "assert_display_snapshot",
     "assert_json_snapshot",
+    "assert_op_expr",
     "assert_ron_snapshot",
     "assert_snapshot",
     "assert_toml_snapshot",


### PR DESCRIPTION
`assert_op_expr!($left, $op, $right)` moves each operand into a `match` scrutinee tuple exactly once, so it honors the once-only contract the built-in allow set requires. Add it to the curated allow list and document the assert-cmp crate in both the source commentary and the planning file's third-party allow group.

https://claude.ai/code/session_01XQKzRJUQTx6xqmCmt2u3qf