### PR TITLE
fix(lint-silence-reason): don't flag proc-macro-generated suppressions

### DIFF
--- a/src/rules/lint_silence_reason.rs
+++ b/src/rules/lint_silence_reason.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
+use clippy_utils::is_from_proc_macro;
 use rustc_ast::{Attribute, LitKind, MetaItem, MetaItemInner, MetaItemKind};
 use rustc_errors::Applicability;
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
@@ -119,6 +120,21 @@ impl EarlyLintPass for LintSilenceReason {
     /// attribute exactly once: bare `#[allow]` / `#[expect]` through
     /// the first branch, `cfg_attr`-wrapped through the second.
     fn check_attribute(&mut self, lint_context: &EarlyContext<'_>, attribute: &Attribute) {
+        // Attributes synthesized by a derive / proc-macro expansion are
+        // not hand-written suppressions, so the author has no place to
+        // add a `reason`. Neither of rustc's usual filters catches them:
+        // macros such as `clap_derive` stamp the generated `#[allow(...)]`
+        // with the *call-site* span of a user `#[clap(...)]` attribute, so
+        // the span carries the root syntax context (`from_expansion` is
+        // `false`) and points at real source (`in_external_macro`, and
+        // hence `report_in_external_macro: false`, reports it as local).
+        // The tell is that the source text under the span reads
+        // `#[clap(...)]`, not `#[allow(...)]`; `is_from_proc_macro`
+        // compares the attribute's name against that text and flags the
+        // mismatch.
+        if is_from_proc_macro(lint_context, attribute) {
+            return;
+        }
         if is_silencing_attribute_name(attribute.name()) {
             if let Some(args) = attribute.meta_item_list() {
                 self.check_silencing(lint_context, attribute.span, &args);

--- a/src/rules/lint_silence_reason.rs
+++ b/src/rules/lint_silence_reason.rs
@@ -117,29 +117,21 @@ impl EarlyLintPass for LintSilenceReason {
     /// `EarlyLintPass::check_attribute` runs once per syntactic
     /// attribute in source — `cfg_attr` is not unwrapped before the
     /// callback. The walker below therefore reaches every silencing
-    /// attribute exactly once: bare `#[allow]` / `#[expect]` through
-    /// the first branch, `cfg_attr`-wrapped through the second.
+    /// attribute exactly once: bare `#[allow]` / `#[expect]` directly,
+    /// `cfg_attr`-wrapped ones via `walk_cfg_attr_inner`.
     fn check_attribute(&mut self, lint_context: &EarlyContext<'_>, attribute: &Attribute) {
-        // Attributes synthesized by a derive / proc-macro expansion are
-        // not hand-written suppressions, so the author has no place to
-        // add a `reason`. Neither of rustc's usual filters catches them:
-        // macros such as `clap_derive` stamp the generated `#[allow(...)]`
-        // with the *call-site* span of a user `#[clap(...)]` attribute, so
-        // the span carries the root syntax context (`from_expansion` is
-        // `false`) and points at real source (`in_external_macro`, and
-        // hence `report_in_external_macro: false`, reports it as local).
-        // The tell is that the source text under the span reads
-        // `#[clap(...)]`, not `#[allow(...)]`; `is_from_proc_macro`
-        // compares the attribute's name against that text and flags the
-        // mismatch.
+        let is_silencing = is_silencing_attribute_name(attribute.name());
+        if !is_silencing && !attribute.has_name(sym::cfg_attr) {
+            return;
+        }
         if is_from_proc_macro(lint_context, attribute) {
             return;
         }
-        if is_silencing_attribute_name(attribute.name()) {
+        if is_silencing {
             if let Some(args) = attribute.meta_item_list() {
                 self.check_silencing(lint_context, attribute.span, &args);
             }
-        } else if attribute.has_name(sym::cfg_attr) {
+        } else {
             let Some(cfg_attr_args) = attribute.meta_item_list() else {
                 return;
             };

--- a/ui/auxiliary/proc_macro_synth_binding.rs
+++ b/ui/auxiliary/proc_macro_synth_binding.rs
@@ -316,6 +316,53 @@ pub fn synth_field_ref_body(input: TokenStream) -> TokenStream {
     wrap_const_block(body)
 }
 
+/// `#[derive(SynthSilenceReason)]` + `#[synth_silence_reason]` →
+/// `#[allow(dead_code)] fn _synth_silence_reason() {}` where the
+/// synthesised `#[allow(dead_code)]` attribute inherits the user-span
+/// of `synth_silence_reason` rather than a call-site span. This is the
+/// exact shape `clap_derive` produces for its generated `#[allow(...)]`
+/// attributes (see <https://github.com/KSXGitHub/parallel-disk-usage/issues/430>):
+/// the attribute carries a root-context user span, so neither
+/// `Span::from_expansion` nor `report_in_external_macro: false` filters
+/// it. `lint_silence_reason` must instead notice that the source text
+/// under the span reads `#[synth_silence_reason]`, not `#[allow(...)]`,
+/// and stay quiet.
+#[proc_macro_derive(SynthSilenceReason, attributes(synth_silence_reason))]
+pub fn synth_silence_reason(input: TokenStream) -> TokenStream {
+    let attr_span = find_attr_span(input, "synth_silence_reason")
+        .expect("`#[derive(SynthSilenceReason)]` requires a `#[synth_silence_reason]`");
+    let call_site = Span::call_site();
+
+    // `allow(dead_code)`, every token stamped with the user span so the
+    // generated attribute looks (to span-based filters) like it was
+    // hand-written at the `#[synth_silence_reason]` site.
+    let at_attr = |mut tree: TokenTree| {
+        tree.set_span(attr_span);
+        tree
+    };
+    let mut allow_args = TokenStream::new();
+    allow_args.extend([at_attr(TokenTree::Ident(Ident::new("dead_code", attr_span)))]);
+    let mut attr_inner = TokenStream::new();
+    attr_inner.extend([
+        at_attr(TokenTree::Ident(Ident::new("allow", attr_span))),
+        at_attr(TokenTree::Group(Group::new(
+            Delimiter::Parenthesis,
+            allow_args,
+        ))),
+    ]);
+
+    let mut out = TokenStream::new();
+    out.extend([
+        at_attr(TokenTree::Punct(Punct::new('#', Spacing::Alone))),
+        at_attr(TokenTree::Group(Group::new(Delimiter::Bracket, attr_inner))),
+        TokenTree::Ident(Ident::new("fn", call_site)),
+        TokenTree::Ident(Ident::new("_synth_silence_reason", call_site)),
+        TokenTree::Group(Group::new(Delimiter::Parenthesis, TokenStream::new())),
+        TokenTree::Group(Group::new(Delimiter::Brace, TokenStream::new())),
+    ]);
+    out
+}
+
 fn wrap_const_block(body: TokenStream) -> TokenStream {
     let call_site = Span::call_site();
     let mut out = TokenStream::new();

--- a/ui/auxiliary/proc_macro_synth_binding.rs
+++ b/ui/auxiliary/proc_macro_synth_binding.rs
@@ -317,16 +317,11 @@ pub fn synth_field_ref_body(input: TokenStream) -> TokenStream {
 }
 
 /// `#[derive(SynthSilenceReason)]` + `#[synth_silence_reason]` →
-/// `#[allow(dead_code)] fn _synth_silence_reason() {}` where the
-/// synthesised `#[allow(dead_code)]` attribute inherits the user-span
-/// of `synth_silence_reason` rather than a call-site span. This is the
-/// exact shape `clap_derive` produces for its generated `#[allow(...)]`
-/// attributes (see <https://github.com/KSXGitHub/parallel-disk-usage/issues/430>):
-/// the attribute carries a root-context user span, so neither
-/// `Span::from_expansion` nor `report_in_external_macro: false` filters
-/// it. `lint_silence_reason` must instead notice that the source text
-/// under the span reads `#[synth_silence_reason]`, not `#[allow(...)]`,
-/// and stay quiet.
+/// `#[allow(dead_code)] const _: () = ();` whose generated `#[allow]`
+/// inherits the user-span of `synth_silence_reason`, mirroring the
+/// `#[allow(...)]` shape `clap_derive` emits (issue #430). The anchor is
+/// an anonymous `const _` so the derive can be applied to several types
+/// in one crate without colliding.
 #[proc_macro_derive(SynthSilenceReason, attributes(synth_silence_reason))]
 pub fn synth_silence_reason(input: TokenStream) -> TokenStream {
     let attr_span = find_attr_span(input, "synth_silence_reason")
@@ -355,10 +350,13 @@ pub fn synth_silence_reason(input: TokenStream) -> TokenStream {
     out.extend([
         at_attr(TokenTree::Punct(Punct::new('#', Spacing::Alone))),
         at_attr(TokenTree::Group(Group::new(Delimiter::Bracket, attr_inner))),
-        TokenTree::Ident(Ident::new("fn", call_site)),
-        TokenTree::Ident(Ident::new("_synth_silence_reason", call_site)),
+        TokenTree::Ident(Ident::new("const", call_site)),
+        TokenTree::Ident(Ident::new("_", call_site)),
+        TokenTree::Punct(Punct::new(':', Spacing::Alone)),
         TokenTree::Group(Group::new(Delimiter::Parenthesis, TokenStream::new())),
-        TokenTree::Group(Group::new(Delimiter::Brace, TokenStream::new())),
+        TokenTree::Punct(Punct::new('=', Spacing::Alone)),
+        TokenTree::Group(Group::new(Delimiter::Parenthesis, TokenStream::new())),
+        TokenTree::Punct(Punct::new(';', Spacing::Alone)),
     ]);
     out
 }

--- a/ui/lint_silence_reason_proc_macro.rs
+++ b/ui/lint_silence_reason_proc_macro.rs
@@ -1,0 +1,22 @@
+// aux-build:proc_macro_synth_binding.rs
+
+// Regression test: `lint_silence_reason` must not fire on an
+// `#[allow(dead_code)]` attribute synthesised by a proc-macro derive
+// whose expansion attaches a user-source span to the attribute.
+// Mirrors `clap_derive`'s generated `#[allow(...)]` shape, which
+// carries the call-site span of a user `#[clap(...)]` attribute and so
+// slips past both `Span::from_expansion` and the rule's
+// `report_in_external_macro: false` filter.
+// See <https://github.com/KSXGitHub/parallel-disk-usage/issues/430>.
+
+#![allow(dead_code, unused_variables, reason = "ui fixture")]
+
+extern crate proc_macro_synth_binding;
+
+use proc_macro_synth_binding::SynthSilenceReason;
+
+#[derive(SynthSilenceReason)]
+#[synth_silence_reason]
+struct UsesSynthSilenceReason;
+
+fn main() {}

--- a/ui/lint_silence_reason_proc_macro.rs
+++ b/ui/lint_silence_reason_proc_macro.rs
@@ -19,4 +19,10 @@ use proc_macro_synth_binding::SynthSilenceReason;
 #[synth_silence_reason]
 struct UsesSynthSilenceReason;
 
+// Applied a second time to confirm the derive's synthesised anchor does
+// not collide across uses in one crate.
+#[derive(SynthSilenceReason)]
+#[synth_silence_reason]
+struct UsesSynthSilenceReasonAgain;
+
 fn main() {}


### PR DESCRIPTION
Fixes a false positive in `perfectionist::lint_silence_reason`: the rule flagged `#[allow(...)]` attributes generated by proc-macro derives such as `clap_derive`. Those derives stamp the generated attribute with the *call-site* span of a user attribute like `#[clap(long)]`; that span has the root syntax context and points at real source, so neither `Span::from_expansion` nor `report_in_external_macro: false` filters it, and the rule fired on `#[clap(...)]` fields the user cannot annotate with a `reason`.

**Fix.** Guard `check_attribute` with `clippy_utils::is_from_proc_macro`, which compares the attribute's name against the source text under its span. Synthesized attributes (the text reads `#[clap(...)]`, not `#[allow(...)]`) are skipped; hand-written suppressions still fire.

**Tests.** Added a `SynthSilenceReason` derive to the shared `proc_macro_synth_binding` aux crate (reproducing clap's span shape) plus a `lint_silence_reason_proc_macro` UI regression fixture, which fails without the fix and passes with it. `just all` is green, including `self-lint`.

Resolves <https://github.com/KSXGitHub/parallel-disk-usage/issues/430>.