### PR TITLE
fix(pages): stop config "Types" h4 style from capturing author headings

### DIFF
--- a/tools/gen-docs/src/render/config.rs
+++ b/tools/gen-docs/src/render/config.rs
@@ -61,7 +61,7 @@ pub(crate) fn config_section(config: &ConfigDoc) -> Markup {
                 }
             }
             @if !config.custom_types.is_empty() {
-                h4 { "Types" }
+                h4.config-types { "Types" }
                 @for ty in &config.custom_types {
                     (custom_type_block(ty))
                 }

--- a/tools/gen-docs/src/style/rules.css
+++ b/tools/gen-docs/src/style/rules.css
@@ -232,9 +232,21 @@ dl.config dd p {
   color: #cf222e;
 }
 
+/* Author-written `####` sub-headings in a rule's rustdoc (e.g.
+   `self_import`'s `#### Style: Forbid`) render as a bare `<h4>` and
+   read as ordinary example sub-headings: a notch below the `<h3>`
+   section headings, normal case. */
 article.rule h4 {
   margin-top: 1.25rem;
   margin-bottom: 0.4rem;
+  font-size: 0.98rem;
+}
+
+/* The auto-generated Configuration "Types" label is also an `<h4>`,
+   but it's a section label, not a heading — keep it small, grey, and
+   uppercase. Scoped to the generated `.config-types` class so it no
+   longer captures author `####` headings (issue #178). */
+article.rule h4.config-types {
   font-size: 0.95rem;
   color: #57606a;
   text-transform: uppercase;


### PR DESCRIPTION
Author-written `####` headings in a rule's rustdoc (e.g. `self_import`'s `#### Style: Forbid`) rendered as a bare `<h4>` — the same tag as the auto-generated Configuration "Types" label. They shared the `article.rule h4` rule, which was tuned for "Types" (small, grey, uppercase), so example sub-headings masqueraded as config-section labels.

This tags the generated label with a `config-types` class and scopes the uppercase-grey style to `article.rule h4.config-types`. Author `<h4>`s now fall back to a plain sub-heading style: a notch below the `<h3>` section headings, normal case.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/178>.