### PR TITLE
fix: ignore `include_str!`-ed files during comment scanning

### DIFF
--- a/src/comment_walk.rs
+++ b/src/comment_walk.rs
@@ -18,9 +18,11 @@
 //! into the source map.
 
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
-use rustc_session::Session;
+use rustc_lint::{LateContext, LintContext};
 use rustc_span::def_id::LOCAL_CRATE;
 use rustc_span::{BytePos, Pos, RelativeBytePos, SourceFile, Span, SyntaxContext};
+
+use crate::module_reparse::crate_module_files;
 
 /// Surface kind for one chunk of comment text handed to the walker
 /// callback.
@@ -98,15 +100,31 @@ impl CommentChunk<'_> {
 
 /// Walk every comment in the local crate's source files, handing each
 /// chunk to `callback`. The callback receives a borrowed
-/// [`CommentChunk`]. Takes the session directly rather than a lint
-/// context so it can run from either an early or a late pass — the
-/// comment-walking rules emit from a late pass (see
-/// [`crate::enclosing_hir::emit_at_enclosing_hir`]) so per-site
+/// [`CommentChunk`].
+///
+/// Only files that back a module in the crate's HIR module tree are
+/// walked (see [`crate_module_files`]); `include_str!` / `include_bytes!`
+/// data files, `include!` fragments, and proc-macro-synthesised modules
+/// are skipped. A bare `http(s)://` URL inside an included YAML file
+/// otherwise lexes as a `//` line comment and would be flagged — and
+/// autofix-rewritten — as if it were a Rust comment
+/// (<https://github.com/KSXGitHub/perfectionist/issues/179>).
+///
+/// Takes a [`LateContext`] both to reach the HIR module tree for that
+/// filter and because the comment-walking rules emit from a late pass
+/// (see [`crate::enclosing_hir::emit_at_enclosing_hir`]) so per-site
 /// `#[allow]` / `#[expect]` resolve at the comment's enclosing item.
-pub(crate) fn walk_local_comments(sess: &Session, mut callback: impl FnMut(&CommentChunk<'_>)) {
-    let source_map = sess.source_map();
+pub(crate) fn walk_local_comments(
+    lint_context: &LateContext<'_>,
+    mut callback: impl FnMut(&CommentChunk<'_>),
+) {
+    let module_files = crate_module_files(lint_context);
+    let source_map = lint_context.sess().source_map();
     for source_file in source_map.files().iter() {
         if source_file.cnum != LOCAL_CRATE {
+            continue;
+        }
+        if !module_files.contains(&source_file.name) {
             continue;
         }
         let Some(source_text) = source_file.src.as_deref() else {

--- a/src/module_reparse.rs
+++ b/src/module_reparse.rs
@@ -74,15 +74,14 @@ pub(crate) fn parse_crate_module_files(
     let tcx = lint_context.tcx;
     let source_map = lint_context.sess().psess.clone_source_map();
 
-    // The files that define a module in this crate's module tree, plus
-    // the body span of every live module (for the inline-recursion guard
+    // The files that define a module in this crate's module tree.
+    let module_files = crate_module_files(lint_context);
+
+    // The body span of every live module (for the inline-recursion guard
     // documented on this function's returned `live_module_spans`).
-    let mut module_files: HashSet<FileName> = HashSet::new();
     let mut live_module_spans: HashSet<SpanRange> = HashSet::new();
-    record_module_file(&source_map, &mut module_files, tcx.hir_root_module().spans);
     for item_id in tcx.hir_free_items() {
         if let rustc_hir::ItemKind::Mod(_, module) = &tcx.hir_item(item_id).kind {
-            record_module_file(&source_map, &mut module_files, module.spans);
             let inner = module.spans.inner_span;
             live_module_spans.insert((inner.lo(), inner.hi()));
         }
@@ -116,6 +115,39 @@ pub(crate) fn parse_crate_module_files(
         .collect();
 
     (crates, live_module_spans)
+}
+
+/// The on-disk source files that back a module in this crate's HIR
+/// module tree, keyed by [`FileName`].
+///
+/// This is the set of files the user actually wrote as Rust modules —
+/// the crate root and every out-of-line `mod foo;` file. It deliberately
+/// excludes everything that lands in the source map without being a
+/// module the user authored: `include_str!` / `include_bytes!` data
+/// files (which may be YAML, lock files, plain text, ...), `include!`
+/// fragments spliced inline rather than backing their own module, and
+/// proc-macro-synthesised `<proc-macro source>` modules.
+///
+/// The comment-scanning rules tokenize the local crate's files as Rust
+/// and must filter the source map through this set: `bare_url`,
+/// `bare_email`, `bare_issue_reference`, and `unicode_ellipsis_in_docs`
+/// via the shared [`crate::comment_walk::walk_local_comments`] walker, plus
+/// `unicode_ellipsis_in_comments` through its own token loop. Otherwise
+/// a bare `http(s)://` URL inside an
+/// `include_str!`-ed YAML file lexes as a `//` line comment and gets
+/// flagged (and, worse, autofix-rewritten) as if it were a Rust comment.
+/// See <https://github.com/KSXGitHub/perfectionist/issues/179>.
+pub(crate) fn crate_module_files(lint_context: &LateContext<'_>) -> HashSet<FileName> {
+    let tcx = lint_context.tcx;
+    let source_map = lint_context.sess().source_map();
+    let mut module_files: HashSet<FileName> = HashSet::new();
+    record_module_file(source_map, &mut module_files, tcx.hir_root_module().spans);
+    for item_id in tcx.hir_free_items() {
+        if let rustc_hir::ItemKind::Mod(_, module) = &tcx.hir_item(item_id).kind {
+            record_module_file(source_map, &mut module_files, module.spans);
+        }
+    }
+    module_files
 }
 
 /// Re-parse every on-disk source file that backs a module in the crate's

--- a/src/rules/bare_email.rs
+++ b/src/rules/bare_email.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir::HirId;
-use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
+use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
 
@@ -147,7 +147,7 @@ impl<'tcx> LateLintPass<'tcx> for BareEmail {
         // form (`self.style`) is uniform across the crate, so it's read
         // once at emission time rather than stored per violation.
         let mut violations: Vec<(Span, String)> = Vec::new();
-        walk_local_comments(lint_context.sess(), |chunk| {
+        walk_local_comments(lint_context, |chunk| {
             let is_doc = matches!(
                 chunk.surface,
                 CommentSurface::DocBlock | CommentSurface::DocBlockBlock,

--- a/src/rules/bare_issue_reference.rs
+++ b/src/rules/bare_issue_reference.rs
@@ -1,7 +1,7 @@
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir::HirId;
-use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
+use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
 
@@ -374,7 +374,7 @@ struct EmitOptions {
 impl<'tcx> LateLintPass<'tcx> for BareIssueReference {
     fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
         let mut violations: Vec<(Span, IssueRefViolation)> = Vec::new();
-        walk_local_comments(lint_context.sess(), |chunk| match chunk.surface {
+        walk_local_comments(lint_context, |chunk| match chunk.surface {
             CommentSurface::DocBlock | CommentSurface::DocBlockBlock => {
                 self.scan_doc(chunk, &mut violations);
             }

--- a/src/rules/bare_url.rs
+++ b/src/rules/bare_url.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
-use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
+use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
 
@@ -141,7 +141,7 @@ impl<'tcx> LateLintPass<'tcx> for BareUrl {
             return;
         }
         let mut violations: Vec<(Span, UrlViolation)> = Vec::new();
-        walk_local_comments(lint_context.sess(), |chunk| match chunk.surface {
+        walk_local_comments(lint_context, |chunk| match chunk.surface {
             CommentSurface::DocBlock | CommentSurface::DocBlockBlock => {
                 if self.scan_doc_comments {
                     self.scan_doc_chunk(chunk, &mut violations);

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -7,6 +7,7 @@ use rustc_span::{BytePos, Pos, RelativeBytePos, SourceFile, Span, SyntaxContext}
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::emit_flagged_char_hir;
+use crate::module_reparse::crate_module_files;
 
 declare_tool_lint! {
     /// ### What it does
@@ -111,10 +112,19 @@ impl<'tcx> LateLintPass<'tcx> for UnicodeEllipsisInComments {
         if !(self.scan_line_comments || self.scan_block_comments) {
             return;
         }
+        // Only scan files the user wrote as Rust modules. A file pulled
+        // in via `include_str!` / `include_bytes!` is data, not Rust, so
+        // a U+2026 inside it (after a `//` the lexer reads as a comment)
+        // must not be flagged. See
+        // <https://github.com/KSXGitHub/perfectionist/issues/179>.
+        let module_files = crate_module_files(lint_context);
         let source_map = lint_context.sess().source_map();
         let mut violations: Vec<(Span, char)> = Vec::new();
         for source_file in source_map.files().iter() {
             if source_file.cnum != LOCAL_CRATE {
+                continue;
+            }
+            if !module_files.contains(&source_file.name) {
                 continue;
             }
             let Some(source_text) = source_file.src.as_deref() else {

--- a/src/rules/unicode_ellipsis_in_docs.rs
+++ b/src/rules/unicode_ellipsis_in_docs.rs
@@ -1,4 +1,4 @@
-use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
+use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
 
@@ -105,7 +105,7 @@ pub fn register_pass(lint_store: &mut LintStore) {
 impl<'tcx> LateLintPass<'tcx> for UnicodeEllipsisInDocs {
     fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
         let mut violations: Vec<(Span, char)> = Vec::new();
-        walk_local_comments(lint_context.sess(), |chunk| match chunk.surface {
+        walk_local_comments(lint_context, |chunk| match chunk.surface {
             CommentSurface::DocBlock | CommentSurface::DocBlockBlock => {
                 self.collect_doc_chunk(chunk, &mut violations);
             }

--- a/ui/bare_url_include_str.data.yaml
+++ b/ui/bare_url_include_str.data.yaml
@@ -1,0 +1,4 @@
+deprecated: please contact us at https://example.com for details
+dependencies:
+  forward-email:
+    resolution: {tarball: https://forwardemail.net/package.tgz}

--- a/ui/bare_url_include_str.rs
+++ b/ui/bare_url_include_str.rs
@@ -1,0 +1,14 @@
+//! Regression test for
+//! <https://github.com/KSXGitHub/perfectionist/issues/179>.
+//!
+//! A bare `http(s)://` URL inside an `include_str!`-ed data file lexes
+//! as a `//` line comment (the `//` after the scheme's `:`), but the
+//! file is data — not Rust the user wrote — so `bare_url` must neither
+//! flag it nor rewrite the included file. This fixture pulls in a YAML
+//! file containing bare URLs and expects zero diagnostics.
+
+const DEPRECATION_NOTICE: &str = include_str!("bare_url_include_str.data.yaml");
+
+fn main() {
+    let _ = DEPRECATION_NOTICE;
+}


### PR DESCRIPTION
Restricts the local-crate source walk in the comment-scanning rules to files that actually back a module in the crate's HIR module tree.

## Problem

`include_str!("fixture.yaml")` loads the data file into the compiler's source map as a local-crate file. The comment-scanning rules walked *every* local-crate source file and tokenized it as Rust. A string like `https://example.com` contains `//` after the scheme's colon, which the Rust lexer reads as a `//` line comment — so `bare_url` flagged it, and its autofix rewrote the included data file, corrupting checked-in fixtures such as `pnpm-lock.yaml`.

## Fix

Factored the module-file enumeration already in `module_reparse` into a shared `crate_module_files` helper (excludes `include_str!` / `include_bytes!` data, `include!` fragments, and proc-macro-synthesised modules), and used it to gate the source walk in:

- `walk_local_comments` — shared by `bare_url`, `bare_email`, `bare_issue_reference`, `unicode_ellipsis_in_docs`
- `unicode_ellipsis_in_comments`' own file loop

## Test

Added regression fixture `ui/bare_url_include_str.rs`, which `include_str!`s a YAML file with bare URLs and expects zero diagnostics. The full `just all` gate passes (fmt, build, doc, clippy, test, self-lint).

Resolves <https://github.com/KSXGitHub/perfectionist/issues/179>.