### PR TITLE
style(docs): space out dense markdown in lint rustdoc

### DIFF
--- a/rules/bare_email.md
+++ b/rules/bare_email.md
@@ -8,6 +8,7 @@
 > bare email address in comment or doc comment; wrap in `<...>` or prefix with `mailto:`
 
 ## What it does
+
 Flags bare email addresses (`user@example.com`) in doc
 comments (`///`, `//!`) and regular comments (`//`, `/* */`).
 Wrapping in `<...>`, prefixing with `mailto:`, or both turns
@@ -18,6 +19,7 @@ A `forbid` style is available for projects that prefer to
 keep contact information out of source entirely.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. Bare
 email addresses rely on the renderer's autolinkification,
 which is inconsistent across markdown engines. The
@@ -25,11 +27,15 @@ which is inconsistent across markdown engines. The
 explicit.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 /// Report security issues to security@example.com.
 ```
+
 **Prefer:**
+
 ```rust,ignore
 /// Report security issues to <security@example.com>.
 ```

--- a/rules/bare_issue_reference.md
+++ b/rules/bare_issue_reference.md
@@ -8,6 +8,7 @@
 > ambiguous bare `#NNN` issue / PR reference in comment
 
 ## What it does
+
 Flags bare `#NNN` issue / pull-request references in doc
 comments (`///`, `//!`) — and, when opted in, in plain `//`
 line comments. The autofix rewrites the reference; the
@@ -26,6 +27,7 @@ also resolve the ambiguity by enclosing the token in backticks
 `#`.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. A
 bare `#123` renders as literal text in CommonMark; only
 GitHub's markdown flavour autolinks the token, and only when
@@ -34,14 +36,18 @@ view. The link form renders portably across rustdoc, GitHub,
 and any other markdown engine.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 /// Closes #123 and supersedes #124.
 ```
+
 **Prefer:** (with
 `repository = "https://github.com/owner/repo"` — `forge`
 is detected from the host), picking the issue link for one
 and the pull-request link for the other:
+
 ```rust,ignore
 /// Closes [#123](https://github.com/owner/repo/issues/123) and
 /// supersedes [#124](https://github.com/owner/repo/pull/124).

--- a/rules/bare_url.md
+++ b/rules/bare_url.md
@@ -8,6 +8,7 @@
 > bare URL in comment or doc comment; wrap in `<...>` or use a labelled markdown link
 
 ## What it does
+
 Flags bare `http://` and `https://` URLs in doc comments
 (`///`, `//!`) and regular comments (`//`, `/* */`). Wrapping
 the URL in `<...>` (or using the labelled `[text](url)` form)
@@ -15,17 +16,22 @@ is the portable rendering across CommonMark, GitHub-flavored
 markdown, and rustdoc.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. Bare
 URLs rely on the renderer's autolinkification: rustdoc renders
 them, GitHub renders them, but plain CommonMark does not. The
 `<...>` form is the explicit, portable spelling.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 /// See https://example.com for details.
 ```
+
 **Prefer:**
+
 ```rust,ignore
 /// See <https://example.com> for details.
 ```

--- a/rules/derive_ordering.md
+++ b/rules/derive_ordering.md
@@ -8,6 +8,7 @@
 > trait names in a `#[derive(...)]` list are not in the configured order
 
 ## What it does
+
 Enforces a project-wide ordering of trait names inside a single
 `#[derive(...)]` list. Two styles are configurable via
 `style`:
@@ -24,6 +25,7 @@ does not police how derives are partitioned across multiple
 author.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. The
 trait order inside `#[derive(...)]` has no semantic effect:
 `#[derive(Debug, Clone)]` and `#[derive(Clone, Debug)]`
@@ -43,14 +45,18 @@ enable = ["derive_ordering"]
 ```
 
 ## Example
+
 Under `style = "alphabetical"`:
 
 **Avoid:**
+
 ```rust,ignore
 #[derive(Debug, Clone, Copy)]
 struct Point;
 ```
+
 **Prefer:**
+
 ```rust,ignore
 #[derive(Clone, Copy, Debug)]
 struct Point;

--- a/rules/flat_module_pattern.md
+++ b/rules/flat_module_pattern.md
@@ -8,12 +8,14 @@
 > submodule defined as `module/mod.rs`; prefer the flat `module.rs` layout
 
 ## What it does
+
 Forbids the `module/mod.rs` layout for submodules. Each
 submodule should be defined by a sibling file named after
 the module (`module.rs`), with any nested children placed
 inside the `module/` directory next to it.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 The flat layout keeps the file name unique to its module,
 so editors, terminal tabs, and `grep` results identify the
@@ -22,6 +24,7 @@ produces dozens of identically-named tabs in editors that
 don't disambiguate by directory.
 
 ## Example
+
 ```text
 // Bad
 src/foo/mod.rs

--- a/rules/import_granularity.md
+++ b/rules/import_granularity.md
@@ -8,6 +8,7 @@
 > import granularity does not match the configured `import_granularity.style`
 
 ## What it does
+
 Enforces a single project-wide import-granularity style, chosen
 via `style`:
 - `crate` — one `use` per crate root, with every shared prefix
@@ -30,6 +31,7 @@ Globs (`use foo::*`) are governed by `perfectionist::no_star_imports`,
 not by this rule: a top-level glob is left alone under `item`.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. None of
 the three shapes is wrong in the abstract — the violation is a
 mismatch with the project's configured `style`. Enforcing one
@@ -39,14 +41,18 @@ nightly channel; this lint gives stable-toolchain projects a hard
 CI check instead of a silent reformat.
 
 ## Example
+
 Under the default `style = "module"`:
 
 **Avoid:**
+
 ```rust,ignore
 use std::collections::HashMap;
 use std::collections::BTreeMap;
 ```
+
 **Prefer:**
+
 ```rust,ignore
 use std::collections::{BTreeMap, HashMap};
 ```

--- a/rules/import_grouping.md
+++ b/rules/import_grouping.md
@@ -8,6 +8,7 @@
 > import grouping does not match the configured `import_grouping.style`
 
 ## What it does
+
 Enforces a single project-wide *grouping* style for the run of
 `use` statements at the top of a module body, chosen via `style`:
 - `single_group` — every `use` sits in one contiguous block with
@@ -26,6 +27,7 @@ Whether items within each `use` are merged or split is the job of
 `perfectionist::import_granularity`.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. Neither
 layout is wrong in the abstract — the violation is a mismatch
 with the project's configured `style`. Enforcing one keeps import
@@ -35,15 +37,19 @@ only on the nightly channel; this lint gives stable-toolchain
 projects a hard CI check instead of a silent reformat.
 
 ## Example
+
 Under the default `style = "grouped"`:
 
 **Avoid:**
+
 ```rust,ignore
 use clap::Parser;
 use std::time::Duration;
 use crate::args::Args;
 ```
+
 **Prefer:**
+
 ```rust,ignore
 use std::time::Duration;
 

--- a/rules/lint_reason_from_comment.md
+++ b/rules/lint_reason_from_comment.md
@@ -8,6 +8,7 @@
 > trailing comment on a lint-level attribute should be lifted into a `reason = "..."` field
 
 ## What it does
+
 When a lint-level attribute (`#[allow]`, `#[expect]`, `#[warn]`,
 `#[deny]`, `#[forbid]`) carries a trailing `// ...` line comment
 — on the same source line as the attribute's closing `]` —
@@ -25,6 +26,7 @@ Doc comments (`///`, `//!`) and block comments (`/* ... */`)
 are out of scope.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 `reason = "..."` is part of the attribute and travels with it
 through every refactor; a free-floating comment can be
@@ -36,12 +38,16 @@ One canonical location for the rationale also removes the
 question.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 #[allow(clippy::too_many_arguments)] // matches upstream signature
 fn build_fetcher(/* ... */) {}
 ```
+
 **Prefer:**
+
 ```rust,ignore
 #[allow(clippy::too_many_arguments, reason = "matches upstream signature")]
 fn build_fetcher(/* ... */) {}

--- a/rules/lint_silence_reason.md
+++ b/rules/lint_silence_reason.md
@@ -8,6 +8,7 @@
 > `#[allow]` / `#[expect]` attribute lacks an explanatory `reason = "..."` field
 
 ## What it does
+
 Requires every `#[allow(<lints>)]` and `#[expect(<lints>)]`
 attribute to carry an explanatory `reason = "..."` field.
 `#[allow]` and `#[expect]` are the two levels that fully
@@ -18,6 +19,7 @@ The check is purely local — the attribute itself — and does
 not depend on any inherited or ambient lint level.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 Suppressions outlive the conditions that justify them. A
 bare `#[allow(clippy::too_many_arguments)]` told the original
@@ -29,12 +31,16 @@ suppression, and rustc renders it back in `unfulfilled_lint_expectations`
 notes when a stale `#[expect]` is encountered.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 #[allow(clippy::too_many_arguments)]
 fn build_fetcher(/* ... */) {}
 ```
+
 **Prefer:**
+
 ```rust,ignore
 #[allow(clippy::too_many_arguments, reason = "matches upstream signature")]
 fn build_fetcher(/* ... */) {}

--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -8,6 +8,7 @@
 > macro invocation passes an impure expression that should be bound to a `let` first
 
 ## What it does
+
 Flags impure expressions passed as top-level arguments to a
 function-like (`name!(...)`) or array-like (`name![...]`) macro
 invocation. The fix is to bind the expression to a `let` first
@@ -20,6 +21,7 @@ convention they are DSL bodies (`thread_local! { ... }`,
 contract is the macro's, not the call site's.
 
 ## Why is this bad?
+
 A function-like or array-like macro may evaluate any top-level
 argument zero, one, or many times depending on its matcher.
 Functions guarantee exactly-once evaluation per argument; macros
@@ -84,11 +86,15 @@ same logic applies to `env!("HOME")` inside
 runtime.
 
 ## Example
+
 **Bad:**
+
 ```rust,ignore
 debug_assert_eq!(map.insert(key, value), None, "duplicate");
 ```
+
 **Good:**
+
 ```rust,ignore
 let ejected = map.insert(key, value);
 debug_assert_eq!(ejected, None, "duplicate");

--- a/rules/macro_trailing_comma.md
+++ b/rules/macro_trailing_comma.md
@@ -8,6 +8,7 @@
 > macro invocation does not follow rustfmt's vertical trailing-comma policy
 
 ## What it does
+
 For function-like macro invocations whose top-level arguments are
 comma-separated, enforces rustfmt's `trailing_comma = "Vertical"`
 policy that rustfmt itself does not apply inside macro bodies:
@@ -24,6 +25,7 @@ Attribute-style invocations (`#[derive(...)]`, `#[serde(...)]`,
 etc.) are out of scope.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. rustfmt's
 default `trailing_comma = "Vertical"` policy keeps argument lists
 uniform: every multi-line list ends with a comma, every single-line
@@ -40,7 +42,9 @@ own line, separate from the delimiter, and strips any comma
 added to the compact shape. The two tools have to agree.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 let xs = vec![
     1,
@@ -49,7 +53,9 @@ let xs = vec![
 ];
 let ys = vec![1, 2, 3,];
 ```
+
 **Prefer:**
+
 ```rust,ignore
 let xs = vec![
     1,

--- a/rules/non_exhaustive_error.md
+++ b/rules/non_exhaustive_error.md
@@ -8,6 +8,7 @@
 > error-shaped type is missing `#[non_exhaustive]`
 
 ## What it does
+
 Flags publicly-exposed error enums that lack a `#[non_exhaustive]`
 attribute. An enum is treated as an error enum when its name ends
 in `Error` (configurable) or it implements `std::error::Error`.
@@ -18,6 +19,7 @@ itself an enum) follow the same rule.
 whole-crate "every item" sweep are configurable.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. Adding
 a variant to an error enum is one of the most common reasons to
 publish a new minor version of an error-producing library, and
@@ -39,14 +41,18 @@ enable = ["non_exhaustive_error"]
 ```
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 #[derive(Debug)]
 pub enum RuntimeError {
     SerializationFailure,
 }
 ```
+
 **Prefer:**
+
 ```rust,ignore
 #[derive(Debug)]
 #[non_exhaustive]

--- a/rules/prefer_derive_more_over_thiserror.md
+++ b/rules/prefer_derive_more_over_thiserror.md
@@ -8,6 +8,7 @@
 > `thiserror` import, derive, or attribute; this catalogue prefers `derive_more::{Display, Error}`
 
 ## What it does
+
 Flags every use of [`thiserror`](https://docs.rs/thiserror) in
 the consumer crate. Three syntactic shapes trigger the lint:
 
@@ -51,6 +52,7 @@ project that hits it can suppress individual sites with
 `#[allow(perfectionist::prefer_derive_more_over_thiserror)]`.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. The
 catalogue picks `derive_more` for error formatting and source
 chaining. Mixing in `thiserror` fragments the attribute
@@ -60,7 +62,9 @@ project that wants the choice the other way around can disable
 this rule.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 use thiserror::Error;
 
@@ -70,7 +74,9 @@ pub enum MyError {
     MissingField(String),
 }
 ```
+
 **Prefer:**
+
 ```rust,ignore
 use derive_more::{Display, Error};
 

--- a/rules/prefer_expect_over_allow.md
+++ b/rules/prefer_expect_over_allow.md
@@ -8,6 +8,7 @@
 > `#[allow]` for a deterministically-firing lint should be `#[expect]`
 
 ## What it does
+
 Rewrites `#[allow(<lints>)]` to `#[expect(<lints>)]` when every
 named lint fires deterministically — a built-in rustc lint (not
 on the exempt list), a `clippy::*` / `rustdoc::*` lint, or a
@@ -28,6 +29,7 @@ lint in one configuration and not another — set
 `apply_to_outer_scopes = true` to opt in.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 A suppression often outlives the problem it suppressed.
 `#[allow]` stays silent forever, including after the underlying
@@ -41,12 +43,16 @@ at the site, so a future refactor that inadvertently fixes the
 issue is observed rather than hidden.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 #[allow(clippy::too_many_arguments, reason = "matches pnpm's signature")]
 fn build_fetcher(/* ... */) {}
 ```
+
 **Prefer:**
+
 ```rust,ignore
 #[expect(clippy::too_many_arguments, reason = "matches pnpm's signature")]
 fn build_fetcher(/* ... */) {}

--- a/rules/prefer_raw_string.md
+++ b/rules/prefer_raw_string.md
@@ -8,6 +8,7 @@
 > string literal contains only raw-expressible escapes; prefer the raw-string form
 
 ## What it does
+
 Forbids regular string literals whose only backslash escapes
 are ones a raw string would express verbatim — `\"`, `\\`,
 and `\'`. The autofix rewrites the literal to the raw form
@@ -31,6 +32,7 @@ force the author to split the literal or fall back to
 `concat!`, which loses more than it gains.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. The
 rule trades one noise source (interior backslash escapes)
 for a slightly more elaborate string syntax. The benefit is
@@ -39,12 +41,16 @@ snippets, or embedded source code — all of which would
 otherwise be a sea of `\\` and `\"`.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 let json = "{\"name\":\"foo\"}";
 let path = "C:\\Users\\foo\\bar";
 ```
+
 **Prefer:**
+
 ```rust,ignore
 let json = r#"{"name":"foo"}"#;
 let path = r"C:\Users\foo\bar";

--- a/rules/print_macro_split.md
+++ b/rules/print_macro_split.md
@@ -8,6 +8,7 @@
 > splittable print macro with an embedded-newline template exceeds the configured line width
 
 ## What it does
+
 Flags a `println!`-style macro call whose format template
 embeds a `\n` newline *and* whose source line is wider than
 `max_line_width` display columns, and folds the template across
@@ -38,6 +39,7 @@ literal, a raw string literal, or a template with no foldable
 interior `\n`, is left alone.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. A long
 single line whose string already contains `\n` is hard to read
 and hard to scan in a diff; folding it at the embedded newlines
@@ -45,11 +47,15 @@ lets each output line read as its own source line without
 changing a byte of what the program prints.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 println!("error: The error was caused by {err_src}\nhint: Run {magic_cmd} to solve the problem");
 ```
+
 **Prefer:**
+
 ```rust,ignore
 println!(
     "error: The error was caused by {err_src}\n\

--- a/rules/self_import.md
+++ b/rules/self_import.md
@@ -8,6 +8,7 @@
 > module imported through `self` against the project's configured `self`-import style
 
 ## What it does
+
 Enforces a project-wide policy for naming a module's own export
 through `self` in `use` statements. The rule is inactive by
 default; a project opts in and sets `style` to one of:
@@ -25,6 +26,7 @@ default; a project opts in and sets `style` to one of:
   a single `use foo::bar::{self, Baz};`.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. Both
 directions are coherent; a project simply picks one and applies
 it everywhere so `self`-in-`use` decisions stop being made
@@ -46,12 +48,16 @@ the module's name in the same parent.
 ## Example
 
 ### Style: Forbid
+
 **Avoid:**
+
 ```rust,ignore
 use foo::bar::{self};
 use foo::qux::{self, Baz};
 ```
+
 **Prefer:** (each statement is fixed independently)
+
 ```rust,ignore
 use foo::bar;
 use foo::qux;
@@ -59,12 +65,16 @@ use foo::qux::Baz;
 ```
 
 ### Style: Combined
+
 **Avoid:**
+
 ```rust,ignore
 use foo::bar;
 use foo::bar::Baz;
 ```
+
 **Prefer:**
+
 ```rust,ignore
 use foo::bar::{self, Baz};
 ```

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -8,6 +8,7 @@
 > closure parameter has a single-letter name
 
 ## What it does
+
 Flags closure parameters whose identifier is one ASCII
 letter, unless the closure is a trivial single-expression
 callback or the identifier is in the conventional-name
@@ -48,6 +49,7 @@ are not structurally trivial, so the exempt set is what
 keeps them out of the diagnostic.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 A multi-line closure body whose parameter is a single
 letter forces the reader to scroll back to the closure
@@ -57,14 +59,18 @@ trivial-callback exception covers `sort_by(|a, b| ...)` and
 parameter's role is unambiguous from the call site.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 .map(|t| {
     let columns = build_columns(t);
     format_row(&columns)
 })
 ```
+
 **Prefer:**
+
 ```rust,ignore
 .map(|tree_row| {
     let columns = build_columns(tree_row);

--- a/rules/single_letter_const_generic.md
+++ b/rules/single_letter_const_generic.md
@@ -8,10 +8,12 @@
 > const generic parameter has a single-letter name
 
 ## What it does
+
 Flags const generic parameter declarations
 (`<const N: usize>`) whose identifier is one ASCII letter.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 A single-letter const generic parameter is opaque at every
 use site; a descriptive identifier (`LEN`, `COLS`, `LANES`)
@@ -19,14 +21,18 @@ documents the parameter's role both at the declaration and
 at every substitution.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 struct Data<Left, Right, const M: usize, const N: usize> {
     left:  [Left;  M],
     right: [Right; N],
 }
 ```
+
 **Prefer:**
+
 ```rust,ignore
 struct Data<Left, Right, const LEFT_LEN: usize, const RIGHT_LEN: usize> {
     left:  [Left;  LEFT_LEN],

--- a/rules/single_letter_const_item.md
+++ b/rules/single_letter_const_item.md
@@ -8,10 +8,12 @@
 > const item has a single-letter name
 
 ## What it does
+
 Flags `const` items (free, associated, and block-level)
 whose identifier is one ASCII letter.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 A single-letter `const` item is opaque at every use site,
 and the item's scope (module-wide or crate-wide for
@@ -20,11 +22,15 @@ identifier (`DIMENSION`, `BUFFER_LEN`, `MAX_RETRIES`)
 carries its own documentation.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 const N: usize = 2;
 ```
+
 **Prefer:**
+
 ```rust,ignore
 const DIMENSION_COUNT: usize = 2;
 ```

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -8,12 +8,14 @@
 > function parameter has a single-letter name
 
 ## What it does
+
 Flags function and method parameters whose identifier is
 one ASCII letter, except for a curated set of conventional
 names (`n` for an unsigned count, `f` for a `fmt::Formatter`,
 `i` / `j` / `k` for indices).
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 Parameter names are the first piece of documentation a
 caller reads (in rustdoc, in IDE hover tips, in error
@@ -21,11 +23,15 @@ messages). A descriptive parameter name carries that
 documentation; a single letter does not.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 fn write_row(w: &mut Writer, t: &TreeRow) -> io::Result<()> { ... }
 ```
+
 **Prefer:**
+
 ```rust,ignore
 fn write_row(writer: &mut Writer, tree_row: &TreeRow) -> io::Result<()> { ... }
 ```

--- a/rules/single_letter_generic.md
+++ b/rules/single_letter_generic.md
@@ -8,10 +8,12 @@
 > generic type parameter has a single-letter name
 
 ## What it does
+
 Flags generic type parameters whose identifier is one ASCII
 letter (`T`, `U`, `K`, `V`, ...).
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 Single-letter generic names propagate through the type
 signatures and bounds; they force every reader to scroll
@@ -24,13 +26,17 @@ can be silenced site-by-site with `#[allow]` or
 `#[expect]`.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 pub fn collect_keys<K, V>(map: BTreeMap<K, V>) -> Vec<K> {
     /* fifty lines */
 }
 ```
+
 **Prefer:**
+
 ```rust,ignore
 pub fn collect_keys<Key, Value>(map: BTreeMap<Key, Value>) -> Vec<Key> {
     /* fifty lines */

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -8,10 +8,12 @@
 > `let` binding has a single-letter name
 
 ## What it does
+
 Flags `let x = ...;` bindings whose identifier is one ASCII
 letter.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 A descriptive `let` binding documents what the right-hand
 side computed; a single-letter name does not. The rule
@@ -20,11 +22,15 @@ set of exempt identifiers for the well-worn cases
 (unsigned counts).
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 let m = entry.metadata()?;
 ```
+
 **Prefer:**
+
 ```rust,ignore
 let metadata = entry.metadata()?;
 ```

--- a/rules/single_letter_static_item.md
+++ b/rules/single_letter_static_item.md
@@ -8,9 +8,11 @@
 > static item has a single-letter name
 
 ## What it does
+
 Flags `static` items whose identifier is one ASCII letter.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 A single-letter `static` item is opaque at every use site,
 and the item's scope (module-wide or crate-wide for
@@ -19,11 +21,15 @@ identifier (`BUFFER`, `CACHE`, `COUNTER`) carries its own
 documentation.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 static N: AtomicUsize = AtomicUsize::new(0);
 ```
+
 **Prefer:**
+
 ```rust,ignore
 static REQUEST_COUNT: AtomicUsize = AtomicUsize::new(0);
 ```

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -8,11 +8,13 @@
 > U+2026 HORIZONTAL ELLIPSIS in non-doc comments; prefer `...`
 
 ## What it does
+
 Forbids U+2026 HORIZONTAL ELLIPSIS (`…`) in regular `//` and
 `/* */` comments. Doc comments (`///`, `//!`) are covered by a
 sibling lint.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 ASCII `...` survives every encoding round-trip, every terminal,
 every `grep` invocation, and every `git diff` viewer without
@@ -20,11 +22,15 @@ rendering as `?` or a tofu box. The Unicode form usually arrives
 by accident from autocorrect.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 // TODO: handle the empty-tree case…
 ```
+
 **Prefer:**
+
 ```rust,ignore
 // TODO: handle the empty-tree case...
 ```

--- a/rules/unicode_ellipsis_in_docs.md
+++ b/rules/unicode_ellipsis_in_docs.md
@@ -8,6 +8,7 @@
 > U+2026 HORIZONTAL ELLIPSIS in doc comments; prefer `...`
 
 ## What it does
+
 Forbids U+2026 HORIZONTAL ELLIPSIS (`…`) in doc comments —
 `///` and `//!` line forms and the `/** */` / `/*! */` block
 forms. Prefer the three-ASCII-dot form `...`. Regular `//` and
@@ -15,6 +16,7 @@ forms. Prefer the three-ASCII-dot form `...`. Regular `//` and
 (`perfectionist::unicode_ellipsis_in_comments`).
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 ASCII `...` survives every encoding round-trip, every terminal,
 every copy-paste, every `grep` invocation, and every `git diff`
@@ -25,11 +27,15 @@ smart-quote setting — rather than as a deliberate choice in
 technical writing.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 /// Walk the tree, collecting sizes…
 ```
+
 **Prefer:**
+
 ```rust,ignore
 /// Walk the tree, collecting sizes...
 ```

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -8,6 +8,7 @@
 > U+2026 HORIZONTAL ELLIPSIS in panic / assertion / expect messages; prefer `...`
 
 ## What it does
+
 Forbids U+2026 HORIZONTAL ELLIPSIS (`…`) in the message of a
 panic-family or assertion-style macro (`panic!`,
 `unimplemented!`, `todo!`, `unreachable!`, `assert!`,
@@ -16,24 +17,30 @@ panic-family or assertion-style macro (`panic!`,
 Prefer the three-ASCII-dot form `...`.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue.
 Panic and assertion messages surface in stderr, CI logs, crash
 reporters, and on terminals whose locale or encoding may not
 be UTF-8. ASCII `...` renders identically everywhere.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 panic!("could not parse manifest…");
 let manifest = load().expect("config missing…");
 ```
+
 **Prefer:**
+
 ```rust,ignore
 panic!("could not parse manifest...");
 let manifest = load().expect("config missing...");
 ```
 
 ## Custom macros
+
 The `extra_macros` configuration accepts any macro name,
 but the lint's per-macro knowledge of which argument is
 the message only covers the built-in panic / assertion

--- a/rules/unit_test_file_layout.md
+++ b/rules/unit_test_file_layout.md
@@ -8,6 +8,7 @@
 > unit-test code is in the wrong file or exceeds the inline-test budget
 
 ## What it does
+
 Enforces where a crate's unit-test code lives. Two independent
 axes are checked:
 
@@ -45,6 +46,7 @@ unit tests misplaced in a production file, so they are left
 untouched.
 
 ## Why restrict this?
+
 This is a stylistic preference, not a correctness issue. Both
 source projects keep large test suites out of the production
 file, so the file an editor tab, a `grep` hit, or a diff shows
@@ -55,7 +57,9 @@ nested-vs-sibling choice are deliberately configurable because
 the exact budget and directory shape vary by project.
 
 ## Example
+
 **Avoid:**
+
 ```rust,ignore
 // File: foo.rs
 #[cfg(test)]
@@ -63,11 +67,14 @@ mod tests {
     /* ... 200 lines of test code ... */
 }
 ```
+
 **Prefer:**
+
 ```rust,ignore
 // File: foo.rs
 mod tests;
 ```
+
 ```rust,ignore
 // File: foo/tests.rs
 /* ... 200 lines of test code ... */

--- a/rules/unknown_perfectionist_lints.md
+++ b/rules/unknown_perfectionist_lints.md
@@ -8,12 +8,14 @@
 > lint-control attribute references a `perfectionist::*` lint that this plugin does not register
 
 ## What it does
+
 Flags lint-control attributes (`allow`, `warn`, `deny`,
 `forbid`, `expect`, including under `cfg_attr`) whose lint
 name starts with `perfectionist::` but does not name a lint
 this plugin actually registers.
 
 ## Why is this bad?
+
 Typos and stale references in `#[allow(perfectionist::...)]`
 silently neutralise the suppression they were written for.
 rustc's own `unknown_lints` covers tool-prefixed names
@@ -21,12 +23,16 @@ inconsistently; this rule fills the gap and offers a
 "did you mean" hint against the registered set.
 
 ## Example
+
 **Bad:**
+
 ```rust,ignore
 #[allow(perfectionist::unicode_ellipsis_in_comment)] // typo
 fn legacy() {}
 ```
+
 **Good:**
+
 ```rust,ignore
 #[allow(perfectionist::unicode_ellipsis_in_comments)]
 fn legacy() {}

--- a/src/rules/bare_email.rs
+++ b/src/rules/bare_email.rs
@@ -14,6 +14,7 @@ use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags bare email addresses (`user@example.com`) in doc
     /// comments (`///`, `//!`) and regular comments (`//`, `/* */`).
     /// Wrapping in `<...>`, prefixing with `mailto:`, or both turns
@@ -24,6 +25,7 @@ declare_tool_lint! {
     /// keep contact information out of source entirely.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. Bare
     /// email addresses rely on the renderer's autolinkification,
     /// which is inconsistent across markdown engines. The
@@ -31,11 +33,15 @@ declare_tool_lint! {
     /// explicit.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// /// Report security issues to security@example.com.
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// /// Report security issues to <security@example.com>.
     /// ```

--- a/src/rules/bare_issue_reference.rs
+++ b/src/rules/bare_issue_reference.rs
@@ -15,6 +15,7 @@ mod repo_url;
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags bare `#NNN` issue / pull-request references in doc
     /// comments (`///`, `//!`) — and, when opted in, in plain `//`
     /// line comments. The autofix rewrites the reference; the
@@ -33,6 +34,7 @@ declare_tool_lint! {
     /// `#`.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. A
     /// bare `#123` renders as literal text in CommonMark; only
     /// GitHub's markdown flavour autolinks the token, and only when
@@ -41,14 +43,18 @@ declare_tool_lint! {
     /// and any other markdown engine.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// /// Closes #123 and supersedes #124.
     /// ```
+    ///
     /// **Prefer:** (with
     /// `repository = "https://github.com/owner/repo"` — `forge`
     /// is detected from the host), picking the issue link for one
     /// and the pull-request link for the other:
+    ///
     /// ```rust,ignore
     /// /// Closes [#123](https://github.com/owner/repo/issues/123) and
     /// /// supersedes [#124](https://github.com/owner/repo/pull/124).

--- a/src/rules/bare_url.rs
+++ b/src/rules/bare_url.rs
@@ -14,6 +14,7 @@ use crate::url_scan::{DEFAULT_FORWARD_SCHEMES, TrailingClass, classify_trailing,
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags bare `http://` and `https://` URLs in doc comments
     /// (`///`, `//!`) and regular comments (`//`, `/* */`). Wrapping
     /// the URL in `<...>` (or using the labelled `[text](url)` form)
@@ -21,17 +22,22 @@ declare_tool_lint! {
     /// markdown, and rustdoc.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. Bare
     /// URLs rely on the renderer's autolinkification: rustdoc renders
     /// them, GitHub renders them, but plain CommonMark does not. The
     /// `<...>` form is the explicit, portable spelling.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// /// See https://example.com for details.
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// /// See <https://example.com> for details.
     /// ```

--- a/src/rules/derive_ordering.rs
+++ b/src/rules/derive_ordering.rs
@@ -13,6 +13,7 @@ use crate::common::{DefaultState, resolved_state};
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Enforces a project-wide ordering of trait names inside a single
     /// `#[derive(...)]` list. Two styles are configurable via
     /// `style`:
@@ -29,6 +30,7 @@ declare_tool_lint! {
     /// author.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. The
     /// trait order inside `#[derive(...)]` has no semantic effect:
     /// `#[derive(Debug, Clone)]` and `#[derive(Clone, Debug)]`
@@ -48,14 +50,18 @@ declare_tool_lint! {
     /// ```
     ///
     /// ### Example
+    ///
     /// Under `style = "alphabetical"`:
     ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// #[derive(Debug, Clone, Copy)]
     /// struct Point;
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// #[derive(Clone, Copy, Debug)]
     /// struct Point;

--- a/src/rules/flat_module_pattern.rs
+++ b/src/rules/flat_module_pattern.rs
@@ -10,12 +10,14 @@ use crate::common::{DefaultState, resolved_state};
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Forbids the `module/mod.rs` layout for submodules. Each
     /// submodule should be defined by a sibling file named after
     /// the module (`module.rs`), with any nested children placed
     /// inside the `module/` directory next to it.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// The flat layout keeps the file name unique to its module,
     /// so editors, terminal tabs, and `grep` results identify the
@@ -24,6 +26,7 @@ declare_tool_lint! {
     /// don't disambiguate by directory.
     ///
     /// ### Example
+    ///
     /// ```text
     /// // Bad
     /// src/foo/mod.rs

--- a/src/rules/import_granularity.rs
+++ b/src/rules/import_granularity.rs
@@ -23,6 +23,7 @@ use crate::module_reparse::for_each_module_file;
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Enforces a single project-wide import-granularity style, chosen
     /// via `style`:
     /// - `crate` — one `use` per crate root, with every shared prefix
@@ -45,6 +46,7 @@ declare_tool_lint! {
     /// not by this rule: a top-level glob is left alone under `item`.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. None of
     /// the three shapes is wrong in the abstract — the violation is a
     /// mismatch with the project's configured `style`. Enforcing one
@@ -54,14 +56,18 @@ declare_tool_lint! {
     /// CI check instead of a silent reformat.
     ///
     /// ### Example
+    ///
     /// Under the default `style = "module"`:
     ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// use std::collections::HashMap;
     /// use std::collections::BTreeMap;
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// use std::collections::{BTreeMap, HashMap};
     /// ```

--- a/src/rules/import_grouping.rs
+++ b/src/rules/import_grouping.rs
@@ -21,6 +21,7 @@ use crate::module_reparse::{SpanRange, parse_crate_module_files};
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Enforces a single project-wide *grouping* style for the run of
     /// `use` statements at the top of a module body, chosen via `style`:
     /// - `single_group` — every `use` sits in one contiguous block with
@@ -39,6 +40,7 @@ declare_tool_lint! {
     /// `perfectionist::import_granularity`.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. Neither
     /// layout is wrong in the abstract — the violation is a mismatch
     /// with the project's configured `style`. Enforcing one keeps import
@@ -48,15 +50,19 @@ declare_tool_lint! {
     /// projects a hard CI check instead of a silent reformat.
     ///
     /// ### Example
+    ///
     /// Under the default `style = "grouped"`:
     ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// use clap::Parser;
     /// use std::time::Duration;
     /// use crate::args::Args;
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// use std::time::Duration;
     ///

--- a/src/rules/lint_reason_from_comment.rs
+++ b/src/rules/lint_reason_from_comment.rs
@@ -11,6 +11,7 @@ mod scan;
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// When a lint-level attribute (`#[allow]`, `#[expect]`, `#[warn]`,
     /// `#[deny]`, `#[forbid]`) carries a trailing `// ...` line comment
     /// — on the same source line as the attribute's closing `]` —
@@ -28,6 +29,7 @@ declare_tool_lint! {
     /// are out of scope.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// `reason = "..."` is part of the attribute and travels with it
     /// through every refactor; a free-floating comment can be
@@ -39,12 +41,16 @@ declare_tool_lint! {
     /// question.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// #[allow(clippy::too_many_arguments)] // matches upstream signature
     /// fn build_fetcher(/* ... */) {}
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// #[allow(clippy::too_many_arguments, reason = "matches upstream signature")]
     /// fn build_fetcher(/* ... */) {}

--- a/src/rules/lint_silence_reason.rs
+++ b/src/rules/lint_silence_reason.rs
@@ -14,6 +14,7 @@ use crate::common::{DefaultState, attr_has_reason, render_meta_path, resolved_st
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Requires every `#[allow(<lints>)]` and `#[expect(<lints>)]`
     /// attribute to carry an explanatory `reason = "..."` field.
     /// `#[allow]` and `#[expect]` are the two levels that fully
@@ -24,6 +25,7 @@ declare_tool_lint! {
     /// not depend on any inherited or ambient lint level.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// Suppressions outlive the conditions that justify them. A
     /// bare `#[allow(clippy::too_many_arguments)]` told the original
@@ -35,12 +37,16 @@ declare_tool_lint! {
     /// notes when a stale `#[expect]` is encountered.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// #[allow(clippy::too_many_arguments)]
     /// fn build_fetcher(/* ... */) {}
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// #[allow(clippy::too_many_arguments, reason = "matches upstream signature")]
     /// fn build_fetcher(/* ... */) {}

--- a/src/rules/macro_argument_binding.rs
+++ b/src/rules/macro_argument_binding.rs
@@ -19,6 +19,7 @@ use purity::{PurityContext, is_pure_expression, looks_like_expression, split_top
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags impure expressions passed as top-level arguments to a
     /// function-like (`name!(...)`) or array-like (`name![...]`) macro
     /// invocation. The fix is to bind the expression to a `let` first
@@ -31,6 +32,7 @@ declare_tool_lint! {
     /// contract is the macro's, not the call site's.
     ///
     /// ### Why is this bad?
+    ///
     /// A function-like or array-like macro may evaluate any top-level
     /// argument zero, one, or many times depending on its matcher.
     /// Functions guarantee exactly-once evaluation per argument; macros
@@ -95,11 +97,15 @@ declare_tool_lint! {
     /// runtime.
     ///
     /// ### Example
+    ///
     /// **Bad:**
+    ///
     /// ```rust,ignore
     /// debug_assert_eq!(map.insert(key, value), None, "duplicate");
     /// ```
+    ///
     /// **Good:**
+    ///
     /// ```rust,ignore
     /// let ejected = map.insert(key, value);
     /// debug_assert_eq!(ejected, None, "duplicate");

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -19,6 +19,7 @@ use queue::PendingViolation;
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// For function-like macro invocations whose top-level arguments are
     /// comma-separated, enforces rustfmt's `trailing_comma = "Vertical"`
     /// policy that rustfmt itself does not apply inside macro bodies:
@@ -35,6 +36,7 @@ declare_tool_lint! {
     /// etc.) are out of scope.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. rustfmt's
     /// default `trailing_comma = "Vertical"` policy keeps argument lists
     /// uniform: every multi-line list ends with a comma, every single-line
@@ -51,7 +53,9 @@ declare_tool_lint! {
     /// added to the compact shape. The two tools have to agree.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// let xs = vec![
     ///     1,
@@ -60,7 +64,9 @@ declare_tool_lint! {
     /// ];
     /// let ys = vec![1, 2, 3,];
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// let xs = vec![
     ///     1,

--- a/src/rules/non_exhaustive_error.rs
+++ b/src/rules/non_exhaustive_error.rs
@@ -17,6 +17,7 @@ use crate::common::{DefaultState, resolve_string_set, resolved_state};
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags publicly-exposed error enums that lack a `#[non_exhaustive]`
     /// attribute. An enum is treated as an error enum when its name ends
     /// in `Error` (configurable) or it implements `std::error::Error`.
@@ -27,6 +28,7 @@ declare_tool_lint! {
     /// whole-crate "every item" sweep are configurable.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. Adding
     /// a variant to an error enum is one of the most common reasons to
     /// publish a new minor version of an error-producing library, and
@@ -48,14 +50,18 @@ declare_tool_lint! {
     /// ```
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// #[derive(Debug)]
     /// pub enum RuntimeError {
     ///     SerializationFailure,
     /// }
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// #[derive(Debug)]
     /// #[non_exhaustive]

--- a/src/rules/prefer_derive_more_over_thiserror.rs
+++ b/src/rules/prefer_derive_more_over_thiserror.rs
@@ -13,6 +13,7 @@ use crate::common::{DefaultState, resolved_state};
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags every use of [`thiserror`](https://docs.rs/thiserror) in
     /// the consumer crate. Three syntactic shapes trigger the lint:
     ///
@@ -56,6 +57,7 @@ declare_tool_lint! {
     /// `#[allow(perfectionist::prefer_derive_more_over_thiserror)]`.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. The
     /// catalogue picks `derive_more` for error formatting and source
     /// chaining. Mixing in `thiserror` fragments the attribute
@@ -65,7 +67,9 @@ declare_tool_lint! {
     /// this rule.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// use thiserror::Error;
     ///
@@ -75,7 +79,9 @@ declare_tool_lint! {
     ///     MissingField(String),
     /// }
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// use derive_more::{Display, Error};
     ///

--- a/src/rules/prefer_expect_over_allow.rs
+++ b/src/rules/prefer_expect_over_allow.rs
@@ -16,6 +16,7 @@ mod tests;
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Rewrites `#[allow(<lints>)]` to `#[expect(<lints>)]` when every
     /// named lint fires deterministically — a built-in rustc lint (not
     /// on the exempt list), a `clippy::*` / `rustdoc::*` lint, or a
@@ -36,6 +37,7 @@ declare_tool_lint! {
     /// `apply_to_outer_scopes = true` to opt in.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// A suppression often outlives the problem it suppressed.
     /// `#[allow]` stays silent forever, including after the underlying
@@ -49,12 +51,16 @@ declare_tool_lint! {
     /// issue is observed rather than hidden.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// #[allow(clippy::too_many_arguments, reason = "matches pnpm's signature")]
     /// fn build_fetcher(/* ... */) {}
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// #[expect(clippy::too_many_arguments, reason = "matches pnpm's signature")]
     /// fn build_fetcher(/* ... */) {}

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -17,6 +17,7 @@ use crate::common::{DefaultState, resolved_state};
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Forbids regular string literals whose only backslash escapes
     /// are ones a raw string would express verbatim — `\"`, `\\`,
     /// and `\'`. The autofix rewrites the literal to the raw form
@@ -40,6 +41,7 @@ declare_tool_lint! {
     /// `concat!`, which loses more than it gains.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. The
     /// rule trades one noise source (interior backslash escapes)
     /// for a slightly more elaborate string syntax. The benefit is
@@ -48,12 +50,16 @@ declare_tool_lint! {
     /// otherwise be a sea of `\\` and `\"`.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// let json = "{\"name\":\"foo\"}";
     /// let path = "C:\\Users\\foo\\bar";
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// let json = r#"{"name":"foo"}"#;
     /// let path = r"C:\Users\foo\bar";

--- a/src/rules/print_macro_split.rs
+++ b/src/rules/print_macro_split.rs
@@ -19,6 +19,7 @@ use scan::{build_fold_suggestion, find_template_literal};
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags a `println!`-style macro call whose format template
     /// embeds a `\n` newline *and* whose source line is wider than
     /// `max_line_width` display columns, and folds the template across
@@ -49,6 +50,7 @@ declare_tool_lint! {
     /// interior `\n`, is left alone.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. A long
     /// single line whose string already contains `\n` is hard to read
     /// and hard to scan in a diff; folding it at the embedded newlines
@@ -56,11 +58,15 @@ declare_tool_lint! {
     /// changing a byte of what the program prints.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// println!("error: The error was caused by {err_src}\nhint: Run {magic_cmd} to solve the problem");
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// println!(
     ///     "error: The error was caused by {err_src}\n\

--- a/src/rules/self_import.rs
+++ b/src/rules/self_import.rs
@@ -41,6 +41,7 @@ mod render;
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Enforces a project-wide policy for naming a module's own export
     /// through `self` in `use` statements. The rule is inactive by
     /// default; a project opts in and sets `style` to one of:
@@ -58,6 +59,7 @@ declare_tool_lint! {
     ///   a single `use foo::bar::{self, Baz};`.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. Both
     /// directions are coherent; a project simply picks one and applies
     /// it everywhere so `self`-in-`use` decisions stop being made
@@ -79,12 +81,16 @@ declare_tool_lint! {
     /// ### Example
     ///
     /// #### Style: Forbid
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// use foo::bar::{self};
     /// use foo::qux::{self, Baz};
     /// ```
+    ///
     /// **Prefer:** (each statement is fixed independently)
+    ///
     /// ```rust,ignore
     /// use foo::bar;
     /// use foo::qux;
@@ -92,12 +98,16 @@ declare_tool_lint! {
     /// ```
     ///
     /// #### Style: Combined
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// use foo::bar;
     /// use foo::bar::Baz;
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// use foo::bar::{self, Baz};
     /// ```

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -18,6 +18,7 @@ use triviality::{is_trivial_wrapper, parent_call_callee_name, single_expression_
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags closure parameters whose identifier is one ASCII
     /// letter, unless the closure is a trivial single-expression
     /// callback or the identifier is in the conventional-name
@@ -58,6 +59,7 @@ declare_tool_lint! {
     /// keeps them out of the diagnostic.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// A multi-line closure body whose parameter is a single
     /// letter forces the reader to scroll back to the closure
@@ -67,14 +69,18 @@ declare_tool_lint! {
     /// parameter's role is unambiguous from the call site.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// .map(|t| {
     ///     let columns = build_columns(t);
     ///     format_row(&columns)
     /// })
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// .map(|tree_row| {
     ///     let columns = build_columns(tree_row);

--- a/src/rules/single_letter_const_generic.rs
+++ b/src/rules/single_letter_const_generic.rs
@@ -14,10 +14,12 @@ use crate::common::{
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags const generic parameter declarations
     /// (`<const N: usize>`) whose identifier is one ASCII letter.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// A single-letter const generic parameter is opaque at every
     /// use site; a descriptive identifier (`LEN`, `COLS`, `LANES`)
@@ -25,14 +27,18 @@ declare_tool_lint! {
     /// at every substitution.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// struct Data<Left, Right, const M: usize, const N: usize> {
     ///     left:  [Left;  M],
     ///     right: [Right; N],
     /// }
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// struct Data<Left, Right, const LEFT_LEN: usize, const RIGHT_LEN: usize> {
     ///     left:  [Left;  LEFT_LEN],

--- a/src/rules/single_letter_const_item.rs
+++ b/src/rules/single_letter_const_item.rs
@@ -14,10 +14,12 @@ use crate::common::{
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags `const` items (free, associated, and block-level)
     /// whose identifier is one ASCII letter.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// A single-letter `const` item is opaque at every use site,
     /// and the item's scope (module-wide or crate-wide for
@@ -26,11 +28,15 @@ declare_tool_lint! {
     /// carries its own documentation.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// const N: usize = 2;
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// const DIMENSION_COUNT: usize = 2;
     /// ```

--- a/src/rules/single_letter_function_param.rs
+++ b/src/rules/single_letter_function_param.rs
@@ -15,12 +15,14 @@ use crate::common::{
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags function and method parameters whose identifier is
     /// one ASCII letter, except for a curated set of conventional
     /// names (`n` for an unsigned count, `f` for a `fmt::Formatter`,
     /// `i` / `j` / `k` for indices).
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// Parameter names are the first piece of documentation a
     /// caller reads (in rustdoc, in IDE hover tips, in error
@@ -28,11 +30,15 @@ declare_tool_lint! {
     /// documentation; a single letter does not.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// fn write_row(w: &mut Writer, t: &TreeRow) -> io::Result<()> { ... }
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// fn write_row(writer: &mut Writer, tree_row: &TreeRow) -> io::Result<()> { ... }
     /// ```

--- a/src/rules/single_letter_generic.rs
+++ b/src/rules/single_letter_generic.rs
@@ -7,10 +7,12 @@ use crate::common::{DefaultState, hir_in_external_macro, is_single_ascii_letter,
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags generic type parameters whose identifier is one ASCII
     /// letter (`T`, `U`, `K`, `V`, ...).
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// Single-letter generic names propagate through the type
     /// signatures and bounds; they force every reader to scroll
@@ -23,13 +25,17 @@ declare_tool_lint! {
     /// `#[expect]`.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// pub fn collect_keys<K, V>(map: BTreeMap<K, V>) -> Vec<K> {
     ///     /* fifty lines */
     /// }
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// pub fn collect_keys<Key, Value>(map: BTreeMap<Key, Value>) -> Vec<Key> {
     ///     /* fifty lines */

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -14,10 +14,12 @@ use crate::common::{
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags `let x = ...;` bindings whose identifier is one ASCII
     /// letter.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// A descriptive `let` binding documents what the right-hand
     /// side computed; a single-letter name does not. The rule
@@ -26,11 +28,15 @@ declare_tool_lint! {
     /// (unsigned counts).
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// let m = entry.metadata()?;
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// let metadata = entry.metadata()?;
     /// ```

--- a/src/rules/single_letter_static_item.rs
+++ b/src/rules/single_letter_static_item.rs
@@ -14,9 +14,11 @@ use crate::common::{
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags `static` items whose identifier is one ASCII letter.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// A single-letter `static` item is opaque at every use site,
     /// and the item's scope (module-wide or crate-wide for
@@ -25,11 +27,15 @@ declare_tool_lint! {
     /// documentation.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// static N: AtomicUsize = AtomicUsize::new(0);
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// static REQUEST_COUNT: AtomicUsize = AtomicUsize::new(0);
     /// ```

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -11,11 +11,13 @@ use crate::module_reparse::crate_module_files;
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Forbids U+2026 HORIZONTAL ELLIPSIS (`…`) in regular `//` and
     /// `/* */` comments. Doc comments (`///`, `//!`) are covered by a
     /// sibling lint.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// ASCII `...` survives every encoding round-trip, every terminal,
     /// every `grep` invocation, and every `git diff` viewer without
@@ -23,11 +25,15 @@ declare_tool_lint! {
     /// by accident from autocorrect.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// // TODO: handle the empty-tree case…
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// // TODO: handle the empty-tree case...
     /// ```

--- a/src/rules/unicode_ellipsis_in_docs.rs
+++ b/src/rules/unicode_ellipsis_in_docs.rs
@@ -10,6 +10,7 @@ use crate::markdown::{position_in_skip, scan_code_regions};
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Forbids U+2026 HORIZONTAL ELLIPSIS (`…`) in doc comments —
     /// `///` and `//!` line forms and the `/** */` / `/*! */` block
     /// forms. Prefer the three-ASCII-dot form `...`. Regular `//` and
@@ -17,6 +18,7 @@ declare_tool_lint! {
     /// (`perfectionist::unicode_ellipsis_in_comments`).
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// ASCII `...` survives every encoding round-trip, every terminal,
     /// every copy-paste, every `grep` invocation, and every `git diff`
@@ -27,11 +29,15 @@ declare_tool_lint! {
     /// technical writing.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// /// Walk the tree, collecting sizes…
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// /// Walk the tree, collecting sizes...
     /// ```

--- a/src/rules/unicode_ellipsis_in_panic_messages.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages.rs
@@ -15,6 +15,7 @@ use config::UnicodeEllipsisInPanicMessages;
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Forbids U+2026 HORIZONTAL ELLIPSIS (`…`) in the message of a
     /// panic-family or assertion-style macro (`panic!`,
     /// `unimplemented!`, `todo!`, `unreachable!`, `assert!`,
@@ -23,24 +24,30 @@ declare_tool_lint! {
     /// Prefer the three-ASCII-dot form `...`.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue.
     /// Panic and assertion messages surface in stderr, CI logs, crash
     /// reporters, and on terminals whose locale or encoding may not
     /// be UTF-8. ASCII `...` renders identically everywhere.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// panic!("could not parse manifest…");
     /// let manifest = load().expect("config missing…");
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// panic!("could not parse manifest...");
     /// let manifest = load().expect("config missing...");
     /// ```
     ///
     /// ### Custom macros
+    ///
     /// The `extra_macros` configuration accepts any macro name,
     /// but the lint's per-macro knowledge of which argument is
     /// the message only covers the built-in panic / assertion

--- a/src/rules/unit_test_file_layout.rs
+++ b/src/rules/unit_test_file_layout.rs
@@ -11,6 +11,7 @@ use config::UnitTestFileLayout;
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Enforces where a crate's unit-test code lives. Two independent
     /// axes are checked:
     ///
@@ -48,6 +49,7 @@ declare_tool_lint! {
     /// untouched.
     ///
     /// ### Why restrict this?
+    ///
     /// This is a stylistic preference, not a correctness issue. Both
     /// source projects keep large test suites out of the production
     /// file, so the file an editor tab, a `grep` hit, or a diff shows
@@ -58,7 +60,9 @@ declare_tool_lint! {
     /// the exact budget and directory shape vary by project.
     ///
     /// ### Example
+    ///
     /// **Avoid:**
+    ///
     /// ```rust,ignore
     /// // File: foo.rs
     /// #[cfg(test)]
@@ -66,11 +70,14 @@ declare_tool_lint! {
     ///     /* ... 200 lines of test code ... */
     /// }
     /// ```
+    ///
     /// **Prefer:**
+    ///
     /// ```rust,ignore
     /// // File: foo.rs
     /// mod tests;
     /// ```
+    ///
     /// ```rust,ignore
     /// // File: foo/tests.rs
     /// /* ... 200 lines of test code ... */

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -8,12 +8,14 @@ use crate::common::{DefaultState, render_meta_path, resolved_state};
 
 declare_tool_lint! {
     /// ### What it does
+    ///
     /// Flags lint-control attributes (`allow`, `warn`, `deny`,
     /// `forbid`, `expect`, including under `cfg_attr`) whose lint
     /// name starts with `perfectionist::` but does not name a lint
     /// this plugin actually registers.
     ///
     /// ### Why is this bad?
+    ///
     /// Typos and stale references in `#[allow(perfectionist::...)]`
     /// silently neutralise the suppression they were written for.
     /// rustc's own `unknown_lints` covers tool-prefixed names
@@ -21,12 +23,16 @@ declare_tool_lint! {
     /// "did you mean" hint against the registered set.
     ///
     /// ### Example
+    ///
     /// **Bad:**
+    ///
     /// ```rust,ignore
     /// #[allow(perfectionist::unicode_ellipsis_in_comment)] // typo
     /// fn legacy() {}
     /// ```
+    ///
     /// **Good:**
+    ///
     /// ```rust,ignore
     /// #[allow(perfectionist::unicode_ellipsis_in_comments)]
     /// fn legacy() {}


### PR DESCRIPTION
Insert blank doc-comment lines at markdown block boundaries in the `declare_tool_lint!` rustdoc blocks — after section headings, before opening code fences, and after closing code fences — so the source is easier to read. Every insertion sits at a block boundary, so the rendered documentation is unchanged.

https://claude.ai/code/session_01L3qFon51vE7fbV3hFKvJiz