### PR TITLE
ci: improve caching

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,18 +64,38 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache rustup toolchain
+        uses: actions/cache@v5
+        timeout-minutes: 1
+        continue-on-error: true
+        with:
+          # The pinned nightly + rustc-dev + rust-src + llvm-tools is
+          # byte-identical every run, so cache `~/.rustup` and let
+          # `Install Rust` find the toolchain already present instead of
+          # re-downloading and re-extracting it each time.
+          path: ~/.rustup
+          key: rustup-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
+
       - name: Cache
         uses: actions/cache@v5
         timeout-minutes: 1
         continue-on-error: true
         with:
-          # `target/integration-fixtures{,-warmup}/` hold the
-          # warmup's incremental-compilation state. rustc ICEs when
-          # any input to the lint-registration fingerprint (e.g. a
-          # rule's `default_level`) changes against a cache
-          # populated under the previous value, so the dirs are
-          # excluded; the expensive plugin build still lives in the
-          # main `target/` cache.
+          # `target/integration-fixtures{,-warmup}/` hold the warmup's
+          # incremental-compilation state. rustc ICEs when any input to
+          # the lint-registration fingerprint (e.g. a rule's
+          # `default_level`) changes against a cache populated under the
+          # previous value, so the dirs are excluded; the expensive
+          # plugin build still lives in the main `target/` cache.
+          #
+          # Cache the WHOLE `~/.cargo`, including `registry/src`. It is
+          # tempting to drop `registry/src` (re-extractable from the
+          # `.crate` tarballs) to shrink the archive, but don't: dropping
+          # it makes cargo re-extract those sources with fresh mtimes
+          # that are newer than the cached `target/` artifacts, so every
+          # build-script crate (proc-macro2, quote, ...) reruns and
+          # cascades a full-graph recompile despite a cache hit. Keeping
+          # `registry/src` preserves the mtimes that match the artifacts.
           path: |
             ~/.cargo
             ~/.dylint_drivers

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,10 +69,6 @@ jobs:
         timeout-minutes: 1
         continue-on-error: true
         with:
-          # The pinned nightly + rustc-dev + rust-src + llvm-tools is
-          # byte-identical every run, so cache `~/.rustup` and let
-          # `Install Rust` find the toolchain already present instead of
-          # re-downloading and re-extracting it each time.
           path: ~/.rustup
           key: rustup-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
 

--- a/justfile
+++ b/justfile
@@ -59,14 +59,7 @@ self-lint:
 warmup-integration-tests:
   cargo run {{locked}} --package _utils --bin warmup -- "$(pwd)"
 
-# Install cargo-dylint and dylint-link into `.dev-tools/`.
-#
-# `_dev_tools` runs before dylint-link exists, so it builds with the
-# system `cc` linker via `--config`. Build it into a SEPARATE target dir
-# (`target/dev-tools-cc`) so its cc-linked dependency artifacts never land
-# in `target/`: sharing that dir with the main dylint-link build flips
-# every shared dep to `ConfigSettingsChanged` and forces a full recompile
-# despite a cache hit.
+# Install cargo-dylint and dylint-link into `.dev-tools/`
 install-dev-tools:
   cargo --config 'target."cfg(all())".linker="cc"' run --locked --target-dir target/dev-tools-cc --package _dev_tools -- "$(pwd)" install
 
@@ -83,13 +76,11 @@ install-git-hooks:
 uninstall-git-hooks:
   git config --unset core.hooksPath 2>/dev/null || true
 
-# Print the dylint_linting version pinned in Cargo.lock.
-# (Own target dir for the `cc` linker — see `install-dev-tools`.)
+# Print the dylint_linting version pinned in Cargo.lock
 dylint-version:
   @cargo --config 'target."cfg(all())".linker="cc"' run --locked --target-dir target/dev-tools-cc --quiet --package _dev_tools -- "$(pwd)" dylint-version
 
-# Append `version=<dylint version>` to $GITHUB_OUTPUT (for CI).
-# (Own target dir for the `cc` linker — see `install-dev-tools`.)
+# Append `version=<dylint version>` to $GITHUB_OUTPUT (for CI)
 gha-dylint-version:
   cargo --config 'target."cfg(all())".linker="cc"' run --locked --target-dir target/dev-tools-cc --package _dev_tools -- "$(pwd)" gha-dylint-version
 

--- a/justfile
+++ b/justfile
@@ -59,9 +59,16 @@ self-lint:
 warmup-integration-tests:
   cargo run {{locked}} --package _utils --bin warmup -- "$(pwd)"
 
-# Install cargo-dylint and dylint-link into `.dev-tools/`
+# Install cargo-dylint and dylint-link into `.dev-tools/`.
+#
+# `_dev_tools` runs before dylint-link exists, so it builds with the
+# system `cc` linker via `--config`. Build it into a SEPARATE target dir
+# (`target/dev-tools-cc`) so its cc-linked dependency artifacts never land
+# in `target/`: sharing that dir with the main dylint-link build flips
+# every shared dep to `ConfigSettingsChanged` and forces a full recompile
+# despite a cache hit.
 install-dev-tools:
-  cargo --config 'target."cfg(all())".linker="cc"' run --locked --package _dev_tools -- "$(pwd)" install
+  cargo --config 'target."cfg(all())".linker="cc"' run --locked --target-dir target/dev-tools-cc --package _dev_tools -- "$(pwd)" install
 
 # Point this checkout's `core.hooksPath` at `.githooks/` so the
 # version-bump contract (see `tools/deploy-check/`) is enforced
@@ -76,13 +83,15 @@ install-git-hooks:
 uninstall-git-hooks:
   git config --unset core.hooksPath 2>/dev/null || true
 
-# Print the dylint_linting version pinned in Cargo.lock
+# Print the dylint_linting version pinned in Cargo.lock.
+# (Own target dir for the `cc` linker — see `install-dev-tools`.)
 dylint-version:
-  @cargo --config 'target."cfg(all())".linker="cc"' run --locked --quiet --package _dev_tools -- "$(pwd)" dylint-version
+  @cargo --config 'target."cfg(all())".linker="cc"' run --locked --target-dir target/dev-tools-cc --quiet --package _dev_tools -- "$(pwd)" dylint-version
 
-# Append `version=<dylint version>` to $GITHUB_OUTPUT (for CI)
+# Append `version=<dylint version>` to $GITHUB_OUTPUT (for CI).
+# (Own target dir for the `cc` linker — see `install-dev-tools`.)
 gha-dylint-version:
-  cargo --config 'target."cfg(all())".linker="cc"' run --locked --package _dev_tools -- "$(pwd)" gha-dylint-version
+  cargo --config 'target."cfg(all())".linker="cc"' run --locked --target-dir target/dev-tools-cc --package _dev_tools -- "$(pwd)" gha-dylint-version
 
 # Render the rule catalogue to `gh-pages/index.html`.
 gen-docs out_dir="gh-pages" git_ref="":


### PR DESCRIPTION
Speeds up cache-hit runs of the `Test` workflow so third-party dependencies are **reused** instead of recompiled.

## Changes

**Cache `~/.rustup`** (keyed on `rust-toolchain`) — `Install Rust` reuses the pinned nightly (+ `rustc-dev` / `rust-src` / `llvm-tools`) instead of re-downloading and re-extracting it every run.

**Isolate the `cc`-linker build** (`justfile`) — `install-dev-tools`, `gha-dylint-version`, and `dylint-version` build `_dev_tools` with the system `cc` linker (dylint-link doesn't exist yet at that point). They now build into a separate `target/dev-tools-cc` instead of the shared `target/`. Sharing it flipped every dependency they touch (`clap`, `anstyle*`, `serde`, `toml*`, …) to `ConfigSettingsChanged`, so the main `dylint-link` build recompiled them on every cache hit.

Also adds a comment documenting why the cache keeps the **whole** `~/.cargo`: dropping `registry/src` makes cargo re-extract crate sources with mtimes newer than the cached `target/` artifacts, which reruns every build-script crate (`proc-macro2`, `quote`, …) and cascades a full-graph recompile despite a hit.

Net effect on a warm run: no third-party dependency recompilation.