### PR TITLE
fix(derive-ordering): order derives written inside `cfg_attr(...)`

### DIFF
--- a/rules/derive_ordering.md
+++ b/rules/derive_ordering.md
@@ -24,6 +24,10 @@ does not police how derives are partitioned across multiple
 `#[derive(...)]` lines — that's a layout decision left to the
 author.
 
+A `cfg`-gated derive written as
+`#[cfg_attr(<cfg>, derive(...))]` is checked the same way as a
+bare `#[derive(...)]`; the `cfg` predicate is left untouched.
+
 ## Why restrict this?
 
 This is a stylistic preference, not a correctness issue. The

--- a/src/rules/derive_ordering.rs
+++ b/src/rules/derive_ordering.rs
@@ -1,5 +1,5 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use rustc_ast::{Attribute, MetaItemInner};
+use rustc_ast::{Attribute, MetaItemInner, MetaItemKind};
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -28,6 +28,10 @@ declare_tool_lint! {
     /// does not police how derives are partitioned across multiple
     /// `#[derive(...)]` lines — that's a layout decision left to the
     /// author.
+    ///
+    /// A `cfg`-gated derive written as
+    /// `#[cfg_attr(<cfg>, derive(...))]` is checked the same way as a
+    /// bare `#[derive(...)]`; the `cfg` predicate is left untouched.
     ///
     /// ### Why restrict this?
     ///
@@ -161,13 +165,40 @@ pub fn register_pass(lint_store: &mut LintStore) {
 
 impl EarlyLintPass for DeriveOrdering {
     fn check_attribute(&mut self, lint_context: &EarlyContext<'_>, attribute: &Attribute) {
-        if !attribute.has_name(sym::derive) {
-            return;
+        // Run before macro expansion (see `register_pass`), so the
+        // attribute arrives in its written form: a bare `#[derive(...)]`
+        // is named `derive`, and a `#[cfg_attr(<cfg>, derive(...))]` is
+        // still named `cfg_attr` with the `derive(...)` un-applied
+        // inside its argument list. A post-expansion pass would never
+        // see either, since the derive tokens are consumed during
+        // expansion — that is also why the `cfg_attr` form has to be
+        // unwrapped here rather than waiting for the synthesised
+        // `derive` attribute (which never materialises pre-expansion).
+        if attribute.has_name(sym::derive) {
+            if let Some(entries) = attribute.meta_item_list() {
+                self.check_derive_list(lint_context, &entries);
+            }
+        } else if attribute.has_name(sym::cfg_attr) {
+            let Some(cfg_attr_args) = attribute.meta_item_list() else {
+                return;
+            };
+            // `cfg_attr(<cfg>, attr_1, attr_2, ...)`: the first item is
+            // the `cfg` predicate; every item after it is an attribute
+            // the predicate gates. Any of them may be a `derive(...)`
+            // whose list we must order.
+            for wrapped_attribute in cfg_attr_args.iter().skip(1) {
+                let Some(wrapped_meta_item) = wrapped_attribute.meta_item() else {
+                    continue;
+                };
+                if !wrapped_meta_item.has_name(sym::derive) {
+                    continue;
+                }
+                let MetaItemKind::List(entries) = &wrapped_meta_item.kind else {
+                    continue;
+                };
+                self.check_derive_list(lint_context, entries);
+            }
         }
-        let Some(entries) = attribute.meta_item_list() else {
-            return;
-        };
-        self.check_derive_list(lint_context, &entries);
     }
 }
 

--- a/ui-toml/derive_ordering/alphabetical/fixture.rs
+++ b/ui-toml/derive_ordering/alphabetical/fixture.rs
@@ -36,4 +36,10 @@ struct _MultiLine;
 #[derive(Debug /* keep me */, Clone, Copy)]
 struct _InlineComment;
 
+// Bad: a `cfg`-gated derive is still ordered. The rule runs before
+// expansion, so the wrapped `derive(...)` is reached regardless of
+// whether the `cfg` predicate holds in this build.
+#[cfg_attr(unix, derive(Debug, Clone, Copy))]
+struct _CfgAttr;
+
 fn main() {}

--- a/ui-toml/derive_ordering/alphabetical/fixture.stderr
+++ b/ui-toml/derive_ordering/alphabetical/fixture.stderr
@@ -26,5 +26,11 @@ warning: derive list is not in ASCII-case-insensitive alphabetical order
 LL | #[derive(Debug /* keep me */, Clone, Copy)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: reorder the derive list: `Clone, Copy, Debug`
 
-warning: 4 warnings emitted
+warning: derive list is not in ASCII-case-insensitive alphabetical order
+  --> $DIR/fixture.rs:42:25
+   |
+LL | #[cfg_attr(unix, derive(Debug, Clone, Copy))]
+   |                         ^^^^^^^^^^^^^^^^^^ help: reorder the derive list: `Clone, Copy, Debug`
+
+warning: 5 warnings emitted
 


### PR DESCRIPTION
The rule runs as a pre-expansion pass, where a `cfg`-gated derive arrives as an un-applied `#[cfg_attr(<cfg>, derive(...))]` attribute named `cfg_attr` rather than `derive`, so `check_attribute` skipped it entirely and never ordered the wrapped list.

Unwrap the `cfg_attr` argument list and order any `derive(...)` it gates, the same as a bare `#[derive(...)]`, leaving the `cfg` predicate untouched.

Fixes <https://github.com/HoangVanKhai/my-translated-lyrics/issues/74>.
