### PR TITLE
fix(unit-test-file-layout): external test behind compound `cfg`

### DIFF
--- a/rules/unit_test_file_layout.md
+++ b/rules/unit_test_file_layout.md
@@ -35,7 +35,11 @@ axes are checked:
    is itself a valid extraction target.
 
 The module identifier is irrelevant to the layout rule; only the
-file's position relative to its parent matters.
+file's position relative to its parent matters. A test module
+gated by a compound predicate that still implies test —
+`#[cfg(all(test, unix))]`, `#[cfg(all(test, feature = "..."))]` —
+is recognised the same as a bare `#[cfg(test)]`, so its external
+file is not re-flagged as inline test code in a production file.
 
 Only the library or binary crate is checked. Integration tests
 (`tests/`), benchmarks (`benches/`), and examples (`examples/`)

--- a/src/rules/unit_test_file_layout.rs
+++ b/src/rules/unit_test_file_layout.rs
@@ -3,6 +3,7 @@ use rustc_session::{declare_tool_lint, impl_lint_pass};
 
 use crate::common::{DefaultState, resolved_state};
 
+mod cfg_test;
 mod config;
 mod layout;
 mod scan;
@@ -38,7 +39,11 @@ declare_tool_lint! {
     ///    is itself a valid extraction target.
     ///
     /// The module identifier is irrelevant to the layout rule; only the
-    /// file's position relative to its parent matters.
+    /// file's position relative to its parent matters. A test module
+    /// gated by a compound predicate that still implies test —
+    /// `#[cfg(all(test, unix))]`, `#[cfg(all(test, feature = "..."))]` —
+    /// is recognised the same as a bare `#[cfg(test)]`, so its external
+    /// file is not re-flagged as inline test code in a production file.
     ///
     /// Only the library or binary crate is checked. Integration tests
     /// (`tests/`), benchmarks (`benches/`), and examples (`examples/`)

--- a/src/rules/unit_test_file_layout/cfg_test.rs
+++ b/src/rules/unit_test_file_layout/cfg_test.rs
@@ -1,0 +1,43 @@
+//! Recognising a `#[cfg(...)]` predicate that gates an item to test
+//! builds, including a compound predicate like `cfg(all(test, unix))`
+//! that `clippy_utils::is_cfg_test` — which only matches a bare
+//! top-level `cfg(test)` — misses.
+
+use rustc_hir::attrs::CfgEntry;
+use rustc_hir::{HirId, find_attr};
+use rustc_middle::ty::TyCtxt;
+use rustc_span::sym;
+
+/// Whether the item at `id` carries a `#[cfg(...)]` whose predicate
+/// mentions `test` in a positive position — a bare `#[cfg(test)]` or a
+/// compound `#[cfg(all(test, unix))]`, `#[cfg(all(test, feature =
+/// "..."))]`, and so on.
+///
+/// `clippy_utils::is_cfg_test` only recognises a top-level `test`
+/// entry, so a `mod tests;` gated by a compound predicate is otherwise
+/// misclassified as a production module — leaving its target file to be
+/// re-flagged as inline test code living in a production file (the
+/// false positive of <https://github.com/KSXGitHub/perfectionist/issues/187>).
+/// This reads the parsed `CfgTrace` predicate rustc leaves on the item
+/// after configuration and walks every `all(...)` / `any(...)` nesting.
+pub(super) fn cfg_predicate_mentions_test(tcx: TyCtxt<'_>, id: HirId) -> bool {
+    find_attr!(tcx, id, CfgTrace(cfgs) => cfgs)
+        .is_some_and(|cfgs| cfgs.iter().any(|(cfg, _)| entry_mentions_test(cfg)))
+}
+
+/// Whether `test` appears as a predicate atom in a positive position.
+/// `all(...)` and `any(...)` are searched recursively; `not(...)` is
+/// deliberately *not* descended into. A `test` under a negation gates
+/// the item *away* from test builds — the opposite of what the caller
+/// asks — and an item whose only mention of `test` sits under a `not`
+/// is configured out of a `cfg(test)` build entirely, so this rule
+/// (which runs in that build) never sees it.
+fn entry_mentions_test(cfg: &CfgEntry) -> bool {
+    match cfg {
+        CfgEntry::NameValue { name, .. } => *name == sym::test,
+        CfgEntry::All(entries, _) | CfgEntry::Any(entries, _) => {
+            entries.iter().any(entry_mentions_test)
+        }
+        CfgEntry::Not(..) | CfgEntry::Bool(..) | CfgEntry::Version(..) => false,
+    }
+}

--- a/src/rules/unit_test_file_layout/scan.rs
+++ b/src/rules/unit_test_file_layout/scan.rs
@@ -7,13 +7,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use clippy_utils::diagnostics::span_lint_and_help;
-use clippy_utils::{is_cfg_test, is_test_function};
+use clippy_utils::is_test_function;
 use rustc_hir::{Item, ItemKind, Mod};
 use rustc_lint::{LateContext, LintContext};
 use rustc_span::hygiene::ExpnKind;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, SourceFile, Span, Symbol};
 
+use super::cfg_test::cfg_predicate_mentions_test;
 use super::config::{InlineStyle, UnitTestFileLayout};
 use super::{UNIT_TEST_FILE_LAYOUT, layout};
 
@@ -88,7 +89,7 @@ fn classify(
         return;
     }
 
-    let cfg_test = is_cfg_test(cx.tcx, item.hir_id());
+    let cfg_test = cfg_predicate_mentions_test(cx.tcx, item.hir_id());
     let is_test = cfg_test
         || (matches!(item.kind, ItemKind::Fn { .. })
             && is_test_function(cx.tcx, item.owner_id.def_id));

--- a/tests/unit_test_file_layout.rs
+++ b/tests/unit_test_file_layout.rs
@@ -102,6 +102,40 @@ fn does_not_flag_external_nested_layout() {
     );
 }
 
+/// A `mod tests;` gated by a *compound* cfg that still implies test
+/// (`#[cfg(all(test, unix))]`) is an external test-module declaration
+/// just like a bare `#[cfg(test)]`, so its target file must not be
+/// re-flagged as inline test code living in a production file. This is
+/// the false positive of
+/// <https://github.com/KSXGitHub/perfectionist/issues/187>: a `use`
+/// in the test file would otherwise count as production and the
+/// `#[test] fn` as misplaced inline test code.
+#[test]
+fn does_not_flag_external_module_gated_by_compound_cfg() {
+    let (_temp, stderr, success) = run_project_with_config(
+        "fixture_utfl_external_compound_cfg",
+        cargo_manifest_dir(),
+        &shared_target_dir(),
+        &[
+            ("src/lib.rs", "pub mod foo;\n"),
+            (
+                "src/foo.rs",
+                "pub fn parse() -> i32 {\n    1\n}\n\n#[cfg(all(test, unix))]\nmod tests;\n",
+            ),
+            (
+                "src/foo/tests.rs",
+                "use super::parse;\n\n#[test]\nfn works() { assert_eq!(parse(), 1); }\n",
+            ),
+        ],
+        "[\"perfectionist::unit_test_file_layout\"]\ninline_style = \"external_only\"\n",
+    );
+    assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");
+    assert!(
+        !stderr.contains(LINT),
+        "a compound-cfg-gated external test module must not be flagged; stderr was:\n{stderr}",
+    );
+}
+
 #[test]
 fn flags_external_module_in_sibling_location() {
     let (_temp, stderr, success) = run_project_with_config(


### PR DESCRIPTION
`clippy_utils::is_cfg_test` only matches a bare top-level `cfg(test)`, so an external `mod tests;` gated by a compound predicate that still implies test — `#[cfg(all(test, unix))]`, `#[cfg(all(test, feature = "..."))]` — was misclassified as a production module. The rule then descended into its file and re-flagged the `#[test]` items there as inline test code living in a production file (even suggesting a nonsensical nested `tests/tests.rs`).

Add a `cfg_test` helper that walks the parsed `CfgTrace` predicate rustc leaves on the item after configuration and reports whether `test` appears in a positive position, recursing through `all(...)` and `any(...)`. Use it in place of `is_cfg_test` when classifying items.

Fixes <https://github.com/KSXGitHub/perfectionist/issues/187>.
