### PR TITLE
fix(import-granularity): never fold a named item into `self`

### DIFF
--- a/src/rules/import_granularity.rs
+++ b/src/rules/import_granularity.rs
@@ -144,9 +144,15 @@ enum Violation {
     /// The group is flagged but no mechanical fix is offered, because
     /// merging would change what is compiled or exported.
     ManualMerge,
-    /// The group can be rewritten into `replacement`.
+    /// The group can be rewritten. `suggestions` holds one candidate for
+    /// an unambiguous merge, or two for an ambiguous `crate`-style merge
+    /// where a bare item shares a module's name: the `self`-fold
+    /// (`thing::{self, T}`) and the sibling-split (`{thing, thing::T}`).
+    /// The two shapes are not interchangeable, so both are offered and
+    /// the human picks — hence the `MaybeIncorrect` applicability the
+    /// caller attaches in that case.
     Reorganize {
-        replacement: String,
+        suggestions: Vec<String>,
         applicability: Applicability,
     },
 }
@@ -192,16 +198,26 @@ impl<'tcx> LateLintPass<'tcx> for ImportGranularity {
                         );
                     }
                     Violation::Reorganize {
-                        replacement,
+                        suggestions,
                         applicability,
-                    } => {
-                        diagnostic.span_suggestion(
-                            span,
-                            "reorganize the imports",
-                            replacement.clone(),
-                            *applicability,
-                        );
-                    }
+                    } => match suggestions.as_slice() {
+                        [single] => {
+                            diagnostic.span_suggestion(
+                                span,
+                                "reorganize the imports",
+                                single.clone(),
+                                *applicability,
+                            );
+                        }
+                        _ => {
+                            diagnostic.span_suggestions(
+                                span,
+                                "reorganize the imports",
+                                suggestions.iter().cloned(),
+                                *applicability,
+                            );
+                        }
+                    },
                 },
             );
         }
@@ -397,6 +413,20 @@ impl ImportGranularity {
             return;
         }
 
+        // Under `crate` style a name that is both an item and a module
+        // has a second, equally-valid shape: the `self`-fold. When it
+        // differs from the default sibling shape the merge is ambiguous —
+        // the rule can't tell from syntax whether the bare name also
+        // binds a value or macro — so both shapes are offered as
+        // `MaybeIncorrect` alternatives. See
+        // <https://github.com/KSXGitHub/perfectionist/issues/186>.
+        let self_fold = if let Style::Crate = self.style {
+            let folded = render::render_crate_self(&leaves);
+            (folded != bodies).then_some(folded)
+        } else {
+            None
+        };
+
         let replace_span = first
             .item
             .span
@@ -429,33 +459,48 @@ impl ImportGranularity {
             prefix.push_str(&pad);
         }
         prefix.push_str(&first.vis);
-        let replacement = bodies
-            .iter()
-            .map(|body| format!("{prefix}use {body};"))
-            .collect::<Vec<_>>()
-            .join(&format!("\n{pad}"));
+        let render_full = |bodies: &[String]| {
+            bodies
+                .iter()
+                .map(|body| format!("{prefix}use {body};"))
+                .collect::<Vec<_>>()
+                .join(&format!("\n{pad}"))
+        };
 
-        // Down to `MaybeIncorrect` when applying the fix would drop
-        // something the rewrite can't carry: an inline comment inside the
-        // replaced span, or a doc comment that differs across the merged
-        // statements (kept only from the first).
-        let has_comment = lint_context
-            .sess()
-            .source_map()
-            .span_to_snippet(replace_span)
-            .is_ok_and(|snippet| snippet.contains("//") || snippet.contains("/*"));
-        let drops_doc = group.iter().any(|entry| entry.attrs != first.attrs);
-        let applicability = if has_comment || drops_doc {
-            Applicability::MaybeIncorrect
-        } else {
-            Applicability::MachineApplicable
+        let (suggestions, applicability) = match self_fold {
+            // Ambiguous `crate` merge: offer the `self`-fold and the
+            // sibling-split, both `MaybeIncorrect`, and let the human
+            // pick the one that matches what the bare name resolves to.
+            Some(folded) => (
+                vec![render_full(&folded), render_full(&bodies)],
+                Applicability::MaybeIncorrect,
+            ),
+            None => {
+                // Down to `MaybeIncorrect` when applying the fix would
+                // drop something the rewrite can't carry: an inline
+                // comment inside the replaced span, or a doc comment that
+                // differs across the merged statements (kept only from
+                // the first).
+                let has_comment = lint_context
+                    .sess()
+                    .source_map()
+                    .span_to_snippet(replace_span)
+                    .is_ok_and(|snippet| snippet.contains("//") || snippet.contains("/*"));
+                let drops_doc = group.iter().any(|entry| entry.attrs != first.attrs);
+                let applicability = if has_comment || drops_doc {
+                    Applicability::MaybeIncorrect
+                } else {
+                    Applicability::MachineApplicable
+                };
+                (vec![render_full(&bodies)], applicability)
+            }
         };
 
         violations.push(Pending {
             anchor: first.item.span,
             span: replace_span,
             violation: Violation::Reorganize {
-                replacement,
+                suggestions,
                 applicability,
             },
         });

--- a/src/rules/import_granularity/check.rs
+++ b/src/rules/import_granularity/check.rs
@@ -74,14 +74,29 @@ fn is_module_shaped(stmt: &StmtInfo) -> bool {
 }
 
 /// `crate` style: every statement is maximally collapsed, descends from
-/// a single crate root, and no two statements share a root.
+/// a single crate root, and no two statements share a root — except a
+/// root imported as a bare crate item, which can't be folded with its
+/// own deeper imports without an unsafe synthesised `self` (see below).
 fn crate_compliant(stmts: &[&StmtInfo]) -> bool {
     if !stmts.iter().all(|stmt| stmt.collapsed) {
         return false;
     }
-    // Unlike `module` style, crate items participate here: `use foo;`
-    // and `use foo::Bar;` share the root `foo` and must collapse to
-    // `use foo::{self, Bar};`.
+    // A root imported as a bare crate item (`use foo;`) can't be folded
+    // together with a deeper import from the same root (`use foo::Bar;`):
+    // the only one-statement form is `use foo::{self, Bar};`, whose
+    // `self` re-imports the *module* `foo` alone, silently dropping any
+    // value or macro named `foo` and breaking the code that used it.
+    // `use foo;` binds `foo` in every namespace it exists in, so it is
+    // not interchangeable with the module-only `self`. There is no safe
+    // one-`use`-per-root shape, so such a root is left split across
+    // statements rather than flagged — the same reasoning that keeps
+    // `is_collapsed` from folding `{thing, thing::Opts}` inside a single
+    // brace. See <https://github.com/KSXGitHub/perfectionist/issues/186>.
+    let bare_item_roots: HashSet<&str> = stmts
+        .iter()
+        .filter(|stmt| stmt.is_crate_item())
+        .filter_map(|stmt| stmt.crate_root())
+        .collect();
     let mut seen: HashSet<&str> = HashSet::new();
     for stmt in stmts {
         // A top-level brace spanning several roots (`use {a::X, b::Y};`)
@@ -89,6 +104,9 @@ fn crate_compliant(stmts: &[&StmtInfo]) -> bool {
         let Some(root) = stmt.crate_root() else {
             return false;
         };
+        if bare_item_roots.contains(root) {
+            continue;
+        }
         if !seen.insert(root) {
             return false;
         }

--- a/src/rules/import_granularity/model.rs
+++ b/src/rules/import_granularity/model.rs
@@ -166,9 +166,10 @@ fn flatten_into(tree: &UseTree, prefix: &[String], out: &mut Vec<Leaf>) -> Optio
 }
 
 /// Whether `tree` is already maximally collapsed: no brace level holds
-/// two entries that share a leading segment, and no brace wraps a single
-/// non-`self` entry. This is the per-statement half of the `crate`-style
-/// check — a collapsed statement with a unique crate root needs no fix.
+/// two entries that share a leading segment *and* can be merged without
+/// synthesising a `self`, and no brace wraps a single non-`self` entry.
+/// This is the per-statement half of the `crate`-style check — a
+/// collapsed statement with a unique crate root needs no fix.
 fn is_collapsed(tree: &UseTree) -> bool {
     let UseTreeKind::Nested { items, .. } = &tree.kind else {
         return true;
@@ -183,27 +184,51 @@ fn is_collapsed(tree: &UseTree) -> bool {
         .iter()
         .map(|(sub, _)| sub.prefix.segments.first().map(|seg| seg.ident.name))
         .collect();
-    // Two entries that share a leading segment are mergeable — and thus
-    // not collapsed — only when at least one of them continues past that
-    // segment (`{path::Path, path::PathBuf}` → `path::{Path, PathBuf}`,
-    // or `{b, b::C}` → `b::{self, C}`). Two terminal leaves that merely
-    // share a name (`{B, B as C}`, distinct local bindings of the same
-    // path) cannot be folded further, so they stay collapsed. A bare
-    // glob (`*`) has no leading segment, shares with nothing, and is
-    // already canonical, so it is skipped.
+    // Two or more entries that share a leading segment are mergeable —
+    // and thus not collapsed — only when every one of them continues
+    // past that segment (`{path::Path, path::PathBuf}` →
+    // `path::{Path, PathBuf}`). When a *bare terminal* entry shares the
+    // segment (`{thing, thing::Opts}`), the only collapse is
+    // `thing::{self, Opts}`, and the synthesised `self` re-imports the
+    // *module* `thing` alone — silently dropping any value or macro
+    // re-exported under the same name, which stops the using code from
+    // compiling. We can't tell from syntax whether such a name exists,
+    // so the bare-terminal form is treated as already collapsed rather
+    // than risk a build-breaking rewrite. See
+    // <https://github.com/KSXGitHub/perfectionist/issues/186>. Two
+    // terminal leaves that merely share a name (`{B, B as C}`, distinct
+    // local bindings of the same path) likewise cannot be folded
+    // further, so they stay collapsed. A bare glob (`*`) has no leading
+    // segment, shares with nothing, and is already canonical, so it is
+    // skipped.
     for index in 0..items.len() {
         let Some(first) = firsts[index] else {
             continue;
         };
-        let mut shared = false;
-        let mut mergeable = continues(&items[index].0);
-        for (other_index, other) in items.iter().enumerate().skip(index + 1) {
+        // Evaluate each distinct leading segment once, over the whole
+        // brace level: skip any segment already handled at an earlier
+        // index. A bare terminal *anywhere* in the group forces `self`,
+        // so the group must be considered as a whole — a windowed scan
+        // would wrongly flag `{thing::A, thing::B}` inside
+        // `{thing, thing::A, thing::B}` while ignoring the bare `thing`.
+        if firsts[..index].contains(&Some(first)) {
+            continue;
+        }
+        let mut continuing = 0usize;
+        let mut bare_terminal = false;
+        for (other_index, other) in items.iter().enumerate() {
             if firsts[other_index] == Some(first) {
-                shared = true;
-                mergeable |= continues(&other.0);
+                if continues(&other.0) {
+                    continuing += 1;
+                } else {
+                    bare_terminal = true;
+                }
             }
         }
-        if shared && mergeable {
+        // `continuing >= 2 && !bare_terminal` means two or more entries
+        // share the segment and every one of them continues past it, so
+        // they fold into `seg::{...}` with no synthesised `self`.
+        if continuing >= 2 && !bare_terminal {
             return false;
         }
     }

--- a/src/rules/import_granularity/render.rs
+++ b/src/rules/import_granularity/render.rs
@@ -133,29 +133,23 @@ fn insert(node: &mut Node, module: &[String], leaf: &Leaf) {
 
 fn node_entries(node: &Node) -> Vec<String> {
     let mut entries: Vec<String> = Vec::new();
+    // Every named item stands on its own — even when its name matches a
+    // child module. `use a::b;` binds `b` in *every* namespace it exists
+    // in (type, value, macro), so it must NOT be folded into the child
+    // module's brace as `self`: `use a::b::{self};` re-imports only the
+    // module, silently dropping any value or macro re-exported under the
+    // same name and breaking the code that used it. The bare item and
+    // the module's own items therefore sit side by side as
+    // `a::{b, b::C}`, which is the most-collapsed form that preserves
+    // every binding. An explicit `self` written in the source
+    // (`LeafItem::SelfMod`) *is* a genuine module-only import and still
+    // renders inside the child brace. See
+    // <https://github.com/KSXGitHub/perfectionist/issues/186>.
     for item in &node.items {
-        // A named item that also names a child module — `use a::b;`
-        // sitting next to `use a::b::C;` — is the module imported as
-        // itself. It folds into that child as `self` below rather than
-        // standing alone, which would leave the duplicate leading
-        // segment `b` the rule flags as not-collapsed.
-        if let LeafItem::Named(name) = &item.item
-            && node.children.contains_key(name)
-        {
-            continue;
-        }
         entries.push(item_entry(item));
     }
     for (segment, child) in &node.children {
-        let mut sub = node_entries(child);
-        for item in &node.items {
-            if let LeafItem::Named(name) = &item.item
-                && name == segment
-            {
-                sub.push(format!("self{}", rename_suffix(&item.rename)));
-            }
-        }
-        sort_entries(&mut sub);
+        let sub = node_entries(child);
         entries.push(wrap(segment, &sub));
     }
     sort_entries(&mut entries);

--- a/src/rules/import_granularity/render.rs
+++ b/src/rules/import_granularity/render.rs
@@ -10,10 +10,28 @@ use super::model::{Leaf, LeafItem};
 
 pub(super) fn render(style: Style, leaves: &[Leaf]) -> Vec<String> {
     match style {
-        Style::Crate => render_crate(leaves),
+        // The default `crate` shape keeps a bare item that shares a
+        // module's name as its own sibling entry (`{thing, thing::T}`)
+        // rather than folding it into `self`, preserving every namespace
+        // the item binds. See [`render_crate_self`].
+        Style::Crate => render_crate(leaves, false),
         Style::Module => render_module(leaves),
         Style::Item => render_item(leaves),
     }
+}
+
+/// The alternative `crate` shape that folds a bare item sharing a
+/// module's name into `self` (`{thing, thing::T}` → `thing::{self, T}`).
+///
+/// This is the form rustfmt's `imports_granularity = "Crate"` produces,
+/// but it is *not* interchangeable with the sibling form: `use a::b;`
+/// binds `b` in every namespace, while `a::b::{self}` re-imports only the
+/// module `b`. When the two shapes differ the caller offers both as
+/// `MaybeIncorrect` alternatives, because the rule can't tell from syntax
+/// whether a value or macro is re-exported under the module's name (see
+/// <https://github.com/KSXGitHub/perfectionist/issues/186>).
+pub(super) fn render_crate_self(leaves: &[Leaf]) -> Vec<String> {
+    render_crate(leaves, true)
 }
 
 fn join(segments: &[String]) -> String {
@@ -131,42 +149,58 @@ fn insert(node: &mut Node, module: &[String], leaf: &Leaf) {
     }
 }
 
-fn node_entries(node: &Node) -> Vec<String> {
+fn node_entries(node: &Node, synthesize_self: bool) -> Vec<String> {
     let mut entries: Vec<String> = Vec::new();
-    // Every named item stands on its own — even when its name matches a
-    // child module. `use a::b;` binds `b` in *every* namespace it exists
-    // in (type, value, macro), so it must NOT be folded into the child
-    // module's brace as `self`: `use a::b::{self};` re-imports only the
-    // module, silently dropping any value or macro re-exported under the
-    // same name and breaking the code that used it. The bare item and
-    // the module's own items therefore sit side by side as
-    // `a::{b, b::C}`, which is the most-collapsed form that preserves
-    // every binding. An explicit `self` written in the source
-    // (`LeafItem::SelfMod`) *is* a genuine module-only import and still
-    // renders inside the child brace. See
-    // <https://github.com/KSXGitHub/perfectionist/issues/186>.
     for item in &node.items {
+        // A named item whose name matches a child module — `use a::b;`
+        // next to `use a::b::C;` — can be read as the module imported as
+        // itself. Only the `synthesize_self` shape folds it into that
+        // child's brace as `self` (below); the default sibling shape
+        // keeps it standing alone. The two are NOT interchangeable:
+        // `use a::b;` binds `b` in *every* namespace, so folding it to
+        // `a::b::{self}` drops any value or macro re-exported under the
+        // module's name. An explicit `self` written in the source
+        // (`LeafItem::SelfMod`) is a genuine module-only import and
+        // renders inside the child brace under both shapes. See
+        // <https://github.com/KSXGitHub/perfectionist/issues/186>.
+        if synthesize_self
+            && let LeafItem::Named(name) = &item.item
+            && node.children.contains_key(name)
+        {
+            continue;
+        }
         entries.push(item_entry(item));
     }
     for (segment, child) in &node.children {
-        let sub = node_entries(child);
+        let mut sub = node_entries(child, synthesize_self);
+        if synthesize_self {
+            for item in &node.items {
+                if let LeafItem::Named(name) = &item.item
+                    && name == segment
+                {
+                    sub.push(format!("self{}", rename_suffix(&item.rename)));
+                }
+            }
+            sort_entries(&mut sub);
+        }
         entries.push(wrap(segment, &sub));
     }
     sort_entries(&mut entries);
     entries
 }
 
-fn render_crate(leaves: &[Leaf]) -> Vec<String> {
+fn render_crate(leaves: &[Leaf], synthesize_self: bool) -> Vec<String> {
     // Everything goes into one trie keyed by path segment; a bare
     // `use foo;` lands as a named item at the root and renders as `foo`,
-    // while `use foo::Bar;` descends into the `foo` child — the two fold
-    // together via [`node_entries`]. Each top-level entry is one
-    // statement.
+    // while `use foo::Bar;` descends into the `foo` child. Under
+    // `synthesize_self` the two fold together as `foo::{self, Bar}`;
+    // otherwise they sit side by side as `{foo, foo::Bar}`. Each
+    // top-level entry is one statement.
     let mut root = Node::default();
     for leaf in leaves {
         insert(&mut root, &leaf.module, leaf);
     }
-    let mut out = node_entries(&root);
+    let mut out = node_entries(&root, synthesize_self);
     out.sort();
     out.dedup();
     out

--- a/src/rules/import_granularity/render.rs
+++ b/src/rules/import_granularity/render.rs
@@ -10,10 +10,6 @@ use super::model::{Leaf, LeafItem};
 
 pub(super) fn render(style: Style, leaves: &[Leaf]) -> Vec<String> {
     match style {
-        // The default `crate` shape keeps a bare item that shares a
-        // module's name as its own sibling entry (`{thing, thing::T}`)
-        // rather than folding it into `self`, preserving every namespace
-        // the item binds. See [`render_crate_self`].
         Style::Crate => render_crate(leaves, false),
         Style::Module => render_module(leaves),
         Style::Item => render_item(leaves),

--- a/ui-toml/import_granularity/crate_style/fixture.rs
+++ b/ui-toml/import_granularity/crate_style/fixture.rs
@@ -66,6 +66,15 @@ mod explicit_self {
     use crate::thing::{self, T};
 }
 
+// Good: the sibling-split form of the very same imports — the bare module
+// `thing` next to the item `T`. It is already one `use` per crate root
+// and preserves every namespace `thing` binds, so it is the minimal
+// crate-granularity shape and is left alone — never "collapsed" further
+// into the `self` form, which the rule cannot prove is equivalent.
+mod sibling_form {
+    use crate::{thing, thing::T};
+}
+
 // A name that is both a module and a value: `dual` is a module *and* a
 // function re-exported at the crate root under the same name.
 mod dual {

--- a/ui-toml/import_granularity/crate_style/fixture.rs
+++ b/ui-toml/import_granularity/crate_style/fixture.rs
@@ -46,14 +46,24 @@ mod thing {
     pub struct T;
 }
 
-// Bad: a bare import plus an item from a module of the same name merge
-// into one `use` per root — but as the sibling form `{thing, thing::T}`,
-// never the `self` form. `use crate::thing;` binds `thing` in every
-// namespace; collapsing it to `crate::thing::{self, T}` would re-import
-// only the module and drop any value or macro named `thing`.
+// Bad: a bare import plus an item from a module of the same name share a
+// crate root and must merge into one `use`. The merge is ambiguous — the
+// `self`-fold `crate::thing::{self, T}` and the sibling-split
+// `crate::{thing, thing::T}` are not interchangeable (the fold re-imports
+// only the module `thing`, dropping any value or macro named `thing`), so
+// the rule offers both as `MaybeIncorrect` suggestions and lets the
+// author pick.
 mod self_merge {
     use crate::thing;
     use crate::thing::T;
+}
+
+// Good: an explicit `self` import is already a valid, compiling collapsed
+// form (the two brace entries name different things — the module via
+// `self` and the item `T`), so it is left alone, never rewritten into the
+// sibling shape.
+mod explicit_self {
+    use crate::thing::{self, T};
 }
 
 // A name that is both a module and a value: `dual` is a module *and* a

--- a/ui-toml/import_granularity/crate_style/fixture.rs
+++ b/ui-toml/import_granularity/crate_style/fixture.rs
@@ -46,11 +46,49 @@ mod thing {
     pub struct T;
 }
 
-// Bad: a module imported on its own line plus an item from it folds
-// into the `self` form.
+// Bad: a bare import plus an item from a module of the same name merge
+// into one `use` per root — but as the sibling form `{thing, thing::T}`,
+// never the `self` form. `use crate::thing;` binds `thing` in every
+// namespace; collapsing it to `crate::thing::{self, T}` would re-import
+// only the module and drop any value or macro named `thing`.
 mod self_merge {
     use crate::thing;
     use crate::thing::T;
+}
+
+// A name that is both a module and a value: `dual` is a module *and* a
+// function re-exported at the crate root under the same name.
+mod dual {
+    pub fn dual() -> u32 {
+        0
+    }
+    pub struct Opts;
+}
+pub use dual::dual;
+
+// Good: a single statement importing the value `dual` *and* an item
+// from the module `dual` is already the minimal crate-granularity form.
+// Collapsing it to `crate::dual::{self, Opts}` would re-import only the
+// module, dropping the value `dual` and breaking the call below — so the
+// rule must leave it alone.
+// See <https://github.com/KSXGitHub/perfectionist/issues/186>.
+mod dual_ns {
+    use crate::{dual, dual::Opts};
+
+    fn use_them() -> u32 {
+        let _opts = Opts;
+        dual()
+    }
+}
+
+// Good: a bare crate-root import (`use std;`) can't be folded with a
+// deeper import from the same root (`use std::io::Write;`). The only
+// one-statement form is `std::{self, io::Write}`, whose `self` re-imports
+// the crate alone — so there's no safe one-`use`-per-root shape and the
+// split is left alone rather than rewritten into a `self` merge.
+mod bare_root_item {
+    use std;
+    use std::io::Write;
 }
 
 fn main() {}

--- a/ui-toml/import_granularity/crate_style/fixture.stderr
+++ b/ui-toml/import_granularity/crate_style/fixture.stderr
@@ -23,11 +23,22 @@ LL | |     use std::io::*;
    | |___________________^ help: reorganize the imports: `use std::io::{Read, *};`
 
 warning: imports are not collapsed to one `use` per crate root
-  --> $DIR/fixture.rs:55:5
+  --> $DIR/fixture.rs:57:5
    |
 LL | /     use crate::thing;
 LL | |     use crate::thing::T;
-   | |________________________^ help: reorganize the imports: `use crate::{thing, thing::T};`
+   | |________________________^
+   |
+help: reorganize the imports
+   |
+LL -     use crate::thing;
+LL -     use crate::thing::T;
+LL +     use crate::thing::{self, T};
+   |
+LL -     use crate::thing;
+LL -     use crate::thing::T;
+LL +     use crate::{thing, thing::T};
+   |
 
 warning: 4 warnings emitted
 

--- a/ui-toml/import_granularity/crate_style/fixture.stderr
+++ b/ui-toml/import_granularity/crate_style/fixture.stderr
@@ -23,11 +23,11 @@ LL | |     use std::io::*;
    | |___________________^ help: reorganize the imports: `use std::io::{Read, *};`
 
 warning: imports are not collapsed to one `use` per crate root
-  --> $DIR/fixture.rs:52:5
+  --> $DIR/fixture.rs:55:5
    |
 LL | /     use crate::thing;
 LL | |     use crate::thing::T;
-   | |________________________^ help: reorganize the imports: `use crate::thing::{self, T};`
+   | |________________________^ help: reorganize the imports: `use crate::{thing, thing::T};`
 
 warning: 4 warnings emitted
 


### PR DESCRIPTION
Under `style = "crate"`, `import_granularity` collapsed `use a::b; use a::b::C;` — and the single statement `use a::{b, b::C}` — into `use a::b::{self, C};`. But `use a::b;` binds `b` in *every* namespace, while `self` re-imports only the module `b`. When a value or macro is re-exported under a module's name, the merge dropped that binding and the code no longer compiled. The parse/model layer already kept a named item distinct from `self`; the fault was in the `crate`-style collapser, which treated the two as interchangeable.

Changes:

- A single statement that is already one `use` per root is no longer flagged — both `use crate::{thing, thing::T};` (namespace-preserving) and `use crate::thing::{self, T};` (explicit `self`, already compiles) are left alone.
- A genuine merge (e.g. two statements `use crate::thing; use crate::thing::T;`) is still flagged, but now offers **two `MaybeIncorrect` suggestions** — the `self`-fold `crate::thing::{self, T}` and the sibling-split `crate::{thing, thing::T}` — and lets the author pick, since the rule is syntactic and can't tell whether the bare name also binds a value or macro.
- A bare crate-root item (`use foo;`) colliding with `use foo::Bar;` has no safe one-`use`-per-root shape either, so it is left split rather than rewritten.

A follow-up (#206) tracks an opt-in knob for projects that want to always enforce one of the two shapes.

Fixes <https://github.com/KSXGitHub/perfectionist/issues/186>.

https://claude.ai/code/session_01NqsDwjD131oyrZhPEYH14A