### PR TITLE
fix(derive-ordering): order derives nested in `cfg_attr`

### DIFF
--- a/src/rules/derive_ordering.rs
+++ b/src/rules/derive_ordering.rs
@@ -178,31 +178,43 @@ impl EarlyLintPass for DeriveOrdering {
             if let Some(entries) = attribute.meta_item_list() {
                 self.check_derive_list(lint_context, &entries);
             }
-        } else if attribute.has_name(sym::cfg_attr) {
-            let Some(cfg_attr_args) = attribute.meta_item_list() else {
-                return;
-            };
-            // `cfg_attr(<cfg>, attr_1, attr_2, ...)`: the first item is
-            // the `cfg` predicate; every item after it is an attribute
-            // the predicate gates. Any of them may be a `derive(...)`
-            // whose list we must order.
-            for wrapped_attribute in cfg_attr_args.iter().skip(1) {
-                let Some(wrapped_meta_item) = wrapped_attribute.meta_item() else {
-                    continue;
-                };
-                if !wrapped_meta_item.has_name(sym::derive) {
-                    continue;
-                }
-                let MetaItemKind::List(entries) = &wrapped_meta_item.kind else {
-                    continue;
-                };
-                self.check_derive_list(lint_context, entries);
-            }
+        } else if attribute.has_name(sym::cfg_attr)
+            && let Some(cfg_attr_args) = attribute.meta_item_list()
+        {
+            self.check_cfg_attr_args(lint_context, &cfg_attr_args);
         }
     }
 }
 
 impl DeriveOrdering {
+    /// Order every `derive(...)` gated by a `cfg_attr`, given its
+    /// argument list `cfg_attr(<cfg>, attr_1, attr_2, ...)`. The first
+    /// item is the `cfg` predicate (left untouched); every item after it
+    /// is an attribute the predicate gates. Any of them may be a
+    /// `derive(...)` whose list we must order — or a nested `cfg_attr`
+    /// (`cfg_attr(a, cfg_attr(b, derive(...)))`, equivalent to
+    /// `cfg_attr(all(a, b), derive(...))`), whose own argument list we
+    /// recurse into so a derive wrapped at any nesting depth is reached.
+    fn check_cfg_attr_args(
+        &self,
+        lint_context: &EarlyContext<'_>,
+        cfg_attr_args: &[MetaItemInner],
+    ) {
+        for wrapped_attribute in cfg_attr_args.iter().skip(1) {
+            let Some(wrapped_meta_item) = wrapped_attribute.meta_item() else {
+                continue;
+            };
+            let MetaItemKind::List(entries) = &wrapped_meta_item.kind else {
+                continue;
+            };
+            if wrapped_meta_item.has_name(sym::derive) {
+                self.check_derive_list(lint_context, entries);
+            } else if wrapped_meta_item.has_name(sym::cfg_attr) {
+                self.check_cfg_attr_args(lint_context, entries);
+            }
+        }
+    }
+
     fn check_derive_list(&self, lint_context: &EarlyContext<'_>, entries: &[MetaItemInner]) {
         // Fewer than two entries can never be in the wrong order: a
         // zero- or one-entry list is vacuously sorted. The same

--- a/ui-toml/derive_ordering/alphabetical/fixture.rs
+++ b/ui-toml/derive_ordering/alphabetical/fixture.rs
@@ -42,4 +42,23 @@ struct _InlineComment;
 #[cfg_attr(unix, derive(Debug, Clone, Copy))]
 struct _CfgAttr;
 
+// Bad: a `cfg_attr` may gate more than one attribute; every
+// `derive(...)` after the predicate is ordered independently. Here only
+// the first list is out of order (`Eq, PartialEq` is already sorted).
+#[cfg_attr(unix, derive(Debug, Clone), derive(Eq, PartialEq))]
+struct _CfgAttrMulti;
+
+// Bad: a compound `cfg` predicate is left untouched while its gated
+// `derive(...)` is ordered — the predicate is just the first item and
+// is skipped regardless of its shape.
+#[cfg_attr(all(unix, target_pointer_width = "64"), derive(Debug, Clone))]
+struct _CfgAttrCompound;
+
+// Bad: a `derive(...)` nested under several `cfg_attr` layers
+// (`cfg_attr(a, cfg_attr(b, derive(...)))`, the same as
+// `cfg_attr(all(a, b), derive(...))`) is reached by recursing into each
+// gated `cfg_attr` argument list.
+#[cfg_attr(unix, cfg_attr(target_os = "linux", derive(Debug, Clone)))]
+struct _CfgAttrNested;
+
 fn main() {}

--- a/ui-toml/derive_ordering/alphabetical/fixture.stderr
+++ b/ui-toml/derive_ordering/alphabetical/fixture.stderr
@@ -32,5 +32,23 @@ warning: derive list is not in ASCII-case-insensitive alphabetical order
 LL | #[cfg_attr(unix, derive(Debug, Clone, Copy))]
    |                         ^^^^^^^^^^^^^^^^^^ help: reorder the derive list: `Clone, Copy, Debug`
 
-warning: 5 warnings emitted
+warning: derive list is not in ASCII-case-insensitive alphabetical order
+  --> $DIR/fixture.rs:48:25
+   |
+LL | #[cfg_attr(unix, derive(Debug, Clone), derive(Eq, PartialEq))]
+   |                         ^^^^^^^^^^^^ help: reorder the derive list: `Clone, Debug`
+
+warning: derive list is not in ASCII-case-insensitive alphabetical order
+  --> $DIR/fixture.rs:54:59
+   |
+LL | #[cfg_attr(all(unix, target_pointer_width = "64"), derive(Debug, Clone))]
+   |                                                           ^^^^^^^^^^^^ help: reorder the derive list: `Clone, Debug`
+
+warning: derive list is not in ASCII-case-insensitive alphabetical order
+  --> $DIR/fixture.rs:61:55
+   |
+LL | #[cfg_attr(unix, cfg_attr(target_os = "linux", derive(Debug, Clone)))]
+   |                                                       ^^^^^^^^^^^^ help: reorder the derive list: `Clone, Debug`
+
+warning: 8 warnings emitted
 


### PR DESCRIPTION
Follow-up to #202, found while reviewing it.

#202 unwrapped a single `cfg_attr` layer to reach the `derive(...)` it gates, but a derive nested under more than one layer slipped through — the inner item is named `cfg_attr`, not `derive`, so the one-level scan ignored it:

```rust
// not ordered before this PR (equivalent to `cfg_attr(all(a, b), derive(...))`)
#[cfg_attr(a, cfg_attr(b, derive(Debug, Clone)))]
struct S;
```

This recurses into each gated `cfg_attr` argument list, so a `derive(...)` wrapped at any nesting depth is ordered. Regression fixtures cover the nested form, a multi-`derive` `cfg_attr`, and a compound-predicate `cfg_attr`.

Verified locally with `just all` (build, doc, lint, test, self-lint).

https://claude.ai/code/session_019QCqyukmaGhH2kMJF4FLmu