### PR TITLE
test(derive-ordering): platform agnostic

### DIFF
--- a/ui-toml/derive_ordering/alphabetical/fixture.rs
+++ b/ui-toml/derive_ordering/alphabetical/fixture.rs
@@ -61,4 +61,13 @@ struct _CfgAttrCompound;
 #[cfg_attr(unix, cfg_attr(target_os = "linux", derive(Debug, Clone)))]
 struct _CfgAttrNested;
 
+// Bad: a derive gated by a predicate that is FALSE on the test host is
+// still ordered — `derive_ordering` is a pre-expansion pass and never
+// evaluates the `cfg` predicate, so the check is host-independent. Keep
+// the predicate as `windows` (false on the Unix CI host): "simplifying"
+// it back to `unix` would silently drop the platform-independence
+// coverage this case exists to pin.
+#[cfg_attr(windows, derive(Debug, Clone, Copy))]
+struct _CfgAttrInactivePredicate;
+
 fn main() {}

--- a/ui-toml/derive_ordering/alphabetical/fixture.stderr
+++ b/ui-toml/derive_ordering/alphabetical/fixture.stderr
@@ -50,5 +50,11 @@ warning: derive list is not in ASCII-case-insensitive alphabetical order
 LL | #[cfg_attr(unix, cfg_attr(target_os = "linux", derive(Debug, Clone)))]
    |                                                       ^^^^^^^^^^^^ help: reorder the derive list: `Clone, Debug`
 
-warning: 8 warnings emitted
+warning: derive list is not in ASCII-case-insensitive alphabetical order
+  --> $DIR/fixture.rs:70:28
+   |
+LL | #[cfg_attr(windows, derive(Debug, Clone, Copy))]
+   |                            ^^^^^^^^^^^^^^^^^^ help: reorder the derive list: `Clone, Copy, Debug`
+
+warning: 9 warnings emitted
 


### PR DESCRIPTION
Adds a regression fixture pinning the host-independence of `perfectionist::derive_ordering`.

`derive_ordering` runs as a pre-expansion pass and skips the `cfg` predicate (`.skip(1)` in `check_cfg_attr_args`) without evaluating it, so a mis-ordered derive gated behind a predicate is ordered regardless of the host platform. The existing `cfg_attr` fixtures all used predicates true on the Unix CI host (`unix`, `target_os = "linux"`), so they'd pass even if the rule wrongly evaluated the predicate first. This adds the missing direction: a predicate that is **false** on the host.

Changes (test-only):
- `ui-toml/derive_ordering/alphabetical/fixture.rs` — new `#[cfg_attr(windows, derive(Debug, Clone, Copy))]` case on `_CfgAttrInactivePredicate`, with a comment explaining why the predicate must stay `windows` (so it isn't "simplified" back to `unix`, dropping the coverage).
- `ui-toml/derive_ordering/alphabetical/fixture.stderr` — matching warning, count bumped to 9.

`just all` passes (fmt, build, doc, lint, test, self-lint).

Resolves <https://github.com/KSXGitHub/perfectionist/issues/212>.