### PR TITLE
refactor: rename `ch` to `char`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -340,9 +340,9 @@ pub(crate) fn resolve_symbol_set_from_chars(
     extras: impl IntoIterator<Item: Into<char>>,
     ignore: impl IntoIterator<Item: Into<char>>,
 ) -> BTreeSet<Symbol> {
-    let intern = |ch: char| {
+    let intern = |char: char| {
         let mut buf = [0u8; 4];
-        Symbol::intern(ch.encode_utf8(&mut buf))
+        Symbol::intern(char.encode_utf8(&mut buf))
     };
     let ignore: BTreeSet<Symbol> = ignore.into_iter().map(Into::into).map(intern).collect();
     defaults

--- a/tools/deploy-check/src/hook.rs
+++ b/tools/deploy-check/src/hook.rs
@@ -88,7 +88,7 @@ pub(crate) fn pre_push(root: &Path) -> Result<(), RuntimeError> {
         if !is_version_literal(tag_name) {
             continue;
         }
-        if local_sha.chars().all(|ch| ch == '0') {
+        if local_sha.chars().all(|char| char == '0') {
             // Tag deletion — nothing to verify.
             continue;
         }

--- a/tools/gen-docs/src/extract/serde_attrs.rs
+++ b/tools/gen-docs/src/extract/serde_attrs.rs
@@ -115,8 +115,8 @@ pub(crate) fn apply_rename_all(style: &str, name: &str) -> String {
 pub(crate) fn pascal_to_snake(name: &str) -> String {
     let mut out = String::with_capacity(name.len() + 2);
     let chars: Vec<char> = name.chars().collect();
-    for (index, &ch) in chars.iter().enumerate() {
-        if ch.is_ascii_uppercase() {
+    for (index, &char) in chars.iter().enumerate() {
+        if char.is_ascii_uppercase() {
             let prev_lower = index > 0 && chars[index - 1].is_ascii_lowercase();
             let next_lower = chars
                 .get(index + 1)
@@ -124,9 +124,9 @@ pub(crate) fn pascal_to_snake(name: &str) -> String {
             if index > 0 && (prev_lower || next_lower) {
                 out.push('_');
             }
-            out.push(ch.to_ascii_lowercase());
+            out.push(char.to_ascii_lowercase());
         } else {
-            out.push(ch);
+            out.push(char);
         }
     }
     out

--- a/tools/gen-docs/src/render/markdown.rs
+++ b/tools/gen-docs/src/render/markdown.rs
@@ -101,9 +101,9 @@ fn highlight_to_html(code: &str, lang: &str) -> String {
 /// `language-...` class is purely decorative here.
 fn lang_class_attr(lang: &str) -> String {
     let safe = !lang.is_empty()
-        && lang
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '+' | '#' | '.'));
+        && lang.chars().all(|char| {
+            char.is_ascii_alphanumeric() || matches!(char, '_' | '-' | '+' | '#' | '.')
+        });
     if safe {
         format!(" class=\"language-{lang}\"")
     } else {


### PR DESCRIPTION
Rename every `ch` binding (the abbreviation for a single character) to `char`. Rust resolves variable-vs-type by position, so `|char: char|` and `for &char in ...` remain valid.

Touched four files:

- `src/common.rs` — the `intern` closure parameter.
- `tools/gen-docs/src/extract/serde_attrs.rs` — the `pascal_to_snake` loop binding.
- `tools/gen-docs/src/render/markdown.rs` — the `lang_class_attr` closure (rustfmt reflowed the closure body).
- `tools/deploy-check/src/hook.rs` — the SHA-scanning closure.

`just all` passes (fmt, build, doc, lint, test, self-lint).

Resolves <https://github.com/KSXGitHub/perfectionist/issues/210>.