### PR TITLE
feat(pages): dark theme

### DIFF
--- a/tools/gen-docs/src/assets/theme-dark.svg
+++ b/tools/gen-docs/src/assets/theme-dark.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  GitHub Octicons `moon-16`, MIT License, Copyright (c) GitHub Inc.
+  https://github.com/primer/octicons/blob/main/LICENSE
+
+  Path is verbatim from upstream. This file is used as a CSS mask, so
+  the fill colour is irrelevant (only the shape's alpha matters); the
+  visible colour comes from the masked element's `background-color`.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="#000000"><path d="M9.598 1.591a.749.749 0 0 1 .785-.175 7.001 7.001 0 1 1-8.967 8.967.75.75 0 0 1 .961-.96 5.5 5.5 0 0 0 7.046-7.046.75.75 0 0 1 .175-.786Zm1.616 1.945a7 7 0 0 1-7.678 7.678 5.499 5.499 0 1 0 7.678-7.678Z"/></svg>

--- a/tools/gen-docs/src/assets/theme-light.svg
+++ b/tools/gen-docs/src/assets/theme-light.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  GitHub Octicons `sun-16`, MIT License, Copyright (c) GitHub Inc.
+  https://github.com/primer/octicons/blob/main/LICENSE
+
+  Path is verbatim from upstream. This file is used as a CSS mask, so
+  the fill colour is irrelevant (only the shape's alpha matters); the
+  visible colour comes from the masked element's `background-color`.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="#000000"><path d="M8 12a4 4 0 1 1 0-8 4 4 0 0 1 0 8Zm0-1.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Zm5.657-8.157a.75.75 0 0 1 0 1.061l-1.061 1.06a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734l1.06-1.06a.75.75 0 0 1 1.06 0Zm-9.193 9.193a.75.75 0 0 1 0 1.06l-1.06 1.061a.75.75 0 1 1-1.061-1.06l1.06-1.061a.75.75 0 0 1 1.061 0ZM8 0a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0V.75A.75.75 0 0 1 8 0ZM3 8a.75.75 0 0 1-.75.75H.75a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 3 8Zm13 0a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5A.75.75 0 0 1 16 8Zm-8 5a.75.75 0 0 1 .75.75v1.5a.75.75 0 0 1-1.5 0v-1.5A.75.75 0 0 1 8 13Zm3.536-1.464a.75.75 0 0 1 1.06 0l1.061 1.06a.75.75 0 0 1-1.06 1.061l-1.061-1.06a.75.75 0 0 1 0-1.061ZM2.343 2.343a.75.75 0 0 1 1.061 0l1.06 1.061a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-1.06-1.06a.75.75 0 0 1 0-1.06Z"/></svg>

--- a/tools/gen-docs/src/assets/theme-system.svg
+++ b/tools/gen-docs/src/assets/theme-system.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  GitHub Octicons `device-desktop-16`, MIT License, Copyright (c) GitHub Inc.
+  https://github.com/primer/octicons/blob/main/LICENSE
+
+  Path is verbatim from upstream. Represents the "System" (follow the
+  device) choice. This file is used as a CSS mask, so the fill colour is
+  irrelevant (only the shape's alpha matters); the visible colour comes
+  from the masked element's `background-color`.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="#000000"><path d="M14.25 1c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12h-3.727c.099 1.041.52 1.872 1.292 2.757A.752.752 0 0 1 11.25 16h-6.5a.75.75 0 0 1-.565-1.243c.772-.885 1.192-1.716 1.292-2.757H1.75A1.75 1.75 0 0 1 0 10.25v-7.5C0 1.784.784 1 1.75 1ZM1.75 2.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25ZM9.018 12H6.982a5.72 5.72 0 0 1-.765 2.5h3.566a5.72 5.72 0 0 1-.765-2.5Z"/></svg>

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -43,10 +43,11 @@ use pipe_trait::Pipe;
 use crate::check_md::{CheckOutcome, check_rules_dir, write_rules_dir};
 use crate::extract::collect_rules;
 use crate::model::{RenderContext, Rule};
-use crate::render::markdown::HIGHLIGHT_CSS;
+use crate::render::markdown::{HIGHLIGHT_CSS, HIGHLIGHT_CSS_DARK};
 use crate::render::{
-    HIGHLIGHT_CSS_FILENAME, NAV_TOGGLE_SCRIPT, NAV_TOGGLE_SCRIPT_FILENAME, RULE_ANCHOR_ICON,
-    RULE_ANCHOR_ICON_FILENAME, STYLESHEETS, render_page,
+    HIGHLIGHT_CSS_DARK_FILENAME, HIGHLIGHT_CSS_FILENAME, NAV_TOGGLE_SCRIPT,
+    NAV_TOGGLE_SCRIPT_FILENAME, RULE_ANCHOR_ICON, RULE_ANCHOR_ICON_FILENAME, STYLESHEETS,
+    THEME_ICONS, THEME_TOGGLE_SCRIPT, THEME_TOGGLE_SCRIPT_FILENAME, render_page,
 };
 
 #[derive(Parser)]
@@ -191,16 +192,33 @@ fn run_html(root: &Path, out_dir: &Path, git_ref: &str) -> ExitCode {
     }
     // The syntax-highlighting CSS is generated at runtime by syntect,
     // so it's written from the live string rather than `include_str!`.
+    // The dark variant is generated the same way and linked after it.
     fs::write(out_dir.join(HIGHLIGHT_CSS_FILENAME), &*HIGHLIGHT_CSS)
         .expect("failed to write highlight CSS");
-    // The navigation script, loaded by the page via `<script src>`.
+    fs::write(
+        out_dir.join(HIGHLIGHT_CSS_DARK_FILENAME),
+        &*HIGHLIGHT_CSS_DARK,
+    )
+    .expect("failed to write dark highlight CSS");
+    // The page scripts, loaded via `<script src>`.
     fs::write(out_dir.join(NAV_TOGGLE_SCRIPT_FILENAME), NAV_TOGGLE_SCRIPT)
         .expect("failed to write nav script");
+    fs::write(
+        out_dir.join(THEME_TOGGLE_SCRIPT_FILENAME),
+        THEME_TOGGLE_SCRIPT,
+    )
+    .expect("failed to write theme script");
 
     // Lands beside index.html so the stylesheet's relative `url(...)`
     // resolves.
     let icon_path = out_dir.join(RULE_ANCHOR_ICON_FILENAME);
     fs::write(&icon_path, RULE_ANCHOR_ICON).expect("failed to write rule-anchor icon");
+
+    // The colour-scheme icons, referenced as CSS masks by settings.css.
+    for (name, content) in THEME_ICONS {
+        let path = out_dir.join(name);
+        fs::write(&path, content).unwrap_or_else(|error| panic!("failed to write {name}: {error}"));
+    }
 
     eprintln!("wrote {} rule(s) to {}", rules.len(), index_path.display());
     ExitCode::SUCCESS

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -43,7 +43,7 @@ use pipe_trait::Pipe;
 use crate::check_md::{CheckOutcome, check_rules_dir, write_rules_dir};
 use crate::extract::collect_rules;
 use crate::model::{RenderContext, Rule};
-use crate::render::markdown::{HIGHLIGHT_CSS, HIGHLIGHT_CSS_DARK};
+use crate::render::markdown::HIGHLIGHT_CSS;
 use crate::render::{
     HIGHLIGHT_CSS_DARK_FILENAME, HIGHLIGHT_CSS_LIGHT_FILENAME, NAV_TOGGLE_SCRIPT,
     NAV_TOGGLE_SCRIPT_FILENAME, RULE_ANCHOR_ICON, RULE_ANCHOR_ICON_FILENAME, STYLESHEETS,
@@ -190,14 +190,18 @@ fn run_html(root: &Path, out_dir: &Path, git_ref: &str) -> ExitCode {
         let path = out_dir.join(name);
         fs::write(&path, content).unwrap_or_else(|error| panic!("failed to write {name}: {error}"));
     }
-    // The syntax-highlighting CSS is generated at runtime by syntect,
-    // so it's written from the live string rather than `include_str!`.
-    // The dark variant is generated the same way and linked after it.
-    fs::write(out_dir.join(HIGHLIGHT_CSS_LIGHT_FILENAME), &*HIGHLIGHT_CSS)
-        .expect("failed to write light highlight CSS");
+    // The syntax-highlighting CSS is generated at runtime by syntect
+    // (both sheets from one theme-set load), so it's written from the
+    // live strings rather than `include_str!`. The dark variant is
+    // linked after the light one.
+    fs::write(
+        out_dir.join(HIGHLIGHT_CSS_LIGHT_FILENAME),
+        &HIGHLIGHT_CSS.light,
+    )
+    .expect("failed to write light highlight CSS");
     fs::write(
         out_dir.join(HIGHLIGHT_CSS_DARK_FILENAME),
-        &*HIGHLIGHT_CSS_DARK,
+        &HIGHLIGHT_CSS.dark,
     )
     .expect("failed to write dark highlight CSS");
     // The page scripts, loaded via `<script src>`.

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -45,7 +45,7 @@ use crate::extract::collect_rules;
 use crate::model::{RenderContext, Rule};
 use crate::render::markdown::{HIGHLIGHT_CSS, HIGHLIGHT_CSS_DARK};
 use crate::render::{
-    HIGHLIGHT_CSS_DARK_FILENAME, HIGHLIGHT_CSS_FILENAME, NAV_TOGGLE_SCRIPT,
+    HIGHLIGHT_CSS_DARK_FILENAME, HIGHLIGHT_CSS_LIGHT_FILENAME, NAV_TOGGLE_SCRIPT,
     NAV_TOGGLE_SCRIPT_FILENAME, RULE_ANCHOR_ICON, RULE_ANCHOR_ICON_FILENAME, STYLESHEETS,
     THEME_ICONS, THEME_TOGGLE_SCRIPT, THEME_TOGGLE_SCRIPT_FILENAME, render_page,
 };
@@ -193,8 +193,8 @@ fn run_html(root: &Path, out_dir: &Path, git_ref: &str) -> ExitCode {
     // The syntax-highlighting CSS is generated at runtime by syntect,
     // so it's written from the live string rather than `include_str!`.
     // The dark variant is generated the same way and linked after it.
-    fs::write(out_dir.join(HIGHLIGHT_CSS_FILENAME), &*HIGHLIGHT_CSS)
-        .expect("failed to write highlight CSS");
+    fs::write(out_dir.join(HIGHLIGHT_CSS_LIGHT_FILENAME), &*HIGHLIGHT_CSS)
+        .expect("failed to write light highlight CSS");
     fs::write(
         out_dir.join(HIGHLIGHT_CSS_DARK_FILENAME),
         &*HIGHLIGHT_CSS_DARK,

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -24,9 +24,16 @@ use crate::render::markdown::{markdown_inline_to_html, markdown_to_html};
 /// room for future sheets without reflowing a monolith. The slice
 /// order is the cascade order the page links them in.
 pub(crate) const STYLESHEETS: &[(&str, &str)] = &[
+    // The palette comes first: light.css declares every `--color-*`
+    // variable (light values, the default) and dark.css the dark
+    // values across the system-preference / explicit-override tiers.
+    // The structural sheets that follow only ever read those variables.
+    ("light.css", include_str!("style/light.css")),
+    ("dark.css", include_str!("style/dark.css")),
     ("base.css", include_str!("style/base.css")),
     ("nav.css", include_str!("style/nav.css")),
     ("rules.css", include_str!("style/rules.css")),
+    ("settings.css", include_str!("style/settings.css")),
 ];
 
 /// File name the syntect-generated highlight CSS (see
@@ -35,6 +42,13 @@ pub(crate) const STYLESHEETS: &[(&str, &str)] = &[
 /// matching the cascade order of the previous single inline `<style>`.
 pub(crate) const HIGHLIGHT_CSS_FILENAME: &str = "highlight.css";
 
+/// File name the dark-mode highlight CSS (see
+/// [`markdown::HIGHLIGHT_CSS_DARK`]) is written under. Linked after
+/// [`HIGHLIGHT_CSS_FILENAME`]; its rules are scoped under a
+/// higher-specificity ancestor so they re-colour the same syntax
+/// classes only when the effective theme is dark.
+pub(crate) const HIGHLIGHT_CSS_DARK_FILENAME: &str = "highlight-dark.css";
+
 /// The navigation script, written beside `index.html` and loaded via
 /// `<script src>` rather than inlined.
 pub(crate) const NAV_TOGGLE_SCRIPT: &str = include_str!("nav_toggle.js");
@@ -42,6 +56,24 @@ pub(crate) const NAV_TOGGLE_SCRIPT: &str = include_str!("nav_toggle.js");
 /// File name [`NAV_TOGGLE_SCRIPT`] is written under; the page's
 /// `<script src>` references the same name, so they must agree.
 pub(crate) const NAV_TOGGLE_SCRIPT_FILENAME: &str = "nav_toggle.js";
+
+/// The theme (colour-scheme) settings script, written beside
+/// `index.html` and loaded via `<script src>` rather than inlined.
+pub(crate) const THEME_TOGGLE_SCRIPT: &str = include_str!("theme_toggle.js");
+
+/// File name [`THEME_TOGGLE_SCRIPT`] is written under; the page's
+/// `<script src>` references the same name, so they must agree.
+pub(crate) const THEME_TOGGLE_SCRIPT_FILENAME: &str = "theme_toggle.js";
+
+/// The three colour-scheme icons (Octicons, MIT), shipped as standalone
+/// files beside `index.html` and referenced from settings.css as CSS
+/// masks rather than inlined — keeping the page free of inline `<svg>`,
+/// matching [`RULE_ANCHOR_ICON`]. Each tuple is `(filename, contents)`.
+pub(crate) const THEME_ICONS: &[(&str, &str)] = &[
+    ("theme-light.svg", include_str!("assets/theme-light.svg")),
+    ("theme-dark.svg", include_str!("assets/theme-dark.svg")),
+    ("theme-system.svg", include_str!("assets/theme-system.svg")),
+];
 
 /// The chain-link glyph for the rule-name heading anchors, shipped as
 /// a standalone file beside `index.html` rather than inlined.
@@ -73,10 +105,12 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
                     link rel="stylesheet" href=(href);
                 }
                 link rel="stylesheet" href=(HIGHLIGHT_CSS_FILENAME);
+                link rel="stylesheet" href=(HIGHLIGHT_CSS_DARK_FILENAME);
             }
             body {
                 h1 id="catalogue" { "perfectionist lints" }
                 (nav_drawer(rules))
+                (settings_panel())
                 div.banner {
                     @if git_ref == "master" {
                         "Showing development docs from " code { "master" } ". "
@@ -125,10 +159,67 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
                     " at " code { (commit_sha) } "."
                 }
                 script src=(NAV_TOGGLE_SCRIPT_FILENAME) {}
+                script src=(THEME_TOGGLE_SCRIPT_FILENAME) {}
             }
         }
     };
     markup.into_string()
+}
+
+/// The colour-scheme settings affordance: a gear button fixed at the
+/// top-right (mirroring the nav hamburger at the top-left) and the panel
+/// it toggles. Both are rendered with the HTML `hidden` attribute and
+/// revealed by `theme_toggle.js` only once its handlers are wired up, so
+/// a page whose script never runs shows neither a dead gear nor an
+/// orphan panel (the `[hidden]` reset in base.css makes that
+/// unconditional). The panel holds a single "Theme" section for now —
+/// three radios (Light / Dark / System) styled as icon tiles, with
+/// System the default — but is shaped to gain further sections later.
+fn settings_panel() -> Markup {
+    html! {
+        button.settings-toggle
+            type="button"
+            hidden
+            aria-controls="settings-panel"
+            aria-expanded="false"
+            aria-label="Settings"
+            title="Settings" {}
+        div.settings-panel id="settings-panel" hidden aria-label="Settings" {
+            p.settings-panel-title { "Settings" }
+            fieldset.settings-section {
+                legend { "Theme" }
+                div.theme-options {
+                    (theme_option("light", "color-scheme-light", "Light", false))
+                    (theme_option("dark", "color-scheme-dark", "Dark", false))
+                    (theme_option("system", "color-scheme-system", "System", true))
+                }
+            }
+        }
+    }
+}
+
+/// One theme radio plus its visible label. The radio keeps real
+/// `<input type="radio">` semantics (exclusive choice, keyboard arrows,
+/// form labelling) but is visually hidden by settings.css; the adjacent
+/// `<label>` is the styled tile, so the pure-CSS
+/// `.theme-radio:checked + .theme-option` selector can highlight the
+/// chosen one. The label must therefore stay the input's immediate next
+/// sibling. The icon is an empty span the stylesheet fills via a CSS
+/// mask referencing one of [`THEME_ICONS`].
+fn theme_option(value: &str, id: &str, label: &str, checked: bool) -> Markup {
+    let option_class = format!("theme-option theme-option-{value}");
+    html! {
+        input.theme-radio
+            type="radio"
+            name="color-scheme"
+            id=(id)
+            value=(value)
+            checked[checked];
+        label class=(option_class) for=(id) {
+            span.theme-icon aria-hidden="true" {}
+            span.theme-label { (label) }
+        }
+    }
 }
 
 /// Collapsible navigation drawer. The visible toggle is a plain

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -41,15 +41,16 @@ pub(crate) const STYLESHEETS: &[(&str, &str)] = &[
     ("dark.css", include_str!("style/dark.css")),
 ];
 
-/// File name the syntect-generated highlight CSS (see
+/// File name the light-mode syntect-generated highlight CSS (see
 /// [`markdown::HIGHLIGHT_CSS`]) is written under. It is linked *after*
 /// the static [`STYLESHEETS`] so its classes win where they overlap,
 /// matching the cascade order of the previous single inline `<style>`.
-pub(crate) const HIGHLIGHT_CSS_FILENAME: &str = "highlight.css";
+/// Named `highlight-light.css` for symmetry with its dark counterpart.
+pub(crate) const HIGHLIGHT_CSS_LIGHT_FILENAME: &str = "highlight-light.css";
 
 /// File name the dark-mode highlight CSS (see
 /// [`markdown::HIGHLIGHT_CSS_DARK`]) is written under. Linked after
-/// [`HIGHLIGHT_CSS_FILENAME`]; its rules are scoped under a
+/// [`HIGHLIGHT_CSS_LIGHT_FILENAME`]; its rules are scoped under a
 /// higher-specificity ancestor so they re-colour the same syntax
 /// classes only when the effective theme is dark.
 pub(crate) const HIGHLIGHT_CSS_DARK_FILENAME: &str = "highlight-dark.css";
@@ -109,7 +110,7 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
                 @for &(href, _) in STYLESHEETS {
                     link rel="stylesheet" href=(href);
                 }
-                link rel="stylesheet" href=(HIGHLIGHT_CSS_FILENAME);
+                link rel="stylesheet" href=(HIGHLIGHT_CSS_LIGHT_FILENAME);
                 link rel="stylesheet" href=(HIGHLIGHT_CSS_DARK_FILENAME);
             }
             body {

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -24,15 +24,6 @@ use crate::render::markdown::{markdown_inline_to_html, markdown_to_html};
 /// room for future sheets without reflowing a monolith. The slice
 /// order is the cascade order the page links them in.
 pub(crate) const STYLESHEETS: &[(&str, &str)] = &[
-    // Structural sheets first (layout, sizing, non-colour rules), then
-    // the two colour layers. The colours were extracted out of the
-    // structural sheets into light.css (the default light values) and
-    // dark.css (the dark tiers); both use literal colours, not CSS
-    // custom properties, so the theming works on engines that predate
-    // `var()`. light.css/dark.css must come *after* the structural
-    // sheets so a colour longhand (e.g. `border-bottom-color`) wins over
-    // the `currentColor` left by a structural border shorthand of equal
-    // specificity; dark.css comes after light.css.
     ("base.css", include_str!("style/base.css")),
     ("nav.css", include_str!("style/nav.css")),
     ("rules.css", include_str!("style/rules.css")),
@@ -72,10 +63,8 @@ pub(crate) const THEME_TOGGLE_SCRIPT: &str = include_str!("theme_toggle.js");
 /// `<script src>` references the same name, so they must agree.
 pub(crate) const THEME_TOGGLE_SCRIPT_FILENAME: &str = "theme_toggle.js";
 
-/// The three colour-scheme icons (Octicons, MIT), shipped as standalone
-/// files beside `index.html` and referenced from settings.css as CSS
-/// masks rather than inlined — keeping the page free of inline `<svg>`,
-/// matching [`RULE_ANCHOR_ICON`]. Each tuple is `(filename, contents)`.
+/// The colour-scheme icons (Octicons, MIT), shipped beside `index.html`
+/// and referenced from settings.css. Each tuple is `(filename, contents)`.
 pub(crate) const THEME_ICONS: &[(&str, &str)] = &[
     ("theme-light.svg", include_str!("assets/theme-light.svg")),
     ("theme-dark.svg", include_str!("assets/theme-dark.svg")),

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -24,16 +24,21 @@ use crate::render::markdown::{markdown_inline_to_html, markdown_to_html};
 /// room for future sheets without reflowing a monolith. The slice
 /// order is the cascade order the page links them in.
 pub(crate) const STYLESHEETS: &[(&str, &str)] = &[
-    // The palette comes first: light.css declares every `--color-*`
-    // variable (light values, the default) and dark.css the dark
-    // values across the system-preference / explicit-override tiers.
-    // The structural sheets that follow only ever read those variables.
-    ("light.css", include_str!("style/light.css")),
-    ("dark.css", include_str!("style/dark.css")),
+    // Structural sheets first (layout, sizing, non-colour rules), then
+    // the two colour layers. The colours were extracted out of the
+    // structural sheets into light.css (the default light values) and
+    // dark.css (the dark tiers); both use literal colours, not CSS
+    // custom properties, so the theming works on engines that predate
+    // `var()`. light.css/dark.css must come *after* the structural
+    // sheets so a colour longhand (e.g. `border-bottom-color`) wins over
+    // the `currentColor` left by a structural border shorthand of equal
+    // specificity; dark.css comes after light.css.
     ("base.css", include_str!("style/base.css")),
     ("nav.css", include_str!("style/nav.css")),
     ("rules.css", include_str!("style/rules.css")),
     ("settings.css", include_str!("style/settings.css")),
+    ("light.css", include_str!("style/light.css")),
+    ("dark.css", include_str!("style/dark.css")),
 ];
 
 /// File name the syntect-generated highlight CSS (see

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -42,14 +42,15 @@ pub(crate) const STYLESHEETS: &[(&str, &str)] = &[
 ];
 
 /// File name the light-mode syntect-generated highlight CSS (see
-/// [`markdown::HIGHLIGHT_CSS`]) is written under. It is linked *after*
-/// the static [`STYLESHEETS`] so its classes win where they overlap,
-/// matching the cascade order of the previous single inline `<style>`.
-/// Named `highlight-light.css` for symmetry with its dark counterpart.
+/// [`markdown::HIGHLIGHT_CSS`]`.light`) is written under. It is linked
+/// *after* the static [`STYLESHEETS`] so its classes win where they
+/// overlap, matching the cascade order of the previous single inline
+/// `<style>`. Named `highlight-light.css` for symmetry with its dark
+/// counterpart.
 pub(crate) const HIGHLIGHT_CSS_LIGHT_FILENAME: &str = "highlight-light.css";
 
 /// File name the dark-mode highlight CSS (see
-/// [`markdown::HIGHLIGHT_CSS_DARK`]) is written under. Linked after
+/// [`markdown::HIGHLIGHT_CSS`]`.dark`) is written under. Linked after
 /// [`HIGHLIGHT_CSS_LIGHT_FILENAME`]; its rules are scoped under a
 /// higher-specificity ancestor so they re-colour the same syntax
 /// classes only when the effective theme is dark.

--- a/tools/gen-docs/src/render/markdown.rs
+++ b/tools/gen-docs/src/render/markdown.rs
@@ -136,8 +136,8 @@ pub(crate) static HIGHLIGHT_CSS: LazyLock<String> = LazyLock::new(|| {
 static DARK_THEME: LazyLock<Theme> = LazyLock::new(|| {
     ThemeSet::load_defaults()
         .themes
-        .remove("base16-ocean.dark")
-        .expect("base16-ocean.dark theme is bundled with syntect")
+        .remove("base16-eighties.dark")
+        .expect("base16-eighties.dark theme is bundled with syntect")
 });
 
 /// Dark-mode highlight CSS. The classed HTML spans (`.comment`,

--- a/tools/gen-docs/src/render/markdown.rs
+++ b/tools/gen-docs/src/render/markdown.rs
@@ -129,6 +129,64 @@ pub(crate) static HIGHLIGHT_CSS: LazyLock<String> = LazyLock::new(|| {
         .expect("generating CSS for a bundled theme should not fail")
 });
 
+/// Dark counterpart to [`THEME`]. `InspiredGitHub`'s colours are tuned
+/// for a white background and wash out on the dark canvas, so a dark
+/// theme supplies legible syntax colours when the effective colour
+/// scheme is dark.
+static DARK_THEME: LazyLock<Theme> = LazyLock::new(|| {
+    ThemeSet::load_defaults()
+        .themes
+        .remove("base16-ocean.dark")
+        .expect("base16-ocean.dark theme is bundled with syntect")
+});
+
+/// Dark-mode highlight CSS. The classed HTML spans (`.comment`,
+/// `.keyword`, ...) are emitted once with [`ClassStyle::Spaced`] class
+/// names shared by both themes, so the dark variant can't switch them
+/// out via a different prefix — it must re-style the *same* classes
+/// under a higher-specificity ancestor. Every selector from the
+/// generated sheet is therefore prefixed twice (see issue 185's
+/// override tiers): once inside `@media (prefers-color-scheme: dark)`,
+/// excluding an explicit Light override, for tier 2; and once under
+/// `:root[color-scheme-override="dark"]` for the tier-3 explicit Dark
+/// choice. The prefixed selectors out-specify the default (unscoped)
+/// light sheet, so dark colours win whenever the page is dark.
+pub(crate) static HIGHLIGHT_CSS_DARK: LazyLock<String> = LazyLock::new(|| {
+    let raw = css_for_theme_with_class_style(&DARK_THEME, ClassStyle::Spaced)
+        .expect("generating CSS for a bundled theme should not fail");
+    let media = scope_highlight_css(&raw, r#":root:not([color-scheme-override="light"])"#);
+    let overridden = scope_highlight_css(&raw, r#":root[color-scheme-override="dark"]"#);
+    format!("@media (prefers-color-scheme: dark) {{\n{media}}}\n{overridden}")
+});
+
+/// Prefix every rule selector in a syntect-generated sheet with `scope`
+/// so the rules apply only inside that ancestor. syntect emits one
+/// selector line per rule — `<selectors> {`, where `<selectors>` may be
+/// comma-separated compound selectors — with the declarations on the
+/// following lines; the selector line is the only one that ends with
+/// `{`. Comment lines (`/* ... */`), declaration lines, and the closing
+/// `}` pass through untouched. Each comma-separated part is prefixed
+/// individually, since a leading `scope ` only binds to the first
+/// selector of a list otherwise.
+fn scope_highlight_css(css: &str, scope: &str) -> String {
+    let mut out = String::new();
+    for line in css.lines() {
+        if let Some(selectors) = line.trim_end().strip_suffix('{') {
+            let scoped = selectors
+                .split(',')
+                .map(|selector| format!("{scope} {}", selector.trim()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            out.push_str(&scoped);
+            out.push_str(" {\n");
+        } else {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
 /// Render a short, single-line snippet of markdown without the
 /// outer `<p>...</p>` wrapper that block-level rendering inserts. Used
 /// for table cells and inline headings where backticks should still
@@ -143,4 +201,23 @@ pub(crate) fn markdown_inline_to_html(markdown: &str) -> String {
     let mut buffer = String::new();
     cmark_html::push_html(&mut buffer, parser);
     buffer.trim_end().to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scope_highlight_css;
+
+    #[test]
+    fn scopes_each_selector_in_a_comma_list() {
+        // syntect emits comma-separated compound selectors on the rule's
+        // opening line; every part must be prefixed individually, or a
+        // bare `scope ` would bind only to the first selector. Comment
+        // lines, declarations, and the closing brace pass through.
+        let input = "/* c */\n.a, .b .c {\n color: #fff;\n}\n";
+        let scoped = scope_highlight_css(input, ":root[x]");
+        assert_eq!(
+            scoped,
+            "/* c */\n:root[x] .a, :root[x] .b .c {\n color: #fff;\n}\n",
+        );
+    }
 }

--- a/tools/gen-docs/src/render/markdown.rs
+++ b/tools/gen-docs/src/render/markdown.rs
@@ -8,7 +8,7 @@
 use std::sync::LazyLock;
 
 use pulldown_cmark::{CodeBlockKind, CowStr, Event, Options, Tag, TagEnd, html as cmark_html};
-use syntect::highlighting::{Theme, ThemeSet};
+use syntect::highlighting::ThemeSet;
 use syntect::html::{ClassStyle, ClassedHTMLGenerator, css_for_theme_with_class_style};
 use syntect::parsing::SyntaxSet;
 use syntect::util::LinesWithEndings;
@@ -118,45 +118,60 @@ fn lang_class_attr(lang: &str) -> String {
 // through to syntect's plain-text fallback while ```rust blocks
 // highlight normally.
 static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(two_face::syntax::extra_newlines);
-static THEME: LazyLock<Theme> = LazyLock::new(|| {
-    ThemeSet::load_defaults()
-        .themes
+
+/// The light and dark classed-highlight stylesheets.
+///
+/// Both are generated from one [`ThemeSet::load_defaults`] call (see
+/// [`HIGHLIGHT_CSS`]). The `Theme` values themselves aren't kept — once
+/// their CSS is generated, nothing else needs them — so this holds only
+/// the two finished sheets.
+pub(crate) struct HighlightCss {
+    /// Light-mode sheet, written to `highlight-light.css`.
+    pub(crate) light: String,
+    /// Dark-mode sheet, written to `highlight-dark.css`.
+    ///
+    /// The classed HTML spans (`.comment`, `.keyword`, ...) are emitted
+    /// once with [`ClassStyle::Spaced`] class names shared by both
+    /// themes, so the dark variant can't switch them out via a different
+    /// prefix — it must re-style the *same* classes under a
+    /// higher-specificity ancestor. Every selector from the generated
+    /// sheet is therefore prefixed twice (see issue 185's override
+    /// tiers): once inside `@media (prefers-color-scheme: dark)`,
+    /// excluding an explicit Light override, for tier 2; and once under
+    /// `html[color-scheme-override="dark"]` for the tier-3 explicit Dark
+    /// choice. The prefixed selectors out-specify the default (unscoped)
+    /// light sheet, so dark colours win whenever the page is dark.
+    pub(crate) dark: String,
+}
+
+/// Light + dark highlight CSS, generated together.
+///
+/// [`ThemeSet::load_defaults`] parses the *entire* bundled theme set, so
+/// it is called exactly once here and both themes are taken from that
+/// single load — calling it per theme would parse the whole set twice.
+pub(crate) static HIGHLIGHT_CSS: LazyLock<HighlightCss> = LazyLock::new(|| {
+    let mut themes = ThemeSet::load_defaults().themes;
+    let light = themes
         .remove("InspiredGitHub")
-        .expect("InspiredGitHub theme is bundled with syntect")
-});
-pub(crate) static HIGHLIGHT_CSS: LazyLock<String> = LazyLock::new(|| {
-    css_for_theme_with_class_style(&THEME, ClassStyle::Spaced)
-        .expect("generating CSS for a bundled theme should not fail")
-});
-
-/// Dark counterpart to [`THEME`]. `InspiredGitHub`'s colours are tuned
-/// for a white background and wash out on the dark canvas, so a dark
-/// theme supplies legible syntax colours when the effective colour
-/// scheme is dark.
-static DARK_THEME: LazyLock<Theme> = LazyLock::new(|| {
-    ThemeSet::load_defaults()
-        .themes
+        .expect("InspiredGitHub theme is bundled with syntect");
+    // `InspiredGitHub`'s colours are tuned for a white background and
+    // wash out on the dark canvas, so a dedicated dark theme supplies
+    // legible syntax colours when the effective colour scheme is dark.
+    let dark = themes
         .remove("base16-eighties.dark")
-        .expect("base16-eighties.dark theme is bundled with syntect")
-});
+        .expect("base16-eighties.dark theme is bundled with syntect");
 
-/// Dark-mode highlight CSS. The classed HTML spans (`.comment`,
-/// `.keyword`, ...) are emitted once with [`ClassStyle::Spaced`] class
-/// names shared by both themes, so the dark variant can't switch them
-/// out via a different prefix — it must re-style the *same* classes
-/// under a higher-specificity ancestor. Every selector from the
-/// generated sheet is therefore prefixed twice (see issue 185's
-/// override tiers): once inside `@media (prefers-color-scheme: dark)`,
-/// excluding an explicit Light override, for tier 2; and once under
-/// `html[color-scheme-override="dark"]` for the tier-3 explicit Dark
-/// choice. The prefixed selectors out-specify the default (unscoped)
-/// light sheet, so dark colours win whenever the page is dark.
-pub(crate) static HIGHLIGHT_CSS_DARK: LazyLock<String> = LazyLock::new(|| {
-    let raw = css_for_theme_with_class_style(&DARK_THEME, ClassStyle::Spaced)
+    let light_css = css_for_theme_with_class_style(&light, ClassStyle::Spaced)
         .expect("generating CSS for a bundled theme should not fail");
-    let media = scope_highlight_css(&raw, r#"html:not([color-scheme-override="light"])"#);
-    let overridden = scope_highlight_css(&raw, r#"html[color-scheme-override="dark"]"#);
-    format!("@media (prefers-color-scheme: dark) {{\n{media}}}\n{overridden}")
+    let dark_raw = css_for_theme_with_class_style(&dark, ClassStyle::Spaced)
+        .expect("generating CSS for a bundled theme should not fail");
+    let media = scope_highlight_css(&dark_raw, r#"html:not([color-scheme-override="light"])"#);
+    let overridden = scope_highlight_css(&dark_raw, r#"html[color-scheme-override="dark"]"#);
+
+    HighlightCss {
+        light: light_css,
+        dark: format!("@media (prefers-color-scheme: dark) {{\n{media}}}\n{overridden}"),
+    }
 });
 
 /// Prefix every rule selector in a syntect-generated sheet with `scope`

--- a/tools/gen-docs/src/render/markdown.rs
+++ b/tools/gen-docs/src/render/markdown.rs
@@ -129,18 +129,6 @@ pub(crate) struct HighlightCss {
     /// Light-mode sheet, written to `highlight-light.css`.
     pub(crate) light: String,
     /// Dark-mode sheet, written to `highlight-dark.css`.
-    ///
-    /// The classed HTML spans (`.comment`, `.keyword`, ...) are emitted
-    /// once with [`ClassStyle::Spaced`] class names shared by both
-    /// themes, so the dark variant can't switch them out via a different
-    /// prefix — it must re-style the *same* classes under a
-    /// higher-specificity ancestor. Every selector from the generated
-    /// sheet is therefore prefixed twice (see issue 185's override
-    /// tiers): once inside `@media (prefers-color-scheme: dark)`,
-    /// excluding an explicit Light override, for tier 2; and once under
-    /// `html[color-scheme-override="dark"]` for the tier-3 explicit Dark
-    /// choice. The prefixed selectors out-specify the default (unscoped)
-    /// light sheet, so dark colours win whenever the page is dark.
     pub(crate) dark: String,
 }
 
@@ -150,21 +138,21 @@ pub(crate) struct HighlightCss {
 /// it is called exactly once here and both themes are taken from that
 /// single load — calling it per theme would parse the whole set twice.
 pub(crate) static HIGHLIGHT_CSS: LazyLock<HighlightCss> = LazyLock::new(|| {
-    let mut themes = ThemeSet::load_defaults().themes;
+    let themes = ThemeSet::load_defaults().themes;
     let light = themes
-        .remove("InspiredGitHub")
+        .get("InspiredGitHub")
         .expect("InspiredGitHub theme is bundled with syntect");
-    // `InspiredGitHub`'s colours are tuned for a white background and
-    // wash out on the dark canvas, so a dedicated dark theme supplies
-    // legible syntax colours when the effective colour scheme is dark.
     let dark = themes
-        .remove("base16-eighties.dark")
+        .get("base16-eighties.dark")
         .expect("base16-eighties.dark theme is bundled with syntect");
 
-    let light_css = css_for_theme_with_class_style(&light, ClassStyle::Spaced)
+    let light_css = css_for_theme_with_class_style(light, ClassStyle::Spaced)
         .expect("generating CSS for a bundled theme should not fail");
-    let dark_raw = css_for_theme_with_class_style(&dark, ClassStyle::Spaced)
+    let dark_raw = css_for_theme_with_class_style(dark, ClassStyle::Spaced)
         .expect("generating CSS for a bundled theme should not fail");
+    // Both themes share the same span classes, so scope the dark sheet
+    // under the system-preference tier (sans an explicit Light override)
+    // and the explicit-Dark tier.
     let media = scope_highlight_css(&dark_raw, r#"html:not([color-scheme-override="light"])"#);
     let overridden = scope_highlight_css(&dark_raw, r#"html[color-scheme-override="dark"]"#);
 

--- a/tools/gen-docs/src/render/markdown.rs
+++ b/tools/gen-docs/src/render/markdown.rs
@@ -148,14 +148,14 @@ static DARK_THEME: LazyLock<Theme> = LazyLock::new(|| {
 /// generated sheet is therefore prefixed twice (see issue 185's
 /// override tiers): once inside `@media (prefers-color-scheme: dark)`,
 /// excluding an explicit Light override, for tier 2; and once under
-/// `:root[color-scheme-override="dark"]` for the tier-3 explicit Dark
+/// `html[color-scheme-override="dark"]` for the tier-3 explicit Dark
 /// choice. The prefixed selectors out-specify the default (unscoped)
 /// light sheet, so dark colours win whenever the page is dark.
 pub(crate) static HIGHLIGHT_CSS_DARK: LazyLock<String> = LazyLock::new(|| {
     let raw = css_for_theme_with_class_style(&DARK_THEME, ClassStyle::Spaced)
         .expect("generating CSS for a bundled theme should not fail");
-    let media = scope_highlight_css(&raw, r#":root:not([color-scheme-override="light"])"#);
-    let overridden = scope_highlight_css(&raw, r#":root[color-scheme-override="dark"]"#);
+    let media = scope_highlight_css(&raw, r#"html:not([color-scheme-override="light"])"#);
+    let overridden = scope_highlight_css(&raw, r#"html[color-scheme-override="dark"]"#);
     format!("@media (prefers-color-scheme: dark) {{\n{media}}}\n{overridden}")
 });
 

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -179,9 +179,9 @@ fn page_links_each_stylesheet_individually() {
     }
     assert!(
         html.contains(&format!(
-            "<link rel=\"stylesheet\" href=\"{HIGHLIGHT_CSS_FILENAME}\">"
+            "<link rel=\"stylesheet\" href=\"{HIGHLIGHT_CSS_LIGHT_FILENAME}\">"
         )),
-        "expected a dedicated <link> for the highlight CSS",
+        "expected a dedicated <link> for the light highlight CSS",
     );
     // Nothing is inlined any more: no `<style>` block survives.
     assert!(

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -352,8 +352,10 @@ fn settings_css_keeps_theme_radios_visually_hidden() {
         "settings.css must keep the .theme-radio visually-hidden recipe",
     );
     // The checked radio highlights its sibling label via a pure-CSS
-    // adjacent-sibling selector (no JS needed for the highlight).
-    assert!(settings.contains(".theme-radio:checked + .theme-option"));
+    // adjacent-sibling selector (no JS needed for the highlight). The
+    // highlight is a colour, so it lives in the colour layer (light.css),
+    // not the structural settings.css.
+    assert!(stylesheet("light.css").contains(".theme-radio:checked + .theme-option"));
 }
 
 #[test]
@@ -373,20 +375,83 @@ fn page_does_not_inline_theme_icon_svgs() {
 }
 
 #[test]
-fn theme_palette_files_define_and_override_color_variables() {
-    // light.css owns the default palette plus the explicit-Light
-    // override; dark.css owns the system-preference and explicit-Dark
-    // dark palette. Pin the load-bearing selectors so the override-tier
-    // cascade (issue 185) can't be refactored away silently.
-    let light = stylesheet("light.css");
-    assert!(light.contains("--color-canvas-default: #ffffff"));
-    assert!(light.contains(r#":root[color-scheme-override="light"]"#));
+fn theme_files_carry_literal_colours_not_variables() {
+    // The colour layers use literal colours, never CSS custom
+    // properties, so the page themes on engines that predate `var()`
+    // (issue 185). light.css holds the default light values; dark.css
+    // holds the dark values under the two override-tier prefixes.
+    // Strip comments first: the files' header comments mention `var()`
+    // while explaining why they avoid it.
+    let light = strip_css_comments(stylesheet("light.css"));
+    assert!(
+        !light.contains("var(") && !light.contains("--color"),
+        "light.css must not use CSS custom properties",
+    );
+    assert!(light.contains("background-color: #ffffff"));
 
-    let dark = stylesheet("dark.css");
+    let dark = strip_css_comments(stylesheet("dark.css"));
+    assert!(
+        !dark.contains("var(") && !dark.contains("--color"),
+        "dark.css must not use CSS custom properties",
+    );
+    // Tier 2 (system preference) and tier 3 (explicit Dark) prefixes,
+    // keyed off the <html> attribute theme_toggle.js sets.
     assert!(dark.contains("@media (prefers-color-scheme: dark)"));
-    assert!(dark.contains(r#":root:not([color-scheme-override="light"])"#));
-    assert!(dark.contains(r#":root[color-scheme-override="dark"]"#));
-    assert!(dark.contains("--color-canvas-default: #0d1117"));
+    assert!(dark.contains(r#"html:not([color-scheme-override="light"])"#));
+    assert!(dark.contains(r#"html[color-scheme-override="dark"]"#));
+    assert!(dark.contains("background-color: #0d1117"));
+}
+
+/// Strip `/* ... */` block comments (the only comment form CSS has) so
+/// colour scans don't trip over prose or issue references inside them.
+fn strip_css_comments(css: &str) -> String {
+    let mut out = String::new();
+    let mut rest = css;
+    while let Some(start) = rest.find("/*") {
+        out.push_str(&rest[..start]);
+        match rest[start..].find("*/") {
+            Some(end) => rest = &rest[start + end + "*/".len()..],
+            None => return out, // unterminated; ignore the tail
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+#[test]
+fn structural_sheets_carry_no_literal_colours() {
+    // The colours were extracted out of the structural sheets; they
+    // should hold layout/sizing only, so a colour change is a one-file
+    // edit in the colour layer. `currentColor` (a structural reference,
+    // not a theme value) and `#id` selectors like `#catalogue` are
+    // fine — only literal `#rrggbb` hexes and `rgb(`/`rgba(` are colours.
+    for name in ["base.css", "nav.css", "rules.css", "settings.css"] {
+        // Strip comments first: prose may mention colours or `var()`.
+        let code = strip_css_comments(stylesheet(name));
+        assert!(
+            !code.contains("var("),
+            "{name} must not reference CSS custom properties",
+        );
+        assert!(
+            !code.contains("rgb"),
+            "{name} should carry no literal rgb()/rgba() colour",
+        );
+        // A `#` followed by six hex digits is a colour literal; `#id`
+        // selectors fail the six-hex test (they contain non-hex letters).
+        let bytes = code.as_bytes();
+        for (index, &byte) in bytes.iter().enumerate() {
+            if byte != b'#' {
+                continue;
+            }
+            let is_six_hex = bytes
+                .get(index + 1..index + 7)
+                .is_some_and(|run| run.iter().all(|byte| byte.is_ascii_hexdigit()));
+            assert!(
+                !is_six_hex,
+                "{name} should carry no literal hex colour near byte {index}",
+            );
+        }
+    }
 }
 
 #[test]
@@ -398,11 +463,11 @@ fn dark_highlight_css_is_scoped_to_the_dark_scheme() {
     // would unconditionally clobber the light colours.
     assert!(HIGHLIGHT_CSS_DARK.contains("@media (prefers-color-scheme: dark)"));
     assert!(
-        HIGHLIGHT_CSS_DARK.contains(r#":root:not([color-scheme-override="light"]) .comment"#),
+        HIGHLIGHT_CSS_DARK.contains(r#"html:not([color-scheme-override="light"]) .comment"#),
         "system-preference dark highlight must scope the syntax classes",
     );
     assert!(
-        HIGHLIGHT_CSS_DARK.contains(r#":root[color-scheme-override="dark"] .comment"#),
+        HIGHLIGHT_CSS_DARK.contains(r#"html[color-scheme-override="dark"] .comment"#),
         "explicit-Dark highlight must scope the syntax classes",
     );
 }

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -177,11 +177,19 @@ fn page_links_each_stylesheet_individually() {
             "expected a dedicated <link> for {name}",
         );
     }
+    // Both runtime-generated highlight sheets are linked — the page now
+    // emits two, so a regression that drops the dark one must fail here.
     assert!(
         html.contains(&format!(
             "<link rel=\"stylesheet\" href=\"{HIGHLIGHT_CSS_LIGHT_FILENAME}\">"
         )),
         "expected a dedicated <link> for the light highlight CSS",
+    );
+    assert!(
+        html.contains(&format!(
+            "<link rel=\"stylesheet\" href=\"{HIGHLIGHT_CSS_DARK_FILENAME}\">"
+        )),
+        "expected a dedicated <link> for the dark highlight CSS",
     );
     // Nothing is inlined any more: no `<style>` block survives.
     assert!(

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -377,9 +377,9 @@ fn page_does_not_inline_theme_icon_svgs() {
 #[test]
 fn theme_files_carry_literal_colours_not_variables() {
     // The colour layers use literal colours, never CSS custom
-    // properties, so the page themes on engines that predate `var()`
-    // (issue 185). light.css holds the default light values; dark.css
-    // holds the dark values under the two override-tier prefixes.
+    // properties, so the page themes on engines that predate `var()`.
+    // light.css holds the default light values; dark.css holds the dark
+    // values under the two override-tier prefixes.
     // Strip comments first: the files' header comments mention `var()`
     // while explaining why they avoid it.
     let light = strip_css_comments(stylesheet("light.css"));

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -456,18 +456,18 @@ fn structural_sheets_carry_no_literal_colours() {
 
 #[test]
 fn dark_highlight_css_is_scoped_to_the_dark_scheme() {
-    use crate::render::markdown::HIGHLIGHT_CSS_DARK;
+    let dark = &crate::render::markdown::HIGHLIGHT_CSS.dark;
     // The dark syntax sheet re-styles the same classes the light sheet
     // emits, so it must be scoped under a higher-specificity ancestor
     // for both the system-preference and explicit-override tiers, or it
     // would unconditionally clobber the light colours.
-    assert!(HIGHLIGHT_CSS_DARK.contains("@media (prefers-color-scheme: dark)"));
+    assert!(dark.contains("@media (prefers-color-scheme: dark)"));
     assert!(
-        HIGHLIGHT_CSS_DARK.contains(r#"html:not([color-scheme-override="light"]) .comment"#),
+        dark.contains(r#"html:not([color-scheme-override="light"]) .comment"#),
         "system-preference dark highlight must scope the syntax classes",
     );
     assert!(
-        HIGHLIGHT_CSS_DARK.contains(r#"html[color-scheme-override="dark"] .comment"#),
+        dark.contains(r#"html[color-scheme-override="dark"] .comment"#),
         "explicit-Dark highlight must scope the syntax classes",
     );
 }

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -280,6 +280,134 @@ fn style_references_rule_anchor_icon() {
 }
 
 #[test]
+fn page_emits_settings_toggle_and_panel_both_hidden() {
+    let html = render_page(&[fake_rule("alpha")], &fake_context());
+    // The gear button mirrors the nav hamburger: a plain <button>
+    // driven by `aria-expanded` and emitted with the HTML `hidden`
+    // attribute so it only appears once theme_toggle.js wires up its
+    // handlers and clears `hidden`. Anchor the assertion to the
+    // toggle's opening tag so a refactor that drops `hidden` is caught.
+    assert!(html.contains(r#"<button class="settings-toggle" type="button" hidden "#));
+    assert!(html.contains(r#"aria-controls="settings-panel""#));
+    assert!(html.contains(r#"aria-label="Settings""#));
+    // The panel is also `hidden` by default — the script reveals only
+    // the gear, and the gear's click handler toggles the panel.
+    assert!(html.contains(r#"<div class="settings-panel" id="settings-panel" hidden "#));
+}
+
+#[test]
+fn page_emits_three_theme_radios_with_system_default() {
+    let html = render_page(&[fake_rule("alpha")], &fake_context());
+    // Real radios (exclusive choice, keyboard arrows, form labelling)
+    // grouped under one name. Three of them: light, dark, system.
+    assert_eq!(
+        html.matches(r#"<input class="theme-radio" type="radio" name="color-scheme""#)
+            .count(),
+        3,
+    );
+    for value in ["light", "dark", "system"] {
+        assert!(
+            html.contains(&format!(r#"value="{value}""#)),
+            "expected a {value} theme radio",
+        );
+    }
+    // System is the default choice (override unset), so only it is
+    // rendered `checked`. The light/dark radios must not carry it.
+    assert!(html.contains(r#"id="color-scheme-system" value="system" checked"#));
+    assert!(!html.contains(r#"value="light" checked"#));
+    assert!(!html.contains(r#"value="dark" checked"#));
+    // Each radio is immediately followed by its <label> tile so the
+    // pure-CSS `.theme-radio:checked + .theme-option` highlight works.
+    assert!(
+        html.contains(r#"value="system" checked><label class="theme-option theme-option-system""#),
+    );
+}
+
+#[test]
+fn page_links_theme_toggle_script_externally() {
+    let html = render_page(&[fake_rule("only")], &fake_context());
+    // The theme script ships as a sibling file loaded via `<script
+    // src>`, not inlined — same contract as the nav script.
+    assert!(
+        html.contains(&format!(
+            "<script src=\"{THEME_TOGGLE_SCRIPT_FILENAME}\"></script>"
+        )),
+        "expected the theme script to be referenced via <script src>",
+    );
+    assert!(
+        !html.contains("<script>(function () {"),
+        "the theme script must not be inlined into the page",
+    );
+}
+
+#[test]
+fn settings_css_keeps_theme_radios_visually_hidden() {
+    // The radios stay in the DOM (for semantics) but must be visually
+    // removed; the visible control is the adjacent label. Pin the
+    // visually-hidden recipe so a refactor can't make raw radio circles
+    // reappear next to the styled tiles.
+    let settings = stylesheet("settings.css");
+    assert!(
+        settings.contains(".theme-radio") && settings.contains("clip: rect(0, 0, 0, 0)"),
+        "settings.css must keep the .theme-radio visually-hidden recipe",
+    );
+    // The checked radio highlights its sibling label via a pure-CSS
+    // adjacent-sibling selector (no JS needed for the highlight).
+    assert!(settings.contains(".theme-radio:checked + .theme-option"));
+}
+
+#[test]
+fn page_does_not_inline_theme_icon_svgs() {
+    // The three colour-scheme icons stay external (referenced as CSS
+    // masks in settings.css), never inlined — same rule as the anchor
+    // icon. The `page_does_not_inline_the_anchor_icon_svg` test already
+    // forbids any `<svg`, but assert the masks reference the files so a
+    // rename can't silently 404 them.
+    let settings = stylesheet("settings.css");
+    for (name, _) in THEME_ICONS {
+        assert!(
+            settings.contains(&format!("url(\"{name}\")")),
+            "settings.css must reference the theme icon {name} as a mask",
+        );
+    }
+}
+
+#[test]
+fn theme_palette_files_define_and_override_color_variables() {
+    // light.css owns the default palette plus the explicit-Light
+    // override; dark.css owns the system-preference and explicit-Dark
+    // dark palette. Pin the load-bearing selectors so the override-tier
+    // cascade (issue 185) can't be refactored away silently.
+    let light = stylesheet("light.css");
+    assert!(light.contains("--color-canvas-default: #ffffff"));
+    assert!(light.contains(r#":root[color-scheme-override="light"]"#));
+
+    let dark = stylesheet("dark.css");
+    assert!(dark.contains("@media (prefers-color-scheme: dark)"));
+    assert!(dark.contains(r#":root:not([color-scheme-override="light"])"#));
+    assert!(dark.contains(r#":root[color-scheme-override="dark"]"#));
+    assert!(dark.contains("--color-canvas-default: #0d1117"));
+}
+
+#[test]
+fn dark_highlight_css_is_scoped_to_the_dark_scheme() {
+    use crate::render::markdown::HIGHLIGHT_CSS_DARK;
+    // The dark syntax sheet re-styles the same classes the light sheet
+    // emits, so it must be scoped under a higher-specificity ancestor
+    // for both the system-preference and explicit-override tiers, or it
+    // would unconditionally clobber the light colours.
+    assert!(HIGHLIGHT_CSS_DARK.contains("@media (prefers-color-scheme: dark)"));
+    assert!(
+        HIGHLIGHT_CSS_DARK.contains(r#":root:not([color-scheme-override="light"]) .comment"#),
+        "system-preference dark highlight must scope the syntax classes",
+    );
+    assert!(
+        HIGHLIGHT_CSS_DARK.contains(r#":root[color-scheme-override="dark"] .comment"#),
+        "explicit-Dark highlight must scope the syntax classes",
+    );
+}
+
+#[test]
 fn nav_toggle_script_is_a_single_iife() {
     // Structural sanity check on `nav_toggle.js`. The whole
     // file is a single IIFE — every helper, every event

--- a/tools/gen-docs/src/style/base.css
+++ b/tools/gen-docs/src/style/base.css
@@ -1,10 +1,24 @@
+/* Colours in this sheet are `var(--color-*)` declared in light.css
+   (light values) and dark.css (dark values); see those files for the
+   override-tier cascade. Nothing here hard-codes a colour. */
+
+/* The page is centred with `margin: auto`, so on wide viewports the
+   body's side gutters expose the root element's background. Paint it
+   the canvas colour too (the variable is defined on `:root`, i.e.
+   <html>) so the gutters match the body instead of falling back to the
+   UA's white. */
+html {
+  background-color: var(--color-canvas-default);
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   max-width: 820px;
   margin: 2rem auto;
   padding: 0 1rem;
   line-height: 1.55;
-  color: #1f2328;
+  color: var(--color-fg-default);
+  background-color: var(--color-canvas-default);
 }
 
 /* Desktop / large-desktop tiers: bump the body's max-width so
@@ -34,16 +48,17 @@ body {
    silently. The `.nav-toggle` rule's `display: flex` does exactly that,
    so without this reset the toggle would remain visible despite the
    Rust template emitting `<button hidden ...>` (defeating the whole
-   "reveal only after JS is ready" defence). `!important` is justified
-   here because the `hidden` semantic is supposed to be unconditional
-   and the alternative is sprinkling `:not([hidden])` through every
-   rule that sets `display`. */
+   "reveal only after JS is ready" defence). The `.settings-toggle` and
+   `.settings-panel` rules rely on the same reset. `!important` is
+   justified here because the `hidden` semantic is supposed to be
+   unconditional and the alternative is sprinkling `:not([hidden])`
+   through every rule that sets `display`. */
 [hidden] {
   display: none !important;
 }
 
 h1 {
-  border-bottom: 1px solid #d0d7de;
+  border-bottom: 1px solid var(--color-border-default);
   padding-bottom: 0.3rem;
 }
 
@@ -60,8 +75,8 @@ h2 {
 }
 
 .banner {
-  background: #fff8c5;
-  border-left: 4px solid #d4a72c;
+  background: var(--color-attention-subtle);
+  border-left: 4px solid var(--color-attention-border);
   padding: 0.75rem 1rem;
   margin: 0 0 1.5rem;
   font-size: 0.9rem;
@@ -73,7 +88,7 @@ code {
 }
 
 pre {
-  background: #f6f8fa;
+  background: var(--color-canvas-subtle);
   padding: 0.75rem 1rem;
   border-radius: 6px;
   overflow-x: auto;
@@ -81,7 +96,7 @@ pre {
 }
 
 code {
-  background: #f6f8fa;
+  background: var(--color-canvas-subtle);
   padding: 0.1rem 0.35rem;
   border-radius: 3px;
   font-size: 0.9rem;
@@ -97,13 +112,13 @@ pre code {
 footer {
   margin-top: 4rem;
   padding-top: 1rem;
-  border-top: 1px solid #eaeef2;
+  border-top: 1px solid var(--color-border-muted);
   font-size: 0.85rem;
-  color: #57606a;
+  color: var(--color-fg-muted);
 }
 
 a {
-  color: #0969da;
+  color: var(--color-accent-fg);
 }
 
 a:hover {

--- a/tools/gen-docs/src/style/base.css
+++ b/tools/gen-docs/src/style/base.css
@@ -1,15 +1,8 @@
-/* Colours in this sheet are `var(--color-*)` declared in light.css
-   (light values) and dark.css (dark values); see those files for the
-   override-tier cascade. Nothing here hard-codes a colour. */
-
-/* The page is centred with `margin: auto`, so on wide viewports the
-   body's side gutters expose the root element's background. Paint it
-   the canvas colour too (the variable is defined on `:root`, i.e.
-   <html>) so the gutters match the body instead of falling back to the
-   UA's white. */
-html {
-  background-color: var(--color-canvas-default);
-}
+/* Structural rules only. Every colour this page uses lives in
+   light.css (defaults) and dark.css (the dark tiers), declared as
+   literal colours with no CSS custom properties so the theming works
+   on engines that predate `var()`. The colour sheets mirror the
+   selectors here and are linked after the structural sheets. */
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
@@ -17,8 +10,6 @@ body {
   margin: 2rem auto;
   padding: 0 1rem;
   line-height: 1.55;
-  color: var(--color-fg-default);
-  background-color: var(--color-canvas-default);
 }
 
 /* Desktop / large-desktop tiers: bump the body's max-width so
@@ -58,7 +49,7 @@ body {
 }
 
 h1 {
-  border-bottom: 1px solid var(--color-border-default);
+  border-bottom: 1px solid;
   padding-bottom: 0.3rem;
 }
 
@@ -75,8 +66,7 @@ h2 {
 }
 
 .banner {
-  background: var(--color-attention-subtle);
-  border-left: 4px solid var(--color-attention-border);
+  border-left: 4px solid;
   padding: 0.75rem 1rem;
   margin: 0 0 1.5rem;
   font-size: 0.9rem;
@@ -88,7 +78,6 @@ code {
 }
 
 pre {
-  background: var(--color-canvas-subtle);
   padding: 0.75rem 1rem;
   border-radius: 6px;
   overflow-x: auto;
@@ -96,7 +85,6 @@ pre {
 }
 
 code {
-  background: var(--color-canvas-subtle);
   padding: 0.1rem 0.35rem;
   border-radius: 3px;
   font-size: 0.9rem;
@@ -104,7 +92,6 @@ code {
 }
 
 pre code {
-  background: none;
   padding: 0;
   font-size: 1rem;
 }
@@ -112,13 +99,8 @@ pre code {
 footer {
   margin-top: 4rem;
   padding-top: 1rem;
-  border-top: 1px solid var(--color-border-muted);
+  border-top: 1px solid;
   font-size: 0.85rem;
-  color: var(--color-fg-muted);
-}
-
-a {
-  color: var(--color-accent-fg);
 }
 
 a:hover {

--- a/tools/gen-docs/src/style/dark.css
+++ b/tools/gen-docs/src/style/dark.css
@@ -1,5 +1,5 @@
-/* Dark theme — the dark colour layer (override tiers 2 and 3 of
- * issue 185). Mirrors the same selectors as light.css with only colour
+/* Dark theme — the dark colour layer (override tiers 2 and 3).
+ * Mirrors the same selectors as light.css with only colour
  * declarations, and like light.css uses no CSS custom properties.
  *
  * Each colour is declared twice because the two dark tiers can't share

--- a/tools/gen-docs/src/style/dark.css
+++ b/tools/gen-docs/src/style/dark.css
@@ -1,0 +1,62 @@
+/* Dark theme — the dark half of the palette declared in light.css.
+ *
+ * Two blocks, mirroring override tiers 2 and 3 from issue #185:
+ *
+ *   * Tier 2 (system preference): `@media (prefers-color-scheme: dark)`
+ *     re-points the `:root` variables at the dark palette. It excludes
+ *     an explicit Light override with `:not([color-scheme-override=
+ *     "light"])` so a reader who forced Light keeps it even on a
+ *     dark-preferring OS. (The light.css `:root[...="light"]` rule
+ *     would win on specificity anyway; the `:not` keeps the *here*
+ *     declaration from even applying, which also covers the
+ *     `color-scheme` property that isn't a custom property.)
+ *
+ *   * Tier 3 (explicit Dark): `:root[...="dark"]` / `body[...="dark"]`,
+ *     set by theme_toggle.js. Specificity >= (0,2,0) / (0,1,1) beats
+ *     the tier-2 `:root` (0,1,0), so an explicit Dark choice wins even
+ *     when the OS prefers light.
+ *
+ * The dark values are listed twice because a rule inside `@media`
+ * can't be merged with one outside it. Keep the two value blocks in
+ * sync.
+ */
+@media (prefers-color-scheme: dark) {
+  :root:not([color-scheme-override="light"]) {
+    color-scheme: dark;
+    --color-canvas-default: #0d1117;
+    --color-canvas-subtle: #161b22;
+    --color-fg-default: #e6edf3;
+    --color-fg-muted: #8b949e;
+    --color-border-default: #30363d;
+    --color-border-muted: #21262d;
+    --color-neutral-muted: #30363d;
+    --color-accent-fg: #4493f8;
+    --color-accent-subtle: rgba(56, 139, 253, 0.15);
+    --color-attention-subtle: rgba(187, 128, 9, 0.15);
+    --color-attention-border: #9e6a03;
+    --color-success-subtle: rgba(46, 160, 67, 0.18);
+    --color-danger-fg: #f85149;
+    --color-danger-subtle: rgba(248, 81, 73, 0.15);
+    --color-shadow: rgba(1, 4, 9, 0.5);
+  }
+}
+
+:root[color-scheme-override="dark"],
+body[color-scheme-override="dark"] {
+  color-scheme: dark;
+  --color-canvas-default: #0d1117;
+  --color-canvas-subtle: #161b22;
+  --color-fg-default: #e6edf3;
+  --color-fg-muted: #8b949e;
+  --color-border-default: #30363d;
+  --color-border-muted: #21262d;
+  --color-neutral-muted: #30363d;
+  --color-accent-fg: #4493f8;
+  --color-accent-subtle: rgba(56, 139, 253, 0.15);
+  --color-attention-subtle: rgba(187, 128, 9, 0.15);
+  --color-attention-border: #9e6a03;
+  --color-success-subtle: rgba(46, 160, 67, 0.18);
+  --color-danger-fg: #f85149;
+  --color-danger-subtle: rgba(248, 81, 73, 0.15);
+  --color-shadow: rgba(1, 4, 9, 0.5);
+}

--- a/tools/gen-docs/src/style/dark.css
+++ b/tools/gen-docs/src/style/dark.css
@@ -1,62 +1,396 @@
-/* Dark theme — the dark half of the palette declared in light.css.
+/* Dark theme — the dark colour layer (override tiers 2 and 3 of
+ * issue 185). Mirrors the same selectors as light.css with only colour
+ * declarations, and like light.css uses no CSS custom properties.
  *
- * Two blocks, mirroring override tiers 2 and 3 from issue #185:
+ * Each colour is declared twice because the two dark tiers can't share
+ * one rule (one lives inside `@media`, the other outside it):
  *
- *   * Tier 2 (system preference): `@media (prefers-color-scheme: dark)`
- *     re-points the `:root` variables at the dark palette. It excludes
- *     an explicit Light override with `:not([color-scheme-override=
- *     "light"])` so a reader who forced Light keeps it even on a
- *     dark-preferring OS. (The light.css `:root[...="light"]` rule
- *     would win on specificity anyway; the `:not` keeps the *here*
- *     declaration from even applying, which also covers the
- *     `color-scheme` property that isn't a custom property.)
+ *   * Tier 2 (system preference): inside
+ *     `@media (prefers-color-scheme: dark)`, every selector is prefixed
+ *     with `html:not([color-scheme-override="light"])` so a reader who
+ *     forced Light keeps it even on a dark-preferring OS, and so the
+ *     prefixed selector out-specifies the light.css default.
+ *   * Tier 3 (explicit Dark): every selector is prefixed with
+ *     `html[color-scheme-override="dark"]`, set by theme_toggle.js. It
+ *     comes after the media block, so an explicit Dark choice wins even
+ *     on a light-preferring OS.
  *
- *   * Tier 3 (explicit Dark): `:root[...="dark"]` / `body[...="dark"]`,
- *     set by theme_toggle.js. Specificity >= (0,2,0) / (0,1,1) beats
- *     the tier-2 `:root` (0,1,0), so an explicit Dark choice wins even
- *     when the OS prefers light.
- *
- * The dark values are listed twice because a rule inside `@media`
- * can't be merged with one outside it. Keep the two value blocks in
- * sync.
+ * theme_toggle.js sets the attribute on <html>, so the prefixes key off
+ * the root element. Keep the two value sets below in sync.
  */
+
 @media (prefers-color-scheme: dark) {
-  :root:not([color-scheme-override="light"]) {
+  html:not([color-scheme-override="light"]) {
     color-scheme: dark;
-    --color-canvas-default: #0d1117;
-    --color-canvas-subtle: #161b22;
-    --color-fg-default: #e6edf3;
-    --color-fg-muted: #8b949e;
-    --color-border-default: #30363d;
-    --color-border-muted: #21262d;
-    --color-neutral-muted: #30363d;
-    --color-accent-fg: #4493f8;
-    --color-accent-subtle: rgba(56, 139, 253, 0.15);
-    --color-attention-subtle: rgba(187, 128, 9, 0.15);
-    --color-attention-border: #9e6a03;
-    --color-success-subtle: rgba(46, 160, 67, 0.18);
-    --color-danger-fg: #f85149;
-    --color-danger-subtle: rgba(248, 81, 73, 0.15);
-    --color-shadow: rgba(1, 4, 9, 0.5);
+    background-color: #0d1117;
+  }
+  html:not([color-scheme-override="light"]) body {
+    color: #e6edf3;
+    background-color: #0d1117;
+  }
+  html:not([color-scheme-override="light"]) h1 {
+    border-bottom-color: #30363d;
+  }
+  html:not([color-scheme-override="light"]) .banner {
+    background: rgba(187, 128, 9, 0.15);
+    border-left-color: #9e6a03;
+  }
+  html:not([color-scheme-override="light"]) pre {
+    background: #161b22;
+  }
+  html:not([color-scheme-override="light"]) code {
+    background: #161b22;
+  }
+  html:not([color-scheme-override="light"]) pre code {
+    background: none;
+  }
+  html:not([color-scheme-override="light"]) footer {
+    border-top-color: #21262d;
+    color: #8b949e;
+  }
+  html:not([color-scheme-override="light"]) a {
+    color: #4493f8;
+  }
+  html:not([color-scheme-override="light"]) .nav-toggle {
+    background: #0d1117;
+    border-color: #30363d;
+    color: #e6edf3;
+    box-shadow: 0 1px 3px rgba(1, 4, 9, 0.5);
+  }
+  html:not([color-scheme-override="light"]) .nav-toggle:hover {
+    background: #161b22;
+  }
+  html:not([color-scheme-override="light"]) .nav-toggle:focus-visible {
+    outline-color: #4493f8;
+  }
+  html:not([color-scheme-override="light"]) .nav-sidebar {
+    background: #0d1117;
+    border-right-color: #30363d;
+    box-shadow: 2px 0 10px rgba(1, 4, 9, 0.5);
+  }
+  html:not([color-scheme-override="light"]) .nav-sidebar-header {
+    background: #0d1117;
+    border-bottom-color: #21262d;
+  }
+  html:not([color-scheme-override="light"]) .nav-sidebar-close {
+    background: #0d1117;
+    border-color: #30363d;
+    color: #e6edf3;
+  }
+  html:not([color-scheme-override="light"]) .nav-sidebar-close:hover {
+    background: #161b22;
+  }
+  html:not([color-scheme-override="light"]) .nav-sidebar-close:focus-visible {
+    outline-color: #4493f8;
+  }
+  html:not([color-scheme-override="light"]) .nav-sidebar-title {
+    color: #e6edf3;
+  }
+  html:not([color-scheme-override="light"]) .nav-sidebar-title:hover {
+    color: #4493f8;
+  }
+  html:not([color-scheme-override="light"]) .nav-sidebar-list a {
+    color: #4493f8;
+  }
+  html:not([color-scheme-override="light"]) .nav-sidebar-list a:hover {
+    background: #161b22;
+  }
+  html:not([color-scheme-override="light"]) table.index td, html:not([color-scheme-override="light"]) table.index th {
+    border-bottom-color: #21262d;
+  }
+  html:not([color-scheme-override="light"]) table.index th {
+    background: #161b22;
+  }
+  html:not([color-scheme-override="light"]) table.index tr {
+    border-bottom-color: #21262d;
+  }
+  html:not([color-scheme-override="light"]) .state-active {
+    background: rgba(46, 160, 67, 0.18);
+  }
+  html:not([color-scheme-override="light"]) .state-inactive {
+    background: #30363d;
+  }
+  html:not([color-scheme-override="light"]) article.rule {
+    border-top-color: #21262d;
+  }
+  html:not([color-scheme-override="light"]) article.rule h2 .lint-prefix {
+    color: #8b949e;
+  }
+  html:not([color-scheme-override="light"]) article.rule h2 .rule-jump-link {
+    color: #8b949e;
+  }
+  html:not([color-scheme-override="light"]) article.rule h2 .rule-jump-link:hover {
+    color: #4493f8;
+  }
+  html:not([color-scheme-override="light"]) article.rule .source {
+    color: #8b949e;
+  }
+  html:not([color-scheme-override="light"]) details.config-details > summary.config-summary {
+    color: #e6edf3;
+  }
+  html:not([color-scheme-override="light"]) details.config-details > summary::before {
+    color: #8b949e;
+  }
+  html:not([color-scheme-override="light"]) p.config-none {
+    color: #8b949e;
+  }
+  html:not([color-scheme-override="light"]) dl.config {
+    background: #161b22;
+  }
+  html:not([color-scheme-override="light"]) .config-key {
+    background: rgba(56, 139, 253, 0.15);
+  }
+  html:not([color-scheme-override="light"]) .config-default {
+    color: #8b949e;
+  }
+  html:not([color-scheme-override="light"]) .badge-optional {
+    background: #30363d;
+    color: #8b949e;
+  }
+  html:not([color-scheme-override="light"]) .badge-mandatory {
+    background: rgba(248, 81, 73, 0.15);
+    color: #f85149;
+  }
+  html:not([color-scheme-override="light"]) article.rule h4.config-types {
+    color: #8b949e;
+  }
+  html:not([color-scheme-override="light"]) div.custom-type {
+    background: #161b22;
+    border-left-color: #30363d;
+  }
+  html:not([color-scheme-override="light"]) .custom-type-name {
+    background: rgba(56, 139, 253, 0.15);
+  }
+  html:not([color-scheme-override="light"]) .custom-type-kind {
+    color: #8b949e;
+  }
+  html:not([color-scheme-override="light"]) div.custom-type dl.config {
+    background: transparent;
+  }
+  html:not([color-scheme-override="light"]) .settings-toggle {
+    background: #0d1117;
+    border-color: #30363d;
+    color: #e6edf3;
+    box-shadow: 0 1px 3px rgba(1, 4, 9, 0.5);
+  }
+  html:not([color-scheme-override="light"]) .settings-toggle:hover {
+    background: #161b22;
+  }
+  html:not([color-scheme-override="light"]) .settings-toggle:focus-visible {
+    outline-color: #4493f8;
+  }
+  html:not([color-scheme-override="light"]) .settings-panel {
+    background: #0d1117;
+    border-color: #30363d;
+    box-shadow: 0 4px 16px rgba(1, 4, 9, 0.5);
+  }
+  html:not([color-scheme-override="light"]) .settings-panel-title {
+    color: #e6edf3;
+  }
+  html:not([color-scheme-override="light"]) .settings-section > legend {
+    color: #8b949e;
+  }
+  html:not([color-scheme-override="light"]) .theme-option {
+    border-color: #30363d;
+    color: #8b949e;
+    background: #0d1117;
+  }
+  html:not([color-scheme-override="light"]) .theme-option:hover {
+    background: #161b22;
+  }
+  html:not([color-scheme-override="light"]) .theme-radio:checked + .theme-option {
+    color: #4493f8;
+    border-color: #4493f8;
+    background: rgba(56, 139, 253, 0.15);
+  }
+  html:not([color-scheme-override="light"]) .theme-radio:focus-visible + .theme-option {
+    outline-color: #4493f8;
   }
 }
 
-:root[color-scheme-override="dark"],
-body[color-scheme-override="dark"] {
+html[color-scheme-override="dark"] {
   color-scheme: dark;
-  --color-canvas-default: #0d1117;
-  --color-canvas-subtle: #161b22;
-  --color-fg-default: #e6edf3;
-  --color-fg-muted: #8b949e;
-  --color-border-default: #30363d;
-  --color-border-muted: #21262d;
-  --color-neutral-muted: #30363d;
-  --color-accent-fg: #4493f8;
-  --color-accent-subtle: rgba(56, 139, 253, 0.15);
-  --color-attention-subtle: rgba(187, 128, 9, 0.15);
-  --color-attention-border: #9e6a03;
-  --color-success-subtle: rgba(46, 160, 67, 0.18);
-  --color-danger-fg: #f85149;
-  --color-danger-subtle: rgba(248, 81, 73, 0.15);
-  --color-shadow: rgba(1, 4, 9, 0.5);
+  background-color: #0d1117;
+}
+html[color-scheme-override="dark"] body {
+  color: #e6edf3;
+  background-color: #0d1117;
+}
+html[color-scheme-override="dark"] h1 {
+  border-bottom-color: #30363d;
+}
+html[color-scheme-override="dark"] .banner {
+  background: rgba(187, 128, 9, 0.15);
+  border-left-color: #9e6a03;
+}
+html[color-scheme-override="dark"] pre {
+  background: #161b22;
+}
+html[color-scheme-override="dark"] code {
+  background: #161b22;
+}
+html[color-scheme-override="dark"] pre code {
+  background: none;
+}
+html[color-scheme-override="dark"] footer {
+  border-top-color: #21262d;
+  color: #8b949e;
+}
+html[color-scheme-override="dark"] a {
+  color: #4493f8;
+}
+html[color-scheme-override="dark"] .nav-toggle {
+  background: #0d1117;
+  border-color: #30363d;
+  color: #e6edf3;
+  box-shadow: 0 1px 3px rgba(1, 4, 9, 0.5);
+}
+html[color-scheme-override="dark"] .nav-toggle:hover {
+  background: #161b22;
+}
+html[color-scheme-override="dark"] .nav-toggle:focus-visible {
+  outline-color: #4493f8;
+}
+html[color-scheme-override="dark"] .nav-sidebar {
+  background: #0d1117;
+  border-right-color: #30363d;
+  box-shadow: 2px 0 10px rgba(1, 4, 9, 0.5);
+}
+html[color-scheme-override="dark"] .nav-sidebar-header {
+  background: #0d1117;
+  border-bottom-color: #21262d;
+}
+html[color-scheme-override="dark"] .nav-sidebar-close {
+  background: #0d1117;
+  border-color: #30363d;
+  color: #e6edf3;
+}
+html[color-scheme-override="dark"] .nav-sidebar-close:hover {
+  background: #161b22;
+}
+html[color-scheme-override="dark"] .nav-sidebar-close:focus-visible {
+  outline-color: #4493f8;
+}
+html[color-scheme-override="dark"] .nav-sidebar-title {
+  color: #e6edf3;
+}
+html[color-scheme-override="dark"] .nav-sidebar-title:hover {
+  color: #4493f8;
+}
+html[color-scheme-override="dark"] .nav-sidebar-list a {
+  color: #4493f8;
+}
+html[color-scheme-override="dark"] .nav-sidebar-list a:hover {
+  background: #161b22;
+}
+html[color-scheme-override="dark"] table.index td, html[color-scheme-override="dark"] table.index th {
+  border-bottom-color: #21262d;
+}
+html[color-scheme-override="dark"] table.index th {
+  background: #161b22;
+}
+html[color-scheme-override="dark"] table.index tr {
+  border-bottom-color: #21262d;
+}
+html[color-scheme-override="dark"] .state-active {
+  background: rgba(46, 160, 67, 0.18);
+}
+html[color-scheme-override="dark"] .state-inactive {
+  background: #30363d;
+}
+html[color-scheme-override="dark"] article.rule {
+  border-top-color: #21262d;
+}
+html[color-scheme-override="dark"] article.rule h2 .lint-prefix {
+  color: #8b949e;
+}
+html[color-scheme-override="dark"] article.rule h2 .rule-jump-link {
+  color: #8b949e;
+}
+html[color-scheme-override="dark"] article.rule h2 .rule-jump-link:hover {
+  color: #4493f8;
+}
+html[color-scheme-override="dark"] article.rule .source {
+  color: #8b949e;
+}
+html[color-scheme-override="dark"] details.config-details > summary.config-summary {
+  color: #e6edf3;
+}
+html[color-scheme-override="dark"] details.config-details > summary::before {
+  color: #8b949e;
+}
+html[color-scheme-override="dark"] p.config-none {
+  color: #8b949e;
+}
+html[color-scheme-override="dark"] dl.config {
+  background: #161b22;
+}
+html[color-scheme-override="dark"] .config-key {
+  background: rgba(56, 139, 253, 0.15);
+}
+html[color-scheme-override="dark"] .config-default {
+  color: #8b949e;
+}
+html[color-scheme-override="dark"] .badge-optional {
+  background: #30363d;
+  color: #8b949e;
+}
+html[color-scheme-override="dark"] .badge-mandatory {
+  background: rgba(248, 81, 73, 0.15);
+  color: #f85149;
+}
+html[color-scheme-override="dark"] article.rule h4.config-types {
+  color: #8b949e;
+}
+html[color-scheme-override="dark"] div.custom-type {
+  background: #161b22;
+  border-left-color: #30363d;
+}
+html[color-scheme-override="dark"] .custom-type-name {
+  background: rgba(56, 139, 253, 0.15);
+}
+html[color-scheme-override="dark"] .custom-type-kind {
+  color: #8b949e;
+}
+html[color-scheme-override="dark"] div.custom-type dl.config {
+  background: transparent;
+}
+html[color-scheme-override="dark"] .settings-toggle {
+  background: #0d1117;
+  border-color: #30363d;
+  color: #e6edf3;
+  box-shadow: 0 1px 3px rgba(1, 4, 9, 0.5);
+}
+html[color-scheme-override="dark"] .settings-toggle:hover {
+  background: #161b22;
+}
+html[color-scheme-override="dark"] .settings-toggle:focus-visible {
+  outline-color: #4493f8;
+}
+html[color-scheme-override="dark"] .settings-panel {
+  background: #0d1117;
+  border-color: #30363d;
+  box-shadow: 0 4px 16px rgba(1, 4, 9, 0.5);
+}
+html[color-scheme-override="dark"] .settings-panel-title {
+  color: #e6edf3;
+}
+html[color-scheme-override="dark"] .settings-section > legend {
+  color: #8b949e;
+}
+html[color-scheme-override="dark"] .theme-option {
+  border-color: #30363d;
+  color: #8b949e;
+  background: #0d1117;
+}
+html[color-scheme-override="dark"] .theme-option:hover {
+  background: #161b22;
+}
+html[color-scheme-override="dark"] .theme-radio:checked + .theme-option {
+  color: #4493f8;
+  border-color: #4493f8;
+  background: rgba(56, 139, 253, 0.15);
+}
+html[color-scheme-override="dark"] .theme-radio:focus-visible + .theme-option {
+  outline-color: #4493f8;
 }

--- a/tools/gen-docs/src/style/dark.css
+++ b/tools/gen-docs/src/style/dark.css
@@ -66,7 +66,6 @@
   html:not([color-scheme-override="light"]) .nav-sidebar {
     background: #0d1117;
     border-right-color: #30363d;
-    box-shadow: 2px 0 10px rgba(1, 4, 9, 0.5);
   }
   html:not([color-scheme-override="light"]) .nav-sidebar-header {
     background: #0d1117;
@@ -94,6 +93,9 @@
   }
   html:not([color-scheme-override="light"]) .nav-sidebar-list a:hover {
     background: #161b22;
+  }
+  html:not([color-scheme-override="light"]) .nav-sidebar-list a code {
+    background: none;
   }
   html:not([color-scheme-override="light"]) table.index td, html:not([color-scheme-override="light"]) table.index th {
     border-bottom-color: #21262d;
@@ -254,7 +256,6 @@ html[color-scheme-override="dark"] .nav-toggle:focus-visible {
 html[color-scheme-override="dark"] .nav-sidebar {
   background: #0d1117;
   border-right-color: #30363d;
-  box-shadow: 2px 0 10px rgba(1, 4, 9, 0.5);
 }
 html[color-scheme-override="dark"] .nav-sidebar-header {
   background: #0d1117;
@@ -282,6 +283,9 @@ html[color-scheme-override="dark"] .nav-sidebar-list a {
 }
 html[color-scheme-override="dark"] .nav-sidebar-list a:hover {
   background: #161b22;
+}
+html[color-scheme-override="dark"] .nav-sidebar-list a code {
+  background: none;
 }
 html[color-scheme-override="dark"] table.index td, html[color-scheme-override="dark"] table.index th {
   border-bottom-color: #21262d;
@@ -393,4 +397,18 @@ html[color-scheme-override="dark"] .theme-radio:checked + .theme-option {
 }
 html[color-scheme-override="dark"] .theme-radio:focus-visible + .theme-option {
   outline-color: #4493f8;
+}
+
+/* The sidebar shadow only applies in the overlay band (601-1099.98px),
+   mirroring light.css. One block per dark tier (system preference, then
+   explicit Dark); the prefixes out-specify the band shadow in light.css. */
+@media (prefers-color-scheme: dark) and (min-width: 601px) and (max-width: 1099.98px) {
+  html:not([color-scheme-override="light"]) .nav-sidebar {
+    box-shadow: 2px 0 10px rgba(1, 4, 9, 0.5);
+  }
+}
+@media (min-width: 601px) and (max-width: 1099.98px) {
+  html[color-scheme-override="dark"] .nav-sidebar {
+    box-shadow: 2px 0 10px rgba(1, 4, 9, 0.5);
+  }
 }

--- a/tools/gen-docs/src/style/light.css
+++ b/tools/gen-docs/src/style/light.css
@@ -70,7 +70,16 @@ a {
 .nav-sidebar {
   background: #ffffff;
   border-right-color: #d0d7de;
-  box-shadow: 2px 0 10px rgba(31, 35, 40, 0.08);
+}
+
+/* The sidebar shadow only applies in the overlay band (601-1099.98px);
+   it is flush at <=600px (full-screen) and >=1100px (permanent). Scoping
+   it here, rather than resetting it at those breakpoints, keeps the
+   `box-shadow: none` overrides out of the structural sheet. */
+@media (min-width: 601px) and (max-width: 1099.98px) {
+  .nav-sidebar {
+    box-shadow: 2px 0 10px rgba(31, 35, 40, 0.08);
+  }
 }
 .nav-sidebar-header {
   background: #ffffff;
@@ -98,6 +107,9 @@ a {
 }
 .nav-sidebar-list a:hover {
   background: #f6f8fa;
+}
+.nav-sidebar-list a code {
+  background: none;
 }
 table.index td, table.index th {
   border-bottom-color: #eaeef2;

--- a/tools/gen-docs/src/style/light.css
+++ b/tools/gen-docs/src/style/light.css
@@ -1,0 +1,45 @@
+/* Light theme — the default palette.
+ *
+ * This file owns the *light* half of the page's colour system: every
+ * colour the hand-written sheets (base.css, nav.css, rules.css,
+ * settings.css) consume is a `var(--color-*)` resolved here. The dark
+ * half lives in dark.css. Splitting the palette into two files is the
+ * "extract the colour rules into dark and light files" requirement from
+ * issue #185; the structural sheets only reference the variables and
+ * never hard-code a colour.
+ *
+ * Override tiers (see issue #185):
+ *
+ *   1. Default — these `:root` values. With neither a system-theme
+ *      media query nor JavaScript, the page is Light.
+ *   2. System preference — `@media (prefers-color-scheme: dark)` in
+ *      dark.css overrides tier 1 when the OS asks for dark.
+ *   3. Explicit override — a `color-scheme-override` attribute on
+ *      <html> (or <body>), set only by theme_toggle.js. The
+ *      `:root[...]`/`body[...]` selectors below carry specificity
+ *      >= (0,2,0) / (0,1,1), which beats the dark `@media` block's
+ *      `:root` (0,1,0) regardless of source order — so an explicit
+ *      Light choice wins even when the OS prefers dark. The `:root`
+ *      base selector and the two override selectors share one rule so
+ *      the light values are written exactly once.
+ */
+:root,
+:root[color-scheme-override="light"],
+body[color-scheme-override="light"] {
+  color-scheme: light;
+  --color-canvas-default: #ffffff;
+  --color-canvas-subtle: #f6f8fa;
+  --color-fg-default: #1f2328;
+  --color-fg-muted: #57606a;
+  --color-border-default: #d0d7de;
+  --color-border-muted: #eaeef2;
+  --color-neutral-muted: #eaeef2;
+  --color-accent-fg: #0969da;
+  --color-accent-subtle: #ddf4ff;
+  --color-attention-subtle: #fff8c5;
+  --color-attention-border: #d4a72c;
+  --color-success-subtle: #dafbe1;
+  --color-danger-fg: #cf222e;
+  --color-danger-subtle: #ffebe9;
+  --color-shadow: rgba(31, 35, 40, 0.08);
+}

--- a/tools/gen-docs/src/style/light.css
+++ b/tools/gen-docs/src/style/light.css
@@ -1,45 +1,212 @@
-/* Light theme — the default palette.
+/* Light theme — the default colour layer.
  *
- * This file owns the *light* half of the page's colour system: every
- * colour the hand-written sheets (base.css, nav.css, rules.css,
- * settings.css) consume is a `var(--color-*)` resolved here. The dark
- * half lives in dark.css. Splitting the palette into two files is the
- * "extract the colour rules into dark and light files" requirement from
- * issue #185; the structural sheets only reference the variables and
- * never hard-code a colour.
+ * This file (and its dark counterpart, dark.css) carries the colours
+ * extracted out of the structural stylesheets (base.css, nav.css,
+ * rules.css, settings.css). Each rule here mirrors a selector from
+ * those files but lists ONLY its colour declarations; the structural
+ * files keep the layout, sizing, and other non-colour properties.
  *
- * Override tiers (see issue #185):
+ * No CSS custom properties are used: every value is a literal colour,
+ * so the page themes correctly on engines that predate `var()`
+ * (maximising backward compatibility). The cost is that dark.css
+ * repeats each colour under the two dark tiers — see that file.
  *
- *   1. Default — these `:root` values. With neither a system-theme
- *      media query nor JavaScript, the page is Light.
- *   2. System preference — `@media (prefers-color-scheme: dark)` in
- *      dark.css overrides tier 1 when the OS asks for dark.
- *   3. Explicit override — a `color-scheme-override` attribute on
- *      <html> (or <body>), set only by theme_toggle.js. The
- *      `:root[...]`/`body[...]` selectors below carry specificity
- *      >= (0,2,0) / (0,1,1), which beats the dark `@media` block's
- *      `:root` (0,1,0) regardless of source order — so an explicit
- *      Light choice wins even when the OS prefers dark. The `:root`
- *      base selector and the two override selectors share one rule so
- *      the light values are written exactly once.
+ * Override tiers (issue 185):
+ *   1. Default Light — these rules. They are the lowest-priority colour
+ *      layer; with neither a system-preference media query nor the
+ *      override attribute, the page is Light.
+ *   2. System preference and 3. explicit override both live in dark.css
+ *      and win over these by being later in the cascade and/or more
+ *      specific.
+ *
+ * Loaded AFTER the structural sheets so a colour longhand here (e.g.
+ * `border-bottom-color`) overrides the `currentColor` left by a
+ * structural border shorthand of equal specificity.
  */
-:root,
-:root[color-scheme-override="light"],
-body[color-scheme-override="light"] {
+
+html {
   color-scheme: light;
-  --color-canvas-default: #ffffff;
-  --color-canvas-subtle: #f6f8fa;
-  --color-fg-default: #1f2328;
-  --color-fg-muted: #57606a;
-  --color-border-default: #d0d7de;
-  --color-border-muted: #eaeef2;
-  --color-neutral-muted: #eaeef2;
-  --color-accent-fg: #0969da;
-  --color-accent-subtle: #ddf4ff;
-  --color-attention-subtle: #fff8c5;
-  --color-attention-border: #d4a72c;
-  --color-success-subtle: #dafbe1;
-  --color-danger-fg: #cf222e;
-  --color-danger-subtle: #ffebe9;
-  --color-shadow: rgba(31, 35, 40, 0.08);
+  background-color: #ffffff;
+}
+body {
+  color: #1f2328;
+  background-color: #ffffff;
+}
+h1 {
+  border-bottom-color: #d0d7de;
+}
+.banner {
+  background: #fff8c5;
+  border-left-color: #d4a72c;
+}
+pre {
+  background: #f6f8fa;
+}
+code {
+  background: #f6f8fa;
+}
+pre code {
+  background: none;
+}
+footer {
+  border-top-color: #eaeef2;
+  color: #57606a;
+}
+a {
+  color: #0969da;
+}
+.nav-toggle {
+  background: #ffffff;
+  border-color: #d0d7de;
+  color: #1f2328;
+  box-shadow: 0 1px 3px rgba(31, 35, 40, 0.08);
+}
+.nav-toggle:hover {
+  background: #f6f8fa;
+}
+.nav-toggle:focus-visible {
+  outline-color: #0969da;
+}
+.nav-sidebar {
+  background: #ffffff;
+  border-right-color: #d0d7de;
+  box-shadow: 2px 0 10px rgba(31, 35, 40, 0.08);
+}
+.nav-sidebar-header {
+  background: #ffffff;
+  border-bottom-color: #eaeef2;
+}
+.nav-sidebar-close {
+  background: #ffffff;
+  border-color: #d0d7de;
+  color: #1f2328;
+}
+.nav-sidebar-close:hover {
+  background: #f6f8fa;
+}
+.nav-sidebar-close:focus-visible {
+  outline-color: #0969da;
+}
+.nav-sidebar-title {
+  color: #1f2328;
+}
+.nav-sidebar-title:hover {
+  color: #0969da;
+}
+.nav-sidebar-list a {
+  color: #0969da;
+}
+.nav-sidebar-list a:hover {
+  background: #f6f8fa;
+}
+table.index td, table.index th {
+  border-bottom-color: #eaeef2;
+}
+table.index th {
+  background: #f6f8fa;
+}
+table.index tr {
+  border-bottom-color: #eaeef2;
+}
+.state-active {
+  background: #dafbe1;
+}
+.state-inactive {
+  background: #eaeef2;
+}
+article.rule {
+  border-top-color: #eaeef2;
+}
+article.rule h2 .lint-prefix {
+  color: #57606a;
+}
+article.rule h2 .rule-jump-link {
+  color: #57606a;
+}
+article.rule h2 .rule-jump-link:hover {
+  color: #0969da;
+}
+article.rule .source {
+  color: #57606a;
+}
+details.config-details > summary.config-summary {
+  color: #1f2328;
+}
+details.config-details > summary::before {
+  color: #57606a;
+}
+p.config-none {
+  color: #57606a;
+}
+dl.config {
+  background: #f6f8fa;
+}
+.config-key {
+  background: #ddf4ff;
+}
+.config-default {
+  color: #57606a;
+}
+.badge-optional {
+  background: #eaeef2;
+  color: #57606a;
+}
+.badge-mandatory {
+  background: #ffebe9;
+  color: #cf222e;
+}
+article.rule h4.config-types {
+  color: #57606a;
+}
+div.custom-type {
+  background: #f6f8fa;
+  border-left-color: #d0d7de;
+}
+.custom-type-name {
+  background: #ddf4ff;
+}
+.custom-type-kind {
+  color: #57606a;
+}
+div.custom-type dl.config {
+  background: transparent;
+}
+.settings-toggle {
+  background: #ffffff;
+  border-color: #d0d7de;
+  color: #1f2328;
+  box-shadow: 0 1px 3px rgba(31, 35, 40, 0.08);
+}
+.settings-toggle:hover {
+  background: #f6f8fa;
+}
+.settings-toggle:focus-visible {
+  outline-color: #0969da;
+}
+.settings-panel {
+  background: #ffffff;
+  border-color: #d0d7de;
+  box-shadow: 0 4px 16px rgba(31, 35, 40, 0.08);
+}
+.settings-panel-title {
+  color: #1f2328;
+}
+.settings-section > legend {
+  color: #57606a;
+}
+.theme-option {
+  border-color: #d0d7de;
+  color: #57606a;
+  background: #ffffff;
+}
+.theme-option:hover {
+  background: #f6f8fa;
+}
+.theme-radio:checked + .theme-option {
+  color: #0969da;
+  border-color: #0969da;
+  background: #ddf4ff;
+}
+.theme-radio:focus-visible + .theme-option {
+  outline-color: #0969da;
 }

--- a/tools/gen-docs/src/style/light.css
+++ b/tools/gen-docs/src/style/light.css
@@ -11,7 +11,7 @@
  * (maximising backward compatibility). The cost is that dark.css
  * repeats each colour under the two dark tiers — see that file.
  *
- * Override tiers (issue 185):
+ * Override tiers:
  *   1. Default Light — these rules. They are the lowest-priority colour
  *      layer; with neither a system-preference media query nor the
  *      override attribute, the page is Light.

--- a/tools/gen-docs/src/style/nav.css
+++ b/tools/gen-docs/src/style/nav.css
@@ -149,7 +149,6 @@
 }
 
 .nav-sidebar-list a code {
-  background: none;
   padding: 0;
   font-size: 0.85rem;
 }
@@ -196,7 +195,6 @@
     width: 100vw;
     max-width: none;
     border-right: none;
-    box-shadow: none;
   }
 }
 
@@ -212,7 +210,6 @@
 
   .nav-sidebar {
     display: block;
-    box-shadow: none;
   }
 
   .nav-sidebar-header {

--- a/tools/gen-docs/src/style/nav.css
+++ b/tools/gen-docs/src/style/nav.css
@@ -35,17 +35,17 @@
   z-index: 100;
   width: 2.5rem;
   height: 2.5rem;
-  background: #ffffff;
-  border: 1px solid #d0d7de;
+  background: var(--color-canvas-default);
+  border: 1px solid var(--color-border-default);
   border-radius: 6px;
   cursor: pointer;
   font-size: 1.4rem;
   line-height: 1;
-  color: #1f2328;
+  color: var(--color-fg-default);
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 1px 3px rgba(31, 35, 40, 0.08);
+  box-shadow: 0 1px 3px var(--color-shadow);
   padding: 0;
 }
 
@@ -54,11 +54,11 @@
 }
 
 .nav-toggle:hover {
-  background: #f6f8fa;
+  background: var(--color-canvas-subtle);
 }
 
 .nav-toggle:focus-visible {
-  outline: 2px solid #0969da;
+  outline: 2px solid var(--color-accent-fg);
   outline-offset: 2px;
 }
 
@@ -81,12 +81,12 @@
   height: 100vh;
   height: 100dvh;
   overflow-y: auto;
-  background: #ffffff;
-  border-right: 1px solid #d0d7de;
+  background: var(--color-canvas-default);
+  border-right: 1px solid var(--color-border-default);
   padding: 0;
   z-index: 99;
   box-sizing: border-box;
-  box-shadow: 2px 0 10px rgba(31, 35, 40, 0.08);
+  box-shadow: 2px 0 10px var(--color-shadow);
   display: none;
 }
 
@@ -100,8 +100,8 @@
   justify-content: space-between;
   gap: 0.5rem;
   padding: 0.6rem 1rem;
-  border-bottom: 1px solid #eaeef2;
-  background: #ffffff;
+  border-bottom: 1px solid var(--color-border-muted);
+  background: var(--color-canvas-default);
   position: sticky;
   top: 0;
   z-index: 1;
@@ -111,13 +111,13 @@
   width: 2.5rem;
   height: 2.5rem;
   flex: none;
-  background: #ffffff;
-  border: 1px solid #d0d7de;
+  background: var(--color-canvas-default);
+  border: 1px solid var(--color-border-default);
   border-radius: 6px;
   cursor: pointer;
   font-size: 1.2rem;
   line-height: 1;
-  color: #1f2328;
+  color: var(--color-fg-default);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -125,11 +125,11 @@
 }
 
 .nav-sidebar-close:hover {
-  background: #f6f8fa;
+  background: var(--color-canvas-subtle);
 }
 
 .nav-sidebar-close:focus-visible {
-  outline: 2px solid #0969da;
+  outline: 2px solid var(--color-accent-fg);
   outline-offset: 2px;
 }
 
@@ -137,14 +137,14 @@
   flex: 1;
   font-weight: 600;
   text-decoration: none;
-  color: #1f2328;
+  color: var(--color-fg-default);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .nav-sidebar-title:hover {
-  color: #0969da;
+  color: var(--color-accent-fg);
 }
 
 .nav-sidebar-list {
@@ -161,13 +161,13 @@
   display: block;
   padding: 0.25rem 0.5rem;
   text-decoration: none;
-  color: #0969da;
+  color: var(--color-accent-fg);
   border-radius: 4px;
   overflow-wrap: anywhere;
 }
 
 .nav-sidebar-list a:hover {
-  background: #f6f8fa;
+  background: var(--color-canvas-subtle);
   text-decoration: none;
 }
 

--- a/tools/gen-docs/src/style/nav.css
+++ b/tools/gen-docs/src/style/nav.css
@@ -35,17 +35,14 @@
   z-index: 100;
   width: 2.5rem;
   height: 2.5rem;
-  background: var(--color-canvas-default);
-  border: 1px solid var(--color-border-default);
+  border: 1px solid;
   border-radius: 6px;
   cursor: pointer;
   font-size: 1.4rem;
   line-height: 1;
-  color: var(--color-fg-default);
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 1px 3px var(--color-shadow);
   padding: 0;
 }
 
@@ -53,12 +50,8 @@
   content: "\2630"; /* ☰ */
 }
 
-.nav-toggle:hover {
-  background: var(--color-canvas-subtle);
-}
-
 .nav-toggle:focus-visible {
-  outline: 2px solid var(--color-accent-fg);
+  outline: 2px solid;
   outline-offset: 2px;
 }
 
@@ -81,12 +74,10 @@
   height: 100vh;
   height: 100dvh;
   overflow-y: auto;
-  background: var(--color-canvas-default);
-  border-right: 1px solid var(--color-border-default);
+  border-right: 1px solid;
   padding: 0;
   z-index: 99;
   box-sizing: border-box;
-  box-shadow: 2px 0 10px var(--color-shadow);
   display: none;
 }
 
@@ -100,8 +91,7 @@
   justify-content: space-between;
   gap: 0.5rem;
   padding: 0.6rem 1rem;
-  border-bottom: 1px solid var(--color-border-muted);
-  background: var(--color-canvas-default);
+  border-bottom: 1px solid;
   position: sticky;
   top: 0;
   z-index: 1;
@@ -111,25 +101,19 @@
   width: 2.5rem;
   height: 2.5rem;
   flex: none;
-  background: var(--color-canvas-default);
-  border: 1px solid var(--color-border-default);
+  border: 1px solid;
   border-radius: 6px;
   cursor: pointer;
   font-size: 1.2rem;
   line-height: 1;
-  color: var(--color-fg-default);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
 }
 
-.nav-sidebar-close:hover {
-  background: var(--color-canvas-subtle);
-}
-
 .nav-sidebar-close:focus-visible {
-  outline: 2px solid var(--color-accent-fg);
+  outline: 2px solid;
   outline-offset: 2px;
 }
 
@@ -137,14 +121,9 @@
   flex: 1;
   font-weight: 600;
   text-decoration: none;
-  color: var(--color-fg-default);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.nav-sidebar-title:hover {
-  color: var(--color-accent-fg);
 }
 
 .nav-sidebar-list {
@@ -161,13 +140,11 @@
   display: block;
   padding: 0.25rem 0.5rem;
   text-decoration: none;
-  color: var(--color-accent-fg);
   border-radius: 4px;
   overflow-wrap: anywhere;
 }
 
 .nav-sidebar-list a:hover {
-  background: var(--color-canvas-subtle);
   text-decoration: none;
 }
 

--- a/tools/gen-docs/src/style/rules.css
+++ b/tools/gen-docs/src/style/rules.css
@@ -8,12 +8,8 @@ table.index td,
 table.index th {
   text-align: left;
   padding: 0.4rem 0.6rem;
-  border-bottom: 1px solid var(--color-border-muted);
+  border-bottom: 1px solid;
   vertical-align: top;
-}
-
-table.index th {
-  background: var(--color-canvas-subtle);
 }
 
 /* On phone-sized viewports the three-column index table no longer
@@ -46,7 +42,7 @@ table.index th {
   }
 
   table.index tr {
-    border-bottom: 1px solid var(--color-border-muted);
+    border-bottom: 1px solid;
     padding: 0.5rem 0;
   }
 
@@ -68,18 +64,10 @@ table.index th {
   margin-right: 0.5rem;
 }
 
-.state-active {
-  background: var(--color-success-subtle);
-}
-
-.state-inactive {
-  background: var(--color-neutral-muted);
-}
-
 article.rule {
   margin-bottom: 3rem;
   padding-top: 1rem;
-  border-top: 1px solid var(--color-border-muted);
+  border-top: 1px solid;
 }
 
 article.rule h2 {
@@ -114,7 +102,6 @@ article.rule h2 .rule-anchor:focus {
 
 article.rule h2 .lint-prefix {
   font-size: 0.89em;
-  color: var(--color-fg-muted);
 }
 
 article.rule h2 .lint-name {
@@ -126,18 +113,15 @@ article.rule h2 .rule-jump-link {
   font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   font-size: 0.8rem;
   font-weight: normal;
-  color: var(--color-fg-muted);
   text-decoration: none;
 }
 
 article.rule h2 .rule-jump-link:hover {
-  color: var(--color-accent-fg);
   text-decoration: underline;
 }
 
 article.rule .source {
   font-size: 0.85rem;
-  color: var(--color-fg-muted);
 }
 
 article.rule h3 {
@@ -151,7 +135,6 @@ details.config-details {
 
 p.config-none {
   margin-top: 1rem;
-  color: var(--color-fg-muted);
 }
 
 details.config-details > summary {
@@ -166,14 +149,12 @@ details.config-details > summary::-webkit-details-marker {
 details.config-details > summary.config-summary {
   font-size: 1.05rem;
   font-weight: 600;
-  color: var(--color-fg-default);
 }
 
 details.config-details > summary::before {
   content: "▸ ";
   display: inline-block;
   width: 1em;
-  color: var(--color-fg-muted);
 }
 
 details.config-details[open] > summary::before {
@@ -183,7 +164,6 @@ details.config-details[open] > summary::before {
 dl.config {
   margin: 0.5rem 0 1rem;
   padding: 0.5rem 0.75rem;
-  background: var(--color-canvas-subtle);
   border-radius: 6px;
 }
 
@@ -205,13 +185,8 @@ dl.config dd p {
   margin: 0.25rem 0;
 }
 
-.config-key {
-  background: var(--color-accent-subtle);
-}
-
 .config-default {
   font-size: 0.85rem;
-  color: var(--color-fg-muted);
 }
 
 .badge {
@@ -220,16 +195,6 @@ dl.config dd p {
   border-radius: 999px;
   vertical-align: middle;
   font-family: ui-monospace, SFMono-Regular, monospace;
-}
-
-.badge-optional {
-  background: var(--color-neutral-muted);
-  color: var(--color-fg-muted);
-}
-
-.badge-mandatory {
-  background: var(--color-danger-subtle);
-  color: var(--color-danger-fg);
 }
 
 /* Author-written `####` sub-headings in a rule's rustdoc (e.g.
@@ -248,7 +213,6 @@ article.rule h4 {
    longer captures author `####` headings (issue #178). */
 article.rule h4.config-types {
   font-size: 0.95rem;
-  color: var(--color-fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -256,8 +220,7 @@ article.rule h4.config-types {
 div.custom-type {
   margin: 0.5rem 0 1rem;
   padding: 0.5rem 0.75rem;
-  background: var(--color-canvas-subtle);
-  border-left: 3px solid var(--color-border-default);
+  border-left: 3px solid;
   border-radius: 0 6px 6px 0;
 }
 
@@ -265,19 +228,13 @@ div.custom-type > p:first-child {
   margin: 0 0 0.25rem;
 }
 
-.custom-type-name {
-  background: var(--color-accent-subtle);
-}
-
 .custom-type-kind {
   font-size: 0.78rem;
-  color: var(--color-fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
 
 div.custom-type dl.config {
-  background: transparent;
   padding: 0;
   margin: 0.25rem 0 0;
 }

--- a/tools/gen-docs/src/style/rules.css
+++ b/tools/gen-docs/src/style/rules.css
@@ -8,12 +8,12 @@ table.index td,
 table.index th {
   text-align: left;
   padding: 0.4rem 0.6rem;
-  border-bottom: 1px solid #eaeef2;
+  border-bottom: 1px solid var(--color-border-muted);
   vertical-align: top;
 }
 
 table.index th {
-  background: #f6f8fa;
+  background: var(--color-canvas-subtle);
 }
 
 /* On phone-sized viewports the three-column index table no longer
@@ -46,7 +46,7 @@ table.index th {
   }
 
   table.index tr {
-    border-bottom: 1px solid #eaeef2;
+    border-bottom: 1px solid var(--color-border-muted);
     padding: 0.5rem 0;
   }
 
@@ -69,17 +69,17 @@ table.index th {
 }
 
 .state-active {
-  background: #dafbe1;
+  background: var(--color-success-subtle);
 }
 
 .state-inactive {
-  background: #eaeef2;
+  background: var(--color-neutral-muted);
 }
 
 article.rule {
   margin-bottom: 3rem;
   padding-top: 1rem;
-  border-top: 1px solid #eaeef2;
+  border-top: 1px solid var(--color-border-muted);
 }
 
 article.rule h2 {
@@ -114,7 +114,7 @@ article.rule h2 .rule-anchor:focus {
 
 article.rule h2 .lint-prefix {
   font-size: 0.89em;
-  color: #57606a;
+  color: var(--color-fg-muted);
 }
 
 article.rule h2 .lint-name {
@@ -126,18 +126,18 @@ article.rule h2 .rule-jump-link {
   font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   font-size: 0.8rem;
   font-weight: normal;
-  color: #57606a;
+  color: var(--color-fg-muted);
   text-decoration: none;
 }
 
 article.rule h2 .rule-jump-link:hover {
-  color: #0969da;
+  color: var(--color-accent-fg);
   text-decoration: underline;
 }
 
 article.rule .source {
   font-size: 0.85rem;
-  color: #57606a;
+  color: var(--color-fg-muted);
 }
 
 article.rule h3 {
@@ -151,7 +151,7 @@ details.config-details {
 
 p.config-none {
   margin-top: 1rem;
-  color: #57606a;
+  color: var(--color-fg-muted);
 }
 
 details.config-details > summary {
@@ -166,14 +166,14 @@ details.config-details > summary::-webkit-details-marker {
 details.config-details > summary.config-summary {
   font-size: 1.05rem;
   font-weight: 600;
-  color: #1f2328;
+  color: var(--color-fg-default);
 }
 
 details.config-details > summary::before {
   content: "▸ ";
   display: inline-block;
   width: 1em;
-  color: #57606a;
+  color: var(--color-fg-muted);
 }
 
 details.config-details[open] > summary::before {
@@ -183,7 +183,7 @@ details.config-details[open] > summary::before {
 dl.config {
   margin: 0.5rem 0 1rem;
   padding: 0.5rem 0.75rem;
-  background: #f6f8fa;
+  background: var(--color-canvas-subtle);
   border-radius: 6px;
 }
 
@@ -206,12 +206,12 @@ dl.config dd p {
 }
 
 .config-key {
-  background: #ddf4ff;
+  background: var(--color-accent-subtle);
 }
 
 .config-default {
   font-size: 0.85rem;
-  color: #57606a;
+  color: var(--color-fg-muted);
 }
 
 .badge {
@@ -223,13 +223,13 @@ dl.config dd p {
 }
 
 .badge-optional {
-  background: #eaeef2;
-  color: #57606a;
+  background: var(--color-neutral-muted);
+  color: var(--color-fg-muted);
 }
 
 .badge-mandatory {
-  background: #ffebe9;
-  color: #cf222e;
+  background: var(--color-danger-subtle);
+  color: var(--color-danger-fg);
 }
 
 /* Author-written `####` sub-headings in a rule's rustdoc (e.g.
@@ -248,7 +248,7 @@ article.rule h4 {
    longer captures author `####` headings (issue #178). */
 article.rule h4.config-types {
   font-size: 0.95rem;
-  color: #57606a;
+  color: var(--color-fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -256,8 +256,8 @@ article.rule h4.config-types {
 div.custom-type {
   margin: 0.5rem 0 1rem;
   padding: 0.5rem 0.75rem;
-  background: #f6f8fa;
-  border-left: 3px solid #d0d7de;
+  background: var(--color-canvas-subtle);
+  border-left: 3px solid var(--color-border-default);
   border-radius: 0 6px 6px 0;
 }
 
@@ -266,12 +266,12 @@ div.custom-type > p:first-child {
 }
 
 .custom-type-name {
-  background: #ddf4ff;
+  background: var(--color-accent-subtle);
 }
 
 .custom-type-kind {
   font-size: 0.78rem;
-  color: #57606a;
+  color: var(--color-fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }

--- a/tools/gen-docs/src/style/settings.css
+++ b/tools/gen-docs/src/style/settings.css
@@ -1,0 +1,193 @@
+/* Settings affordance: a gear button in the top-right corner and the
+   panel it toggles. Colours are `var(--color-*)` from light.css /
+   dark.css; see issue #185.
+
+   The gear is the mirror image of the nav hamburger (nav.css): same
+   size and inset, but pinned to the right instead of the left so the
+   two corners read as a symmetrical pair. Both start with the HTML
+   `hidden` attribute and are revealed by their script only once its
+   handlers are wired up, so a page whose JS never runs shows neither a
+   dead hamburger nor a dead gear (the `[hidden]` reset in base.css
+   makes that unconditional). */
+
+.settings-toggle {
+  position: fixed;
+  top: 0.6rem;
+  right: 0.6rem;
+  /* Just below the nav drawer's z-index (toggle 100 / sidebar 99) so
+     the full-screen mobile nav overlay covers the gear while it's open
+     — nav_toggle.js also marks the gear `inert` then, but this keeps it
+     visually behind too. Still well above the page's static content. */
+  z-index: 98;
+  width: 2.5rem;
+  height: 2.5rem;
+  background: var(--color-canvas-default);
+  border: 1px solid var(--color-border-default);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 1.4rem;
+  line-height: 1;
+  color: var(--color-fg-default);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 3px var(--color-shadow);
+  padding: 0;
+  /* Half-transparent at rest, fully opaque on hover / focus / while
+     the panel is open, with a short ease between the two states. */
+  opacity: 0.5;
+  transition: opacity 0.18s ease;
+}
+
+.settings-toggle::before {
+  content: "\2699"; /* ⚙ U+2699 GEAR */
+}
+
+.settings-toggle:hover,
+.settings-toggle:focus-visible,
+.settings-toggle[aria-expanded="true"] {
+  opacity: 1;
+}
+
+.settings-toggle:hover {
+  background: var(--color-canvas-subtle);
+}
+
+.settings-toggle:focus-visible {
+  outline: 2px solid var(--color-accent-fg);
+  outline-offset: 2px;
+}
+
+/* The panel drops down from just under the gear, pinned to the same
+   right edge. Fixed, so it tracks the gear rather than scrolling with
+   the page. Toggled by clearing/setting its `hidden` attribute in JS. */
+.settings-panel {
+  position: fixed;
+  top: 3.4rem;
+  right: 0.6rem;
+  z-index: 98;
+  width: 16rem;
+  max-width: calc(100vw - 1.2rem);
+  background: var(--color-canvas-default);
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px var(--color-shadow);
+  padding: 0.85rem 1rem 1rem;
+  box-sizing: border-box;
+}
+
+.settings-panel-title {
+  margin: 0 0 0.6rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-fg-default);
+}
+
+/* The theme chooser is a <fieldset> of three radios. Strip the default
+   fieldset chrome so it reads as a plain section. */
+.settings-section {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.settings-section > legend {
+  padding: 0;
+  margin: 0 0 0.4rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-fg-muted);
+}
+
+/* Three equal-width choices in a row. */
+.theme-options {
+  display: flex;
+  gap: 0.4rem;
+}
+
+/* The radio inputs keep their semantics (one exclusive choice, keyboard
+   arrow navigation, form labelling) but are visually removed — the
+   visible control is the adjacent <label>. `clip` + 1px box is the
+   standard visually-hidden recipe; `display: none` would drop the input
+   from the tab/arrow order, and `opacity: 0` alone would leave it
+   occupying layout. */
+.theme-radio {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.theme-option {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.5rem 0.25rem;
+  border: 1px solid var(--color-border-default);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--color-fg-muted);
+  background: var(--color-canvas-default);
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.theme-option:hover {
+  background: var(--color-canvas-subtle);
+}
+
+/* The icon is recoloured by the label's own `color` via a CSS mask, so
+   it follows the theme (and the highlighted state below) without
+   shipping a separate light/dark copy of each SVG. `background-color`
+   paints through the mask; the SVG only contributes its alpha. Browsers
+   without mask support (pre-2023 engines) simply show no glyph — the
+   text label beneath still names the choice, so the control degrades to
+   text-only rather than breaking. */
+.theme-icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  background-color: currentColor;
+}
+
+.theme-option-light .theme-icon {
+  -webkit-mask: url("theme-light.svg") no-repeat center / contain;
+  mask: url("theme-light.svg") no-repeat center / contain;
+}
+
+.theme-option-dark .theme-icon {
+  -webkit-mask: url("theme-dark.svg") no-repeat center / contain;
+  mask: url("theme-dark.svg") no-repeat center / contain;
+}
+
+.theme-option-system .theme-icon {
+  -webkit-mask: url("theme-system.svg") no-repeat center / contain;
+  mask: url("theme-system.svg") no-repeat center / contain;
+}
+
+/* The checked radio highlights its label: accent border, accent text
+   (which the masked icon inherits), and a faint accent wash. The radio
+   is the label's previous sibling, so the adjacent-sibling selector
+   keyed off `:checked` needs no JS. */
+.theme-radio:checked + .theme-option {
+  color: var(--color-accent-fg);
+  border-color: var(--color-accent-fg);
+  background: var(--color-accent-subtle);
+}
+
+/* Keyboard focus on the visually-hidden radio surfaces on its label. */
+.theme-radio:focus-visible + .theme-option {
+  outline: 2px solid var(--color-accent-fg);
+  outline-offset: 2px;
+}

--- a/tools/gen-docs/src/style/settings.css
+++ b/tools/gen-docs/src/style/settings.css
@@ -1,6 +1,6 @@
 /* Settings affordance: a gear button in the top-right corner and the
-   panel it toggles. Colours are `var(--color-*)` from light.css /
-   dark.css; see issue #185.
+   panel it toggles. Structural rules only; the colours for these
+   selectors live in light.css (defaults) and dark.css (dark tiers).
 
    The gear is the mirror image of the nav hamburger (nav.css): same
    size and inset, but pinned to the right instead of the left so the
@@ -21,17 +21,14 @@
   z-index: 98;
   width: 2.5rem;
   height: 2.5rem;
-  background: var(--color-canvas-default);
-  border: 1px solid var(--color-border-default);
+  border: 1px solid;
   border-radius: 6px;
   cursor: pointer;
   font-size: 1.4rem;
   line-height: 1;
-  color: var(--color-fg-default);
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 1px 3px var(--color-shadow);
   padding: 0;
   /* Half-transparent at rest, fully opaque on hover / focus / while
      the panel is open, with a short ease between the two states. */
@@ -49,12 +46,8 @@
   opacity: 1;
 }
 
-.settings-toggle:hover {
-  background: var(--color-canvas-subtle);
-}
-
 .settings-toggle:focus-visible {
-  outline: 2px solid var(--color-accent-fg);
+  outline: 2px solid;
   outline-offset: 2px;
 }
 
@@ -68,10 +61,8 @@
   z-index: 98;
   width: 16rem;
   max-width: calc(100vw - 1.2rem);
-  background: var(--color-canvas-default);
-  border: 1px solid var(--color-border-default);
+  border: 1px solid;
   border-radius: 8px;
-  box-shadow: 0 4px 16px var(--color-shadow);
   padding: 0.85rem 1rem 1rem;
   box-sizing: border-box;
 }
@@ -80,7 +71,6 @@
   margin: 0 0 0.6rem;
   font-size: 1rem;
   font-weight: 600;
-  color: var(--color-fg-default);
 }
 
 /* The theme chooser is a <fieldset> of three radios. Strip the default
@@ -98,7 +88,6 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--color-fg-muted);
 }
 
 /* Three equal-width choices in a row. */
@@ -132,20 +121,14 @@
   align-items: center;
   gap: 0.3rem;
   padding: 0.5rem 0.25rem;
-  border: 1px solid var(--color-border-default);
+  border: 1px solid;
   border-radius: 6px;
   cursor: pointer;
   font-size: 0.8rem;
-  color: var(--color-fg-muted);
-  background: var(--color-canvas-default);
   transition:
     color 0.15s ease,
     border-color 0.15s ease,
     background-color 0.15s ease;
-}
-
-.theme-option:hover {
-  background: var(--color-canvas-subtle);
 }
 
 /* The icon is recoloured by the label's own `color` via a CSS mask, so
@@ -176,18 +159,13 @@
   mask: url("theme-system.svg") no-repeat center / contain;
 }
 
-/* The checked radio highlights its label: accent border, accent text
-   (which the masked icon inherits), and a faint accent wash. The radio
-   is the label's previous sibling, so the adjacent-sibling selector
-   keyed off `:checked` needs no JS. */
-.theme-radio:checked + .theme-option {
-  color: var(--color-accent-fg);
-  border-color: var(--color-accent-fg);
-  background: var(--color-accent-subtle);
-}
+/* The checked radio highlights its label (accent border / text / wash)
+   via a pure-CSS adjacent-sibling selector — the colours live in
+   light.css / dark.css. The radio is the label's previous sibling, so
+   the highlight needs no JS. */
 
 /* Keyboard focus on the visually-hidden radio surfaces on its label. */
 .theme-radio:focus-visible + .theme-option {
-  outline: 2px solid var(--color-accent-fg);
+  outline: 2px solid;
   outline-offset: 2px;
 }

--- a/tools/gen-docs/src/theme_toggle.js
+++ b/tools/gen-docs/src/theme_toggle.js
@@ -1,0 +1,158 @@
+// ============================================================================
+// Theme (colour-scheme) settings.
+//
+// Drives the gear button and the Settings panel it toggles, and applies
+// the reader's saved colour-scheme choice. The page's colours are CSS
+// variables (style/light.css + style/dark.css) selected across three
+// override tiers (see issue #185 and the comments in those files):
+//
+//   1. Default: Light.
+//   2. System preference: `@media (prefers-color-scheme: dark)` swaps in
+//      the dark palette.
+//   3. Explicit override: a `color-scheme-override="dark"|"light"`
+//      attribute on <html>, which beats both tiers above. ONLY this
+//      script sets it.
+//
+// This file's job, in order:
+//
+//   1. Assign the event listeners (gear toggle, the three theme radios,
+//      outside-click / Escape to dismiss).
+//   2. Reveal the gear button (the Rust template emits it with the HTML
+//      `hidden` attribute; clearing it is how the button appears).
+//   3. Read `perfectionist-color-scheme-override` from localStorage and
+//      apply it.
+//
+// If step 1 throws — the likely cause being a browser too old for the
+// APIs used — execution stops before steps 2 and 3, so the gear stays
+// hidden rather than appearing as a dead control. This is the same
+// "reveal only once wired up" contract the nav hamburger uses, and the
+// absence of a try/catch is deliberate: a half-supported browser should
+// get the plain Light/System-preference page, not a visible-but-inert
+// settings UI. (The `[hidden] { display: none !important }` reset in
+// style/base.css keeps the `hidden` attribute authoritative against the
+// `.settings-toggle { display: flex }` rule.)
+//
+// The localStorage key is `perfectionist-color-scheme-override` — long
+// on purpose, because `gh-pages/index.html` is also opened over
+// `file:///`, where the origin is shared across every local HTML file
+// and a short key would risk collisions.
+// ============================================================================
+
+(function () {
+  var html = document.documentElement;
+  var STORAGE_KEY = "perfectionist-color-scheme-override";
+  var ATTRIBUTE = "color-scheme-override";
+
+  var toggle = document.querySelector(".settings-toggle");
+  var panel = document.querySelector(".settings-panel");
+  if (!toggle || !panel) return;
+
+  var radios = panel.querySelectorAll('input[name="color-scheme"]');
+  if (radios.length === 0) return;
+
+  // Apply a choice to the live page. "dark"/"light" set the override
+  // attribute (tier 3); anything else ("system") removes it so the
+  // page falls back to tiers 1–2.
+  function applyScheme(value) {
+    if (value === "dark" || value === "light") {
+      html.setAttribute(ATTRIBUTE, value);
+    } else {
+      html.removeAttribute(ATTRIBUTE);
+    }
+  }
+
+  // Persist a choice. "system" clears the key (its absence IS the
+  // default), keeping the stored set to exactly {dark, light, unset}.
+  function persistScheme(value) {
+    if (value === "dark" || value === "light") {
+      window.localStorage.setItem(STORAGE_KEY, value);
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  function selectRadio(value) {
+    for (var i = 0; i < radios.length; i++) {
+      radios[i].checked = radios[i].value === value;
+    }
+  }
+
+  function openPanel() {
+    panel.hidden = false;
+    toggle.setAttribute("aria-expanded", "true");
+  }
+
+  function closePanel() {
+    panel.hidden = true;
+    toggle.setAttribute("aria-expanded", "false");
+  }
+
+  // ---- (1) event listeners ----------------------------------------------
+
+  toggle.addEventListener("click", function () {
+    if (toggle.getAttribute("aria-expanded") === "true") {
+      closePanel();
+    } else {
+      openPanel();
+    }
+  });
+
+  for (var i = 0; i < radios.length; i++) {
+    radios[i].addEventListener("change", function (event) {
+      applyScheme(event.target.value);
+      persistScheme(event.target.value);
+    });
+  }
+
+  // Dismiss the panel on a click anywhere outside it (and outside the
+  // gear, whose own handler already toggles). Registered on the
+  // document so any stray click closes the dropdown, the conventional
+  // behaviour for this kind of menu.
+  document.addEventListener("click", function (event) {
+    if (toggle.getAttribute("aria-expanded") !== "true") return;
+    if (toggle.contains(event.target) || panel.contains(event.target)) return;
+    closePanel();
+  });
+
+  // Escape closes the panel and returns focus to the gear.
+  document.addEventListener("keydown", function (event) {
+    if (event.key !== "Escape") return;
+    if (toggle.getAttribute("aria-expanded") !== "true") return;
+    closePanel();
+    toggle.focus();
+  });
+
+  // Mirror the hamburger's Visual Viewport API compensation (see
+  // nav_toggle.js): on mobile browsers that anchor `position: fixed` to
+  // the layout viewport rather than the visual viewport, translate the
+  // gear and its panel by the visual viewport's offset so they stay
+  // glued to the top-right of the visible area as the URL bar collapses.
+  if (window.visualViewport) {
+    var vv = window.visualViewport;
+    var syncToViewport = function () {
+      var transform = "translate(" + vv.offsetLeft + "px, " + vv.offsetTop + "px)";
+      toggle.style.transform = transform;
+      panel.style.transform = transform;
+    };
+    vv.addEventListener("scroll", syncToViewport);
+    vv.addEventListener("resize", syncToViewport);
+    syncToViewport();
+  }
+
+  // ---- (2) reveal the gear ----------------------------------------------
+  //
+  // Everything the button needs is wired up; drop the `hidden` attribute
+  // so it appears exactly when it's functional. If anything above threw,
+  // this line is never reached and the gear stays hidden.
+  toggle.hidden = false;
+
+  // ---- (3) load + apply the persisted choice ----------------------------
+  var stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === "dark" || stored === "light") {
+    applyScheme(stored);
+    selectRadio(stored);
+  } else {
+    applyScheme(null);
+    selectRadio("system");
+  }
+})();

--- a/tools/gen-docs/src/theme_toggle.js
+++ b/tools/gen-docs/src/theme_toggle.js
@@ -2,9 +2,9 @@
 // Theme (colour-scheme) settings.
 //
 // Drives the gear button and the Settings panel it toggles, and applies
-// the reader's saved colour-scheme choice. The page's colours are CSS
-// variables (style/light.css + style/dark.css) selected across three
-// override tiers (see issue #185 and the comments in those files):
+// the reader's saved colour-scheme choice. The page's colours live in
+// style/light.css and style/dark.css, selected across three override
+// tiers (see the comments in those files):
 //
 //   1. Default: Light.
 //   2. System preference: `@media (prefers-color-scheme: dark)` swaps in


### PR DESCRIPTION
Adds a dark / light / system colour-scheme chooser to the generated lint catalogue (`tools/gen-docs`).

- **Colours extracted into theme files.** The colours are pulled out of the structural sheets into `style/light.css` (default light) and `style/dark.css` (dark), as literal colours — no CSS custom properties, for maximum backward compatibility. Three override tiers: default Light → `prefers-color-scheme` → an explicit `color-scheme-override` attribute on `<html>` that wins over both (pure cascade/specificity).
- **Settings UI.** A fixed top-right gear (mirroring the nav hamburger) toggles a Settings panel whose Theme section has three icon-tile radios (Light / Dark / System, System default). Real radio semantics, a pure-CSS `:checked + label` highlight, Octicons icons recoloured via CSS masks.
- **Dark code highlighting.** A scoped `base16-eighties.dark` syntax sheet keeps code blocks legible on the dark canvas.
- **`theme_toggle.js`.** Wires listeners, reveals the gear, then loads/applies the `perfectionist-color-scheme-override` localStorage key — the gear appears only after setup succeeds.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/185>.