### PR TITLE
feat(import-granularity): enforce `self_merge` style

### DIFF
--- a/rules/import_granularity.md
+++ b/rules/import_granularity.md
@@ -27,6 +27,14 @@ statements that sit next to each other in a module body, share a
 visibility, and carry matching attributes are merged; the three
 `respect_*` knobs tighten or loosen that grouping.
 
+Under `crate` style a name that is both an item and a module
+(`use crate::thing;` next to `use crate::thing::T;`) has two valid
+one-`use` shapes — the `self`-fold `crate::thing::{self, T}` and
+the sibling-split `crate::{thing, thing::T}` — that bind different
+namespaces. By default neither single-statement form is flagged
+and both are offered when a merge is forced; the optional
+`self_merge` knob (`fold` / `split`) picks one and enforces it.
+
 Globs (`use foo::*`) are governed by `perfectionist::no_star_imports`,
 not by this rule: a top-level glob is left alone under `item`.
 
@@ -90,6 +98,18 @@ Never merge a `use` that carries its own doc comment (`///` or
 keeps describing exactly the import it was written above.
 Defaults to `true`. Set `false` to allow such a `use` to merge.
 
+### `self_merge`: `SelfMerge` (optional)
+
+Under `style = "crate"`, force one shape when a path segment
+names both an item and a module (`use crate::thing;` next to
+`use crate::thing::T;`). Unset by default — the two shapes are
+not interchangeable, so the rule flags neither single-statement
+form and offers both as `MaybeIncorrect` when a merge is forced.
+Set `fold` to always enforce `use crate::thing::{self, T};`, or
+`split` to always enforce `use crate::{thing, thing::T};`;
+either value also flags the opposite single-statement form.
+Ignored under `module` and `item` style.
+
 ### Types
 
 #### `Style` (enum)
@@ -115,3 +135,22 @@ on their own `use` lines, e.g.
 
 One `use` per leaf item. Every imported name lives on its own
 line, e.g. `use std::collections::BTreeMap;`.
+
+#### `SelfMerge` (enum)
+
+How to resolve a path segment that names **both** an item and a
+module under `crate` style — `use crate::thing;` next to
+`use crate::thing::T;`. The two one-`use`-per-root shapes are not
+interchangeable, so unless this knob is set the rule offers both and
+the author picks. Only consulted under `style = "crate"`.
+
+##### `"fold"` (Rust: `Fold`)
+
+Always enforce the `self`-fold `use crate::thing::{self, T};` —
+the shape rustfmt's `imports_granularity = "Crate"` produces. The
+sibling-split form is flagged and rewritten to it.
+
+##### `"split"` (Rust: `Split`)
+
+Always enforce the sibling-split `use crate::{thing, thing::T};`.
+The `self`-fold form is flagged and rewritten to it.

--- a/src/rules/import_granularity.rs
+++ b/src/rules/import_granularity.rs
@@ -14,7 +14,7 @@ mod model;
 mod render;
 
 use check::is_compliant;
-use config::{Config, Style};
+use config::{Config, SelfMerge, Style};
 use model::{Leaf, StmtInfo, stmt_info};
 
 use crate::common::{DefaultState, resolved_state};
@@ -41,6 +41,14 @@ declare_tool_lint! {
     /// statements that sit next to each other in a module body, share a
     /// visibility, and carry matching attributes are merged; the three
     /// `respect_*` knobs tighten or loosen that grouping.
+    ///
+    /// Under `crate` style a name that is both an item and a module
+    /// (`use crate::thing;` next to `use crate::thing::T;`) has two valid
+    /// one-`use` shapes — the `self`-fold `crate::thing::{self, T}` and
+    /// the sibling-split `crate::{thing, thing::T}` — that bind different
+    /// namespaces. By default neither single-statement form is flagged
+    /// and both are offered when a merge is forced; the optional
+    /// `self_merge` knob (`fold` / `split`) picks one and enforces it.
     ///
     /// Globs (`use foo::*`) are governed by `perfectionist::no_star_imports`,
     /// not by this rule: a top-level glob is left alone under `item`.
@@ -90,6 +98,7 @@ pub struct ImportGranularity {
     respect_cfg_blocks: bool,
     respect_visibility: bool,
     respect_doc_comments: bool,
+    self_merge: Option<SelfMerge>,
 }
 
 impl ImportGranularity {
@@ -100,6 +109,7 @@ impl ImportGranularity {
             respect_cfg_blocks: config.respect_cfg_blocks,
             respect_visibility: config.respect_visibility,
             respect_doc_comments: config.respect_doc_comments,
+            self_merge: config.self_merge,
         }
     }
 }
@@ -150,7 +160,9 @@ enum Violation {
     /// (`thing::{self, T}`) and the sibling-split (`{thing, thing::T}`).
     /// The two shapes are not interchangeable, so both are offered and
     /// the human picks — hence the `MaybeIncorrect` applicability the
-    /// caller attaches in that case.
+    /// caller attaches in that case. When `self_merge` is set the
+    /// ambiguity is resolved to the configured shape and only that one
+    /// candidate is offered.
     Reorganize {
         suggestions: Vec<String>,
         applicability: Applicability,
@@ -400,7 +412,7 @@ impl ImportGranularity {
             return;
         };
         let stmts: Vec<&StmtInfo> = group.iter().map(|entry| &entry.info).collect();
-        if is_compliant(self.style, &stmts) {
+        if is_compliant(self.style, self.self_merge, &stmts) {
             return;
         }
 
@@ -412,20 +424,6 @@ impl ImportGranularity {
         if bodies.is_empty() {
             return;
         }
-
-        // Under `crate` style a name that is both an item and a module
-        // has a second, equally-valid shape: the `self`-fold. When it
-        // differs from the default sibling shape the merge is ambiguous —
-        // the rule can't tell from syntax whether the bare name also
-        // binds a value or macro — so both shapes are offered as
-        // `MaybeIncorrect` alternatives. See
-        // <https://github.com/KSXGitHub/perfectionist/issues/186>.
-        let self_fold = if let Style::Crate = self.style {
-            let folded = render::render_crate_self(&leaves);
-            (folded != bodies).then_some(folded)
-        } else {
-            None
-        };
 
         let replace_span = first
             .item
@@ -467,33 +465,63 @@ impl ImportGranularity {
                 .join(&format!("\n{pad}"))
         };
 
-        let (suggestions, applicability) = match self_fold {
-            // Ambiguous `crate` merge: offer the `self`-fold and the
-            // sibling-split, both `MaybeIncorrect`, and let the human
-            // pick the one that matches what the bare name resolves to.
-            Some(folded) => (
-                vec![render_full(&folded), render_full(&bodies)],
-                Applicability::MaybeIncorrect,
-            ),
-            None => {
-                // Down to `MaybeIncorrect` when applying the fix would
-                // drop something the rewrite can't carry: an inline
-                // comment inside the replaced span, or a doc comment that
-                // differs across the merged statements (kept only from
-                // the first).
-                let has_comment = lint_context
-                    .sess()
-                    .source_map()
-                    .span_to_snippet(replace_span)
-                    .is_ok_and(|snippet| snippet.contains("//") || snippet.contains("/*"));
-                let drops_doc = group.iter().any(|entry| entry.attrs != first.attrs);
-                let applicability = if has_comment || drops_doc {
-                    Applicability::MaybeIncorrect
-                } else {
-                    Applicability::MachineApplicable
-                };
-                (vec![render_full(&bodies)], applicability)
+        // Down to `MaybeIncorrect` when applying the fix would drop
+        // something the rewrite can't carry: an inline comment inside the
+        // replaced span, or a doc comment that differs across the merged
+        // statements (kept only from the first). A `self_merge` rewrite
+        // that changes which namespaces a name binds (`lossy`, below) is
+        // likewise `MaybeIncorrect`.
+        let has_comment = lint_context
+            .sess()
+            .source_map()
+            .span_to_snippet(replace_span)
+            .is_ok_and(|snippet| snippet.contains("//") || snippet.contains("/*"));
+        let drops_doc = group.iter().any(|entry| entry.attrs != first.attrs);
+        let applic = |lossy: bool| {
+            if lossy || has_comment || drops_doc {
+                Applicability::MaybeIncorrect
+            } else {
+                Applicability::MachineApplicable
             }
+        };
+
+        let (suggestions, applicability) = match (self.style, self.self_merge) {
+            // `crate` style with the item-and-module ambiguity resolved by
+            // `self_merge`: enforce exactly the configured shape and offer
+            // only that one candidate. The rewrite changes which
+            // namespaces a name binds when it folds a bare item into
+            // `self` or raises a `self` to a bare item, so it is
+            // `MaybeIncorrect` in that case — the project asserts a
+            // preference, not a proof of equivalence. See
+            // <https://github.com/KSXGitHub/perfectionist/issues/206>.
+            (Style::Crate, Some(SelfMerge::Fold)) => {
+                let folded = render::render_crate_self(&leaves);
+                let lossy = model::has_bare_item_dual(&leaves);
+                (vec![render_full(&folded)], applic(lossy))
+            }
+            (Style::Crate, Some(SelfMerge::Split)) => {
+                let split = render::render_crate_split(&leaves);
+                let lossy = model::has_self_dual(&leaves);
+                (vec![render_full(&split)], applic(lossy))
+            }
+            // `crate` style, knob unset: when the `self`-fold differs from
+            // the sibling-split a name is both an item and a module, and
+            // the rule can't tell from syntax which shape is correct.
+            // Offer both as `MaybeIncorrect` and let the author pick. See
+            // <https://github.com/KSXGitHub/perfectionist/issues/186>.
+            (Style::Crate, None) => {
+                let folded = render::render_crate_self(&leaves);
+                if folded == bodies {
+                    (vec![render_full(&bodies)], applic(false))
+                } else {
+                    (
+                        vec![render_full(&folded), render_full(&bodies)],
+                        Applicability::MaybeIncorrect,
+                    )
+                }
+            }
+            // `module` / `item` style: `self_merge` does not apply.
+            _ => (vec![render_full(&bodies)], applic(false)),
         };
 
         violations.push(Pending {

--- a/src/rules/import_granularity/check.rs
+++ b/src/rules/import_granularity/check.rs
@@ -6,14 +6,18 @@
 
 use std::collections::HashSet;
 
-use super::config::Style;
-use super::model::{LeafItem, StmtInfo, TopKind};
+use super::config::{SelfMerge, Style};
+use super::model::{LeafItem, StmtInfo, TopKind, has_bare_item_dual, has_self_dual};
 
-pub(super) fn is_compliant(style: Style, stmts: &[&StmtInfo]) -> bool {
+pub(super) fn is_compliant(
+    style: Style,
+    self_merge: Option<SelfMerge>,
+    stmts: &[&StmtInfo],
+) -> bool {
     match style {
         Style::Item => stmts.iter().all(|stmt| is_item_shaped(stmt)),
         Style::Module => module_compliant(stmts),
-        Style::Crate => crate_compliant(stmts),
+        Style::Crate => crate_compliant(self_merge, stmts),
     }
 }
 
@@ -77,7 +81,22 @@ fn is_module_shaped(stmt: &StmtInfo) -> bool {
 /// a single crate root, and no two statements share a root — except a
 /// root imported as a bare crate item, which can't be folded with its
 /// own deeper imports without an unsafe synthesised `self` (see below).
-fn crate_compliant(stmts: &[&StmtInfo]) -> bool {
+fn crate_compliant(self_merge: Option<SelfMerge>, stmts: &[&StmtInfo]) -> bool {
+    // With `self_merge` set, the project has picked one shape for a name
+    // that is both an item and a module, so the opposite single-statement
+    // form is no longer compliant: `fold` flags the sibling-split
+    // (`{thing, thing::T}`) and `split` flags the `self`-fold
+    // (`thing::{self, T}`). Unset, both shapes stay compliant (the safe
+    // default). See
+    // <https://github.com/KSXGitHub/perfectionist/issues/206>.
+    let off_shape = match self_merge {
+        Some(SelfMerge::Fold) => stmts.iter().any(|stmt| has_bare_item_dual(&stmt.leaves)),
+        Some(SelfMerge::Split) => stmts.iter().any(|stmt| has_self_dual(&stmt.leaves)),
+        None => false,
+    };
+    if off_shape {
+        return false;
+    }
     if !stmts.iter().all(|stmt| stmt.collapsed) {
         return false;
     }

--- a/src/rules/import_granularity/config.rs
+++ b/src/rules/import_granularity/config.rs
@@ -1,6 +1,7 @@
-//! Configuration for `import_granularity`: the chosen [`Style`] plus
-//! the three `respect_*` knobs that decide which `use` statements may
-//! be merged with one another.
+//! Configuration for `import_granularity`: the chosen [`Style`], the
+//! three `respect_*` knobs that decide which `use` statements may be
+//! merged with one another, and the optional [`SelfMerge`] knob that
+//! resolves the item-and-module name ambiguity under `crate` style.
 
 /// Import-granularity style. The three values map one-to-one onto
 /// rustfmt's unstable `imports_granularity` option (`Crate`, `Module`,
@@ -21,6 +22,23 @@ pub(super) enum Style {
     /// One `use` per leaf item. Every imported name lives on its own
     /// line, e.g. `use std::collections::BTreeMap;`.
     Item,
+}
+
+/// How to resolve a path segment that names **both** an item and a
+/// module under `crate` style — `use crate::thing;` next to
+/// `use crate::thing::T;`. The two one-`use`-per-root shapes are not
+/// interchangeable, so unless this knob is set the rule offers both and
+/// the author picks. Only consulted under `style = "crate"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum SelfMerge {
+    /// Always enforce the `self`-fold `use crate::thing::{self, T};` —
+    /// the shape rustfmt's `imports_granularity = "Crate"` produces. The
+    /// sibling-split form is flagged and rewritten to it.
+    Fold,
+    /// Always enforce the sibling-split `use crate::{thing, thing::T};`.
+    /// The `self`-fold form is flagged and rewritten to it.
+    Split,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -47,6 +65,16 @@ pub(super) struct Config {
     /// keeps describing exactly the import it was written above.
     /// Defaults to `true`. Set `false` to allow such a `use` to merge.
     pub(super) respect_doc_comments: bool,
+    /// Under `style = "crate"`, force one shape when a path segment
+    /// names both an item and a module (`use crate::thing;` next to
+    /// `use crate::thing::T;`). Unset by default — the two shapes are
+    /// not interchangeable, so the rule flags neither single-statement
+    /// form and offers both as `MaybeIncorrect` when a merge is forced.
+    /// Set `fold` to always enforce `use crate::thing::{self, T};`, or
+    /// `split` to always enforce `use crate::{thing, thing::T};`;
+    /// either value also flags the opposite single-statement form.
+    /// Ignored under `module` and `item` style.
+    pub(super) self_merge: Option<SelfMerge>,
 }
 
 impl Default for Config {
@@ -56,6 +84,7 @@ impl Default for Config {
             respect_cfg_blocks: true,
             respect_visibility: true,
             respect_doc_comments: true,
+            self_merge: None,
         }
     }
 }

--- a/src/rules/import_granularity/model.rs
+++ b/src/rules/import_granularity/model.rs
@@ -102,29 +102,38 @@ pub(super) fn has_bare_item_dual(leaves: &[Leaf]) -> bool {
     })
 }
 
-/// Whether `leaves` contains a `self` import that has a deeper sibling —
-/// the `thing::{self, T}` pattern. The `split` `self_merge` setting
-/// rewrites it to `{thing, thing::T}`; raising the module-only `self` to
-/// a bare item binds `thing` in *every* namespace, so it is the lossy
-/// half of the `split` rewrite. A lone `use thing::{self}` has no deeper
-/// sibling and is left alone. See
+/// Whether `leaves` contains a `self` import that has a splittable
+/// sibling — the `thing::{self, T}` pattern. The `split` `self_merge`
+/// setting rewrites it to `{thing, thing::T}`; raising the module-only
+/// `self` to a bare item binds `thing` in *every* namespace, so it is the
+/// lossy half of the `split` rewrite. A lone `use thing::{self}`, or one
+/// paired only with another `self` for the same module
+/// (`thing::{self, self as alt}`), has no sibling to split against and is
+/// left alone. See
 /// <https://github.com/KSXGitHub/perfectionist/issues/206>.
 pub(super) fn has_self_dual(leaves: &[Leaf]) -> bool {
     leaves.iter().enumerate().any(|(index, leaf)| {
-        matches!(leaf.item, LeafItem::SelfMod) && has_deeper_sibling(leaves, index)
+        matches!(leaf.item, LeafItem::SelfMod) && self_has_splittable_sibling(leaves, index)
     })
 }
 
-/// Whether some other leaf lives in the module named by `leaves[index]`
-/// (or deeper) — i.e. `leaves[index]` is a `self`/module import with a
-/// sibling under the same path. The leaf at `index` is excluded from the
+/// Whether the `self`/module import at `leaves[index]` has a sibling that
+/// lives *inside* the module it names — an item directly in the module
+/// (`thing::{self, T}`) or a deeper import (`thing::{self, sub::X}`) — and
+/// so can be split into a bare item plus that sibling. Another
+/// module-only `self` for the *same* module
+/// (`thing::{self, self as alt}`) is **not** such a sibling: it binds the
+/// same module with nothing deeper to split against, so lowering the
+/// `self` to a bare item would change which namespaces the name binds for
+/// no granularity gain. The leaf at `index` is excluded from the
 /// comparison so it never counts as its own sibling.
-pub(super) fn has_deeper_sibling(leaves: &[Leaf], index: usize) -> bool {
+pub(super) fn self_has_splittable_sibling(leaves: &[Leaf], index: usize) -> bool {
     let module = &leaves[index].module;
-    leaves
-        .iter()
-        .enumerate()
-        .any(|(other, sibling)| other != index && sibling.module.starts_with(module))
+    leaves.iter().enumerate().any(|(other, sibling)| {
+        other != index
+            && sibling.module.starts_with(module)
+            && !(sibling.module.len() == module.len() && matches!(sibling.item, LeafItem::SelfMod))
+    })
 }
 
 /// Build a [`StmtInfo`] for one top-level `use` tree, or `None` when the

--- a/src/rules/import_granularity/model.rs
+++ b/src/rules/import_granularity/model.rs
@@ -81,6 +81,52 @@ impl StmtInfo {
     }
 }
 
+/// Whether `leaves` contains a bare named item that shares its name
+/// with a deeper sibling — the `{thing, thing::T}` pattern. The `fold`
+/// `self_merge` setting rewrites it to `thing::{self, T}`; that fold
+/// re-imports only the *module* `thing`, silently dropping any value or
+/// macro bound under the same name, so it is the lossy half of the
+/// `fold` rewrite and is never applied without the opt-in. See
+/// <https://github.com/KSXGitHub/perfectionist/issues/206>.
+pub(super) fn has_bare_item_dual(leaves: &[Leaf]) -> bool {
+    leaves.iter().enumerate().any(|(index, leaf)| {
+        let LeafItem::Named(name) = &leaf.item else {
+            return false;
+        };
+        let mut deeper = leaf.module.clone();
+        deeper.push(name.clone());
+        leaves
+            .iter()
+            .enumerate()
+            .any(|(other, sibling)| other != index && sibling.module.starts_with(&deeper))
+    })
+}
+
+/// Whether `leaves` contains a `self` import that has a deeper sibling —
+/// the `thing::{self, T}` pattern. The `split` `self_merge` setting
+/// rewrites it to `{thing, thing::T}`; raising the module-only `self` to
+/// a bare item binds `thing` in *every* namespace, so it is the lossy
+/// half of the `split` rewrite. A lone `use thing::{self}` has no deeper
+/// sibling and is left alone. See
+/// <https://github.com/KSXGitHub/perfectionist/issues/206>.
+pub(super) fn has_self_dual(leaves: &[Leaf]) -> bool {
+    leaves.iter().enumerate().any(|(index, leaf)| {
+        matches!(leaf.item, LeafItem::SelfMod) && has_deeper_sibling(leaves, index)
+    })
+}
+
+/// Whether some other leaf lives in the module named by `leaves[index]`
+/// (or deeper) — i.e. `leaves[index]` is a `self`/module import with a
+/// sibling under the same path. The leaf at `index` is excluded from the
+/// comparison so it never counts as its own sibling.
+pub(super) fn has_deeper_sibling(leaves: &[Leaf], index: usize) -> bool {
+    let module = &leaves[index].module;
+    leaves
+        .iter()
+        .enumerate()
+        .any(|(other, sibling)| other != index && sibling.module.starts_with(module))
+}
+
 /// Build a [`StmtInfo`] for one top-level `use` tree, or `None` when the
 /// statement contains something the rule declines to rewrite (a global
 /// `::` path root, or a malformed `self`).

--- a/src/rules/import_granularity/render.rs
+++ b/src/rules/import_granularity/render.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 
 use super::config::Style;
-use super::model::{Leaf, LeafItem};
+use super::model::{Leaf, LeafItem, has_deeper_sibling};
 
 pub(super) fn render(style: Style, leaves: &[Leaf]) -> Vec<String> {
     match style {
@@ -28,6 +28,40 @@ pub(super) fn render(style: Style, leaves: &[Leaf]) -> Vec<String> {
 /// <https://github.com/KSXGitHub/perfectionist/issues/186>).
 pub(super) fn render_crate_self(leaves: &[Leaf]) -> Vec<String> {
     render_crate(leaves, true)
+}
+
+/// The alternative `crate` shape that splits a module-only `self` sharing
+/// its name with a deeper sibling back into a bare item
+/// (`thing::{self, T}` → `{thing, thing::T}`).
+///
+/// This is the inverse of [`render_crate_self`]: where the fold collapses
+/// `{thing, thing::T}` into `thing::{self, T}`, the split lowers each
+/// `self` that has a deeper sibling into the bare item one level up. A
+/// `self` with no deeper sibling (`use thing::{self}`) is a genuine
+/// module-only import with no sibling to split against, so it is left
+/// untouched. Selected by the `split` `self_merge` setting (see
+/// <https://github.com/KSXGitHub/perfectionist/issues/206>).
+pub(super) fn render_crate_split(leaves: &[Leaf]) -> Vec<String> {
+    let lowered: Vec<Leaf> = leaves
+        .iter()
+        .enumerate()
+        .map(|(index, leaf)| {
+            if matches!(leaf.item, LeafItem::SelfMod) && has_deeper_sibling(leaves, index) {
+                let mut module = leaf.module.clone();
+                let name = module
+                    .pop()
+                    .expect("a `self` leaf always has a module path");
+                Leaf {
+                    module,
+                    item: LeafItem::Named(name),
+                    rename: leaf.rename.clone(),
+                }
+            } else {
+                leaf.clone()
+            }
+        })
+        .collect();
+    render_crate(&lowered, false)
 }
 
 fn join(segments: &[String]) -> String {

--- a/src/rules/import_granularity/render.rs
+++ b/src/rules/import_granularity/render.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 
 use super::config::Style;
-use super::model::{Leaf, LeafItem, has_deeper_sibling};
+use super::model::{Leaf, LeafItem, self_has_splittable_sibling};
 
 pub(super) fn render(style: Style, leaves: &[Leaf]) -> Vec<String> {
     match style {
@@ -31,22 +31,24 @@ pub(super) fn render_crate_self(leaves: &[Leaf]) -> Vec<String> {
 }
 
 /// The alternative `crate` shape that splits a module-only `self` sharing
-/// its name with a deeper sibling back into a bare item
+/// its name with a sibling inside the module back into a bare item
 /// (`thing::{self, T}` → `{thing, thing::T}`).
 ///
 /// This is the inverse of [`render_crate_self`]: where the fold collapses
 /// `{thing, thing::T}` into `thing::{self, T}`, the split lowers each
-/// `self` that has a deeper sibling into the bare item one level up. A
-/// `self` with no deeper sibling (`use thing::{self}`) is a genuine
-/// module-only import with no sibling to split against, so it is left
-/// untouched. Selected by the `split` `self_merge` setting (see
+/// `self` that has a splittable sibling into the bare item one level up. A
+/// `self` with no such sibling (`use thing::{self}`, or one paired only
+/// with another `self` for the same module) is a genuine module-only
+/// import with nothing to split against, so it is left untouched. Selected
+/// by the `split` `self_merge` setting (see
 /// <https://github.com/KSXGitHub/perfectionist/issues/206>).
 pub(super) fn render_crate_split(leaves: &[Leaf]) -> Vec<String> {
     let lowered: Vec<Leaf> = leaves
         .iter()
         .enumerate()
         .map(|(index, leaf)| {
-            if matches!(leaf.item, LeafItem::SelfMod) && has_deeper_sibling(leaves, index) {
+            if matches!(leaf.item, LeafItem::SelfMod) && self_has_splittable_sibling(leaves, index)
+            {
                 let mut module = leaf.module.clone();
                 let name = module
                     .pop()

--- a/tests/import_granularity.rs
+++ b/tests/import_granularity.rs
@@ -32,6 +32,8 @@ struct RuleConfig {
     respect_visibility: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     respect_doc_comments: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    self_merge: Option<&'static str>,
 }
 
 fn dylint_toml(config: RuleConfig) -> String {
@@ -68,6 +70,36 @@ fn item_style_splits_per_leaf() {
         "ui-toml/import_granularity/item_style",
         RuleConfig {
             style: Some("item"),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn self_merge_fold_enforces_self() {
+    // `crate` style with `self_merge = "fold"`: a name that is both an
+    // item and a module is always written `crate::thing::{self, T}`. The
+    // sibling-split single statement is flagged and rewritten to it.
+    run(
+        "ui-toml/import_granularity/self_merge_fold",
+        RuleConfig {
+            style: Some("crate"),
+            self_merge: Some("fold"),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn self_merge_split_enforces_siblings() {
+    // `crate` style with `self_merge = "split"`: the same name is always
+    // written `crate::{thing, thing::T}`. The `self`-fold single
+    // statement is flagged and rewritten to it.
+    run(
+        "ui-toml/import_granularity/self_merge_split",
+        RuleConfig {
+            style: Some("crate"),
+            self_merge: Some("split"),
             ..Default::default()
         },
     );

--- a/ui-toml/import_granularity/self_merge_fold/fixture.rs
+++ b/ui-toml/import_granularity/self_merge_fold/fixture.rs
@@ -1,0 +1,43 @@
+#![feature(register_tool)]
+#![register_tool(perfectionist)]
+#![allow(
+    unknown_lints,
+    dead_code,
+    unused_imports,
+    reason = "ui fixture"
+)]
+
+// Under `style = "crate"` with `self_merge = "fold"`: a path segment that
+// names both an item and a module is always written as the `self`-fold
+// `use crate::thing::{self, T};`.
+
+mod thing {
+    pub struct T;
+}
+
+// Bad: the sibling-split single statement is now flagged and rewritten to
+// the fold. The rewrite drops any value or macro bound by the bare name,
+// so it stays `MaybeIncorrect` (shown as a diff).
+mod sibling_to_fold {
+    use crate::{thing, thing::T};
+}
+
+// Bad: two statements that must merge collapse straight to the fold.
+mod merge_to_fold {
+    use crate::thing;
+    use crate::thing::T;
+}
+
+// Good: already the fold shape, left untouched.
+mod already_fold {
+    use crate::thing::{self, T};
+}
+
+// Good: a plain crate merge with no dual name collapses normally, with a
+// machine-applicable fix.
+mod plain_merge {
+    use std::collections::HashMap;
+    use std::io::Read;
+}
+
+fn main() {}

--- a/ui-toml/import_granularity/self_merge_fold/fixture.stderr
+++ b/ui-toml/import_granularity/self_merge_fold/fixture.stderr
@@ -1,0 +1,24 @@
+warning: imports are not collapsed to one `use` per crate root
+  --> $DIR/fixture.rs:22:5
+   |
+LL |     use crate::{thing, thing::T};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: reorganize the imports: `use crate::thing::{self, T};`
+   |
+   = note: `#[warn(perfectionist::import_granularity)]` on by default
+
+warning: imports are not collapsed to one `use` per crate root
+  --> $DIR/fixture.rs:27:5
+   |
+LL | /     use crate::thing;
+LL | |     use crate::thing::T;
+   | |________________________^ help: reorganize the imports: `use crate::thing::{self, T};`
+
+warning: imports are not collapsed to one `use` per crate root
+  --> $DIR/fixture.rs:39:5
+   |
+LL | /     use std::collections::HashMap;
+LL | |     use std::io::Read;
+   | |______________________^ help: reorganize the imports: `use std::{collections::HashMap, io::Read};`
+
+warning: 3 warnings emitted
+

--- a/ui-toml/import_granularity/self_merge_split/fixture.rs
+++ b/ui-toml/import_granularity/self_merge_split/fixture.rs
@@ -1,0 +1,43 @@
+#![feature(register_tool)]
+#![register_tool(perfectionist)]
+#![allow(
+    unknown_lints,
+    dead_code,
+    unused_imports,
+    reason = "ui fixture"
+)]
+
+// Under `style = "crate"` with `self_merge = "split"`: a path segment that
+// names both an item and a module is always written as the sibling-split
+// `use crate::{thing, thing::T};`.
+
+mod thing {
+    pub struct T;
+}
+
+// Bad: the `self`-fold single statement is now flagged and rewritten to
+// the split. Raising the module-only `self` to a bare item binds the name
+// in every namespace, so it stays `MaybeIncorrect` (shown as a diff).
+mod fold_to_split {
+    use crate::thing::{self, T};
+}
+
+// Bad: two statements that must merge collapse to the split. No `self` is
+// raised here, so the fix is machine-applicable.
+mod merge_to_split {
+    use crate::thing;
+    use crate::thing::T;
+}
+
+// Good: already the split shape, left untouched.
+mod already_split {
+    use crate::{thing, thing::T};
+}
+
+// Good: a lone module-only `self` has no deeper sibling to split against,
+// so it is left alone.
+mod lone_self {
+    use crate::thing::{self};
+}
+
+fn main() {}

--- a/ui-toml/import_granularity/self_merge_split/fixture.rs
+++ b/ui-toml/import_granularity/self_merge_split/fixture.rs
@@ -40,4 +40,13 @@ mod lone_self {
     use crate::thing::{self};
 }
 
+// Two module-only `self` imports of the same module (one renamed) must
+// merge to `crate::thing::{self, self as alt}`, NOT be split into bare
+// items: there is no deeper, non-`self` sibling to split against, so
+// splitting would bind `thing` in every namespace for no granularity gain.
+mod self_pair {
+    use crate::thing::{self};
+    use crate::thing::{self as alt};
+}
+
 fn main() {}

--- a/ui-toml/import_granularity/self_merge_split/fixture.stderr
+++ b/ui-toml/import_granularity/self_merge_split/fixture.stderr
@@ -1,0 +1,17 @@
+warning: imports are not collapsed to one `use` per crate root
+  --> $DIR/fixture.rs:22:5
+   |
+LL |     use crate::thing::{self, T};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: reorganize the imports: `use crate::{thing, thing::T};`
+   |
+   = note: `#[warn(perfectionist::import_granularity)]` on by default
+
+warning: imports are not collapsed to one `use` per crate root
+  --> $DIR/fixture.rs:28:5
+   |
+LL | /     use crate::thing;
+LL | |     use crate::thing::T;
+   | |________________________^ help: reorganize the imports: `use crate::{thing, thing::T};`
+
+warning: 2 warnings emitted
+

--- a/ui-toml/import_granularity/self_merge_split/fixture.stderr
+++ b/ui-toml/import_granularity/self_merge_split/fixture.stderr
@@ -13,5 +13,12 @@ LL | /     use crate::thing;
 LL | |     use crate::thing::T;
    | |________________________^ help: reorganize the imports: `use crate::{thing, thing::T};`
 
-warning: 2 warnings emitted
+warning: imports are not collapsed to one `use` per crate root
+  --> $DIR/fixture.rs:48:5
+   |
+LL | /     use crate::thing::{self};
+LL | |     use crate::thing::{self as alt};
+   | |____________________________________^ help: reorganize the imports: `use crate::thing::{self, self as alt};`
+
+warning: 3 warnings emitted
 


### PR DESCRIPTION
Adds an opt-in `self_merge` knob to `import_granularity`, consulted only under `style = "crate"`.

When a path segment names both an item and a module (`use crate::thing;` next to `use crate::thing::T;`), two one-`use` shapes are valid but not interchangeable: the `self`-fold `crate::thing::{self, T}` and the sibling-split `crate::{thing, thing::T}`. Unset (default), behaviour is unchanged: neither single-statement form is flagged, and a forced merge offers both as `MaybeIncorrect`.

- `fold` — enforce `crate::thing::{self, T}`; the sibling-split form is flagged and rewritten to it.
- `split` — enforce `crate::{thing, thing::T}`; the `self`-fold form is flagged and rewritten to it. A `self` with nothing inside the module to split against — a lone `use crate::thing::{self}`, or one paired only with another same-module `self` (`{self, self as alt}`) — is left as a module-only `self`.

A rewrite stays `MaybeIncorrect` when it changes which namespaces a name binds (folding a bare item into `self`, or raising a `self` to a bare item); otherwise it's `MachineApplicable`.

Includes config/docs (regenerated `rules/import_granularity.md`) and UI fixtures for both shapes. Full `just all` passes.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/206>.