### PR TITLE
docs(flat-module-pattern): correct and improve

### DIFF
--- a/rules/flat_module_pattern.md
+++ b/rules/flat_module_pattern.md
@@ -28,8 +28,8 @@ don't disambiguate by directory.
 **Avoid:**
 
 ```text
-src
-└── foo
+src/
+└── foo/
     ├── mod.rs
     └── bar.rs
 ```
@@ -37,9 +37,9 @@ src
 **Prefer:**
 
 ```text
-src
+src/
 ├── foo.rs
-└── foo
+└── foo/
     └── bar.rs
 ```
 

--- a/rules/flat_module_pattern.md
+++ b/rules/flat_module_pattern.md
@@ -28,15 +28,19 @@ don't disambiguate by directory.
 **Avoid:**
 
 ```text
-src/foo/mod.rs
-src/foo/bar.rs
+src
+└── foo
+    ├── mod.rs
+    └── bar.rs
 ```
 
 **Prefer:**
 
 ```text
-src/foo.rs
-src/foo/bar.rs
+src
+├── foo.rs
+└── foo
+    └── bar.rs
 ```
 
 ## Configuration

--- a/rules/flat_module_pattern.md
+++ b/rules/flat_module_pattern.md
@@ -29,6 +29,7 @@ don't disambiguate by directory.
 
 ```text
 src/foo/mod.rs
+src/foo/bar.rs
 ```
 
 **Prefer:**

--- a/rules/flat_module_pattern.md
+++ b/rules/flat_module_pattern.md
@@ -25,11 +25,15 @@ don't disambiguate by directory.
 
 ## Example
 
-```text
-// Bad
-src/foo/mod.rs
+**Avoid:**
 
-// Good
+```text
+src/foo/mod.rs
+```
+
+**Prefer:**
+
+```text
 src/foo.rs
 src/foo/bar.rs
 ```

--- a/src/rules/flat_module_pattern.rs
+++ b/src/rules/flat_module_pattern.rs
@@ -27,11 +27,15 @@ declare_tool_lint! {
     ///
     /// ### Example
     ///
-    /// ```text
-    /// // Bad
-    /// src/foo/mod.rs
+    /// **Avoid:**
     ///
-    /// // Good
+    /// ```text
+    /// src/foo/mod.rs
+    /// ```
+    ///
+    /// **Prefer:**
+    ///
+    /// ```text
     /// src/foo.rs
     /// src/foo/bar.rs
     /// ```

--- a/src/rules/flat_module_pattern.rs
+++ b/src/rules/flat_module_pattern.rs
@@ -30,15 +30,19 @@ declare_tool_lint! {
     /// **Avoid:**
     ///
     /// ```text
-    /// src/foo/mod.rs
-    /// src/foo/bar.rs
+    /// src
+    /// └── foo
+    ///     ├── mod.rs
+    ///     └── bar.rs
     /// ```
     ///
     /// **Prefer:**
     ///
     /// ```text
-    /// src/foo.rs
-    /// src/foo/bar.rs
+    /// src
+    /// ├── foo.rs
+    /// └── foo
+    ///     └── bar.rs
     /// ```
     pub perfectionist::FLAT_MODULE_PATTERN,
     Warn,

--- a/src/rules/flat_module_pattern.rs
+++ b/src/rules/flat_module_pattern.rs
@@ -31,6 +31,7 @@ declare_tool_lint! {
     ///
     /// ```text
     /// src/foo/mod.rs
+    /// src/foo/bar.rs
     /// ```
     ///
     /// **Prefer:**

--- a/src/rules/flat_module_pattern.rs
+++ b/src/rules/flat_module_pattern.rs
@@ -30,8 +30,8 @@ declare_tool_lint! {
     /// **Avoid:**
     ///
     /// ```text
-    /// src
-    /// └── foo
+    /// src/
+    /// └── foo/
     ///     ├── mod.rs
     ///     └── bar.rs
     /// ```
@@ -39,9 +39,9 @@ declare_tool_lint! {
     /// **Prefer:**
     ///
     /// ```text
-    /// src
+    /// src/
     /// ├── foo.rs
-    /// └── foo
+    /// └── foo/
     ///     └── bar.rs
     /// ```
     pub perfectionist::FLAT_MODULE_PATTERN,


### PR DESCRIPTION
Docs-only fixes to the `flat_module_pattern` rule example.

## Changes

1. **Conform to the Avoid/Prefer pattern.** The example crammed both layouts into one fenced block with inline `// Bad` / `// Good` comments, unlike every other rule, which uses separate `**Avoid:**` / `**Prefer:**` labelled blocks. Split it to match.

2. **Show the nested child in both layouts.** The Avoid side originally listed only the module root, implying the flat layout introduces a child file. The lint only flags `mod.rs`; the nested child lives at the same path in both layouts, so it now appears on both sides and the sole real difference (`foo/mod.rs` → `foo.rs`) stands out.

3. **Render the layouts as directory trees** with trailing slashes on directories, so the structure and the placement of `mod.rs` are obvious at a glance:

   **Avoid:**
   ```text
   src/
   └── foo/
       ├── mod.rs
       └── bar.rs
   ```

   **Prefer:**
   ```text
   src/
   ├── foo.rs
   └── foo/
       └── bar.rs
   ```

Both the rustdoc (source of truth) and the in-tree `rules/` catalogue (regenerated from it) are updated. `just all` passes.

Follow-up deferred to #224: the file-tree blocks render with line gaps on the gh-pages site (out of scope here).

https://claude.ai/code/session_01F3hyEUNGyau2Sq6e5EQHTT