### PR TITLE
docs(rules): list every style in multi-style rule examples

### DIFF
--- a/rules/derive_ordering.md
+++ b/rules/derive_ordering.md
@@ -50,7 +50,7 @@ enable = ["derive_ordering"]
 
 ## Example
 
-Under `style = "alphabetical"`:
+### Style: Alphabetical (default)
 
 **Avoid:**
 
@@ -63,6 +63,23 @@ struct Point;
 
 ```rust,ignore
 #[derive(Clone, Copy, Debug)]
+struct Point;
+```
+
+### Style: Prefix then alphabetical
+
+**Avoid:**
+
+```rust,ignore
+#[derive(Clone, Debug, Serialize, Copy)]
+struct Point;
+```
+
+**Prefer:** (default `prefix`: `Debug`, `Default`, `Clone`, `Copy`, ...,
+then the remaining traits alphabetically)
+
+```rust,ignore
+#[derive(Debug, Clone, Copy, Serialize)]
 struct Point;
 ```
 

--- a/rules/import_granularity.md
+++ b/rules/import_granularity.md
@@ -50,7 +50,7 @@ CI check instead of a silent reformat.
 
 ## Example
 
-Under the default `style = "module"`:
+### Style: Module (default)
 
 **Avoid:**
 
@@ -63,6 +63,36 @@ use std::collections::BTreeMap;
 
 ```rust,ignore
 use std::collections::{BTreeMap, HashMap};
+```
+
+### Style: Crate
+
+**Avoid:**
+
+```rust,ignore
+use std::collections::{BTreeMap, HashMap};
+use std::io::Read;
+```
+
+**Prefer:**
+
+```rust,ignore
+use std::{collections::{BTreeMap, HashMap}, io::Read};
+```
+
+### Style: Item
+
+**Avoid:**
+
+```rust,ignore
+use std::collections::{BTreeMap, HashMap};
+```
+
+**Prefer:**
+
+```rust,ignore
+use std::collections::BTreeMap;
+use std::collections::HashMap;
 ```
 
 ## Configuration

--- a/rules/import_grouping.md
+++ b/rules/import_grouping.md
@@ -38,7 +38,7 @@ projects a hard CI check instead of a silent reformat.
 
 ## Example
 
-Under the default `style = "grouped"`:
+### Style: Grouped (default)
 
 **Avoid:**
 
@@ -56,6 +56,26 @@ use std::time::Duration;
 use crate::args::Args;
 
 use clap::Parser;
+```
+
+### Style: Single group
+
+**Avoid:**
+
+```rust,ignore
+use std::time::Duration;
+
+use crate::args::Args;
+
+use clap::Parser;
+```
+
+**Prefer:** (one contiguous block; inner order left to `cargo fmt`)
+
+```rust,ignore
+use clap::Parser;
+use crate::args::Args;
+use std::time::Duration;
 ```
 
 ## Configuration

--- a/src/rules/derive_ordering.rs
+++ b/src/rules/derive_ordering.rs
@@ -55,7 +55,7 @@ declare_tool_lint! {
     ///
     /// ### Example
     ///
-    /// Under `style = "alphabetical"`:
+    /// #### Style: Alphabetical (default)
     ///
     /// **Avoid:**
     ///
@@ -68,6 +68,23 @@ declare_tool_lint! {
     ///
     /// ```rust,ignore
     /// #[derive(Clone, Copy, Debug)]
+    /// struct Point;
+    /// ```
+    ///
+    /// #### Style: Prefix then alphabetical
+    ///
+    /// **Avoid:**
+    ///
+    /// ```rust,ignore
+    /// #[derive(Clone, Debug, Serialize, Copy)]
+    /// struct Point;
+    /// ```
+    ///
+    /// **Prefer:** (default `prefix`: `Debug`, `Default`, `Clone`, `Copy`, ...,
+    /// then the remaining traits alphabetically)
+    ///
+    /// ```rust,ignore
+    /// #[derive(Debug, Clone, Copy, Serialize)]
     /// struct Point;
     /// ```
     pub perfectionist::DERIVE_ORDERING,

--- a/src/rules/import_granularity.rs
+++ b/src/rules/import_granularity.rs
@@ -65,7 +65,7 @@ declare_tool_lint! {
     ///
     /// ### Example
     ///
-    /// Under the default `style = "module"`:
+    /// #### Style: Module (default)
     ///
     /// **Avoid:**
     ///
@@ -78,6 +78,36 @@ declare_tool_lint! {
     ///
     /// ```rust,ignore
     /// use std::collections::{BTreeMap, HashMap};
+    /// ```
+    ///
+    /// #### Style: Crate
+    ///
+    /// **Avoid:**
+    ///
+    /// ```rust,ignore
+    /// use std::collections::{BTreeMap, HashMap};
+    /// use std::io::Read;
+    /// ```
+    ///
+    /// **Prefer:**
+    ///
+    /// ```rust,ignore
+    /// use std::{collections::{BTreeMap, HashMap}, io::Read};
+    /// ```
+    ///
+    /// #### Style: Item
+    ///
+    /// **Avoid:**
+    ///
+    /// ```rust,ignore
+    /// use std::collections::{BTreeMap, HashMap};
+    /// ```
+    ///
+    /// **Prefer:**
+    ///
+    /// ```rust,ignore
+    /// use std::collections::BTreeMap;
+    /// use std::collections::HashMap;
     /// ```
     pub perfectionist::IMPORT_GRANULARITY,
     Warn,

--- a/src/rules/import_grouping.rs
+++ b/src/rules/import_grouping.rs
@@ -51,7 +51,7 @@ declare_tool_lint! {
     ///
     /// ### Example
     ///
-    /// Under the default `style = "grouped"`:
+    /// #### Style: Grouped (default)
     ///
     /// **Avoid:**
     ///
@@ -69,6 +69,26 @@ declare_tool_lint! {
     /// use crate::args::Args;
     ///
     /// use clap::Parser;
+    /// ```
+    ///
+    /// #### Style: Single group
+    ///
+    /// **Avoid:**
+    ///
+    /// ```rust,ignore
+    /// use std::time::Duration;
+    ///
+    /// use crate::args::Args;
+    ///
+    /// use clap::Parser;
+    /// ```
+    ///
+    /// **Prefer:** (one contiguous block; inner order left to `cargo fmt`)
+    ///
+    /// ```rust,ignore
+    /// use clap::Parser;
+    /// use crate::args::Args;
+    /// use std::time::Duration;
     /// ```
     pub perfectionist::IMPORT_GROUPING,
     Warn,


### PR DESCRIPTION
The `### Example` section of `perfectionist::self_import` is the exemplar: it lists **every** `style` variant under a `#### Style: X` subheading, each with its own Avoid/Prefer pair.

Three other multi-style rules instead opened their example with a single-variant prose preamble ("Under the default `style = ...`") and documented just one variant. This makes them follow the exemplar:

| Rule | Was | Now |
|------|-----|-----|
| `import_grouping` | only `grouped` | `Grouped (default)` + `Single group` |
| `import_granularity` | only `module` | `Module (default)` + `Crate` + `Item` |
| `derive_ordering` | only `alphabetical` | `Alphabetical (default)` + `Prefix then alphabetical` |

Edited the rustdoc on each `declare_tool_lint!` block; regenerated the derived `rules/*.md` catalogue to match.

### Notes
- Scanning every `### Example` heading for ones followed by prose (rather than `**Avoid:**` / a subheading / a code fence) surfaced exactly these three — now resolved.
- `bare_email` (5-variant `style`) and `inline_test_footprint` (2 styles, one shared fix shape) were left as-is: neither uses the prose-preamble pattern, and a clean conversion would add repetition without clarifying anything.
- `just all` passes, including `self-lint`.

https://claude.ai/code/session_01UXZuw48nj8RgPpuy8rUN4q