### PR TITLE
feat(pages): specialized style for file tree code blocks

### DIFF
--- a/rules/flat_module_pattern.md
+++ b/rules/flat_module_pattern.md
@@ -27,7 +27,7 @@ don't disambiguate by directory.
 
 **Avoid:**
 
-```text
+```ascii-file-tree
 src/
 └── foo/
     ├── mod.rs
@@ -36,7 +36,7 @@ src/
 
 **Prefer:**
 
-```text
+```ascii-file-tree
 src/
 ├── foo.rs
 └── foo/

--- a/src/rules/flat_module_pattern.rs
+++ b/src/rules/flat_module_pattern.rs
@@ -29,7 +29,7 @@ declare_tool_lint! {
     ///
     /// **Avoid:**
     ///
-    /// ```text
+    /// ```ascii-file-tree
     /// src/
     /// └── foo/
     ///     ├── mod.rs
@@ -38,7 +38,7 @@ declare_tool_lint! {
     ///
     /// **Prefer:**
     ///
-    /// ```text
+    /// ```ascii-file-tree
     /// src/
     /// ├── foo.rs
     /// └── foo/

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -9,6 +9,7 @@
 //! directory verbatim.
 
 pub(crate) mod config;
+pub(crate) mod file_tree;
 pub(crate) mod markdown;
 
 use maud::{DOCTYPE, Markup, PreEscaped, html};

--- a/tools/gen-docs/src/render/file_tree.rs
+++ b/tools/gen-docs/src/render/file_tree.rs
@@ -20,13 +20,14 @@
 //! `line-height` joins them everywhere — a value that touches on one
 //! font gaps or overlaps on another.
 //!
-//! So the connectors are drawn as CSS borders instead. The block stays
+//! So the connectors are drawn with CSS instead. The block stays
 //! a real `<pre>` of the original text — every box-drawing prefix
 //! (`│   `, `    `, `├── `, `└── `) is wrapped in an inline-block
 //! `<span>` whose glyphs are painted transparent (so copy, selection,
 //! and assistive tech still see the original characters) and over which
 //! the `.file-tree` rules in `style/base.css` draw the vertical and
-//! horizontal segments. Each segment spans its span's full line-box
+//! horizontal segments as thin `::before`/`::after` pseudo-elements.
+//! Each segment spans its span's full line-box
 //! height, so consecutive lines' verticals meet exactly regardless of
 //! font or line-height, and the rows keep comfortable spacing without
 //! ever breaking the tree.

--- a/tools/gen-docs/src/render/file_tree.rs
+++ b/tools/gen-docs/src/render/file_tree.rs
@@ -66,36 +66,38 @@ pub(crate) fn render_file_tree(code: &str) -> String {
 }
 
 /// Emit one line: its box-drawing prefix as connector spans, then the
-/// node name as a plain run. The prefix is consumed in four-column
-/// groups keyed off the first character of each group — `│` / space are
-/// ancestor columns (a through-running pipe or a blank), `├` / `└` are
-/// the node's own connector and end the prefix. A line with no
-/// box-drawing prefix (a root) emits just its name.
+/// node name as a plain run. The prefix is consumed as exact four-column
+/// tokens — `│   ` / `    ` are ancestor columns (a through-running pipe
+/// or a blank), `├── ` / `└── ` are the node's own connector and end the
+/// prefix. The match is deliberately exact: anything that isn't one of
+/// those well-formed tokens (a root line, or a malformed/non-standard
+/// diagram) ends the prefix and is emitted verbatim as the visible name,
+/// rather than being swallowed four characters at a time into a
+/// transparent cell where it would render invisibly.
 fn emit_line(out: &mut String, content: &str) {
     let chars: Vec<char> = content.chars().collect();
     let mut index = 0;
-    while let Some(&first) = chars.get(index) {
-        let class = match first {
-            '│' => "ft-cell ft-pipe",
-            ' ' => "ft-cell",
-            '├' => "ft-cell ft-tee",
-            '└' => "ft-cell ft-ell",
-            // Anything else is the start of the node name.
+    while let Some(group) = chars.get(index..index + INDENT_WIDTH) {
+        let (class, is_connector) = match group {
+            ['│', ' ', ' ', ' '] => ("ft-cell ft-pipe", false),
+            [' ', ' ', ' ', ' '] => ("ft-cell", false),
+            ['├', '─', '─', ' '] => ("ft-cell ft-tee", true),
+            ['└', '─', '─', ' '] => ("ft-cell ft-ell", true),
+            // Not a well-formed prefix token: the node name starts here.
             _ => break,
         };
-        let end = (index + INDENT_WIDTH).min(chars.len());
         out.push_str(r#"<span class=""#);
         out.push_str(class);
         out.push_str(r#"">"#);
-        push_escaped(out, &chars[index..end]);
+        push_escaped(out, group);
         out.push_str("</span>");
-        index = end;
+        index += INDENT_WIDTH;
         // `├` / `└` introduce the node itself; the name follows.
-        if matches!(first, '├' | '└') {
+        if is_connector {
             break;
         }
     }
-    let name = &chars[index.min(chars.len())..];
+    let name = &chars[index..];
     if !name.is_empty() {
         out.push_str(r#"<span class="ft-name">"#);
         push_escaped(out, name);

--- a/tools/gen-docs/src/render/file_tree.rs
+++ b/tools/gen-docs/src/render/file_tree.rs
@@ -1,0 +1,161 @@
+//! Render ` ```ascii-file-tree ` fenced blocks as structural HTML whose
+//! tree connectors are drawn with CSS borders instead of box-drawing
+//! glyphs.
+//!
+//! The catalogue documents module layouts as `tree`-style diagrams:
+//!
+//! ```text
+//! src/
+//! └── foo/
+//!     ├── mod.rs
+//!     └── bar.rs
+//! ```
+//!
+//! Rendered with the literal `│ ├ └` glyphs, whether the vertical
+//! connectors join top-to-bottom is font-dependent: the glyphs only
+//! tile seamlessly when the line box height matches their drawn extent,
+//! which varies per font (≈1em on plain monospaces, larger on
+//! terminal/Nerd fonts that pad their line metrics). No single CSS
+//! `line-height` joins them everywhere — a value that touches on one
+//! font gaps or overlaps on another.
+//!
+//! So this module throws the glyphs away. It parses the diagram into
+//! rows of (indentation, connector, name) and emits one `<div>` per
+//! row whose connector cells carry CSS-drawn vertical and horizontal
+//! line segments (see the `.file-tree` rules in `style/base.css`).
+//! Each segment spans its cell's full row height, so consecutive rows'
+//! verticals meet exactly regardless of font or line-height, and the
+//! rows can keep comfortable spacing without ever breaking the tree.
+
+/// The fence language tag these blocks use. The unqualified token is
+/// also what `markdown::lang_class_attr` would emit as a `language-...`
+/// class, but file-tree blocks bypass that path entirely.
+pub(crate) const FILE_TREE_LANG: &str = "ascii-file-tree";
+
+/// Width of one indentation level, matching the four-column groups a
+/// `tree`-style diagram uses (`│   `, `    `, `├── `, `└── `).
+const INDENT_WIDTH: usize = 4;
+
+/// The connector glyph that introduces a node.
+#[derive(Debug, PartialEq, Eq)]
+enum Connector {
+    /// `├──`: a node with at least one following sibling. Its vertical
+    /// runs the full height of the row so it joins the sibling below.
+    Tee,
+    /// `└──`: the last node at its level. Its vertical stops halfway
+    /// down, where the horizontal arm turns off to the name.
+    Ell,
+}
+
+/// One line of the diagram, decomposed into its drawable parts.
+struct Row {
+    /// One entry per ancestor level, left to right: `true` where a
+    /// vertical line passes through (the ancestor has a later sibling,
+    /// drawn `│   `), `false` where the column is blank (`    `).
+    ancestors: Vec<bool>,
+    /// The node's own connector, or `None` for the root line (which has
+    /// no incoming branch).
+    connector: Option<Connector>,
+    /// The node's label — everything after the connector.
+    name: String,
+}
+
+/// Parse one diagram line into a [`Row`]. The prefix is consumed in
+/// four-column groups: `│   ` / `    ` are ancestor columns, `├── ` /
+/// `└── ` is the node's connector and ends the prefix. A line with no
+/// box-drawing prefix is a root node (`connector: None`).
+fn parse_row(line: &str) -> Row {
+    let chars: Vec<char> = line.chars().collect();
+    let mut index = 0;
+    let mut ancestors = Vec::new();
+    let mut connector = None;
+    loop {
+        match chars.get(index) {
+            Some('│') => ancestors.push(true),
+            Some(' ') => ancestors.push(false),
+            Some('├') => {
+                connector = Some(Connector::Tee);
+                index += INDENT_WIDTH;
+                break;
+            }
+            Some('└') => {
+                connector = Some(Connector::Ell);
+                index += INDENT_WIDTH;
+                break;
+            }
+            // A non-space, non-box-drawing character (or end of line):
+            // the node name starts here, with no connector — the root.
+            _ => break,
+        }
+        index += INDENT_WIDTH;
+    }
+    // `index` can overshoot a malformed prefix; clamp to an empty name.
+    let name: String = chars.get(index..).unwrap_or(&[]).iter().collect();
+    Row {
+        ancestors,
+        connector,
+        name,
+    }
+}
+
+/// Render an `ascii-file-tree` block to a `<pre class="file-tree">`
+/// whose rows draw their connectors with CSS borders. Reusing `<pre>`
+/// inherits the themed code-block box (background, padding, radius)
+/// from the existing stylesheets; `white-space: normal` on the class
+/// keeps the inter-tag newlines below from showing as blank lines.
+pub(crate) fn render_file_tree(code: &str) -> String {
+    let mut out = String::from(r#"<pre class="file-tree">"#);
+    for line in code.lines() {
+        // Skip wholly blank lines: they carry no node and would render
+        // as an empty row.
+        if line.trim().is_empty() {
+            continue;
+        }
+        let row = parse_row(line);
+        out.push_str(r#"<div class="ft-row">"#);
+        for &pipe in &row.ancestors {
+            if pipe {
+                out.push_str(r#"<span class="ft-cell ft-pipe"></span>"#);
+            } else {
+                out.push_str(r#"<span class="ft-cell"></span>"#);
+            }
+        }
+        // A connectorless row is a root: its name sits flush, with no
+        // arm to leave room for (the `ft-root` class drops the padding).
+        let name_class = match row.connector {
+            Some(Connector::Tee) => {
+                out.push_str(r#"<span class="ft-cell ft-tee"></span>"#);
+                "ft-name"
+            }
+            Some(Connector::Ell) => {
+                out.push_str(r#"<span class="ft-cell ft-ell"></span>"#);
+                "ft-name"
+            }
+            None => "ft-name ft-root",
+        };
+        out.push_str(r#"<span class=""#);
+        out.push_str(name_class);
+        out.push_str(r#"">"#);
+        push_escaped(&mut out, &row.name);
+        out.push_str("</span></div>");
+    }
+    out.push_str("</pre>\n");
+    out
+}
+
+/// Append `text` to `out` with the HTML metacharacters escaped. Node
+/// names are author-controlled, but a stray `<`, `&`, or `>` (e.g. a
+/// generics example) must not break out of the `<span>`.
+fn push_escaped(out: &mut String, text: &str) {
+    for ch in text.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(ch),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/tools/gen-docs/src/render/file_tree.rs
+++ b/tools/gen-docs/src/render/file_tree.rs
@@ -1,6 +1,7 @@
-//! Render ` ```ascii-file-tree ` fenced blocks as structural HTML whose
-//! tree connectors are drawn with CSS borders instead of box-drawing
-//! glyphs.
+//! Render ` ```ascii-file-tree ` fenced blocks as HTML whose tree
+//! connectors are drawn with CSS borders, while the literal diagram
+//! text stays in the DOM so it copies, selects, and reads exactly as
+//! authored.
 //!
 //! The catalogue documents module layouts as `tree`-style diagrams:
 //!
@@ -14,18 +15,21 @@
 //! Rendered with the literal `│ ├ └` glyphs, whether the vertical
 //! connectors join top-to-bottom is font-dependent: the glyphs only
 //! tile seamlessly when the line box height matches their drawn extent,
-//! which varies per font (≈1em on plain monospaces, larger on
+//! which varies per font (about 1em on plain monospaces, larger on
 //! terminal/Nerd fonts that pad their line metrics). No single CSS
 //! `line-height` joins them everywhere — a value that touches on one
 //! font gaps or overlaps on another.
 //!
-//! So this module throws the glyphs away. It parses the diagram into
-//! rows of (indentation, connector, name) and emits one `<div>` per
-//! row whose connector cells carry CSS-drawn vertical and horizontal
-//! line segments (see the `.file-tree` rules in `style/base.css`).
-//! Each segment spans its cell's full row height, so consecutive rows'
-//! verticals meet exactly regardless of font or line-height, and the
-//! rows can keep comfortable spacing without ever breaking the tree.
+//! So the connectors are drawn as CSS borders instead. The block stays
+//! a real `<pre>` of the original text — every box-drawing prefix
+//! (`│   `, `    `, `├── `, `└── `) is wrapped in an inline-block
+//! `<span>` whose glyphs are painted transparent (so copy, selection,
+//! and assistive tech still see the original characters) and over which
+//! the `.file-tree` rules in `style/base.css` draw the vertical and
+//! horizontal segments. Each segment spans its span's full line-box
+//! height, so consecutive lines' verticals meet exactly regardless of
+//! font or line-height, and the rows keep comfortable spacing without
+//! ever breaking the tree.
 
 /// The fence language tag these blocks use. The unqualified token is
 /// also what `markdown::lang_class_attr` would emit as a `language-...`
@@ -36,118 +40,74 @@ pub(crate) const FILE_TREE_LANG: &str = "ascii-file-tree";
 /// `tree`-style diagram uses (`│   `, `    `, `├── `, `└── `).
 const INDENT_WIDTH: usize = 4;
 
-/// The connector glyph that introduces a node.
-#[derive(Debug, PartialEq, Eq)]
-enum Connector {
-    /// `├──`: a node with at least one following sibling. Its vertical
-    /// runs the full height of the row so it joins the sibling below.
-    Tee,
-    /// `└──`: the last node at its level. Its vertical stops halfway
-    /// down, where the horizontal arm turns off to the name.
-    Ell,
-}
-
-/// One line of the diagram, decomposed into its drawable parts.
-struct Row {
-    /// One entry per ancestor level, left to right: `true` where a
-    /// vertical line passes through (the ancestor has a later sibling,
-    /// drawn `│   `), `false` where the column is blank (`    `).
-    ancestors: Vec<bool>,
-    /// The node's own connector, or `None` for the root line (which has
-    /// no incoming branch).
-    connector: Option<Connector>,
-    /// The node's label — everything after the connector.
-    name: String,
-}
-
-/// Parse one diagram line into a [`Row`]. The prefix is consumed in
-/// four-column groups: `│   ` / `    ` are ancestor columns, `├── ` /
-/// `└── ` is the node's connector and ends the prefix. A line with no
-/// box-drawing prefix is a root node (`connector: None`).
-fn parse_row(line: &str) -> Row {
-    let chars: Vec<char> = line.chars().collect();
-    let mut index = 0;
-    let mut ancestors = Vec::new();
-    let mut connector = None;
-    loop {
-        match chars.get(index) {
-            Some('│') => ancestors.push(true),
-            Some(' ') => ancestors.push(false),
-            Some('├') => {
-                connector = Some(Connector::Tee);
-                index += INDENT_WIDTH;
-                break;
-            }
-            Some('└') => {
-                connector = Some(Connector::Ell);
-                index += INDENT_WIDTH;
-                break;
-            }
-            // A non-space, non-box-drawing character (or end of line):
-            // the node name starts here, with no connector — the root.
-            _ => break,
-        }
-        index += INDENT_WIDTH;
-    }
-    // `index` can overshoot a malformed prefix; clamp to an empty name.
-    let name: String = chars.get(index..).unwrap_or(&[]).iter().collect();
-    Row {
-        ancestors,
-        connector,
-        name,
-    }
-}
-
-/// Render an `ascii-file-tree` block to a `<pre class="file-tree">`
-/// whose rows draw their connectors with CSS borders. Reusing `<pre>`
-/// inherits the themed code-block box (background, padding, radius)
-/// from the existing stylesheets; `white-space: normal` on the class
-/// keeps the inter-tag newlines below from showing as blank lines.
+/// Render an `ascii-file-tree` block to a `<pre class="file-tree">`.
+///
+/// The text content is preserved verbatim — concatenating the emitted
+/// spans' text reproduces the input byte-for-byte — so the rendered
+/// block copies, selects, and reads as the original ASCII diagram. Only
+/// the box-drawing prefix of each line is wrapped in connector spans
+/// for the CSS to draw over; the rest of the line (the node name) is
+/// emitted as a plain visible run.
 pub(crate) fn render_file_tree(code: &str) -> String {
-    let mut out = String::from(r#"<pre class="file-tree">"#);
-    for line in code.lines() {
-        // Skip wholly blank lines: they carry no node and would render
-        // as an empty row.
-        if line.trim().is_empty() {
-            continue;
-        }
-        let row = parse_row(line);
-        out.push_str(r#"<div class="ft-row">"#);
-        for &pipe in &row.ancestors {
-            if pipe {
-                out.push_str(r#"<span class="ft-cell ft-pipe"></span>"#);
-            } else {
-                out.push_str(r#"<span class="ft-cell"></span>"#);
-            }
-        }
-        // A connectorless row is a root: its name sits flush, with no
-        // arm to leave room for (the `ft-root` class drops the padding).
-        let name_class = match row.connector {
-            Some(Connector::Tee) => {
-                out.push_str(r#"<span class="ft-cell ft-tee"></span>"#);
-                "ft-name"
-            }
-            Some(Connector::Ell) => {
-                out.push_str(r#"<span class="ft-cell ft-ell"></span>"#);
-                "ft-name"
-            }
-            None => "ft-name ft-root",
+    let mut out = String::from(r#"<pre class="file-tree"><code>"#);
+    // `split_inclusive` keeps each line's trailing newline attached, so
+    // re-emitting it preserves the original line breaks (and any final
+    // newline) as literal, copyable text under `white-space: pre`.
+    for line in code.split_inclusive('\n') {
+        let (content, newline) = match line.strip_suffix('\n') {
+            Some(rest) => (rest, "\n"),
+            None => (line, ""),
         };
-        out.push_str(r#"<span class=""#);
-        out.push_str(name_class);
-        out.push_str(r#"">"#);
-        push_escaped(&mut out, &row.name);
-        out.push_str("</span></div>");
+        emit_line(&mut out, content);
+        out.push_str(newline);
     }
-    out.push_str("</pre>\n");
+    out.push_str("</code></pre>\n");
     out
 }
 
-/// Append `text` to `out` with the HTML metacharacters escaped. Node
+/// Emit one line: its box-drawing prefix as connector spans, then the
+/// node name as a plain run. The prefix is consumed in four-column
+/// groups keyed off the first character of each group — `│` / space are
+/// ancestor columns (a through-running pipe or a blank), `├` / `└` are
+/// the node's own connector and end the prefix. A line with no
+/// box-drawing prefix (a root) emits just its name.
+fn emit_line(out: &mut String, content: &str) {
+    let chars: Vec<char> = content.chars().collect();
+    let mut index = 0;
+    while let Some(&first) = chars.get(index) {
+        let class = match first {
+            '│' => "ft-cell ft-pipe",
+            ' ' => "ft-cell",
+            '├' => "ft-cell ft-tee",
+            '└' => "ft-cell ft-ell",
+            // Anything else is the start of the node name.
+            _ => break,
+        };
+        let end = (index + INDENT_WIDTH).min(chars.len());
+        out.push_str(r#"<span class=""#);
+        out.push_str(class);
+        out.push_str(r#"">"#);
+        push_escaped(out, &chars[index..end]);
+        out.push_str("</span>");
+        index = end;
+        // `├` / `└` introduce the node itself; the name follows.
+        if matches!(first, '├' | '└') {
+            break;
+        }
+    }
+    let name = &chars[index.min(chars.len())..];
+    if !name.is_empty() {
+        out.push_str(r#"<span class="ft-name">"#);
+        push_escaped(out, name);
+        out.push_str("</span>");
+    }
+}
+
+/// Append `chars` to `out` with the HTML metacharacters escaped. Node
 /// names are author-controlled, but a stray `<`, `&`, or `>` (e.g. a
 /// generics example) must not break out of the `<span>`.
-fn push_escaped(out: &mut String, text: &str) {
-    for ch in text.chars() {
+fn push_escaped(out: &mut String, chars: &[char]) {
+    for &ch in chars {
         match ch {
             '&' => out.push_str("&amp;"),
             '<' => out.push_str("&lt;"),

--- a/tools/gen-docs/src/render/file_tree/tests.rs
+++ b/tools/gen-docs/src/render/file_tree/tests.rs
@@ -75,3 +75,31 @@ fn escapes_html_metacharacters_in_names() {
     // ...and the escaping round-trips back to the original text.
     assert_eq!(copied_text(&html), "Vec<T> & Box<U>\n");
 }
+
+#[test]
+fn non_four_column_prefix_is_kept_visible_not_swallowed() {
+    // Prefix tokens are matched exactly. A line whose indentation isn't a
+    // well-formed `│   `/`    `/`├── `/`└── ` token must NOT have its first
+    // characters consumed into a transparent `.ft-cell` (where they'd
+    // render invisibly) — the whole run becomes the visible name instead.
+    // Two-space indent: the leading spaces aren't a four-space column.
+    let two_space = render_file_tree("  indented\n");
+    assert!(!two_space.contains("ft-cell"));
+    assert!(two_space.contains(r#"<span class="ft-name">  indented</span>"#));
+
+    // A connector without the conventional `── ` separator isn't a token,
+    // so it renders literally rather than hiding the following character.
+    let tight = render_file_tree("└──tight\n");
+    assert!(!tight.contains("ft-cell"));
+    assert!(tight.contains(r#"<span class="ft-name">└──tight</span>"#));
+
+    // A mis-sized ancestor column doesn't swallow the real connector.
+    let bad_pipe = render_file_tree("│  ├── x\n");
+    assert!(!bad_pipe.contains("ft-cell"));
+    assert!(bad_pipe.contains(r#"<span class="ft-name">│  ├── x</span>"#));
+
+    // In every case the text still copies back verbatim.
+    assert_eq!(copied_text(&two_space), "  indented\n");
+    assert_eq!(copied_text(&tight), "└──tight\n");
+    assert_eq!(copied_text(&bad_pipe), "│  ├── x\n");
+}

--- a/tools/gen-docs/src/render/file_tree/tests.rs
+++ b/tools/gen-docs/src/render/file_tree/tests.rs
@@ -1,0 +1,71 @@
+use super::{Connector, parse_row, render_file_tree};
+
+#[test]
+fn parses_a_root_line_as_a_connectorless_node() {
+    let row = parse_row("src/");
+    assert!(row.ancestors.is_empty());
+    assert_eq!(row.connector, None);
+    assert_eq!(row.name, "src/");
+}
+
+#[test]
+fn parses_a_top_level_branch() {
+    // `└── foo/`: no ancestors, a last-child connector, name after the
+    // four-column `└── ` group.
+    let row = parse_row("└── foo/");
+    assert!(row.ancestors.is_empty());
+    assert_eq!(row.connector, Some(Connector::Ell));
+    assert_eq!(row.name, "foo/");
+}
+
+#[test]
+fn parses_a_nested_branch_under_a_last_child() {
+    // Under a `└──` parent the column is blank (`    `), so the child
+    // has one non-pipe ancestor before its own connector.
+    let row = parse_row("    ├── mod.rs");
+    assert_eq!(row.ancestors, vec![false]);
+    assert_eq!(row.connector, Some(Connector::Tee));
+    assert_eq!(row.name, "mod.rs");
+}
+
+#[test]
+fn parses_a_pipe_ancestor_column() {
+    // Under a `├──` parent the column keeps a vertical (`│   `), so the
+    // ancestor entry is a pipe.
+    let row = parse_row("│   └── bar.rs");
+    assert_eq!(row.ancestors, vec![true]);
+    assert_eq!(row.connector, Some(Connector::Ell));
+    assert_eq!(row.name, "bar.rs");
+}
+
+#[test]
+fn renders_pipe_blank_tee_and_ell_cells() {
+    let html = render_file_tree("src/\n└── foo/\n    ├── mod.rs\n    └── bar.rs\n");
+    // Root has just a name, no cells, and is marked flush.
+    assert!(
+        html.contains(r#"<div class="ft-row"><span class="ft-name ft-root">src/</span></div>"#),
+    );
+    // Top-level last child: one ell cell.
+    assert!(
+        html.contains(r#"<span class="ft-cell ft-ell"></span><span class="ft-name">foo/</span>"#),
+    );
+    // Nested non-last child: a blank ancestor cell then a tee.
+    assert!(html.contains(
+        r#"<span class="ft-cell"></span><span class="ft-cell ft-tee"></span><span class="ft-name">mod.rs</span>"#,
+    ));
+    assert!(html.starts_with(r#"<pre class="file-tree">"#));
+    assert!(html.ends_with("</pre>\n"));
+}
+
+#[test]
+fn escapes_html_metacharacters_in_names() {
+    let html = render_file_tree("Vec<T> & Box<U>\n");
+    assert!(html.contains("Vec&lt;T&gt; &amp; Box&lt;U&gt;"));
+    assert!(!html.contains("<T>"));
+}
+
+#[test]
+fn skips_blank_lines() {
+    let html = render_file_tree("a/\n\n└── b\n");
+    assert_eq!(html.matches(r#"class="ft-row""#).count(), 2);
+}

--- a/tools/gen-docs/src/render/file_tree/tests.rs
+++ b/tools/gen-docs/src/render/file_tree/tests.rs
@@ -14,9 +14,12 @@ fn text_content(html: &str) -> String {
             _ => {}
         }
     }
-    out.replace("&amp;", "&")
-        .replace("&lt;", "<")
+    // Decode `&amp;` last: otherwise an escaped literal ampersand-entity
+    // like `&amp;lt;` would first become `&lt;` and then wrongly decode
+    // again to `<`, instead of copying back as the literal text `&lt;`.
+    out.replace("&lt;", "<")
         .replace("&gt;", ">")
+        .replace("&amp;", "&")
 }
 
 /// The text a copy or screen reader would yield: the content of the
@@ -74,6 +77,17 @@ fn escapes_html_metacharacters_in_names() {
     assert!(!html.contains("<T>"));
     // ...and the escaping round-trips back to the original text.
     assert_eq!(copied_text(&html), "Vec<T> & Box<U>\n");
+}
+
+#[test]
+fn round_trips_a_literal_entity_in_a_name() {
+    // A name that is itself entity-like text (`&lt;`) must escape to
+    // `&amp;lt;` and copy back as the original four characters — never
+    // double-decode to `<`. Guards the entity-decode order in
+    // `text_content`/the renderer.
+    let html = render_file_tree("&lt;\n");
+    assert!(html.contains("&amp;lt;"));
+    assert_eq!(copied_text(&html), "&lt;\n");
 }
 
 #[test]

--- a/tools/gen-docs/src/render/file_tree/tests.rs
+++ b/tools/gen-docs/src/render/file_tree/tests.rs
@@ -1,60 +1,70 @@
-use super::{Connector, parse_row, render_file_tree};
+use super::render_file_tree;
+
+/// Strip every `<...>` tag and undo the handful of entities the renderer
+/// emits, recovering the block's text content — i.e. what a copy or a
+/// screen reader would yield.
+fn text_content(html: &str) -> String {
+    let mut out = String::new();
+    let mut in_tag = false;
+    for ch in html.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(ch),
+            _ => {}
+        }
+    }
+    out.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+}
+
+/// The text a copy or screen reader would yield: the content of the
+/// `<code>` wrapper, with tags stripped and entities undone.
+fn copied_text(html: &str) -> String {
+    let inner = html
+        .strip_prefix(r#"<pre class="file-tree"><code>"#)
+        .and_then(|rest| rest.strip_suffix("</code></pre>\n"))
+        .expect("pre/code wrapper");
+    text_content(inner)
+}
+
+const AVOID: &str = "src/\n└── foo/\n    ├── mod.rs\n    └── bar.rs\n";
 
 #[test]
-fn parses_a_root_line_as_a_connectorless_node() {
-    let row = parse_row("src/");
-    assert!(row.ancestors.is_empty());
-    assert_eq!(row.connector, None);
-    assert_eq!(row.name, "src/");
+fn text_content_reproduces_the_original_diagram() {
+    // The whole point: the rendered block must copy/select/read back as
+    // the exact ASCII it was authored from, box-drawing glyphs and all.
+    let html = render_file_tree(AVOID);
+    assert_eq!(copied_text(&html), AVOID);
 }
 
 #[test]
-fn parses_a_top_level_branch() {
-    // `└── foo/`: no ancestors, a last-child connector, name after the
-    // four-column `└── ` group.
-    let row = parse_row("└── foo/");
-    assert!(row.ancestors.is_empty());
-    assert_eq!(row.connector, Some(Connector::Ell));
-    assert_eq!(row.name, "foo/");
+fn wraps_each_box_drawing_group_in_a_connector_span() {
+    let html = render_file_tree(AVOID);
+    // Last child at top level: an ell connector carrying the literal
+    // `└── `, then the visible name.
+    let ell = r#"<span class="ft-cell ft-ell">└── </span><span class="ft-name">foo/</span>"#;
+    assert!(html.contains(ell));
+    // Nested non-last child: a blank indent column (`    `) then a tee.
+    let tee = r#"<span class="ft-cell">    </span><span class="ft-cell ft-tee">├── </span><span class="ft-name">mod.rs</span>"#;
+    assert!(html.contains(tee));
 }
 
 #[test]
-fn parses_a_nested_branch_under_a_last_child() {
-    // Under a `└──` parent the column is blank (`    `), so the child
-    // has one non-pipe ancestor before its own connector.
-    let row = parse_row("    ├── mod.rs");
-    assert_eq!(row.ancestors, vec![false]);
-    assert_eq!(row.connector, Some(Connector::Tee));
-    assert_eq!(row.name, "mod.rs");
+fn marks_a_through_running_pipe_column() {
+    // A `│   ` ancestor column (parent has a later sibling) becomes a
+    // pipe cell carrying the literal pipe glyph.
+    let html = render_file_tree("│   └── bar.rs\n");
+    assert!(html.contains(r#"<span class="ft-cell ft-pipe">│   </span>"#));
 }
 
 #[test]
-fn parses_a_pipe_ancestor_column() {
-    // Under a `├──` parent the column keeps a vertical (`│   `), so the
-    // ancestor entry is a pipe.
-    let row = parse_row("│   └── bar.rs");
-    assert_eq!(row.ancestors, vec![true]);
-    assert_eq!(row.connector, Some(Connector::Ell));
-    assert_eq!(row.name, "bar.rs");
-}
-
-#[test]
-fn renders_pipe_blank_tee_and_ell_cells() {
-    let html = render_file_tree("src/\n└── foo/\n    ├── mod.rs\n    └── bar.rs\n");
-    // Root has just a name, no cells, and is marked flush.
-    assert!(
-        html.contains(r#"<div class="ft-row"><span class="ft-name ft-root">src/</span></div>"#),
-    );
-    // Top-level last child: one ell cell.
-    assert!(
-        html.contains(r#"<span class="ft-cell ft-ell"></span><span class="ft-name">foo/</span>"#),
-    );
-    // Nested non-last child: a blank ancestor cell then a tee.
-    assert!(html.contains(
-        r#"<span class="ft-cell"></span><span class="ft-cell ft-tee"></span><span class="ft-name">mod.rs</span>"#,
-    ));
-    assert!(html.starts_with(r#"<pre class="file-tree">"#));
-    assert!(html.ends_with("</pre>\n"));
+fn emits_a_root_line_as_a_bare_name() {
+    // No box-drawing prefix: just the name, no connector cell.
+    let html = render_file_tree("src/\n");
+    assert!(html.contains(r#"<code><span class="ft-name">src/</span>"#));
+    assert!(!html.contains("ft-cell"));
 }
 
 #[test]
@@ -62,10 +72,6 @@ fn escapes_html_metacharacters_in_names() {
     let html = render_file_tree("Vec<T> & Box<U>\n");
     assert!(html.contains("Vec&lt;T&gt; &amp; Box&lt;U&gt;"));
     assert!(!html.contains("<T>"));
-}
-
-#[test]
-fn skips_blank_lines() {
-    let html = render_file_tree("a/\n\n└── b\n");
-    assert_eq!(html.matches(r#"class="ft-row""#).count(), 2);
+    // ...and the escaping round-trips back to the original text.
+    assert_eq!(copied_text(&html), "Vec<T> & Box<U>\n");
 }

--- a/tools/gen-docs/src/render/markdown.rs
+++ b/tools/gen-docs/src/render/markdown.rs
@@ -13,6 +13,8 @@ use syntect::html::{ClassStyle, ClassedHTMLGenerator, css_for_theme_with_class_s
 use syntect::parsing::SyntaxSet;
 use syntect::util::LinesWithEndings;
 
+use crate::render::file_tree::{self, FILE_TREE_LANG};
+
 pub(crate) fn markdown_to_html(markdown: &str) -> String {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
@@ -55,7 +57,15 @@ fn highlight_code_blocks<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Eve
             }
             Event::End(TagEnd::CodeBlock) if current_lang.is_some() => {
                 let lang = current_lang.take().expect("guarded above");
-                let html = highlight_to_html(&code_buffer, &lang);
+                // `ascii-file-tree` blocks aren't highlighted as text: the
+                // box-drawing connectors only join seamlessly when drawn as
+                // CSS borders rather than glyphs (whose tiling is
+                // font-dependent), so they get their own structural HTML.
+                let html = if lang == FILE_TREE_LANG {
+                    file_tree::render_file_tree(&code_buffer)
+                } else {
+                    highlight_to_html(&code_buffer, &lang)
+                };
                 out.push(Event::Html(CowStr::Boxed(html.into_boxed_str())));
             }
             Event::Text(text) if current_lang.is_some() => {
@@ -89,13 +99,7 @@ fn highlight_to_html(code: &str, lang: &str) -> String {
     }
     let body = generator.finalize();
     let class_attr = lang_class_attr(lang);
-    // The class is emitted on the `<pre>` as well as the `<code>`: the
-    // line box that governs vertical spacing is the block-level `<pre>`'s
-    // strut, so a line-height override (e.g. tightening ASCII file-tree
-    // diagrams so their box-drawing connectors join) has to target the
-    // `<pre>`. A class on the inline `<code>` alone can't reach it
-    // without `:has()`, which the catalogue avoids.
-    format!("<pre{class_attr}><code{class_attr}>{body}</code></pre>\n")
+    format!("<pre><code{class_attr}>{body}</code></pre>\n")
 }
 
 /// Render the `language-...` class attribute for a code block, but

--- a/tools/gen-docs/src/render/markdown.rs
+++ b/tools/gen-docs/src/render/markdown.rs
@@ -89,7 +89,13 @@ fn highlight_to_html(code: &str, lang: &str) -> String {
     }
     let body = generator.finalize();
     let class_attr = lang_class_attr(lang);
-    format!("<pre><code{class_attr}>{body}</code></pre>\n")
+    // The class is emitted on the `<pre>` as well as the `<code>`: the
+    // line box that governs vertical spacing is the block-level `<pre>`'s
+    // strut, so a line-height override (e.g. tightening ASCII file-tree
+    // diagrams so their box-drawing connectors join) has to target the
+    // `<pre>`. A class on the inline `<code>` alone can't reach it
+    // without `:has()`, which the catalogue avoids.
+    format!("<pre{class_attr}><code{class_attr}>{body}</code></pre>\n")
 }
 
 /// Render the `language-...` class attribute for a code block, but

--- a/tools/gen-docs/src/render/markdown.rs
+++ b/tools/gen-docs/src/render/markdown.rs
@@ -58,8 +58,8 @@ fn highlight_code_blocks<'a>(parser: impl Iterator<Item = Event<'a>>) -> Vec<Eve
             Event::End(TagEnd::CodeBlock) if current_lang.is_some() => {
                 let lang = current_lang.take().expect("guarded above");
                 // `ascii-file-tree` blocks aren't highlighted as text: the
-                // box-drawing connectors only join seamlessly when drawn as
-                // CSS borders rather than glyphs (whose tiling is
+                // box-drawing connectors only join seamlessly when drawn
+                // with CSS rather than as glyphs (whose tiling is
                 // font-dependent), so they get their own structural HTML.
                 let html = if lang == FILE_TREE_LANG {
                     file_tree::render_file_tree(&code_buffer)

--- a/tools/gen-docs/src/style/base.css
+++ b/tools/gen-docs/src/style/base.css
@@ -100,14 +100,20 @@ pre code {
    connectors (│ └ ├) that must touch top-to-bottom to read as a
    continuous tree. The body's comfortable 1.55 line-height cascades
    into the block and leaves leading between rows, breaking the
-   connectors into disjoint segments. Collapse the leading to 1 for
-   these blocks only; prose code blocks keep the roomier spacing. The
-   override targets the `<pre>` (not the inner `<code>`) because the
-   line box height is set by the block-level element's strut — a
-   line-height on the inline `<code>` leaves the strut at 1.55 and the
-   gaps remain. */
+   connectors into disjoint segments.
+
+   `line-height: normal` (not a unitless ratio) is what makes them
+   join the way a terminal renders them: it defers to the font's own
+   line metrics, and box-drawing glyphs are designed by the font
+   author to tile seamlessly at exactly that spacing. A tighter value
+   like `1` is shorter than the font's natural cell, so the verticals
+   overrun into each other and the text looks cramped; `1.55` is
+   looser, so they fall short and leave gaps. The override targets the
+   `<pre>` (not the inner `<code>`) because the line box height is set
+   by the block-level element's strut — a line-height on the inline
+   `<code>` leaves the strut at 1.55 and the gaps remain. */
 pre.language-ascii-file-tree {
-  line-height: 1;
+  line-height: normal;
 }
 
 footer {

--- a/tools/gen-docs/src/style/base.css
+++ b/tools/gen-docs/src/style/base.css
@@ -130,19 +130,27 @@ pre code {
   color: transparent;
 }
 
-/* Keep the prefix glyphs invisible even while selected. Browsers force
-   selected text to paint with the selection's foreground colour, which
-   would otherwise override `color: transparent` and reveal the raw
-   box-drawing glyphs layered on top of the CSS connectors. Suppressing
-   only the painting leaves the text selected and copied as before. Two
-   separate rules, not a `::selection, ::-moz-selection` list: an engine
-   that knows only one keyword discards a list containing the other
-   whole, but applies a standalone rule it understands. */
+/* Keep the prefix glyphs invisible even while selected, but still show
+   the selection highlight over them. Browsers force selected text to
+   paint with the selection's foreground colour, which would otherwise
+   override `color: transparent` and reveal the raw box-drawing glyphs
+   layered on top of the CSS connectors — so pin the selected colour
+   transparent too. That alone suppresses the highlight background for
+   the now fully-transparent run, leaving a ragged selection (blue
+   behind the names, nothing behind the diagram), so restore it with the
+   `Highlight` system colour — the same blue the browser paints behind
+   the adjacent names by default, in both themes. The text stays
+   selected and copied verbatim throughout. Two separate rules, not a
+   `::selection, ::-moz-selection` list: an engine that knows only one
+   keyword discards a list containing the other whole, but applies a
+   standalone rule it understands. */
 .ft-cell::selection {
   color: transparent;
+  background: Highlight;
 }
 .ft-cell::-moz-selection {
   color: transparent;
+  background: Highlight;
 }
 
 /* Vertical segments. A pipe ancestor (`│`) and a tee (`├`) run the full

--- a/tools/gen-docs/src/style/base.css
+++ b/tools/gen-docs/src/style/base.css
@@ -99,10 +99,14 @@ pre code {
 /* ASCII file-tree diagrams (```ascii-file-tree fences) draw vertical
    connectors (│ └ ├) that must touch top-to-bottom to read as a
    continuous tree. The body's comfortable 1.55 line-height cascades
-   into `pre code` and leaves leading between rows, breaking the
-   connectors into disjoint segments. Collapse the leading to ~1 for
-   these blocks only; prose code blocks keep the roomier spacing. */
-pre code.language-ascii-file-tree {
+   into the block and leaves leading between rows, breaking the
+   connectors into disjoint segments. Collapse the leading to 1 for
+   these blocks only; prose code blocks keep the roomier spacing. The
+   override targets the `<pre>` (not the inner `<code>`) because the
+   line box height is set by the block-level element's strut — a
+   line-height on the inline `<code>` leaves the strut at 1.55 and the
+   gaps remain. */
+pre.language-ascii-file-tree {
   line-height: 1;
 }
 

--- a/tools/gen-docs/src/style/base.css
+++ b/tools/gen-docs/src/style/base.css
@@ -97,46 +97,44 @@ pre code {
 }
 
 /* ASCII file-tree diagrams (```ascii-file-tree fences) are rendered by
-   `gen-docs` as a structural `<pre class="file-tree">` rather than the
-   literal `│ ├ └` glyphs. The connectors are drawn here with CSS
-   borders so they join the tree top-to-bottom on every font: whether
-   the box-drawing glyphs themselves tile is font-dependent (a single
-   `line-height` that touches on one font gaps or overlaps on another),
-   but a border that spans each row's full height always meets the next
-   row's, with no glyph involved. Reusing `<pre>` inherits the themed
-   code-block box (background, padding, radius, font); the rules below
-   add only the tree layout. See `render/file_tree.rs`. */
+   `gen-docs` as a `<pre class="file-tree">` that keeps the original
+   diagram as real text — so it copies, selects, and reads back exactly
+   as authored — while the tree connectors are drawn here with CSS
+   borders. Whether the literal `│ ├ └` glyphs join top-to-bottom is
+   font-dependent (a single `line-height` that touches on one font gaps
+   or overlaps on another), but a border spanning each line's full box
+   height always meets the next line's, with no glyph involved.
+
+   Each box-drawing prefix group is wrapped in a `.ft-cell` span whose
+   own glyph is painted transparent (the character stays in the text for
+   copy/selection/AT) and over which the segments below are drawn. The
+   connectors' colour can't be `currentColor` — that resolves to the
+   span's own transparent text colour — so it's set in light.css /
+   dark.css instead. Reusing `<pre>` inherits the themed code-block box
+   (background, padding, radius, font). See `render/file_tree.rs`. */
 .file-tree {
-  /* Rows are flex `<div>`s, not preformatted text — keep the newlines
-     gen-docs emits between tags from rendering as blank lines. */
-  white-space: normal;
   /* Comfortable, terminal-like row spacing. The connectors are borders
-     spanning the full row height, so loosening this can't break them. */
+     spanning the full line height, so loosening this can't break them. */
   line-height: 1.7;
-  font-size: 1rem;
 }
 
-.ft-row {
-  display: flex;
-  align-items: center;
-  /* Natural width so a deep tree scrolls inside the `<pre>` (overflow-x)
-     instead of wrapping a row. */
-  width: max-content;
-}
-
-/* One indentation level. Cells stretch to the row's full height so the
-   vertical borders of stacked rows meet edge-to-edge. */
+/* One box-drawing group (`│   `, `    `, `├── `, `└── `). Inline-block so
+   it establishes a positioning context the full line-box tall — its
+   stacked siblings' verticals meet edge-to-edge — while staying on the
+   line (no copy-breaking block boundaries). `transparent` hides the
+   glyph; its width still reserves the column. */
 .ft-cell {
+  display: inline-block;
+  vertical-align: top;
   position: relative;
-  flex: 0 0 auto;
-  align-self: stretch;
-  width: 1.5em;
+  color: transparent;
 }
 
 /* Vertical segments. A pipe ancestor (`│`) and a tee (`├`) run the full
-   row height; an ell (`└`) stops at the mid-row corner. All sit at the
-   cell's left edge, so a child's vertical lands under the first column
-   of its parent's name — the `tree` alignment. */
+   line height; an ell (`└`) stops at the mid-line corner. All sit at the
+   cell's left edge, where the box-drawing glyph would be, so a child's
+   vertical lands under the first column of its parent's name — the
+   `tree` alignment. */
 .ft-pipe::before,
 .ft-tee::before,
 .ft-ell::before {
@@ -145,7 +143,6 @@ pre code {
   left: 0;
   top: 0;
   width: 1px;
-  background: currentColor;
 }
 
 .ft-pipe::before,
@@ -157,27 +154,17 @@ pre code {
   height: 50%;
 }
 
-/* Horizontal arm of a connector, from the vertical across to the name. */
+/* Horizontal arm of a connector, from the vertical across toward the
+   name. It stops a little short of the cell's right edge to leave the
+   gap the `── ` connector has before the name in the source. */
 .ft-tee::after,
 .ft-ell::after {
   content: "";
   position: absolute;
   left: 0;
+  right: 0.35em;
   top: 50%;
-  width: 100%;
   height: 1px;
-  background: currentColor;
-}
-
-/* The node label. The left padding is the space a `── ` connector
-   leaves before the name; the root line (no connector) sits flush. */
-.ft-name {
-  white-space: pre;
-  padding-left: 0.4em;
-}
-
-.ft-name.ft-root {
-  padding-left: 0;
 }
 
 footer {

--- a/tools/gen-docs/src/style/base.css
+++ b/tools/gen-docs/src/style/base.css
@@ -130,6 +130,21 @@ pre code {
   color: transparent;
 }
 
+/* Keep the prefix glyphs invisible even while selected. Browsers force
+   selected text to paint with the selection's foreground colour, which
+   would otherwise override `color: transparent` and reveal the raw
+   box-drawing glyphs layered on top of the CSS connectors. Suppressing
+   only the painting leaves the text selected and copied as before. Two
+   separate rules, not a `::selection, ::-moz-selection` list: an engine
+   that knows only one keyword discards a list containing the other
+   whole, but applies a standalone rule it understands. */
+.ft-cell::selection {
+  color: transparent;
+}
+.ft-cell::-moz-selection {
+  color: transparent;
+}
+
 /* Vertical segments. A pipe ancestor (`│`) and a tee (`├`) run the full
    line height; an ell (`└`) stops at the mid-line corner. All sit at the
    cell's left edge, where the box-drawing glyph would be, so a child's

--- a/tools/gen-docs/src/style/base.css
+++ b/tools/gen-docs/src/style/base.css
@@ -99,11 +99,14 @@ pre code {
 /* ASCII file-tree diagrams (```ascii-file-tree fences) are rendered by
    `gen-docs` as a `<pre class="file-tree">` that keeps the original
    diagram as real text — so it copies, selects, and reads back exactly
-   as authored — while the tree connectors are drawn here with CSS
-   borders. Whether the literal `│ ├ └` glyphs join top-to-bottom is
-   font-dependent (a single `line-height` that touches on one font gaps
-   or overlaps on another), but a border spanning each line's full box
-   height always meets the next line's, with no glyph involved.
+   as authored — while the tree connectors are drawn here as thin,
+   absolutely-positioned `::before`/`::after` pseudo-elements filled via
+   `background` (no glyphs, no `border` property; the fill colour lives
+   in light.css / dark.css). Whether the literal `│ ├ └` glyphs join
+   top-to-bottom is font-dependent (a single `line-height` that touches
+   on one font gaps or overlaps on another), but a 1px pseudo-element
+   spanning each line's full box height always meets the next line's,
+   with no glyph involved.
 
    Each box-drawing prefix group is wrapped in a `.ft-cell` span whose
    own glyph is painted transparent (the character stays in the text for
@@ -113,8 +116,8 @@ pre code {
    dark.css instead. Reusing `<pre>` inherits the themed code-block box
    (background, padding, radius, font). See `render/file_tree.rs`. */
 .file-tree {
-  /* Comfortable, terminal-like row spacing. The connectors are borders
-     spanning the full line height, so loosening this can't break them. */
+  /* Comfortable, terminal-like row spacing. The connector pseudo-elements
+     span the full line height, so loosening this can't break them. */
   line-height: 1.7;
 }
 

--- a/tools/gen-docs/src/style/base.css
+++ b/tools/gen-docs/src/style/base.css
@@ -96,24 +96,88 @@ pre code {
   font-size: 1rem;
 }
 
-/* ASCII file-tree diagrams (```ascii-file-tree fences) draw vertical
-   connectors (│ └ ├) that must touch top-to-bottom to read as a
-   continuous tree. The body's comfortable 1.55 line-height cascades
-   into the block and leaves leading between rows, breaking the
-   connectors into disjoint segments.
+/* ASCII file-tree diagrams (```ascii-file-tree fences) are rendered by
+   `gen-docs` as a structural `<pre class="file-tree">` rather than the
+   literal `│ ├ └` glyphs. The connectors are drawn here with CSS
+   borders so they join the tree top-to-bottom on every font: whether
+   the box-drawing glyphs themselves tile is font-dependent (a single
+   `line-height` that touches on one font gaps or overlaps on another),
+   but a border that spans each row's full height always meets the next
+   row's, with no glyph involved. Reusing `<pre>` inherits the themed
+   code-block box (background, padding, radius, font); the rules below
+   add only the tree layout. See `render/file_tree.rs`. */
+.file-tree {
+  /* Rows are flex `<div>`s, not preformatted text — keep the newlines
+     gen-docs emits between tags from rendering as blank lines. */
+  white-space: normal;
+  /* Comfortable, terminal-like row spacing. The connectors are borders
+     spanning the full row height, so loosening this can't break them. */
+  line-height: 1.7;
+  font-size: 1rem;
+}
 
-   `line-height: normal` (not a unitless ratio) is what makes them
-   join the way a terminal renders them: it defers to the font's own
-   line metrics, and box-drawing glyphs are designed by the font
-   author to tile seamlessly at exactly that spacing. A tighter value
-   like `1` is shorter than the font's natural cell, so the verticals
-   overrun into each other and the text looks cramped; `1.55` is
-   looser, so they fall short and leave gaps. The override targets the
-   `<pre>` (not the inner `<code>`) because the line box height is set
-   by the block-level element's strut — a line-height on the inline
-   `<code>` leaves the strut at 1.55 and the gaps remain. */
-pre.language-ascii-file-tree {
-  line-height: normal;
+.ft-row {
+  display: flex;
+  align-items: center;
+  /* Natural width so a deep tree scrolls inside the `<pre>` (overflow-x)
+     instead of wrapping a row. */
+  width: max-content;
+}
+
+/* One indentation level. Cells stretch to the row's full height so the
+   vertical borders of stacked rows meet edge-to-edge. */
+.ft-cell {
+  position: relative;
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: 1.5em;
+}
+
+/* Vertical segments. A pipe ancestor (`│`) and a tee (`├`) run the full
+   row height; an ell (`└`) stops at the mid-row corner. All sit at the
+   cell's left edge, so a child's vertical lands under the first column
+   of its parent's name — the `tree` alignment. */
+.ft-pipe::before,
+.ft-tee::before,
+.ft-ell::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 1px;
+  background: currentColor;
+}
+
+.ft-pipe::before,
+.ft-tee::before {
+  bottom: 0;
+}
+
+.ft-ell::before {
+  height: 50%;
+}
+
+/* Horizontal arm of a connector, from the vertical across to the name. */
+.ft-tee::after,
+.ft-ell::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 100%;
+  height: 1px;
+  background: currentColor;
+}
+
+/* The node label. The left padding is the space a `── ` connector
+   leaves before the name; the root line (no connector) sits flush. */
+.ft-name {
+  white-space: pre;
+  padding-left: 0.4em;
+}
+
+.ft-name.ft-root {
+  padding-left: 0;
 }
 
 footer {

--- a/tools/gen-docs/src/style/base.css
+++ b/tools/gen-docs/src/style/base.css
@@ -96,6 +96,16 @@ pre code {
   font-size: 1rem;
 }
 
+/* ASCII file-tree diagrams (```ascii-file-tree fences) draw vertical
+   connectors (│ └ ├) that must touch top-to-bottom to read as a
+   continuous tree. The body's comfortable 1.55 line-height cascades
+   into `pre code` and leaves leading between rows, breaking the
+   connectors into disjoint segments. Collapse the leading to ~1 for
+   these blocks only; prose code blocks keep the roomier spacing. */
+pre code.language-ascii-file-tree {
+  line-height: 1;
+}
+
 footer {
   margin-top: 4rem;
   padding-top: 1rem;

--- a/tools/gen-docs/src/style/dark.css
+++ b/tools/gen-docs/src/style/dark.css
@@ -44,6 +44,9 @@
   html:not([color-scheme-override="light"]) pre code {
     background: none;
   }
+  html:not([color-scheme-override="light"]) .ft-pipe::before, html:not([color-scheme-override="light"]) .ft-tee::before, html:not([color-scheme-override="light"]) .ft-ell::before, html:not([color-scheme-override="light"]) .ft-tee::after, html:not([color-scheme-override="light"]) .ft-ell::after {
+    background: #e6edf3;
+  }
   html:not([color-scheme-override="light"]) footer {
     border-top-color: #21262d;
     color: #8b949e;
@@ -233,6 +236,9 @@ html[color-scheme-override="dark"] code {
 }
 html[color-scheme-override="dark"] pre code {
   background: none;
+}
+html[color-scheme-override="dark"] .ft-pipe::before, html[color-scheme-override="dark"] .ft-tee::before, html[color-scheme-override="dark"] .ft-ell::before, html[color-scheme-override="dark"] .ft-tee::after, html[color-scheme-override="dark"] .ft-ell::after {
+  background: #e6edf3;
 }
 html[color-scheme-override="dark"] footer {
   border-top-color: #21262d;

--- a/tools/gen-docs/src/style/light.css
+++ b/tools/gen-docs/src/style/light.css
@@ -48,6 +48,16 @@ code {
 pre code {
   background: none;
 }
+/* File-tree connectors. The drawing spans paint their glyphs transparent
+   (so the text still copies), so `currentColor` would be invisible — set
+   the segment colour to match body text instead. */
+.ft-pipe::before,
+.ft-tee::before,
+.ft-ell::before,
+.ft-tee::after,
+.ft-ell::after {
+  background: #1f2328;
+}
 footer {
   border-top-color: #eaeef2;
   color: #57606a;


### PR DESCRIPTION
File-tree diagrams in the rule catalogue rendered with gaps between rows on the gh-pages site, breaking the box-drawing connectors (`│ └ ├`) into disjoint segments.

No single CSS `line-height` fixes this across fonts: whether the box-drawing glyphs tile top-to-bottom depends on the font (≈1em on plain monospaces, larger on terminal/Nerd fonts that pad their line metrics), so any value that touches on one font gaps or overlaps on another. So the connectors are drawn with CSS instead — while the original ASCII stays in the DOM so the block still copies, selects, and reads as authored.

## Changes

- **`src/rules/flat_module_pattern.rs`** — retag both file-tree fences from ` ```text ` to ` ```ascii-file-tree `, so gen-docs can recognise them.
- **`tools/gen-docs/src/render/file_tree.rs`** (new, with tests) — renders an `ascii-file-tree` block as a `<pre>` holding the verbatim diagram text; each box-drawing prefix group (`│   `, `    `, `├── `, `└── `) is wrapped in an inline-block span for the CSS to draw over, and the prefix is matched as exact four-column tokens so a malformed diagram renders literally rather than hiding characters. Tests assert the rendered text round-trips to the original ASCII.
- **`tools/gen-docs/src/render/markdown.rs`** — route `ascii-file-tree` fences to the new renderer.
- **`tools/gen-docs/src/style/base.css`** — `.file-tree` rules: the prefix glyphs are painted transparent (kept in the text for copy/selection/AT) and each connector's vertical/horizontal segments are drawn as thin absolutely-positioned `::before`/`::after` pseudo-elements spanning the full line-box height, so consecutive lines' verticals always meet — independent of font and line-height. `::selection` rules keep the glyphs transparent while selected (so selection doesn't reveal the raw glyphs over the connectors) and restore the highlight background with the `Highlight` system colour, so the selected diagram reads as one uniform blue block.
- **`tools/gen-docs/src/style/light.css` / `dark.css`** — connector colour (it can't be `currentColor`, which would resolve to the transparent glyph colour), matching body text in each theme.
- **`rules/flat_module_pattern.md`** — regenerated to stay in sync (the in-repo catalogue keeps the plain ASCII, rendered by GitHub — out of scope).

## Verification

- `just all` passes (fmt, build, doc, lint, test, self-lint).
- Headless Chromium over the generated site (served from `localhost`, light and dark): selecting a diagram copies back the exact original ASCII (box-drawing glyphs and indentation intact); the glyphs stay hidden during selection while the highlight covers the whole diagram uniformly (`Highlight` matches the names' default selection blue, pixel-for-pixel, in both themes); the connectors join top-to-bottom with comfortable spacing; and forcing an extreme `line-height: 3` (simulating an inflated Nerd-Font line box) keeps them joined, confirming the rendering no longer depends on the font.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/224>.