### PR TITLE
feat(pages): buttons to expand and collapse all configuration sections

### DIFF
--- a/tools/gen-docs/src/config_toggle.js
+++ b/tools/gen-docs/src/config_toggle.js
@@ -46,13 +46,18 @@
   var collapseButton = section.querySelector('button[data-config-open="false"]');
   if (!expandButton || !collapseButton) return;
 
+  // The Configuration panels. A generated catalogue is static after render
+  // (nothing adds or removes panels at runtime), so query once and reuse the
+  // NodeList everywhere rather than re-scanning the DOM per call — the same
+  // cache-the-query approach theme_toggle.js takes with its radios.
+  var panels = document.querySelectorAll("details.config-details");
+
   // Nothing to toggle means nothing to reveal: a catalogue with no
   // configurable rule renders no `details.config-details`, so leaving the
   // section hidden avoids two buttons that would silently do nothing.
-  if (document.querySelectorAll("details.config-details").length === 0) return;
+  if (panels.length === 0) return;
 
   function setAllOpen(open) {
-    var panels = document.querySelectorAll("details.config-details");
     for (var i = 0; i < panels.length; i++) {
       panels[i].open = open;
     }
@@ -63,7 +68,6 @@
   // they can't both be true once there's at least one panel, and both are
   // false in a mixed state, so neither button highlights then.
   function reflectState() {
-    var panels = document.querySelectorAll("details.config-details");
     var allOpen = true;
     var allClosed = true;
     for (var i = 0; i < panels.length; i++) {
@@ -72,6 +76,9 @@
       } else {
         allOpen = false;
       }
+      // Mixed state is terminal: neither flag can flip back to true, so the
+      // remaining panels can't change the outcome. Stop scanning them.
+      if (!allOpen && !allClosed) break;
     }
     expandButton.setAttribute("aria-pressed", String(allOpen));
     collapseButton.setAttribute("aria-pressed", String(allClosed));
@@ -101,6 +108,9 @@
   // One capturing listener for the non-bubbling `toggle` event, filtered to
   // the Configuration panels so unrelated <details> (if any are ever added)
   // don't drive the recompute.
+  // No trailing comma after the final argument: a trailing comma in a
+  // function CALL is ES2017 and a parse error in older engines this page
+  // still aims to support, which would take the whole script down.
   document.addEventListener(
     "toggle",
     function (event) {
@@ -109,15 +119,23 @@
         scheduleReflect();
       }
     },
-    true,
+    true
   );
-
-  // Everything is wired up; reveal the section so the buttons appear exactly
-  // when they work.
-  section.hidden = false;
 
   // Phase 1: a non-blocking initial pass so the buttons reflect whatever
   // state the page loads in (all collapsed by default, but the browser may
   // restore open panels via bfcache or open one for a fragment target).
+  //
+  // Run it BEFORE revealing the section. scheduleReflect() is the only line
+  // here that touches requestAnimationFrame, so if that API is missing the
+  // script throws at this point — leaving the section hidden rather than
+  // revealing controls whose state-reflection can never run. That mirrors
+  // the "reveal only once functional" contract the nav and theme toggles
+  // follow (reveal is the last thing that happens, never before a still-
+  // unproven dependency).
   scheduleReflect();
+
+  // Everything is wired up and the initial pass is queued; reveal the section
+  // so the buttons appear exactly when they work.
+  section.hidden = false;
 })();

--- a/tools/gen-docs/src/config_toggle.js
+++ b/tools/gen-docs/src/config_toggle.js
@@ -1,0 +1,58 @@
+// ============================================================================
+// Configuration "Expand all" / "Collapse all" controls.
+//
+// The Settings panel's Configuration section holds two buttons that open or
+// close every rule's Configuration <details> (details.config-details) at
+// once. Toggling every <details> from one control has no pure-CSS
+// expression, so this is the only part of the Settings panel that genuinely
+// needs script.
+//
+// The Rust template (see config_controls() in render.rs) emits the whole
+// section with the HTML `hidden` attribute; this file reveals it only after
+// the click handlers are wired up — the same "reveal once functional"
+// contract the gear and hamburger follow (the
+// `[hidden] { display: none !important }` reset in style/base.css keeps
+// `hidden` authoritative against the section's own `display`). A browser too
+// old for the APIs used throws before the reveal line, so the section stays
+// hidden rather than showing two dead buttons. Hiding the whole <fieldset>
+// (not just the buttons) also keeps the "Configuration" legend from showing
+// alone above an empty row.
+//
+// Kept separate from theme_toggle.js so the two Settings sections degrade
+// independently: a failure in one script leaves its controls hidden without
+// taking the other's down.
+//
+// The buttons are stateless — they set or clear `open` and don't track or
+// reflect the current open/closed mix. A stateless pair is the simplest cut
+// and matches what the catalogue needs.
+// ============================================================================
+
+(function () {
+  var section = document.querySelector(".config-controls");
+  if (!section) return;
+
+  var buttons = section.querySelectorAll("button[data-config-open]");
+  if (buttons.length === 0) return;
+
+  // Nothing to toggle means nothing to reveal: a catalogue with no
+  // configurable rule renders no `details.config-details`, so leaving the
+  // section hidden avoids two buttons that would silently do nothing.
+  if (document.querySelectorAll("details.config-details").length === 0) return;
+
+  function setAllOpen(open) {
+    var panels = document.querySelectorAll("details.config-details");
+    for (var i = 0; i < panels.length; i++) {
+      panels[i].open = open;
+    }
+  }
+
+  for (var i = 0; i < buttons.length; i++) {
+    buttons[i].addEventListener("click", function (event) {
+      setAllOpen(event.currentTarget.getAttribute("data-config-open") === "true");
+    });
+  }
+
+  // Everything is wired up; reveal the section so the buttons appear exactly
+  // when they work.
+  section.hidden = false;
+})();

--- a/tools/gen-docs/src/config_toggle.js
+++ b/tools/gen-docs/src/config_toggle.js
@@ -22,17 +22,29 @@
 // independently: a failure in one script leaves its controls hidden without
 // taking the other's down.
 //
-// The buttons are stateless — they set or clear `open` and don't track or
-// reflect the current open/closed mix. A stateless pair is the simplest cut
-// and matches what the catalogue needs.
+// The buttons also reflect state: "Expand all" is highlighted while every
+// panel is open, "Collapse all" while every panel is closed, neither in a
+// mixed state. The highlight rides on `aria-pressed` — both the
+// accessibility signal (the pair become toggle buttons) and the CSS hook the
+// colour layer keys off. State is kept live by listening for the <details>
+// `toggle` event, which the browser fires whenever a panel's open state
+// changes (user click, the bulk buttons here, or find-in-page auto-expand).
+//
+// `toggle` does not bubble, so a single CAPTURING listener on the document
+// covers every panel — the capture phase reaches non-bubbling events from
+// descendants. And because the browser fires one (asynchronous, per-element)
+// `toggle` event per panel, a bulk action over N panels fires N events;
+// rather than recompute N times, each event just requests a single recompute
+// on the next animation frame, coalescing the burst into one pass.
 // ============================================================================
 
 (function () {
   var section = document.querySelector(".config-controls");
   if (!section) return;
 
-  var buttons = section.querySelectorAll("button[data-config-open]");
-  if (buttons.length === 0) return;
+  var expandButton = section.querySelector('button[data-config-open="true"]');
+  var collapseButton = section.querySelector('button[data-config-open="false"]');
+  if (!expandButton || !collapseButton) return;
 
   // Nothing to toggle means nothing to reveal: a catalogue with no
   // configurable rule renders no `details.config-details`, so leaving the
@@ -46,13 +58,66 @@
     }
   }
 
-  for (var i = 0; i < buttons.length; i++) {
-    buttons[i].addEventListener("click", function (event) {
-      setAllOpen(event.currentTarget.getAttribute("data-config-open") === "true");
-    });
+  // Reflect the current open/closed mix onto the two buttons. A single pass
+  // tracks whether every panel is open and whether every panel is closed —
+  // they can't both be true once there's at least one panel, and both are
+  // false in a mixed state, so neither button highlights then.
+  function reflectState() {
+    var panels = document.querySelectorAll("details.config-details");
+    var allOpen = true;
+    var allClosed = true;
+    for (var i = 0; i < panels.length; i++) {
+      if (panels[i].open) {
+        allClosed = false;
+      } else {
+        allOpen = false;
+      }
+    }
+    expandButton.setAttribute("aria-pressed", String(allOpen));
+    collapseButton.setAttribute("aria-pressed", String(allClosed));
   }
+
+  // Coalesce a burst of `toggle` events into one recompute per frame: the
+  // first event in a frame queues the pass, the rest are no-ops until it
+  // runs. This keeps "Expand all" / "Collapse all" — which fire one event
+  // per panel — at a single pass instead of one per panel.
+  var frame = 0;
+  function runReflect() {
+    frame = 0;
+    reflectState();
+  }
+  function scheduleReflect() {
+    if (frame) return;
+    frame = window.requestAnimationFrame(runReflect);
+  }
+
+  expandButton.addEventListener("click", function () {
+    setAllOpen(true);
+  });
+  collapseButton.addEventListener("click", function () {
+    setAllOpen(false);
+  });
+
+  // One capturing listener for the non-bubbling `toggle` event, filtered to
+  // the Configuration panels so unrelated <details> (if any are ever added)
+  // don't drive the recompute.
+  document.addEventListener(
+    "toggle",
+    function (event) {
+      var target = event.target;
+      if (target instanceof Element && target.matches("details.config-details")) {
+        scheduleReflect();
+      }
+    },
+    true,
+  );
 
   // Everything is wired up; reveal the section so the buttons appear exactly
   // when they work.
   section.hidden = false;
+
+  // Phase 1: a non-blocking initial pass so the buttons reflect whatever
+  // state the page loads in (all collapsed by default, but the browser may
+  // restore open panels via bfcache or open one for a fragment target).
+  scheduleReflect();
 })();

--- a/tools/gen-docs/src/main.rs
+++ b/tools/gen-docs/src/main.rs
@@ -45,9 +45,10 @@ use crate::extract::collect_rules;
 use crate::model::{RenderContext, Rule};
 use crate::render::markdown::HIGHLIGHT_CSS;
 use crate::render::{
-    HIGHLIGHT_CSS_DARK_FILENAME, HIGHLIGHT_CSS_LIGHT_FILENAME, NAV_TOGGLE_SCRIPT,
-    NAV_TOGGLE_SCRIPT_FILENAME, RULE_ANCHOR_ICON, RULE_ANCHOR_ICON_FILENAME, STYLESHEETS,
-    THEME_ICONS, THEME_TOGGLE_SCRIPT, THEME_TOGGLE_SCRIPT_FILENAME, render_page,
+    CONFIG_TOGGLE_SCRIPT, CONFIG_TOGGLE_SCRIPT_FILENAME, HIGHLIGHT_CSS_DARK_FILENAME,
+    HIGHLIGHT_CSS_LIGHT_FILENAME, NAV_TOGGLE_SCRIPT, NAV_TOGGLE_SCRIPT_FILENAME, RULE_ANCHOR_ICON,
+    RULE_ANCHOR_ICON_FILENAME, STYLESHEETS, THEME_ICONS, THEME_TOGGLE_SCRIPT,
+    THEME_TOGGLE_SCRIPT_FILENAME, render_page,
 };
 
 #[derive(Parser)]
@@ -203,6 +204,11 @@ fn run_html(root: &Path, out_dir: &Path, git_ref: &str) -> ExitCode {
         THEME_TOGGLE_SCRIPT,
     )
     .expect("failed to write theme script");
+    fs::write(
+        out_dir.join(CONFIG_TOGGLE_SCRIPT_FILENAME),
+        CONFIG_TOGGLE_SCRIPT,
+    )
+    .expect("failed to write config-toggle script");
 
     // Lands beside index.html so the stylesheet's relative `url(...)`
     // resolves.

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -214,8 +214,11 @@ fn settings_panel() -> Markup {
 /// unconditional). Hiding the section, rather than just the two
 /// buttons, also keeps the "Configuration" legend from showing alone
 /// above an empty row when the script never runs. The `data-config-open`
-/// attribute carries which action each button performs, so the script
-/// needs no per-button branching.
+/// attribute selects each button; the script also reflects the page's
+/// open/closed mix back onto them via `aria-pressed` (highlighting
+/// "Expand all" when every panel is open, "Collapse all" when every
+/// panel is closed), so they carry no `aria-pressed` until the script
+/// turns them into toggle buttons.
 fn config_controls() -> Markup {
     html! {
         fieldset.settings-section.config-controls hidden {

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -63,6 +63,17 @@ pub(crate) const THEME_TOGGLE_SCRIPT: &str = include_str!("theme_toggle.js");
 /// `<script src>` references the same name, so they must agree.
 pub(crate) const THEME_TOGGLE_SCRIPT_FILENAME: &str = "theme_toggle.js";
 
+/// The Configuration "Expand all" / "Collapse all" script, written
+/// beside `index.html` and loaded via `<script src>` rather than
+/// inlined. Kept separate from [`THEME_TOGGLE_SCRIPT`] so the two
+/// Settings sections degrade independently: if one script fails to
+/// run, its controls stay hidden while the other's keep working.
+pub(crate) const CONFIG_TOGGLE_SCRIPT: &str = include_str!("config_toggle.js");
+
+/// File name [`CONFIG_TOGGLE_SCRIPT`] is written under; the page's
+/// `<script src>` references the same name, so they must agree.
+pub(crate) const CONFIG_TOGGLE_SCRIPT_FILENAME: &str = "config_toggle.js";
+
 /// The colour-scheme icons (Octicons, MIT), shipped beside `index.html`
 /// and referenced from settings.css. Each tuple is `(filename, contents)`.
 pub(crate) const THEME_ICONS: &[(&str, &str)] = &[
@@ -149,6 +160,7 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
                 }
                 script src=(NAV_TOGGLE_SCRIPT_FILENAME) {}
                 script src=(THEME_TOGGLE_SCRIPT_FILENAME) {}
+                script src=(CONFIG_TOGGLE_SCRIPT_FILENAME) {}
             }
         }
     };
@@ -161,9 +173,10 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
 /// revealed by `theme_toggle.js` only once its handlers are wired up, so
 /// a page whose script never runs shows neither a dead gear nor an
 /// orphan panel (the `[hidden]` reset in base.css makes that
-/// unconditional). The panel holds a single "Theme" section for now —
-/// three radios (Light / Dark / System) styled as icon tiles, with
-/// System the default — but is shaped to gain further sections later.
+/// unconditional). The panel holds two sections: "Theme" — three
+/// radios (Light / Dark / System) styled as icon tiles, with System
+/// the default — and "Configuration", the two bulk-toggle buttons
+/// (see [`config_controls`]). It is shaped to gain further sections.
 fn settings_panel() -> Markup {
     html! {
         button.settings-toggle
@@ -182,6 +195,34 @@ fn settings_panel() -> Markup {
                     (theme_option("dark", "color-scheme-dark", "Dark", false))
                     (theme_option("system", "color-scheme-system", "System", true))
                 }
+            }
+            (config_controls())
+        }
+    }
+}
+
+/// The "Configuration" Settings section: a pair of stateless buttons
+/// that open ("Expand all") or close ("Collapse all") every rule's
+/// Configuration `<details>` (`details.config-details`) at once.
+/// Toggling every `<details>` from one control has no pure-CSS
+/// expression, so the buttons are driven by `config_toggle.js`.
+///
+/// The whole `<fieldset>` is emitted with the HTML `hidden` attribute
+/// and revealed by that script only once its click handlers are wired
+/// up — the same "reveal only when functional" contract the gear and
+/// hamburger follow (the `[hidden]` reset in base.css makes it
+/// unconditional). Hiding the section, rather than just the two
+/// buttons, also keeps the "Configuration" legend from showing alone
+/// above an empty row when the script never runs. The `data-config-open`
+/// attribute carries which action each button performs, so the script
+/// needs no per-button branching.
+fn config_controls() -> Markup {
+    html! {
+        fieldset.settings-section.config-controls hidden {
+            legend { "Configuration" }
+            div.config-actions {
+                button.config-action type="button" data-config-open="true" { "Expand all" }
+                button.config-action type="button" data-config-open="false" { "Collapse all" }
             }
         }
     }

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -416,8 +416,11 @@ fn config_toggle_script_reflects_state_onto_buttons() {
     );
     // The highlight colours live in the colour layer (light.css / dark.css),
     // not the structural settings.css — same split as the theme tiles'
-    // checked highlight.
+    // checked highlight. Both layers must carry the rule, or the highlight
+    // silently vanishes in one theme; pin each so the dark variant can't be
+    // dropped while the light one keeps the test green.
     assert!(stylesheet("light.css").contains(r#".config-action[aria-pressed="true"]"#));
+    assert!(stylesheet("dark.css").contains(r#".config-action[aria-pressed="true"]"#));
 }
 
 #[test]

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -396,6 +396,31 @@ fn page_links_config_toggle_script_externally() {
 }
 
 #[test]
+fn config_toggle_script_reflects_state_onto_buttons() {
+    // The buttons highlight when every panel shares one state. That state
+    // is reflected onto `aria-pressed` (the CSS hook the colour layer keys
+    // off) and kept live by listening for the <details> `toggle` event in
+    // the capture phase (it doesn't bubble) and coalescing a burst of them
+    // into one recompute per animation frame.
+    assert!(
+        CONFIG_TOGGLE_SCRIPT.contains("aria-pressed"),
+        "the script must reflect state onto aria-pressed",
+    );
+    assert!(
+        CONFIG_TOGGLE_SCRIPT.contains(r#""toggle""#),
+        "the script must listen for the <details> toggle event",
+    );
+    assert!(
+        CONFIG_TOGGLE_SCRIPT.contains("requestAnimationFrame"),
+        "the script must coalesce toggle bursts via requestAnimationFrame",
+    );
+    // The highlight colours live in the colour layer (light.css / dark.css),
+    // not the structural settings.css — same split as the theme tiles'
+    // checked highlight.
+    assert!(stylesheet("light.css").contains(r#".config-action[aria-pressed="true"]"#));
+}
+
+#[test]
 fn config_toggle_script_is_a_single_iife() {
     // Same structural sanity check as `nav_toggle_script_is_a_single_iife`:
     // the whole file is one IIFE so a stray block after the closer can't

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -348,6 +348,63 @@ fn page_links_theme_toggle_script_externally() {
 }
 
 #[test]
+fn page_emits_config_controls_section_hidden_with_two_buttons() {
+    let html = render_page(&[fake_rule("alpha")], &fake_context());
+    // The Configuration section is a <fieldset> emitted with the HTML
+    // `hidden` attribute: config_toggle.js reveals it only once its
+    // click handlers are wired up, so a page whose script never runs
+    // shows neither dead buttons nor an orphan "Configuration" legend.
+    // Anchor to the opening tag so a refactor that drops `hidden`
+    // (or hides only the buttons, leaving the legend) is caught.
+    assert!(
+        html.contains(r#"<fieldset class="settings-section config-controls" hidden>"#),
+        "the Configuration section must be a `hidden` <fieldset>",
+    );
+    assert!(html.contains("<legend>Configuration</legend>"));
+    // Two stateless buttons. `data-config-open` carries the action so
+    // the script needs no per-button branching; pin both values.
+    assert!(
+        html.contains(
+            r#"<button class="config-action" type="button" data-config-open="true">Expand all</button>"#
+        ),
+        "expected an `Expand all` button carrying data-config-open=true",
+    );
+    assert!(
+        html.contains(
+            r#"<button class="config-action" type="button" data-config-open="false">Collapse all</button>"#
+        ),
+        "expected a `Collapse all` button carrying data-config-open=false",
+    );
+}
+
+#[test]
+fn page_links_config_toggle_script_externally() {
+    let html = render_page(&[fake_rule("only")], &fake_context());
+    // The config-toggle script ships as a sibling file loaded via
+    // `<script src>`, not inlined — same contract as the nav and theme
+    // scripts.
+    assert!(
+        html.contains(&format!(
+            "<script src=\"{CONFIG_TOGGLE_SCRIPT_FILENAME}\"></script>"
+        )),
+        "expected the config-toggle script to be referenced via <script src>",
+    );
+    assert!(
+        !html.contains("<script>(function () {"),
+        "the config-toggle script must not be inlined into the page",
+    );
+}
+
+#[test]
+fn config_toggle_script_is_a_single_iife() {
+    // Same structural sanity check as `nav_toggle_script_is_a_single_iife`:
+    // the whole file is one IIFE so a stray block after the closer can't
+    // reference a `var` that's already out of scope.
+    assert_eq!(CONFIG_TOGGLE_SCRIPT.matches("(function () {").count(), 1);
+    assert_eq!(CONFIG_TOGGLE_SCRIPT.matches("})();").count(), 1);
+}
+
+#[test]
 fn settings_css_keeps_theme_radios_visually_hidden() {
     // The radios stay in the DOM (for semantics) but must be visually
     // removed; the visible control is the adjacent label. Pin the

--- a/tools/gen-docs/src/style/dark.css
+++ b/tools/gen-docs/src/style/dark.css
@@ -208,6 +208,17 @@
   html:not([color-scheme-override="light"]) .theme-radio:focus-visible + .theme-option {
     outline-color: #4493f8;
   }
+  html:not([color-scheme-override="light"]) .config-action {
+    border-color: #30363d;
+    color: #e6edf3;
+    background: #0d1117;
+  }
+  html:not([color-scheme-override="light"]) .config-action:hover {
+    background: #161b22;
+  }
+  html:not([color-scheme-override="light"]) .config-action:focus-visible {
+    outline-color: #4493f8;
+  }
 }
 
 html[color-scheme-override="dark"] {
@@ -396,6 +407,17 @@ html[color-scheme-override="dark"] .theme-radio:checked + .theme-option {
   background: rgba(56, 139, 253, 0.15);
 }
 html[color-scheme-override="dark"] .theme-radio:focus-visible + .theme-option {
+  outline-color: #4493f8;
+}
+html[color-scheme-override="dark"] .config-action {
+  border-color: #30363d;
+  color: #e6edf3;
+  background: #0d1117;
+}
+html[color-scheme-override="dark"] .config-action:hover {
+  background: #161b22;
+}
+html[color-scheme-override="dark"] .config-action:focus-visible {
   outline-color: #4493f8;
 }
 

--- a/tools/gen-docs/src/style/dark.css
+++ b/tools/gen-docs/src/style/dark.css
@@ -219,6 +219,11 @@
   html:not([color-scheme-override="light"]) .config-action:focus-visible {
     outline-color: #4493f8;
   }
+  html:not([color-scheme-override="light"]) .config-action[aria-pressed="true"] {
+    color: #4493f8;
+    border-color: #4493f8;
+    background: rgba(56, 139, 253, 0.15);
+  }
 }
 
 html[color-scheme-override="dark"] {
@@ -419,6 +424,11 @@ html[color-scheme-override="dark"] .config-action:hover {
 }
 html[color-scheme-override="dark"] .config-action:focus-visible {
   outline-color: #4493f8;
+}
+html[color-scheme-override="dark"] .config-action[aria-pressed="true"] {
+  color: #4493f8;
+  border-color: #4493f8;
+  background: rgba(56, 139, 253, 0.15);
 }
 
 /* The sidebar shadow only applies in the overlay band (601-1099.98px),

--- a/tools/gen-docs/src/style/light.css
+++ b/tools/gen-docs/src/style/light.css
@@ -233,3 +233,8 @@ div.custom-type dl.config {
 .config-action:focus-visible {
   outline-color: #0969da;
 }
+.config-action[aria-pressed="true"] {
+  color: #0969da;
+  border-color: #0969da;
+  background: #ddf4ff;
+}

--- a/tools/gen-docs/src/style/light.css
+++ b/tools/gen-docs/src/style/light.css
@@ -222,3 +222,14 @@ div.custom-type dl.config {
 .theme-radio:focus-visible + .theme-option {
   outline-color: #0969da;
 }
+.config-action {
+  border-color: #d0d7de;
+  color: #1f2328;
+  background: #ffffff;
+}
+.config-action:hover {
+  background: #f6f8fa;
+}
+.config-action:focus-visible {
+  outline-color: #0969da;
+}

--- a/tools/gen-docs/src/style/settings.css
+++ b/tools/gen-docs/src/style/settings.css
@@ -73,12 +73,19 @@
   font-weight: 600;
 }
 
-/* The theme chooser is a <fieldset> of three radios. Strip the default
-   fieldset chrome so it reads as a plain section. */
+/* Each panel section is a <fieldset> with its chrome stripped so it reads
+   as a plain section. */
 .settings-section {
   border: 0;
   margin: 0;
   padding: 0;
+}
+
+/* Space the second section (Configuration) below the first (Theme). Keyed
+   off the adjacent-sibling combinator so the first section keeps a flush
+   top and any future section inherits the same gap. */
+.settings-section + .settings-section {
+  margin-top: 0.85rem;
 }
 
 .settings-section > legend {
@@ -166,6 +173,37 @@
 
 /* Keyboard focus on the visually-hidden radio surfaces on its label. */
 .theme-radio:focus-visible + .theme-option {
+  outline: 2px solid;
+  outline-offset: 2px;
+}
+
+/* The Configuration section's two bulk-toggle buttons ("Expand all" /
+   "Collapse all") sit in an equal-width row, mirroring the theme tiles.
+   The whole <fieldset class="config-controls"> starts with the HTML
+   `hidden` attribute and is revealed by config_toggle.js only once its
+   click handlers are wired up, so a page whose script never runs shows
+   neither dead buttons nor an orphan "Configuration" legend (the
+   `[hidden]` reset in base.css makes that unconditional). Structural
+   rules only; the colours live in light.css / dark.css. */
+.config-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.config-action {
+  flex: 1;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.config-action:focus-visible {
   outline: 2px solid;
   outline-offset: 2px;
 }


### PR DESCRIPTION
Adds a **Configuration** section to the Settings panel with two buttons — **Expand all** and **Collapse all** — that open or close every rule's Configuration `<details>` (`details.config-details`) at once.

## How it works

- Toggling every `<details>` from one control has no pure-CSS expression, so the buttons are driven by a new sibling script, `config_toggle.js`, kept separate from `theme_toggle.js` so the two Settings sections degrade independently.
- The whole `<fieldset>` is emitted with the HTML `hidden` attribute and revealed by the script only once its click handlers are wired up — so a page whose script never runs shows neither dead buttons nor an orphan "Configuration" legend.
- **The active button is highlighted:** "Expand all" while every panel is open, "Collapse all" while every panel is closed, neither in a mixed state. The highlight rides on `aria-pressed` (the accessibility signal + the CSS hook) and reuses the theme tiles' checked-accent colours.
- State stays live via a single **capturing** listener for the non-bubbling `<details>` `toggle` event. A bulk action fires one event per panel; rather than recompute per event, each just requests one recompute on the next animation frame, coalescing the burst into a single pass.

## Changes (`tools/gen-docs/`)

- `src/render.rs` — `config_controls()` renders the section in `settings_panel()`; new script constants + `<script src>` tag.
- `src/config_toggle.js` — the behaviour script (single IIFE): bulk toggle, `aria-pressed` reflection, rAF-coalesced `toggle` listener.
- `src/main.rs` — writes the script to the output directory.
- `src/style/settings.css` — structural styling; `light.css` / `dark.css` — button + `aria-pressed` highlight colours across all theme tiers.
- `src/render/tests.rs` — tests for the hidden section, the external script link, the single-IIFE shape, and the state-reflection wiring.

`just all` passes (including `self-lint`). Verified in headless Chromium across light/dark: Expand/Collapse toggle all panels, and the active button highlights correctly for all-open, all-closed, and mixed states.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/221>.