### PR TITLE
docs(plan): normalize example sections to the implemented-rule convention

### DIFF
--- a/planned-rules/cfg-attr-ignore-tests.md
+++ b/planned-rules/cfg-attr-ignore-tests.md
@@ -35,15 +35,19 @@ For every `#[cfg_attr(<pred>, ignore)]` on a `#[test]` item, require the
 
 ## Examples
 
+**Avoid:** skip via cfg, but body uses only cross-platform types
+
 ```rust
-// Bad: skip via cfg, but body uses only cross-platform types
 #[cfg(unix)]
 #[test]
 fn unix_path_logic() {
     assert_eq!(Path::new("/a/b").display().to_string(), "/a/b");
 }
+```
 
-// Good
+**Prefer:**
+
+```rust
 #[test]
 #[cfg_attr(not(unix), ignore = "only one path separator style is tested")]
 fn unix_path_logic() {
@@ -51,8 +55,9 @@ fn unix_path_logic() {
 }
 ```
 
+**Not flagged:** body genuinely cannot compile on non-unix
+
 ```rust
-// Acceptable: body genuinely cannot compile on non-unix
 #[cfg(unix)]
 #[test]
 fn unix_permissions() {

--- a/planned-rules/clap-help-length.md
+++ b/planned-rules/clap-help-length.md
@@ -63,8 +63,9 @@ override keys as the markdown rule.
 
 ## Examples
 
+**Avoid:** about exceeds the line budget
+
 ```rust
-// Bad: about exceeds the line budget
 #[derive(clap::Parser)]
 struct Cli {
     /// Walks the source tree starting at the directory specified by
@@ -72,15 +73,21 @@ struct Cli {
     /// and prints a tabulated summary of each file's size on disk.
     root: PathBuf,
 }
+```
 
-// Good (trimmed)
+**Prefer:** (trimmed)
+
+```rust
 #[derive(clap::Parser)]
 struct Cli {
     /// Root directory to scan.
     root: PathBuf,
 }
+```
 
-// Good (rich docs preserved, help overridden)
+**Prefer:** (rich docs preserved, help overridden)
+
+```rust
 #[derive(clap::Parser)]
 struct Cli {
     /// Walks the source tree starting at the directory specified by

--- a/planned-rules/clap-help-no-markdown.md
+++ b/planned-rules/clap-help-no-markdown.md
@@ -69,8 +69,9 @@ The lint **does not fire** when the same item carries any of:
 
 ## Examples
 
+**Avoid:**
+
 ```rust
-// Bad
 #[derive(clap::Parser)]
 struct Cli {
     /// Path to the [`PackageManifest`].
@@ -78,8 +79,11 @@ struct Cli {
     /// See [the manifest format](https://example.com/manifest).
     manifest: PathBuf,
 }
+```
 
-// Good (override the help text with plain prose)
+**Prefer:** (override the help text with plain prose)
+
+```rust
 #[derive(clap::Parser)]
 struct Cli {
     /// Path to the [`PackageManifest`].
@@ -88,8 +92,11 @@ struct Cli {
     #[arg(help = "Path to the package manifest.")]
     manifest: PathBuf,
 }
+```
 
-// Also good (no markdown in the first place)
+**Prefer:** (no markdown in the first place)
+
+```rust
 #[derive(clap::Parser)]
 struct Cli {
     /// Path to the package manifest.

--- a/planned-rules/commit-id-length.md
+++ b/planned-rules/commit-id-length.md
@@ -125,24 +125,38 @@ A compare URL emits up to two diagnostics, one per SHA.
 
 ## Examples
 
+### Default config (any length 6..=40)
+
+**Not flagged:** every SHA falls within the default window.
+
 ```rust
-// Default config (any length 6..=40): all of these pass.
 /// See <https://github.com/owner/repo/commit/8c1f6e2>.
 /// See <https://github.com/owner/repo/commit/8c1f6e2a6d33c1b1a2f9e0e1d3b8a4c7d6e5f4a3>.
 /// See <https://github.com/owner/repo/compare/abcdef0...feedface>.
+```
 
-// Bad under default 6..=40: SHA shorter than the minimum.
+**Avoid:** a SHA shorter than the minimum.
+
+```rust
 /// See <https://github.com/owner/repo/commit/abc>.
+```
 
-// Under `commit_length_min = 12, commit_length_max = 12`:
-//   the 7-char SHA is flagged; the 40-char SHA is also flagged
-//   because it's longer than 12.
+### Under `commit_length_min = 12, commit_length_max = 12`
+
+The 7-char SHA is flagged; the 40-char SHA is also flagged because
+it's longer than 12.
+
+```rust
 /// See <https://github.com/owner/repo/commit/8c1f6e2>.            // bad
 /// See <https://github.com/owner/repo/commit/8c1f6e2a6d33>.       // good
 /// See <https://github.com/owner/repo/commit/8c1f6e2a6d33c1...>.  // bad
+```
 
-// Under `commit_length_min = 40, commit_length_max = 40`:
-//   only full SHAs accepted.
+### Under `commit_length_min = 40, commit_length_max = 40`
+
+Only full SHAs accepted.
+
+```rust
 /// See <https://github.com/owner/repo/blob/8c1f6e2/file.rs>.      // bad
 ```
 

--- a/planned-rules/core-or-std.md
+++ b/planned-rules/core-or-std.md
@@ -52,12 +52,16 @@ Optional knobs:
 Flag any path whose written first segment is `std` but whose resolved
 `DefId` belongs to the `core` or `alloc` crate.
 
+**Avoid:**
+
 ```rust
-// Bad (under style = "prefer_core")
 use std::fmt::Display;
 use std::collections::HashMap;   // re-exported from `alloc::collections`
+```
 
-// Good
+**Prefer:**
+
+```rust
 use core::fmt::Display;
 use alloc::collections::BTreeMap;
 ```
@@ -71,12 +75,16 @@ under any style — there is no narrower path to suggest.
 Flag any path whose written first segment is `core` or `alloc` and
 suggest the matching `std::` path.
 
+**Avoid:**
+
 ```rust
-// Bad (under style = "prefer_std")
 use core::fmt::Display;
 use alloc::sync::Arc;
+```
 
-// Good
+**Prefer:**
+
+```rust
 use std::fmt::Display;
 use std::sync::Arc;
 ```

--- a/planned-rules/derive-more-inlined-args.md
+++ b/planned-rules/derive-more-inlined-args.md
@@ -11,15 +11,19 @@ rule fills that gap.
 In a `#[display("format string", arg, arg, ...)]` (or any other
 `derive_more` attribute that accepts `format!`-shaped arguments — see
 *Scope* below), prefer the *inlined* form when an argument is a
-simple identifier:
+simple identifier.
+
+**Avoid:**
 
 ```rust
-// Bad
 #[derive(Display)]
 #[display("({}, {})", x, y)]
 struct Point { x: i32, y: i32 }
+```
 
-// Good
+**Prefer:**
+
+```rust
 #[derive(Display)]
 #[display("({x}, {y})")]
 struct Point { x: i32, y: i32 }
@@ -74,25 +78,59 @@ suggestion preserves the spec: `{:>5}` paired with `name` becomes
 
 ## Examples
 
+### Simple-ident args
+
+**Avoid:**
+
 ```rust
-// Bad: simple-ident args
 #[display("({}, {})", x, y)]
-// Good
+```
+
+**Prefer:**
+
+```rust
 #[display("({x}, {y})")]
+```
 
-// Bad: positional placeholders with positional args
+### Positional placeholders with positional args
+
+**Avoid:**
+
+```rust
 #[display("({}, {})", _0, _1)]
-// Good
+```
+
+**Prefer:**
+
+```rust
 #[display("({_0}, {_1})")]
+```
 
-// Mixed: only the inlinable arg is rewritten
+### Mixed: only the inlinable arg is rewritten
+
+**Avoid:**
+
+```rust
 #[display("{} (line {})", file, self.line_number())]
-// Good
-#[display("{file} (line {})", self.line_number())]
+```
 
-// Format spec preserved
+**Prefer:**
+
+```rust
+#[display("{file} (line {})", self.line_number())]
+```
+
+### Format spec preserved
+
+**Avoid:**
+
+```rust
 #[display("[{:>5}]", code)]
-// Good
+```
+
+**Prefer:**
+
+```rust
 #[display("[{code:>5}]")]
 ```
 

--- a/planned-rules/derive-more-template-wrap.md
+++ b/planned-rules/derive-more-template-wrap.md
@@ -11,7 +11,9 @@ attribute-form templates.
 
 A `derive_more` `#[display(...)]` or `#[debug(...)]` attribute
 whose source line exceeds the configured width is hard to read
-and produces a noisy diff:
+and produces a noisy diff.
+
+**Avoid:**
 
 ```rust
 #[display("error: The error was caused by {_0}\nhint: Run {_1} to solve the problem")]
@@ -22,7 +24,9 @@ The attribute is consumed by a derive macro, so splitting into
 multiple attributes is not viable — `derive_more` reads exactly
 one `#[display(...)]` per item. The only applicable rewrite is
 folding the template across multiple source lines with
-`\<newline>` continuations:
+`\<newline>` continuations.
+
+**Prefer:**
 
 ```rust
 #[display(
@@ -64,12 +68,18 @@ For every recognised attribute on a struct, enum, or variant:
 
 ## Examples
 
+### `#[display(...)]`
+
+**Avoid:** a long source line in a `#[display(...)]` attribute.
+
 ```rust
-// Bad: long source line in a #[display(...)] attribute
 #[display("error: The error was caused by {_0}\nhint: Run {_1} to solve the problem")]
 struct UserMessage(String, String);
+```
 
-// Good
+**Prefer:**
+
+```rust
 #[display(
     "error: The error was caused by {_0}\n\
     hint: Run {_1} to solve the problem"
@@ -77,12 +87,18 @@ struct UserMessage(String, String);
 struct UserMessage(String, String);
 ```
 
+### `#[debug(...)]`
+
+**Avoid:** a long `#[debug(...)]` template.
+
 ```rust
-// Bad: long #[debug(...)] template
 #[debug("Token {{ kind: {kind:?}, span: {span:?}, lexeme: {lexeme:?}, source_id: {source_id} }}")]
 struct Token { /* ... */ }
+```
 
-// Good
+**Prefer:**
+
+```rust
 #[debug(
     "Token {{ kind: {kind:?}, span: {span:?}, \
     lexeme: {lexeme:?}, source_id: {source_id} }}"
@@ -90,13 +106,15 @@ struct Token { /* ... */ }
 struct Token { /* ... */ }
 ```
 
+### Skipped cases
+
+**Not flagged:**
+
 ```rust
-// Skipped: short source line
-#[display("err: {code}")]
+#[display("err: {code}")]  // short source line
 struct ErrCode(u32);
 
-// Skipped: not a string literal template
-#[display(fmt = renderer::DEFAULT_TEMPLATE)]
+#[display(fmt = renderer::DEFAULT_TEMPLATE)]  // not a string literal template
 struct Custom;
 ```
 

--- a/planned-rules/em-dash-prose.md
+++ b/planned-rules/em-dash-prose.md
@@ -47,19 +47,33 @@ Do *not* flag em dashes when they appear:
 
 ## Examples
 
+In doc comments:
+
+**Avoid:**
+
 ```rust
-// Bad
 /// Walks the tree — including hidden directories — and returns the
 /// total size.
+```
 
-// Good
+**Prefer:**
+
+```rust
 /// Walks the tree, including hidden directories. Returns the total
 /// size.
+```
 
-// Bad
+In user-facing macro strings:
+
+**Avoid:**
+
+```rust
 println!("Skipping path — {path:?}");
+```
 
-// Good
+**Prefer:**
+
+```rust
 println!("Skipping path: {path:?}");
 ```
 

--- a/planned-rules/error-type-derives.md
+++ b/planned-rules/error-type-derives.md
@@ -159,25 +159,27 @@ a never-used type is rarely what the author wanted.
 
 ## Examples
 
+**Avoid:** `Error` derived but never used as one
+
 ```rust
-// Bad: Error derived but never used as one
 #[derive(Debug, Display, Error)]
 struct ConfigSummaryError(String);
 
 fn main() {
     println!("{}", ConfigSummaryError("hi".into()));
 }
+```
 
-// Good — drop the Error derive; rename to drop the now-misleading
-//        Error suffix (the type isn't an error, even if it once was).
+**Prefer:** drop the `Error` derive; rename to drop the now-misleading `Error` suffix (the type isn't an error, even if it once was).
+
+```rust
 #[derive(Debug, Display)]
 struct ConfigSummary(String);
 ```
 
+**Avoid:** shape and name both signal this is not an error — `copyable_error` fires on `Copy + Error`, and `unconventional_error_name` fires on the missing `Error` suffix.
+
 ```rust
-// Bad: shape and name both signal this is not an error
-//   — `copyable_error` fires on `Copy + Error`
-//   — `unconventional_error_name` fires on the missing `Error` suffix
 #[derive(Debug, Display, Clone, Copy, Error)]
 pub enum ParsedValue {
     #[display("{value}   ")]
@@ -185,8 +187,11 @@ pub enum ParsedValue {
     #[display("{coefficient:.1}{unit}")]
     Big { coefficient: f32, unit: char, scale: u64, exponent: usize },
 }
+```
 
-// Good
+**Prefer:**
+
+```rust
 #[derive(Debug, Display, Clone, Copy)]
 pub enum ParsedValue { /* ... */ }
 ```

--- a/planned-rules/format-macro-wrap.md
+++ b/planned-rules/format-macro-wrap.md
@@ -9,7 +9,9 @@ be turned into multiple calls without changing semantics.
 ## Statement
 
 A `format!`-style macro call whose source line exceeds the
-configured width is hard to read and produces a noisy diff:
+configured width is hard to read and produces a noisy diff.
+
+**Avoid:**
 
 ```rust
 format!("error: The error was caused by {err_src}\nhint: Run {magic_cmd} to solve the problem")
@@ -18,7 +20,9 @@ format!("error: The error was caused by {err_src}\nhint: Run {magic_cmd} to solv
 Unlike `println!`, splitting `format!` into multiple calls would
 change the result type (one `String` becomes two). The only
 applicable rewrite is folding the template across multiple source
-lines with `\<newline>` continuations:
+lines with `\<newline>` continuations.
+
+**Prefer:**
 
 ```rust
 format!(
@@ -70,33 +74,51 @@ For every invocation of a target macro:
 
 ## Examples
 
-```rust
-// Bad: long source line; format! can't be split into multiple calls
-format!("error: The error was caused by {err_src}\nhint: Run {magic_cmd} to solve the problem")
+### `format!`
 
-// Good
+**Avoid:** a long source line; `format!` can't be split into multiple calls.
+
+```rust
+format!("error: The error was caused by {err_src}\nhint: Run {magic_cmd} to solve the problem")
+```
+
+**Prefer:**
+
+```rust
 format!(
     "error: The error was caused by {err_src}\n\
     hint: Run {magic_cmd} to solve the problem",
 )
 ```
 
-```rust
-// Bad: panic! with a long message
-panic!("invariant violated: expected {expected} but got {actual} after {steps} iterations");
+### `panic!`
 
-// Good
+**Avoid:** a `panic!` with a long message.
+
+```rust
+panic!("invariant violated: expected {expected} but got {actual} after {steps} iterations");
+```
+
+**Prefer:**
+
+```rust
 panic!(
     "invariant violated: expected {expected} but got {actual} \
     after {steps} iterations",
 );
 ```
 
-```rust
-// Bad: assert_eq! message is too long
-assert_eq!(actual, expected, "decoder mismatch: stream {stream_id} chunk {chunk_id} produced wrong output");
+### `assert_eq!`
 
-// Good
+**Avoid:** an `assert_eq!` message that is too long.
+
+```rust
+assert_eq!(actual, expected, "decoder mismatch: stream {stream_id} chunk {chunk_id} produced wrong output");
+```
+
+**Prefer:**
+
+```rust
 assert_eq!(
     actual,
     expected,
@@ -105,15 +127,14 @@ assert_eq!(
 );
 ```
 
+### Skipped cases
+
+**Not flagged:**
+
 ```rust
-// Skipped: short source line, even with embedded newline
-format!("a\nb")
-
-// Skipped: not in target_macros (println! is splittable; covered by print-macro-split)
-println!("a\nb {x}")
-
-// Skipped: not in target_macros (write! is splittable)
-write!(f, "a\nb {x}")?;
+format!("a\nb")  // short source line, even with embedded newline
+println!("a\nb {x}")  // not in target_macros (println! is splittable; covered by print-macro-split)
+write!(f, "a\nb {x}")?;  // not in target_macros (write! is splittable)
 ```
 
 ## Configuration

--- a/planned-rules/intra-doc-links.md
+++ b/planned-rules/intra-doc-links.md
@@ -27,12 +27,16 @@ Resolution rules:
 
 ## Examples
 
+**Avoid:**
+
 ```rust
-// Bad
 /// Installs the package described by `PackageManifest` into `Store`.
 pub fn install(manifest: &PackageManifest, store: &Store) { /* ... */ }
+```
 
-// Good
+**Prefer:**
+
+```rust
 /// Installs the package described by [`PackageManifest`] into [`Store`].
 pub fn install(manifest: &PackageManifest, store: &Store) { /* ... */ }
 ```

--- a/planned-rules/lint-downgrade-reason.md
+++ b/planned-rules/lint-downgrade-reason.md
@@ -104,14 +104,22 @@ including `#[warn]` over `#[deny]`.
 
 ## Examples
 
+Under a crate-level `#![deny(clippy::missing_errors_doc)]`:
+
+**Avoid:** downgrades from the crate-level `deny` without a reason
+
 ```rust
 #![deny(clippy::missing_errors_doc)]
 
-// Bad — downgrades from the crate-level `deny` without a reason
 #[warn(clippy::missing_errors_doc)]
 pub fn parse(input: &str) -> Result<Manifest, ParseError> { /* ... */ }
+```
 
-// Good
+**Prefer:**
+
+```rust
+#![deny(clippy::missing_errors_doc)]
+
 #[warn(
     clippy::missing_errors_doc,
     reason = "stub during the parser-rewrite migration; tighten back to deny in #1234",
@@ -119,26 +127,25 @@ pub fn parse(input: &str) -> Result<Manifest, ParseError> { /* ... */ }
 pub fn parse(input: &str) -> Result<Manifest, ParseError> { /* ... */ }
 ```
 
+**Avoid:** relaxed below the crate-level `deny`, but the `reason` is shorter than `min_reason_length`
+
 ```rust
 #![deny(clippy::missing_errors_doc)]
 
-// Bad — relaxed below the crate-level `deny`, but the `reason`
-// is shorter than `min_reason_length`
 #[warn(clippy::missing_errors_doc, reason = "x")]
 pub fn parse(input: &str) -> Result<Manifest, ParseError> { /* ... */ }
 ```
 
+**Not flagged:** `#[deny]` and `#[forbid]` are never flagged — they tighten, not loosen.
+
 ```rust
-// `#[deny]` and `#[forbid]` are never flagged — they tighten,
-// not loosen.
 #[deny(clippy::too_many_arguments)]
 mod hot_path {}
 ```
 
+**Not flagged:** `#[warn]` does not lower the lint below its inherited `warn`, so the attribute is a no-op relative to ambient policy.
+
 ```rust
-// Not flagged — `#[warn]` does not lower the lint below its
-// inherited `warn`, so the attribute is a no-op relative to
-// ambient policy.
 #[warn(clippy::too_many_arguments)]
 fn build(/* ... */) {}
 ```

--- a/planned-rules/macro-argument-binding.md
+++ b/planned-rules/macro-argument-binding.md
@@ -563,55 +563,61 @@ introduces a new name in the enclosing scope.
 
 ### The motivating bug
 
-```rust
-// Bad — release skips `insert` entirely
-debug_assert_eq!(my_map.insert(key, value), None, "duplicate key");
+**Avoid:** release skips `insert` entirely
 
-// Good
+```rust
+debug_assert_eq!(my_map.insert(key, value), None, "duplicate key");
+```
+
+**Prefer:**
+
+```rust
 let ejected = my_map.insert(key, value);
 debug_assert_eq!(ejected, None, "duplicate key");
 ```
 
 ### Pure arguments stay inline
 
+**Not flagged:** `count`, `MAX_RETRIES`, `&buffer` are all pure.
+
 ```rust
-// Accepted — `count`, `MAX_RETRIES`, `&buffer` are all pure.
 debug_assert_eq!(count, MAX_RETRIES, "expected {MAX_RETRIES} retries");
 ```
 
 ### Allowed macros pass through
 
+**Not flagged:** `format!` is in the curated allow set; arguments are evaluated exactly once.
+
 ```rust
-// Accepted — `format!` is in the curated allow set; arguments
-// are evaluated exactly once.
 let msg = format!("retrying {} ({} failures)", endpoint, count.fetch_add(1, Ordering::Relaxed));
 ```
 
 ### Compile-time `core` / `std` macros pass through
 
+**Not flagged:** `concat!`, `env!`, `include_str!`, and the rest of the compile-time family are in the allow set, and their expansion is itself a literal so they also count as pure atoms when used inside another macro. Both rules together make these idioms invisible to the lint.
+
 ```rust
-// Accepted — `concat!`, `env!`, `include_str!`, and the rest of
-// the compile-time family are in the allow set, and their
-// expansion is itself a literal so they also count as pure
-// atoms when used inside another macro. Both rules together
-// make these idioms invisible to the lint:
 let msg = concat!("home: ", env!("HOME"));
 debug_assert_eq!(env!("EXPECTED"), include_str!("expected.txt"));
 ```
 
 ### Array-like invocation is in scope
 
+**Not flagged:** under default config — `vec!` is in the allow set.
+
 ```rust
-// Accepted under default config — `vec!` is in the allow set.
 let xs = vec![compute(), compute(), compute()];
 ```
 
-```rust
-// Flagged under blanket mode — every impure argument is
-// a candidate, allow set or not.
-let xs = vec![compute(), compute(), compute()];
+**Avoid:** under blanket mode — every impure argument is a candidate, allow set or not.
 
-// Good (blanket-mode rewrite)
+```rust
+let xs = vec![compute(), compute(), compute()];
+```
+
+**Prefer:** (blanket-mode rewrite)
+
+```rust
 let a = compute();
 let b = compute();
 let c = compute();
@@ -620,16 +626,23 @@ let xs = vec![a, b, c];
 
 ### Multiple-evaluation trap
 
+Given a macro that expands its capture more than once:
+
 ```rust
 macro_rules! double_use {
     ($e:expr) => { $e + $e };
 }
+```
 
-// Bad — `iter.next()` runs twice. `total` ends up as
-// `current_item + next_item`, not `2 * current_item`.
+**Avoid:** `iter.next()` runs twice. `total` ends up as `current_item + next_item`, not `2 * current_item`.
+
+```rust
 let total = double_use!(iter.next().unwrap());
+```
 
-// Good
+**Prefer:**
+
+```rust
 let v = iter.next().unwrap();
 let total = double_use!(v);
 ```
@@ -639,14 +652,9 @@ the expansion, so the macro fails the exactly-once check.
 
 ### Procedural macros require explicit configuration
 
+**Not flagged:** whether this is safe depends on the proc macro's expansion, which the lint cannot inspect. `serde_json::json` already ships in the built-in allow set (the macro walks its input once and evaluates each captured expression once); a project that uses a *different* proc macro with the same contract adds its path to `allow_extra` once project-wide after confirming each argument is evaluated exactly once.
+
 ```rust
-// Whether this is safe depends on the proc macro's expansion,
-// which the lint cannot inspect. `serde_json::json` already
-// ships in the built-in allow set (the macro walks its input
-// once and evaluates each captured expression once); a project
-// that uses a *different* proc macro with the same contract
-// adds its path to `allow_extra` once project-wide after
-// confirming each argument is evaluated exactly once.
 let payload = serde_json::json!({ "id": next_id(), "ts": now() });
 ```
 

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -295,15 +295,19 @@ revision could shift which arm matches.
 
 ### Name-based: `vec!`
 
+**Avoid:** multi-line, missing trailing comma
+
 ```rust
-// Bad: multi-line, missing trailing comma
 let xs = vec![
     1,
     2,
     3
 ];
+```
 
-// Good
+**Prefer:**
+
+```rust
 let xs = vec![
     1,
     2,
@@ -311,22 +315,29 @@ let xs = vec![
 ];
 ```
 
-```rust
-// Bad: single-line, gratuitous trailing comma
-let xs = vec![1, 2, 3,];
+**Avoid:** single-line, gratuitous trailing comma
 
-// Good
+```rust
+let xs = vec![1, 2, 3,];
+```
+
+**Prefer:**
+
+```rust
 let xs = vec![1, 2, 3];
 ```
 
+**Avoid:** single-argument multi-line invocation, no trailing comma. Matches rustfmt's behaviour for function calls.
+
 ```rust
-// Bad: single-argument multi-line invocation, no trailing
-// comma. Matches rustfmt's behaviour for function calls.
 dbg!(
     expensive_function_call(arg)
 );
+```
 
-// Good
+**Prefer:**
+
+```rust
 dbg!(
     expensive_function_call(arg),
 );
@@ -334,15 +345,19 @@ dbg!(
 
 ### Name-based: `assert_eq!`
 
+**Avoid:** multi-line panic message
+
 ```rust
-// Bad: multi-line panic message
 assert_eq!(
     actual,
     expected,
     "decoder mismatch: stream {stream_id} chunk {chunk_id}"
 );
+```
 
-// Good
+**Prefer:**
+
+```rust
 assert_eq!(
     actual,
     expected,
@@ -352,19 +367,27 @@ assert_eq!(
 
 ### Matcher-based: `macro_rules!` ending in `$(,)?`
 
+Given a macro whose matcher absorbs an optional trailing comma:
+
 ```rust
 macro_rules! comma_list {
     ($($item:expr),* $(,)?) => { /* ... */ };
 }
+```
 
-// Bad: multi-line, missing trailing comma
+**Avoid:** multi-line, missing trailing comma
+
+```rust
 comma_list!(
     a,
     b,
     c
 );
+```
 
-// Good
+**Prefer:**
+
+```rust
 comma_list!(
     a,
     b,
@@ -374,16 +397,15 @@ comma_list!(
 
 ### Skipped: not shaped like a comma-separated list
 
-```rust
-// Skipped: `vec![value; count]` uses `;`, not a list separator.
-// A top-level `;` indicates a different macro form.
-let zeros = vec![0; 10];
+**Not flagged:** `vec![value; count]` uses `;`, not a list separator. A top-level `;` indicates a different macro form.
 
-// Skipped: `quote!` is a token-tree passthrough, not a
-// comma-separated list. It isn't on the curated name-based
-// list, and matcher-based detection's $(,)? / $(,)* predicate
-// doesn't match its grammar — so step 3's eligibility check
-// fails and the lint never reaches the trailing-comma check.
+```rust
+let zeros = vec![0; 10];
+```
+
+**Not flagged:** `quote!` is a token-tree passthrough, not a comma-separated list. It isn't on the curated name-based list, and matcher-based detection's $(,)? / $(,)* predicate doesn't match its grammar — so step 3's eligibility check fails and the lint never reaches the trailing-comma check.
+
+```rust
 quote! {
     fn foo() -> i32 { 42 }
 };
@@ -391,14 +413,17 @@ quote! {
 
 ### Skipped: macro requires the trailing comma
 
+Given a macro whose matcher requires the trailing comma:
+
 ```rust
 macro_rules! always_comma {
     ($($item:expr,)*) => { /* ... */ };
 }
+```
 
-// Skipped: removing the trailing comma here would fail to
-// match. The matcher is `$($item:expr,)*` — every item must
-// be followed by a literal comma, including the last.
+**Not flagged:** removing the trailing comma here would fail to match. The matcher is `$($item:expr,)*` — every item must be followed by a literal comma, including the last.
+
+```rust
 always_comma!(
     a,
     b,
@@ -408,22 +433,17 @@ always_comma!(
 
 ### Skipped: macro with fully-optional commas
 
+Given a matcher with per-item optional commas: every comma in the list is independently optional, so both comma-separated and no-comma styles are valid. `build-fs-tree::dir!` is a real-world example.
+
 ```rust
-// Matcher with per-item optional commas: every comma in the
-// list is independently optional, so both comma-separated and
-// no-comma styles are valid. `build-fs-tree::dir!` is a
-// real-world example.
 macro_rules! dir {
     ($($key:literal => $value:expr $(,)?)*) => { /* ... */ };
 }
+```
 
-// Skipped: the matcher's top-level tail is `)*`, not a
-// top-level `$(,)?`. Matcher-based detection's predicate
-// (`$(,)?` at the tail of the top-level matcher) doesn't
-// match, so the lint correctly leaves the call alone. The
-// macro must also not be added to `extra_macros` — users
-// who write entries without any commas would otherwise get a
-// stray trailing comma against an otherwise comma-free style.
+**Not flagged:** the matcher's top-level tail is `)*`, not a top-level `$(,)?`. Matcher-based detection's predicate (`$(,)?` at the tail of the top-level matcher) doesn't match, so the lint correctly leaves the call alone. The macro must also not be added to `extra_macros` — users who write entries without any commas would otherwise get a stray trailing comma against an otherwise comma-free style.
+
+```rust
 dir! {
     "foo" => file!("a")
     "bar" => file!("b")
@@ -433,10 +453,9 @@ dir! {
 
 ### Skipped: unknown procedural macro
 
+**Not flagged:** `my_proc::custom!` is a procedural macro and is not in the user's `extra_macros` list. The lint cannot inspect a proc-macro grammar.
+
 ```rust
-// Skipped: `my_proc::custom!` is a procedural macro and is
-// not in the user's `extra_macros` list. The lint cannot
-// inspect a proc-macro grammar.
 my_proc::custom!(
     a,
     b,

--- a/planned-rules/module-item-order.md
+++ b/planned-rules/module-item-order.md
@@ -22,8 +22,9 @@ nested deeper (e.g., inside an `impl`) are out of scope.
 
 ## Examples
 
+**Prefer:**
+
 ```rust
-// Good
 pub mod parser;
 pub mod printer;
 
@@ -35,14 +36,16 @@ use std::collections::HashMap;
 fn helper() { /* ... */ }
 ```
 
+**Avoid:** `pub use` precedes `pub mod`
+
 ```rust
-// Bad: pub use precedes pub mod
 pub use parser::Parser;
 pub mod parser;
 ```
 
+**Avoid:** private fn precedes `pub use`
+
 ```rust
-// Bad: private fn precedes pub use
 fn helper() {}
 pub use parser::Parser;
 ```

--- a/planned-rules/named-prelude-import.md
+++ b/planned-rules/named-prelude-import.md
@@ -33,17 +33,24 @@ segment.
 
 ## Examples
 
+**Avoid:**
+
 ```rust
-// Bad
 use serde::prelude::Serialize;
 use serde::prelude::ser::Serialize;
 use diesel::prelude::{table, AsChangeset};
+```
 
-// Good
+**Prefer:**
+
+```rust
 use serde::Serialize;
 use diesel::{table, AsChangeset};
+```
 
-// Allowed (the canonical prelude shape)
+**Not flagged:** the canonical prelude shape.
+
+```rust
 use serde::prelude::*;
 ```
 

--- a/planned-rules/no-star-imports.md
+++ b/planned-rules/no-star-imports.md
@@ -34,45 +34,61 @@ When both exceptions are disabled the lint flags every glob `use`.
 
 ## Examples
 
+**Avoid:**
+
 ```rust
-// Bad
 #[cfg(test)]
 mod tests {
     use super::*;
 }
+```
 
-// Good
+**Prefer:**
+
+```rust
 #[cfg(test)]
 mod tests {
     use super::{ParsedThing, parse_thing};
 }
 ```
 
-```rust
-// Allowed by default (prelude exception)
-use rayon::prelude::*;
+**Not flagged:** the prelude exception.
 
-// Allowed by default (root re-export)
+```rust
+use rayon::prelude::*;
+```
+
+**Not flagged:** the root re-export exception.
+
+```rust
 pub use comver::*;
 ```
 
 When `prelude` is disabled (`exceptions = ["root_reexport"]`):
 
-```rust
-// Bad (under that config)
-use rayon::prelude::*;
+**Avoid:**
 
-// Good
+```rust
+use rayon::prelude::*;
+```
+
+**Prefer:**
+
+```rust
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 ```
 
 When `root_reexport` is disabled (`exceptions = ["prelude"]`):
 
-```rust
-// Bad (under that config)
-pub use comver::*;
+**Avoid:**
 
-// Good
+```rust
+pub use comver::*;
+```
+
+**Prefer:**
+
+```rust
 pub use comver::{Version, VersionReq};
 ```
 

--- a/planned-rules/pipe-style.md
+++ b/planned-rules/pipe-style.md
@@ -41,32 +41,38 @@ Either condition being true makes the pipe acceptable: a method-
 call receiver "continues" an existing chain, and a trailing
 `.method()` makes the pipe "continued by" one.
 
+**Avoid:**
+
 ```rust
-// Bad: value is not a method call AND pipe is the tail
+// value is not a method call AND pipe is the tail
 let result = value.pipe(foo);
 let some = value.pipe(Some);
 
-// Bad: stdin() is a free-function call, not a method call,
+// stdin() is a free-function call, not a method call,
 // AND .pipe(...) is the tail
 let data = stdin().pipe(serde_json::from_reader::<_, JsonData>);
+```
 
-// Good (entry-point form, no chain involved)
+**Prefer:**
+
+```rust
+// entry-point form, no chain involved
 let result = foo(value);
 let some = Some(value);
 
-// Good: receiver is a method call, so .pipe(Some) continues it
+// receiver is a method call, so .pipe(Some) continues it
 let summary = report.summarize().pipe(Some);
 
-// Good: receiver continues to be a method call across pipes
+// receiver continues to be a method call across pipes
 let name = entry.file_name().pipe(OsStringDisplay::from).pipe(Some);
 
-// Good: receiver is a free function call BUT .pipe(...) is followed
+// receiver is a free function call BUT .pipe(...) is followed
 // by another method call, so it sits between two method calls
 let parsed = stdin()
     .pipe(serde_json::from_reader::<_, JsonData>)
     .map(post_process);
 
-// Good: receiver is a method call AND the callable inside .pipe(...)
+// receiver is a method call AND the callable inside .pipe(...)
 // carries a turbofish — the turbofish lives between the parens of
 // .pipe(...) and is preserved as-is.
 let parsed = request.body().pipe(serde_json::from_reader::<_, MyData>);
@@ -82,8 +88,9 @@ argument doesn't constitute a chain, and lifting it across pipe
 would just produce the entry-point pattern that `entry_point`
 forbids.
 
+**Avoid:** arg is a method call (chain)
+
 ```rust
-// Bad: arg is a method call (chain)
 let name = Some(OsStringDisplay::from(entry.file_name()));
 let wrapped = Ok(items.iter().map(|x| x.id).collect::<Vec<_>>());
 let err = Err(parser.tokens().peek().cloned());
@@ -92,8 +99,11 @@ let lock = Arc::clone(
         .or_insert_with(|| Arc::new(Mutex::new(())))
         .value(),
 );
+```
 
-// Good
+**Prefer:**
+
+```rust
 let name = entry.file_name().pipe(OsStringDisplay::from).pipe(Some);
 let wrapped = items.iter().map(|x| x.id).collect::<Vec<_>>().pipe(Ok);
 let err = parser.tokens().peek().cloned().pipe(Err);
@@ -102,11 +112,15 @@ let lock = locks
     .or_insert_with(|| Arc::new(Mutex::new(())))
     .value()
     .pipe(Arc::clone);
+```
 
-// Not flagged: arg is a free function call, not a method call
+**Not flagged:**
+
+```rust
+// arg is a free function call, not a method call
 let data = serde_json::from_reader::<_, JsonData>(stdin());
 
-// Not flagged: arg is a leaf
+// arg is a leaf
 let some = Some(value);
 let ok = Ok(42);
 ```

--- a/planned-rules/prefer-json-macro.md
+++ b/planned-rules/prefer-json-macro.md
@@ -193,10 +193,11 @@ where possible (see [Autofix](#autofix)).
 
 ### Literal mode
 
+**Avoid:** structural literal, easy to typo
+
 ```rust
 #[test]
 fn writes_manifest() {
-    // Bad: structural literal, easy to typo
     let manifest = r#"{
         "name": "test",
         "version": "0.0.0",
@@ -204,8 +205,11 @@ fn writes_manifest() {
     }"#;
     fs::write(&manifest_path, manifest).expect("write");
 }
+```
 
-// Good
+**Prefer:**
+
+```rust
 #[test]
 fn writes_manifest() {
     let manifest = serde_json::json!({
@@ -220,11 +224,11 @@ fn writes_manifest() {
 
 ### Format mode
 
+**Avoid:** doubled braces, runtime value could contain `"` and corrupt the output
+
 ```rust
 #[test]
 fn writes_manifest_with_marker() {
-    // Bad: doubled braces, runtime value could contain `"` and
-    // corrupt the output
     let manifest = format!(
         r#"{{
             "name": "test",
@@ -235,8 +239,11 @@ fn writes_manifest_with_marker() {
     );
     fs::write(&manifest_path, manifest).expect("write");
 }
+```
 
-// Good
+**Prefer:**
+
+```rust
 #[test]
 fn writes_manifest_with_marker() {
     let manifest = serde_json::json!({
@@ -256,20 +263,22 @@ fn writes_manifest_with_marker() {
 
 ### Skipped contexts
 
+**Not flagged:**
+
 ```rust
-// Skipped: not in a test context (no `#[cfg(test)]`, not under
+// not in a test context (no `#[cfg(test)]`, not under
 // `tests/`, no `#[test]` attribute on the enclosing fn).
 fn render_payload() -> String {
     r#"{"name":"hot path","fast":true}"#.to_string()
 }
 
-// Skipped: scalar document
+// scalar document
 #[test]
 fn scalar() {
     let _ = r#""hello""#;
 }
 
-// Skipped: structurally uninteresting — no non-empty object
+// structurally uninteresting — no non-empty object
 // anywhere in the tree.
 #[test]
 fn flat_primitive_array() {
@@ -278,7 +287,7 @@ fn flat_primitive_array() {
     let _ = "[[]]";
 }
 
-// Skipped: not valid JSON
+// not valid JSON
 #[test]
 fn not_json() {
     let _ = "name=test, version=0.0.0";

--- a/planned-rules/prefer-owned-parameter.md
+++ b/planned-rules/prefer-owned-parameter.md
@@ -17,19 +17,23 @@ the caller already has an owned value, while preserving the same
 ergonomics for callers that have a borrowed value (they just call
 `.to_owned()` themselves).
 
-The pacquet example, slightly condensed:
+The pacquet example, slightly condensed.
+
+**Avoid:** the borrowed parameter forces a copy of `my_path_buf`
+even when the caller already owns a `PathBuf`.
 
 ```rust
-// Suboptimal: forces a copy of `my_path_buf` even when the caller
-// already owns a `PathBuf`.
 fn push_path(list: &mut Vec<PathBuf>, item: &Path) {
     list.push(item.to_path_buf());
 }
+```
 
-// Better: the caller's `PathBuf` is moved in directly. A caller
-// with a `&Path` writes `push_path(&mut list, p.to_path_buf())`,
-// performing the same copy that the borrowed signature was
-// performing inside the function.
+**Prefer:** the caller's `PathBuf` is moved in directly. A caller
+with a `&Path` writes `push_path(&mut list, p.to_path_buf())`,
+performing the same copy that the borrowed signature was
+performing inside the function.
+
+```rust
 fn push_path(list: &mut Vec<PathBuf>, item: PathBuf) {
     list.push(item);
 }
@@ -81,32 +85,41 @@ The lint stays silent when:
 
 ## Examples
 
+**Avoid:**
+
 ```rust
-// Bad
 fn push_path(list: &mut Vec<PathBuf>, item: &Path) {
     list.push(item.to_path_buf());
 }
+```
 
-// Good
+**Prefer:**
+
+```rust
 fn push_path(list: &mut Vec<PathBuf>, item: PathBuf) {
     list.push(item);
 }
 ```
 
+**Avoid:**
+
 ```rust
-// Bad
 fn store(name: &str, registry: &mut HashMap<String, u32>) {
     registry.insert(name.to_owned(), 0);
 }
+```
 
-// Good
+**Prefer:**
+
+```rust
 fn store(name: String, registry: &mut HashMap<String, u32>) {
     registry.insert(name, 0);
 }
 ```
 
+**Not flagged:** the conversion is conditional.
+
 ```rust
-// Not flagged: conversion is conditional.
 fn maybe_store(name: &str, registry: &mut HashMap<String, u32>) {
     if !registry.contains_key(name) {
         registry.insert(name.to_owned(), 0);
@@ -114,8 +127,9 @@ fn maybe_store(name: &str, registry: &mut HashMap<String, u32>) {
 }
 ```
 
+**Not flagged:** the parameter is used in borrowed form too.
+
 ```rust
-// Not flagged: parameter is used in borrowed form too.
 fn log_and_store(name: &str, registry: &mut HashMap<String, u32>) {
     eprintln!("inserting {name}");
     registry.insert(name.to_owned(), 0);

--- a/planned-rules/prefer-text-block.md
+++ b/planned-rules/prefer-text-block.md
@@ -110,21 +110,31 @@ then:
 
 ### Default style (`text_block_macros`)
 
-```rust
-// Bad: two or more newlines, not a template
-let banner = "foo\nbar\nbaz";
+**Avoid:** two or more newlines, not a template
 
-// Good (no trailing newline)
+```rust
+let banner = "foo\nbar\nbaz";
+```
+
+**Prefer:** (no trailing newline)
+
+```rust
 let banner = text_block! {
     "foo"
     "bar"
     "baz"
 };
+```
 
-// Bad: trailing newline
+**Avoid:** trailing newline
+
+```rust
 let banner = "foo\nbar\nbaz\n";
+```
 
-// Good
+**Prefer:**
+
+```rust
 let banner = text_block_fnl! {
     "foo"
     "bar"
@@ -134,11 +144,15 @@ let banner = text_block_fnl! {
 
 ### Style `line_continuation`
 
-```rust
-// Bad
-let banner = "foo\nbar\nbaz";
+**Avoid:**
 
-// Good
+```rust
+let banner = "foo\nbar\nbaz";
+```
+
+**Prefer:**
+
+```rust
 let banner = "foo\n\
               bar\n\
               baz";
@@ -146,11 +160,15 @@ let banner = "foo\n\
 
 ### Width trigger (single long line)
 
-```rust
-// Bad: one line that exceeds `max_line_width = 100`
-let url = "https://very-long-subdomain.example.com/api/v2/resources/very-long-identifier?param=value";
+**Avoid:** one line that exceeds `max_line_width = 100`
 
-// Good: line_continuation form keeps the runtime value identical
+```rust
+let url = "https://very-long-subdomain.example.com/api/v2/resources/very-long-identifier?param=value";
+```
+
+**Prefer:** line_continuation form keeps the runtime value identical
+
+```rust
 let url = "https://very-long-subdomain.example.com/api/v2/resources/\
            very-long-identifier?param=value";
 ```
@@ -162,12 +180,15 @@ changing the runtime value.
 
 ### Both triggers (multi-line and a long line)
 
-```rust
-// Bad: two newlines AND the middle line is too long
-let banner = "header\nthis is a very long line that exceeds the configured max_line_width\nfooter";
+**Avoid:** two newlines AND the middle line is too long
 
-// Good (style = text_block_macros): outer text_block, inner
-// line-continuation on the long quoted line
+```rust
+let banner = "header\nthis is a very long line that exceeds the configured max_line_width\nfooter";
+```
+
+**Prefer:** (style = text_block_macros) outer text_block, inner line-continuation on the long quoted line
+
+```rust
 let banner = text_block! {
     "header"
     "this is a very long line that exceeds the \
@@ -178,21 +199,21 @@ let banner = text_block! {
 
 ### Skipped contexts
 
-```rust
-// Skipped: format template
-println!("a\nb\nc\n{x}", x = 42);
+**Not flagged:**
 
-// Skipped: derive_more display template
+```rust
+println!("a\nb\nc\n{x}", x = 42);  // format template
+
+// derive_more display template
 #[derive(Display)]
 #[display("line1\nline2\nline3")]
 struct Banner;
 
-// Skipped: doc attribute
+// doc attribute
 #[doc = "first line\nsecond line\nthird line"]
 fn documented() {}
 
-// Skipped: already inside text_block!
-let _ = text_block! { "foo" "bar" "baz" };
+let _ = text_block! { "foo" "bar" "baz" };  // already inside text_block!
 ```
 
 ## Configuration

--- a/planned-rules/print-macro-split.md
+++ b/planned-rules/print-macro-split.md
@@ -117,20 +117,28 @@ For every invocation of a target macro:
 
 ### Default style (`multiple_calls`)
 
-```rust
-// Bad: long source line, embedded newline, splittable macro
-println!("error: The error was caused by {err_src}\nhint: Run {magic_cmd} to solve the problem");
+**Avoid:** a long source line with an embedded newline in a splittable macro.
 
-// Good
+```rust
+println!("error: The error was caused by {err_src}\nhint: Run {magic_cmd} to solve the problem");
+```
+
+**Prefer:**
+
+```rust
 println!("error: The error was caused by {err_src}");
 println!("hint: Run {magic_cmd} to solve the problem");
 ```
 
-```rust
-// Bad: writeln! with two segments
-writeln!(f, "header: {h}\nbody: {b}\nfooter: {ft}")?;
+**Avoid:** a `writeln!` with two segments.
 
-// Good
+```rust
+writeln!(f, "header: {h}\nbody: {b}\nfooter: {ft}")?;
+```
+
+**Prefer:**
+
+```rust
 writeln!(f, "header: {h}")?;
 writeln!(f, "body: {b}")?;
 writeln!(f, "footer: {ft}")?;
@@ -138,11 +146,15 @@ writeln!(f, "footer: {ft}")?;
 
 ### Style `line_continuation`
 
-```rust
-// Bad
-println!("error: The error was caused by {err_src}\nhint: Run {magic_cmd} to solve the problem");
+**Avoid:**
 
-// Good
+```rust
+println!("error: The error was caused by {err_src}\nhint: Run {magic_cmd} to solve the problem");
+```
+
+**Prefer:**
+
+```rust
 println!(
     "error: The error was caused by {err_src}\n\
     hint: Run {magic_cmd} to solve the problem",
@@ -151,18 +163,13 @@ println!(
 
 ### Skipped contexts
 
+**Not flagged:**
+
 ```rust
-// Skipped: format! returns a value
-let s = format!("a\nb\nc");
-
-// Skipped: panic! terminates
-panic!("a\nb");
-
-// Skipped: assert! message is one-shot
-assert!(cond, "a\nb");
-
-// Skipped: short source line
-println!("a\nb");
+let s = format!("a\nb\nc");  // format! returns a value
+panic!("a\nb");  // panic! terminates
+assert!(cond, "a\nb");  // assert! message is one-shot
+println!("a\nb");  // short source line
 ```
 
 ## Configuration

--- a/planned-rules/qualified-paths.md
+++ b/planned-rules/qualified-paths.md
@@ -96,14 +96,18 @@ forbidden_paths = []
 
 ## Style: `unqualified`
 
+**Avoid:**
+
 ```rust
-// Bad
 std::fs::create_dir_all(&dir).unwrap();
 #[derive(clap::Parser)]
 struct Cli;
 let parsed: serde_json::Value = serde_json::from_str(&s)?;
+```
 
-// Good
+**Prefer:**
+
+```rust
 use clap::Parser;
 use serde_json::Value;
 use std::fs::create_dir_all;
@@ -128,16 +132,20 @@ auto-rewrite.
 
 ## Style: `qualified`
 
+**Avoid:**
+
 ```rust
-// Bad
 use clap::Parser;
 use std::fs::create_dir_all;
 
 create_dir_all(&dir).unwrap();
 #[derive(Parser)]
 struct Cli;
+```
 
-// Good
+**Prefer:**
+
+```rust
 std::fs::create_dir_all(&dir).unwrap();
 #[derive(clap::Parser)]
 struct Cli;

--- a/planned-rules/serde-source-types.md
+++ b/planned-rules/serde-source-types.md
@@ -41,18 +41,25 @@ gated behind `serde_source_types.advisory = true` in `dylint.toml`.
 
 ## Examples
 
+**Avoid:**
+
 ```rust
-// Bad
 #[derive(serde::Deserialize)]
 #[serde(try_from = "&'de str")]
 struct Port(u16);
+```
 
-// Good (retains nothing)
+**Prefer:** (retains nothing)
+
+```rust
 #[derive(serde::Deserialize)]
 #[serde(try_from = "Cow<'de, str>")]
 struct Port(u16);
+```
 
-// Good (retains the entire input)
+**Prefer:** (retains the entire input)
+
+```rust
 #[derive(serde::Deserialize)]
 #[serde(try_from = "String")]
 struct PackageName(String);

--- a/planned-rules/serde-wrapper-style.md
+++ b/planned-rules/serde-wrapper-style.md
@@ -11,9 +11,11 @@ type, two attribute forms produce the same wire output:
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
 struct A(Inner);
+```
 
-// vs.
+versus:
 
+```rust
 #[derive(Serialize, Deserialize)]
 #[serde(from = "Inner", into = "Inner")]
 struct B(Inner);
@@ -62,8 +64,9 @@ style = "transparent"
 
 ## Style: `transparent`
 
+**Avoid:**
+
 ```rust
-// Bad (under style = "transparent")
 #[derive(Serialize, Deserialize)]
 #[serde(from = "Inner", into = "Inner")]
 struct A(Inner);
@@ -74,8 +77,11 @@ impl From<Inner> for A {
 impl From<A> for Inner {
     fn from(wrapper: A) -> Self { wrapper.0 }
 }
+```
 
-// Good
+**Prefer:**
+
+```rust
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
 struct A(Inner);
@@ -84,8 +90,9 @@ struct A(Inner);
 The lint *does not* fire when the `From` impls do anything beyond
 trivially construct/destruct:
 
+**Not flagged:** the `From` impl validates.
+
 ```rust
-// Not flagged: the From impl validates.
 #[serde(from = "Inner", into = "Inner")]
 struct ValidatedPort(u16);
 
@@ -99,13 +106,17 @@ impl From<Inner> for ValidatedPort {
 
 ## Style: `from_into`
 
+**Avoid:**
+
 ```rust
-// Bad (under style = "from_into")
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
 struct A(Inner);
+```
 
-// Good
+**Prefer:**
+
+```rust
 #[derive(Serialize, Deserialize)]
 #[serde(from = "Inner", into = "Inner")]
 struct A(Inner);

--- a/planned-rules/unpinned-repo-ref.md
+++ b/planned-rules/unpinned-repo-ref.md
@@ -54,27 +54,21 @@ that explains a SHA is expected.
 
 ## Examples
 
+**Avoid:**
+
 ```rust
-// Bad: branch ref
-/// See <https://github.com/owner/repo/blob/main/src/lib.rs>.
+/// See <https://github.com/owner/repo/blob/main/src/lib.rs>.            // branch ref
+/// See <https://github.com/owner/repo/blob/v1.2.3/src/lib.rs>.         // tag ref (cannot be distinguished from a branch by name)
+/// See <https://codeberg.org/owner/repo/src/branch/main/src/lib.rs>.   // Gitea-style: explicit `/src/branch/`
+/// See <https://codeberg.org/owner/repo/src/tag/v1.2.3/src/lib.rs>.    // Gitea-style: explicit `/src/tag/`
+```
 
-// Bad: tag ref (cannot be distinguished from a branch by name)
-/// See <https://github.com/owner/repo/blob/v1.2.3/src/lib.rs>.
+**Prefer:**
 
-// Good: long SHA
-/// See <https://github.com/owner/repo/blob/8c1f6e2a6d33c1b1a2f9e0e1d3b8a4c7d6e5f4a3/src/lib.rs>.
-
-// Good: short SHA (any length the lint recognises as hex)
-/// See <https://github.com/owner/repo/blob/8c1f6e2/src/lib.rs>.
-
-// Bad on Gitea-style: explicit `/src/branch/`
-/// See <https://codeberg.org/owner/repo/src/branch/main/src/lib.rs>.
-
-// Bad on Gitea-style: explicit `/src/tag/`
-/// See <https://codeberg.org/owner/repo/src/tag/v1.2.3/src/lib.rs>.
-
-// Good on Gitea-style: explicit `/src/commit/`
-/// See <https://codeberg.org/owner/repo/src/commit/8c1f6e2.../src/lib.rs>.
+```rust
+/// See <https://github.com/owner/repo/blob/8c1f6e2a6d33c1b1a2f9e0e1d3b8a4c7d6e5f4a3/src/lib.rs>.  // long SHA
+/// See <https://github.com/owner/repo/blob/8c1f6e2/src/lib.rs>.                                   // short SHA (any length the lint recognises as hex)
+/// See <https://codeberg.org/owner/repo/src/commit/8c1f6e2.../src/lib.rs>.                        // Gitea-style: explicit `/src/commit/`
 ```
 
 ## Configuration

--- a/planned-rules/where-clause-bounds.md
+++ b/planned-rules/where-clause-bounds.md
@@ -30,14 +30,21 @@ to `where`).
 
 ## Examples
 
+**Not flagged:** one bound on one parameter
+
 ```rust
-// Acceptable: one bound on one parameter
 fn render<W: Write>(out: &mut W) { /* ... */ }
+```
 
-// Bad: two bounds on one parameter
+**Avoid:** two bounds on one parameter
+
+```rust
 fn render<W: Write + Send>(out: &mut W) { /* ... */ }
+```
 
-// Good
+**Prefer:**
+
+```rust
 fn render<W>(out: &mut W)
 where
     W: Write + Send,


### PR DESCRIPTION
Normalizes the Example sections across `planned-rules/*.md` to the convention the implemented rules already follow (`import_granularity`, `import_grouping`, `derive_ordering`, `self_import`).

- Comment-as-label snippet headings (`// Bad`, `// Good`, `// Skipped`, `// Allowed`, `// Accepted`, `// Not flagged`) lifted out of the code blocks into `**Avoid:**` / `**Prefer:**` / `**Not flagged:**` prose lead-ins, carrying any reason or parenthetical into the prose.
- Mixed bad/good blocks split so no two example code blocks sit adjacent without intervening prose (the "false sub-section" rendering).
- Distinct variants separated by prose lead-ins or real `###`/`####` sub-headings; existing sub-headings kept.

Docs-only: 27 files, code inside every block preserved verbatim; genuine per-line annotations kept.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/177>.