### PR TITLE
fix(prefer-raw-string): cover macro arguments

### DIFF
--- a/rules/prefer_raw_string.md
+++ b/rules/prefer_raw_string.md
@@ -16,12 +16,23 @@ and `\'`. The autofix rewrites the literal to the raw form
 avoids a delimiter collision.
 
 This includes literals passed as arguments to macros such as
-`println!`, `format!`, `vec!`, and `assert!`. Suppress per
-call site with `#[allow(perfectionist::prefer_raw_string)]`
-when the regular form is deliberately preferred.
+`println!`, `format!`, `vec!`, and `assert!` — even a `format!`
+template carrying a `{...}` placeholder, which expansion would
+otherwise split apart before the lint sees it. The rewrite is
+value-preserving (a raw string still parses placeholders, and
+`{{` / `}}` survive verbatim), so the literal's role doesn't
+matter. Suppress per call site with
+`#[allow(perfectionist::prefer_raw_string)]` when the regular
+form is deliberately preferred — for instance when a macro
+reflects the literal's *source spelling* rather than its value
+(`stringify!`, `dbg!`), where the raw form, though equal in
+value, changes the printed text.
 
-Pattern-position literals (e.g. `match s { "C:\\path" => ... }`)
-are out of scope — the rule only visits expression literals.
+Pattern-position literals in ordinary code
+(e.g. `match s { "C:\\path" => ... }`) are out of scope — the
+late pass only visits expression literals. A literal written as a
+pattern *inside a macro* (e.g. `matches!(s, "C:\\path")`) is
+reached through the pre-expansion scan, however.
 
 Whitespace and control-character escapes (`\n`, `\t`, `\r`,
 `\0`) and Unicode escapes (`\x..`, `\u{..}`) are exempt — a

--- a/rules/prefer_raw_string.md
+++ b/rules/prefer_raw_string.md
@@ -15,28 +15,28 @@ and `\'`. The autofix rewrites the literal to the raw form
 `r"..."` / `r#"..."#`, picking the smallest hash count that
 avoids a delimiter collision.
 
-The scan does not respect macro-argument boundaries: it reaches
-every string literal a macro receives, even ones expansion would
-otherwise consume before the late pass sees them — most visibly a
-`format!`-family template carrying a `{...}` placeholder, which is
-split into static pieces. The rewrite is value-preserving (a raw
-string still parses placeholders, and `{{` / `}}` survive
-verbatim), so the literal's role doesn't matter. Silence a site
-the usual way where the regular form is deliberately preferred.
+Literals inside macro invocations are covered too: every string
+literal in a macro call, whatever its position — including a
+`format!`-family template that contains a `{...}` placeholder. The
+rewrite is value-preserving (a raw string still parses
+placeholders, and `{{` / `}}` survive verbatim), so the literal's
+role doesn't matter. Suppress a site where the regular form is
+deliberately preferred.
 
-That reach also covers literals used for their *source spelling*
+That includes literals a macro uses for their *source spelling*
 rather than their value, such as `stringify!` and `dbg!`, where
 the raw form has the same value but a different reflected text.
-That is intentional rather than carved out of the lint: code
-whose behaviour depends on a literal's exact spelling instead of
-its value is rare and a code smell; suppress it per site with
+This is intentional: code whose behaviour depends on a literal's
+exact spelling instead of its value is rare and a code smell;
+suppress it per site with
 `#[expect(perfectionist::prefer_raw_string)]`.
 
 Pattern-position literals in ordinary code
-(e.g. `match s { "C:\\path" => ... }`) are out of scope — the
-late pass only visits expression literals. A literal written as a
-pattern *inside a macro* (e.g. `matches!(s, "C:\\path")`) is
-reached through the pre-expansion scan, however.
+(e.g. `match s { "C:\\path" => ... }`) are out of scope; only
+expression-position literals are rewritten. A literal written as a
+pattern *inside a macro call* (e.g. `matches!(s, "C:\\path")`) is
+rewritten anyway, since a literal's position isn't distinguished
+inside a macro.
 
 Whitespace and control-character escapes (`\n`, `\t`, `\r`,
 `\0`) and Unicode escapes (`\x..`, `\u{..}`) are exempt — a

--- a/rules/prefer_raw_string.md
+++ b/rules/prefer_raw_string.md
@@ -21,12 +21,19 @@ template carrying a `{...}` placeholder, which expansion would
 otherwise split apart before the lint sees it. The rewrite is
 value-preserving (a raw string still parses placeholders, and
 `{{` / `}}` survive verbatim), so the literal's role doesn't
-matter. Suppress per call site with
-`#[allow(perfectionist::prefer_raw_string)]` when the regular
-form is deliberately preferred — for instance when a macro
-reflects the literal's *source spelling* rather than its value
-(`stringify!`, `dbg!`), where the raw form, though equal in
-value, changes the printed text.
+matter. Silence a site the usual way where the regular form is
+deliberately preferred.
+
+The scan does not respect macro-argument boundaries: it reaches
+every string literal a macro receives, including ones a macro
+echoes by *source spelling* rather than by value — `stringify!`
+and `dbg!`. There the raw form carries the same value but a
+different reflected text (`dbg!("a\"b")` would print `r#"a"b"#`
+as the expression). That is intentional rather than carved out
+of the lint: code whose behaviour depends on a literal's exact
+spelling instead of its value is rare and a code smell, so the
+rare deliberate case is left to a per-site
+`#[expect(perfectionist::prefer_raw_string)]`.
 
 Pattern-position literals in ordinary code
 (e.g. `match s { "C:\\path" => ... }`) are out of scope — the

--- a/rules/prefer_raw_string.md
+++ b/rules/prefer_raw_string.md
@@ -25,13 +25,13 @@ matter. Silence a site the usual way where the regular form is
 deliberately preferred.
 
 The scan does not respect macro-argument boundaries: it reaches
-every string literal a macro receives, including ones a macro
-echoes by *source spelling* rather than by value — `stringify!`
-and `dbg!`. There the raw form carries the same value but a
-different reflected text. That is intentional rather than carved
-out of the lint: code whose behaviour depends on a literal's
-exact spelling instead of its value is rare and a code smell;
-suppress it per site with
+every string literal a macro receives, including ones used for
+their *source spelling* rather than their value, such as
+`stringify!` and `dbg!`. There the raw form carries the same
+value but a different reflected text. That is intentional rather
+than carved out of the lint: code whose behaviour depends on a
+literal's exact spelling instead of its value is rare and a code
+smell; suppress it per site with
 `#[expect(perfectionist::prefer_raw_string)]`.
 
 Pattern-position literals in ordinary code

--- a/rules/prefer_raw_string.md
+++ b/rules/prefer_raw_string.md
@@ -15,23 +15,21 @@ and `\'`. The autofix rewrites the literal to the raw form
 `r"..."` / `r#"..."#`, picking the smallest hash count that
 avoids a delimiter collision.
 
-This includes literals passed as arguments to macros such as
-`println!`, `format!`, `vec!`, and `assert!` — even a `format!`
-template carrying a `{...}` placeholder, which expansion would
-otherwise split apart before the lint sees it. The rewrite is
-value-preserving (a raw string still parses placeholders, and
-`{{` / `}}` survive verbatim), so the literal's role doesn't
-matter. Silence a site the usual way where the regular form is
-deliberately preferred.
-
 The scan does not respect macro-argument boundaries: it reaches
-every string literal a macro receives, including ones used for
-their *source spelling* rather than their value, such as
-`stringify!` and `dbg!`. There the raw form carries the same
-value but a different reflected text. That is intentional rather
-than carved out of the lint: code whose behaviour depends on a
-literal's exact spelling instead of its value is rare and a code
-smell; suppress it per site with
+every string literal a macro receives, even ones expansion would
+otherwise consume before the late pass sees them — most visibly a
+`format!`-family template carrying a `{...}` placeholder, which is
+split into static pieces. The rewrite is value-preserving (a raw
+string still parses placeholders, and `{{` / `}}` survive
+verbatim), so the literal's role doesn't matter. Silence a site
+the usual way where the regular form is deliberately preferred.
+
+That reach also covers literals used for their *source spelling*
+rather than their value, such as `stringify!` and `dbg!`, where
+the raw form has the same value but a different reflected text.
+That is intentional rather than carved out of the lint: code
+whose behaviour depends on a literal's exact spelling instead of
+its value is rare and a code smell; suppress it per site with
 `#[expect(perfectionist::prefer_raw_string)]`.
 
 Pattern-position literals in ordinary code

--- a/rules/prefer_raw_string.md
+++ b/rules/prefer_raw_string.md
@@ -28,11 +28,10 @@ The scan does not respect macro-argument boundaries: it reaches
 every string literal a macro receives, including ones a macro
 echoes by *source spelling* rather than by value — `stringify!`
 and `dbg!`. There the raw form carries the same value but a
-different reflected text (`dbg!("a\"b")` would print `r#"a"b"#`
-as the expression). That is intentional rather than carved out
-of the lint: code whose behaviour depends on a literal's exact
-spelling instead of its value is rare and a code smell, so the
-rare deliberate case is left to a per-site
+different reflected text. That is intentional rather than carved
+out of the lint: code whose behaviour depends on a literal's
+exact spelling instead of its value is rare and a code smell;
+suppress it per site with
 `#[expect(perfectionist::prefer_raw_string)]`.
 
 Pattern-position literals in ordinary code

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ mod common;
 mod enclosing_hir;
 mod literal_scan;
 mod macro_path;
+mod macro_template;
 mod markdown;
 mod module_reparse;
 mod rules;

--- a/src/macro_template.rs
+++ b/src/macro_template.rs
@@ -1,19 +1,21 @@
-//! Locating the format template in a macro invocation's token stream.
+//! Locating string literals in a macro invocation's token stream.
 //!
-//! A `format!`-family macro takes its format string as the first
-//! argument that is, on its own, a single cooked string literal. The
-//! same "first lone cooked string literal" rule pins the template down
-//! across the whole family regardless of which positional slot it lands
-//! in: `format!`'s and `println!`'s template is the first argument,
-//! `write!`'s is the second (the writer comes first and isn't a bare
-//! literal), `log!`'s is the second (the level comes first), and
-//! `log::info!`'s is the first.
+//! Two shapes are needed by two rules:
 //!
-//! Two rules read this: `print_macro_split`, which folds a long
-//! template across lines, and `prefer_raw_string`, which rewrites a
-//! template whose only escapes are raw-expressible into the raw-string
-//! form even when format-args lowering would otherwise hide it from the
-//! late pass.
+//! - [`find_template_literal`] returns the single *format template* — the
+//!   first argument that is, on its own, a lone cooked string literal.
+//!   `print_macro_split` uses it because it may only ever touch a genuine
+//!   format template (its `\n`-fold is output-preserving only there).
+//! - [`find_all_cooked_str_literals`] returns *every* cooked string
+//!   literal anywhere in the token stream, descending into delimited
+//!   groups. `prefer_raw_string` uses it: its raw-string rewrite is
+//!   value-preserving for any literal, so it has no reason to single out
+//!   the template, and it must reach literals that format-args lowering
+//!   would otherwise hide from the late pass.
+//!
+//! Both skip raw strings (`r"..."`): `print_macro_split` would mis-fold
+//! one, and `prefer_raw_string` rewrites *into* the raw form, so an
+//! already-raw literal is never a candidate.
 
 use rustc_ast::token::{LitKind, TokenKind};
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
@@ -69,4 +71,24 @@ fn cooked_str_literal_span(tree: &TokenTree) -> Option<Span> {
     // `print_macro_split` nor the escape-elimination scan in
     // `prefer_raw_string` may run over one.
     matches!(literal.kind, LitKind::Str).then_some(token.span)
+}
+
+/// Span of every cooked string literal anywhere in `tokens`, in source
+/// order, descending into delimited groups so a literal nested inside a
+/// call or sub-group (`assert!(cond, "msg {x}")`, `foo(bar("..."))`) is
+/// found too. Raw strings are skipped, as in [`cooked_str_literal_span`].
+pub(crate) fn find_all_cooked_str_literals(tokens: &TokenStream) -> Vec<Span> {
+    let mut spans = Vec::new();
+    collect_cooked_str_literals(tokens, &mut spans);
+    spans
+}
+
+fn collect_cooked_str_literals(tokens: &TokenStream, spans: &mut Vec<Span>) {
+    for tree in tokens.iter() {
+        if let Some(span) = cooked_str_literal_span(tree) {
+            spans.push(span);
+        } else if let TokenTree::Delimited(_, _, _, inner) = tree {
+            collect_cooked_str_literals(inner, spans);
+        }
+    }
 }

--- a/src/macro_template.rs
+++ b/src/macro_template.rs
@@ -27,6 +27,12 @@ use rustc_span::Span;
 /// result, or a template that is the second argument behind a writer
 /// expression that itself isn't a lone string literal, etc.).
 ///
+/// "First lone cooked string literal" is what makes the same scan work
+/// across the whole `format!`-family: `println!`'s template is the first
+/// argument, `write!`'s is the second (the writer comes first and isn't
+/// a bare literal), `log!`'s is the second (the level comes first), and
+/// `log::info!`'s is the first.
+///
 /// Raw strings (`r"..."`) are deliberately not matched: both callers
 /// either fold escapes the raw form has none of, or rewrite *into* the
 /// raw form, so a literal that is already raw is never a candidate.
@@ -75,8 +81,13 @@ fn cooked_str_literal_span(tree: &TokenTree) -> Option<Span> {
 
 /// Span of every cooked string literal anywhere in `tokens`, in source
 /// order, descending into delimited groups so a literal nested inside a
-/// call or sub-group (`assert!(cond, "msg {x}")`, `foo(bar("..."))`) is
-/// found too. Raw strings are skipped, as in [`cooked_str_literal_span`].
+/// sub-group is found too — e.g. a `maud::html!` markup string buried in
+/// `code { "..." }`, which a top-level-only scan (as `print_macro_split`
+/// uses) would miss. The cost is that a literal inside a *nested macro
+/// call* is visited once here and again when that inner macro's own
+/// `check_mac` fires; `prefer_raw_string`'s byte-range dedup discards the
+/// duplicate, so the descent is correct, just not minimal. Raw strings
+/// are skipped, as in [`cooked_str_literal_span`].
 pub(crate) fn find_all_cooked_str_literals(tokens: &TokenStream) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_cooked_str_literals(tokens, &mut spans);

--- a/src/macro_template.rs
+++ b/src/macro_template.rs
@@ -1,0 +1,72 @@
+//! Locating the format template in a macro invocation's token stream.
+//!
+//! A `format!`-family macro takes its format string as the first
+//! argument that is, on its own, a single cooked string literal. The
+//! same "first lone cooked string literal" rule pins the template down
+//! across the whole family regardless of which positional slot it lands
+//! in: `format!`'s and `println!`'s template is the first argument,
+//! `write!`'s is the second (the writer comes first and isn't a bare
+//! literal), `log!`'s is the second (the level comes first), and
+//! `log::info!`'s is the first.
+//!
+//! Two rules read this: `print_macro_split`, which folds a long
+//! template across lines, and `prefer_raw_string`, which rewrites a
+//! template whose only escapes are raw-expressible into the raw-string
+//! form even when format-args lowering would otherwise hide it from the
+//! late pass.
+
+use rustc_ast::token::{LitKind, TokenKind};
+use rustc_ast::tokenstream::{TokenStream, TokenTree};
+use rustc_span::Span;
+
+/// Span of the first top-level argument that is, on its own, a single
+/// cooked string literal — the format template. Returns `None` when no
+/// such argument exists (a runtime-expression template, a `concat!`
+/// result, or a template that is the second argument behind a writer
+/// expression that itself isn't a lone string literal, etc.).
+///
+/// Raw strings (`r"..."`) are deliberately not matched: both callers
+/// either fold escapes the raw form has none of, or rewrite *into* the
+/// raw form, so a literal that is already raw is never a candidate.
+pub(crate) fn find_template_literal(tokens: &TokenStream) -> Option<Span> {
+    let mut argument_len: usize = 0;
+    let mut argument_lead_literal: Option<Span> = None;
+    let mut found: Option<Span> = None;
+    let finish_argument = |len: usize, lead: Option<Span>, found: &mut Option<Span>| {
+        if found.is_none() && len == 1 {
+            *found = lead;
+        }
+    };
+    for tree in tokens.iter() {
+        if is_top_level_comma(tree) {
+            finish_argument(argument_len, argument_lead_literal, &mut found);
+            argument_len = 0;
+            argument_lead_literal = None;
+            continue;
+        }
+        if argument_len == 0 {
+            argument_lead_literal = cooked_str_literal_span(tree);
+        }
+        argument_len += 1;
+    }
+    finish_argument(argument_len, argument_lead_literal, &mut found);
+    found
+}
+
+fn is_top_level_comma(tree: &TokenTree) -> bool {
+    matches!(tree, TokenTree::Token(token, _) if token.kind == TokenKind::Comma)
+}
+
+fn cooked_str_literal_span(tree: &TokenTree) -> Option<Span> {
+    let TokenTree::Token(token, _) = tree else {
+        return None;
+    };
+    let TokenKind::Literal(literal) = token.kind else {
+        return None;
+    };
+    // Cooked (`"..."`) only. A raw string (`r"..."`) treats `\` as an
+    // ordinary character, so neither the escape-aware fold in
+    // `print_macro_split` nor the escape-elimination scan in
+    // `prefer_raw_string` may run over one.
+    matches!(literal.kind, LitKind::Str).then_some(token.span)
+}

--- a/src/rules/lint_reason_from_comment/insertion.rs
+++ b/src/rules/lint_reason_from_comment/insertion.rs
@@ -153,7 +153,7 @@ pub(super) fn escape_for_rust_string(input: &str) -> String {
                 // Any other C0 byte / DEL: use the `\u{...}` form
                 // — the only escape that works for every control
                 // codepoint without a dedicated short form.
-                let _ = write!(out, "\\u{{{:x}}}", character as u32);
+                let _ = write!(out, r"\u{{{:x}}}", character as u32);
             }
             character => out.push(character),
         }

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -38,12 +38,19 @@ declare_tool_lint! {
     /// otherwise split apart before the lint sees it. The rewrite is
     /// value-preserving (a raw string still parses placeholders, and
     /// `{{` / `}}` survive verbatim), so the literal's role doesn't
-    /// matter. Suppress per call site with
-    /// `#[allow(perfectionist::prefer_raw_string)]` when the regular
-    /// form is deliberately preferred — for instance when a macro
-    /// reflects the literal's *source spelling* rather than its value
-    /// (`stringify!`, `dbg!`), where the raw form, though equal in
-    /// value, changes the printed text.
+    /// matter. Silence a site the usual way where the regular form is
+    /// deliberately preferred.
+    ///
+    /// The scan does not respect macro-argument boundaries: it reaches
+    /// every string literal a macro receives, including ones a macro
+    /// echoes by *source spelling* rather than by value — `stringify!`
+    /// and `dbg!`. There the raw form carries the same value but a
+    /// different reflected text (`dbg!("a\"b")` would print `r#"a"b"#`
+    /// as the expression). That is intentional rather than carved out
+    /// of the lint: code whose behaviour depends on a literal's exact
+    /// spelling instead of its value is rare and a code smell, so the
+    /// rare deliberate case is left to a per-site
+    /// `#[expect(perfectionist::prefer_raw_string)]`.
     ///
     /// Pattern-position literals in ordinary code
     /// (e.g. `match s { "C:\\path" => ... }`) are out of scope — the

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -45,11 +45,10 @@ declare_tool_lint! {
     /// every string literal a macro receives, including ones a macro
     /// echoes by *source spelling* rather than by value — `stringify!`
     /// and `dbg!`. There the raw form carries the same value but a
-    /// different reflected text (`dbg!("a\"b")` would print `r#"a"b"#`
-    /// as the expression). That is intentional rather than carved out
-    /// of the lint: code whose behaviour depends on a literal's exact
-    /// spelling instead of its value is rare and a code smell, so the
-    /// rare deliberate case is left to a per-site
+    /// different reflected text. That is intentional rather than carved
+    /// out of the lint: code whose behaviour depends on a literal's
+    /// exact spelling instead of its value is rare and a code smell;
+    /// suppress it per site with
     /// `#[expect(perfectionist::prefer_raw_string)]`.
     ///
     /// Pattern-position literals in ordinary code

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -148,8 +148,10 @@ pub(super) struct ResolvedConfig {
     pub(super) eligible_escapes: Vec<String>,
 }
 
-/// Load and validate the rule's configuration once, from the shared
-/// `CONFIG_KEY` table.
+/// Load and validate the rule's configuration from the shared
+/// `CONFIG_KEY` table. Called once per pass — the early and late passes
+/// each build their own copy — so the validation lives here instead of
+/// being duplicated across them; the result is not cached.
 pub(super) fn resolved_config() -> ResolvedConfig {
     let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
     // Drop entries that aren't one of the three self-decoding

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -99,6 +99,14 @@ declare_tool_lint! {
 
 const CONFIG_KEY: &str = "perfectionist::prefer_raw_string";
 
+/// Diagnostic message, shared by the late inline path and the queued
+/// pre-expansion path ([`emit::emit_raw_string`]) so the two firing
+/// routes read identically to the user.
+pub(super) const VIOLATION_MESSAGE: &str =
+    "string literal uses escapes that a raw string would avoid";
+/// Suggestion label, shared for the same reason as [`VIOLATION_MESSAGE`].
+pub(super) const SUGGESTION_LABEL: &str = "use a raw string";
+
 #[derive(Debug, serde::Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 struct Config {
@@ -241,15 +249,23 @@ impl<'tcx> LateLintPass<'tcx> for PreferRawString {
         if !matches!(literal.node, LitKind::Str(_, StrStyle::Cooked)) {
             return;
         }
-        // Record that this literal survived into the HIR so the
-        // pre-expansion drain leaves it to us — before any of the bails
-        // below, so even a literal we don't end up emitting on still
-        // suppresses a duplicate queued candidate at the same source
-        // range.
-        VISITED_LITERALS
+        // Record that this literal survived into the HIR (so the
+        // pre-expansion drain leaves its source range to us) and dedup on
+        // the way in: `insert` returns `false` when this exact source
+        // range was already visited. That happens when a `macro_rules!`
+        // fragment is expanded into several surviving positions — every
+        // copy reuses the one call-site span — so the first occurrence
+        // owns the diagnostic and the later copies (and the queued
+        // candidate at this range) are suppressed. The insert happens
+        // before the bails below so an ineligible literal still claims its
+        // range against a duplicate queued candidate.
+        if !VISITED_LITERALS
             .lock()
             .unwrap_or_else(|err| err.into_inner())
-            .insert((literal.span.lo().0, literal.span.hi().0));
+            .insert((literal.span.lo().0, literal.span.hi().0))
+        {
+            return;
+        }
         let Ok(snippet) = lint_context
             .sess()
             .source_map()
@@ -283,8 +299,8 @@ impl<'tcx> LateLintPass<'tcx> for PreferRawString {
             lint_context,
             PREFER_RAW_STRING,
             literal.span,
-            "string literal uses escapes that a raw string would avoid",
-            "use a raw string",
+            VIOLATION_MESSAGE,
+            SUGGESTION_LABEL,
             build_raw_string_suggestion(&scan.decoded),
             Applicability::MachineApplicable,
         );

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -42,13 +42,13 @@ declare_tool_lint! {
     /// deliberately preferred.
     ///
     /// The scan does not respect macro-argument boundaries: it reaches
-    /// every string literal a macro receives, including ones a macro
-    /// echoes by *source spelling* rather than by value — `stringify!`
-    /// and `dbg!`. There the raw form carries the same value but a
-    /// different reflected text. That is intentional rather than carved
-    /// out of the lint: code whose behaviour depends on a literal's
-    /// exact spelling instead of its value is rare and a code smell;
-    /// suppress it per site with
+    /// every string literal a macro receives, including ones used for
+    /// their *source spelling* rather than their value, such as
+    /// `stringify!` and `dbg!`. There the raw form carries the same
+    /// value but a different reflected text. That is intentional rather
+    /// than carved out of the lint: code whose behaviour depends on a
+    /// literal's exact spelling instead of its value is rare and a code
+    /// smell; suppress it per site with
     /// `#[expect(perfectionist::prefer_raw_string)]`.
     ///
     /// Pattern-position literals in ordinary code

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -32,28 +32,28 @@ declare_tool_lint! {
     /// `r"..."` / `r#"..."#`, picking the smallest hash count that
     /// avoids a delimiter collision.
     ///
-    /// The scan does not respect macro-argument boundaries: it reaches
-    /// every string literal a macro receives, even ones expansion would
-    /// otherwise consume before the late pass sees them — most visibly a
-    /// `format!`-family template carrying a `{...}` placeholder, which is
-    /// split into static pieces. The rewrite is value-preserving (a raw
-    /// string still parses placeholders, and `{{` / `}}` survive
-    /// verbatim), so the literal's role doesn't matter. Silence a site
-    /// the usual way where the regular form is deliberately preferred.
+    /// Literals inside macro invocations are covered too: every string
+    /// literal in a macro call, whatever its position — including a
+    /// `format!`-family template that contains a `{...}` placeholder. The
+    /// rewrite is value-preserving (a raw string still parses
+    /// placeholders, and `{{` / `}}` survive verbatim), so the literal's
+    /// role doesn't matter. Suppress a site where the regular form is
+    /// deliberately preferred.
     ///
-    /// That reach also covers literals used for their *source spelling*
+    /// That includes literals a macro uses for their *source spelling*
     /// rather than their value, such as `stringify!` and `dbg!`, where
     /// the raw form has the same value but a different reflected text.
-    /// That is intentional rather than carved out of the lint: code
-    /// whose behaviour depends on a literal's exact spelling instead of
-    /// its value is rare and a code smell; suppress it per site with
+    /// This is intentional: code whose behaviour depends on a literal's
+    /// exact spelling instead of its value is rare and a code smell;
+    /// suppress it per site with
     /// `#[expect(perfectionist::prefer_raw_string)]`.
     ///
     /// Pattern-position literals in ordinary code
-    /// (e.g. `match s { "C:\\path" => ... }`) are out of scope — the
-    /// late pass only visits expression literals. A literal written as a
-    /// pattern *inside a macro* (e.g. `matches!(s, "C:\\path")`) is
-    /// reached through the pre-expansion scan, however.
+    /// (e.g. `match s { "C:\\path" => ... }`) are out of scope; only
+    /// expression-position literals are rewritten. A literal written as a
+    /// pattern *inside a macro call* (e.g. `matches!(s, "C:\\path")`) is
+    /// rewritten anyway, since a literal's position isn't distinguished
+    /// inside a macro.
     ///
     /// Whitespace and control-character escapes (`\n`, `\t`, `\r`,
     /// `\0`) and Unicode escapes (`\x..`, `\u{..}`) are exempt — a

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 use std::sync::Mutex;
 
@@ -32,12 +33,23 @@ declare_tool_lint! {
     /// avoids a delimiter collision.
     ///
     /// This includes literals passed as arguments to macros such as
-    /// `println!`, `format!`, `vec!`, and `assert!`. Suppress per
-    /// call site with `#[allow(perfectionist::prefer_raw_string)]`
-    /// when the regular form is deliberately preferred.
+    /// `println!`, `format!`, `vec!`, and `assert!` — even a `format!`
+    /// template carrying a `{...}` placeholder, which expansion would
+    /// otherwise split apart before the lint sees it. The rewrite is
+    /// value-preserving (a raw string still parses placeholders, and
+    /// `{{` / `}}` survive verbatim), so the literal's role doesn't
+    /// matter. Suppress per call site with
+    /// `#[allow(perfectionist::prefer_raw_string)]` when the regular
+    /// form is deliberately preferred — for instance when a macro
+    /// reflects the literal's *source spelling* rather than its value
+    /// (`stringify!`, `dbg!`), where the raw form, though equal in
+    /// value, changes the printed text.
     ///
-    /// Pattern-position literals (e.g. `match s { "C:\\path" => ... }`)
-    /// are out of scope — the rule only visits expression literals.
+    /// Pattern-position literals in ordinary code
+    /// (e.g. `match s { "C:\\path" => ... }`) are out of scope — the
+    /// late pass only visits expression literals. A literal written as a
+    /// pattern *inside a macro* (e.g. `matches!(s, "C:\\path")`) is
+    /// reached through the pre-expansion scan, however.
     ///
     /// Whitespace and control-character escapes (`\n`, `\t`, `\r`,
     /// `\0`) and Unicode escapes (`\x..`, `\u{..}`) are exempt — a
@@ -129,8 +141,8 @@ impl Default for Config {
 }
 
 /// The rule's settings after parsing and validation, shared by the late
-/// `ExprKind::Lit` pass and the pre-expansion `format!`-template pass so
-/// both apply the same threshold and eligible-escape set.
+/// `ExprKind::Lit` pass and the pre-expansion macro-literal pass so both
+/// apply the same threshold and eligible-escape set.
 pub(super) struct ResolvedConfig {
     pub(super) min_escapes_to_trigger: NonZeroUsize,
     pub(super) eligible_escapes: Vec<String>,
@@ -179,6 +191,20 @@ impl PreferRawString {
 /// pre-expansion and late halves; see [`mod@queue`].
 static PENDING_VIOLATIONS: Mutex<Vec<PendingViolation>> = Mutex::new(Vec::new());
 
+/// Source byte ranges (`lo`, `hi`) of the cooked string literals the
+/// late `check_expr` pass saw in the HIR. The drain at
+/// `check_crate_post` skips any queued pre-expansion candidate whose
+/// range is in here — those literals survived lowering and the late pass
+/// already owns them, so only the *consumed* literals (split format
+/// templates, `stringify!` contents, ...) are emitted from the queue.
+///
+/// Keyed by raw `BytePos` rather than `Span` so the comparison is immune
+/// to the macro-hygiene `SyntaxContext` differences between a
+/// pre-expansion token span and its post-expansion HIR span; a literal's
+/// source byte range uniquely identifies it within one crate's
+/// `SourceMap`.
+static VISITED_LITERALS: Mutex<BTreeSet<(u32, u32)>> = Mutex::new(BTreeSet::new());
+
 fn queue(violation: PendingViolation) {
     let mut guard = PENDING_VIOLATIONS
         .lock()
@@ -197,10 +223,10 @@ pub fn register_pass(lint_store: &mut LintStore) {
     if let DefaultState::Inactive = resolved_state("prefer_raw_string", DefaultState::Active) {
         return;
     }
-    // The pre-expansion pass sees `format!`-family templates while their
-    // source tokens are intact — before placeholder-carrying ones are
-    // split away from the HIR — and parks each rewrite for the late pass
-    // to anchor and emit. See [`mod@early`].
+    // The pre-expansion pass sees every macro's string literals while
+    // the source tokens are intact — including the ones lowering would
+    // consume before the HIR exists — and parks each rewrite for the late
+    // pass to dedup, anchor, and emit. See [`mod@early`].
     lint_store.register_pre_expansion_pass(|| Box::new(PreferRawStringEarly::new()));
     lint_store.register_late_pass(|_| Box::new(PreferRawString::new()));
 }
@@ -213,6 +239,15 @@ impl<'tcx> LateLintPass<'tcx> for PreferRawString {
         if !matches!(literal.node, LitKind::Str(_, StrStyle::Cooked)) {
             return;
         }
+        // Record that this literal survived into the HIR so the
+        // pre-expansion drain leaves it to us — before any of the bails
+        // below, so even a literal we don't end up emitting on still
+        // suppresses a duplicate queued candidate at the same source
+        // range.
+        VISITED_LITERALS
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .insert((literal.span.lo().0, literal.span.hi().0));
         let Ok(snippet) = lint_context
             .sess()
             .source_map()
@@ -253,9 +288,14 @@ impl<'tcx> LateLintPass<'tcx> for PreferRawString {
         );
     }
 
-    /// Drain the pre-expansion pass's queue of `format!`-template
-    /// rewrites and emit each at its deepest enclosing HIR node, by which
-    /// point `cfg_attr` has resolved and a per-site `#[allow]` applies.
+    /// Drain the pre-expansion pass's queue of rewrites for literals the
+    /// HIR walk never reached, and emit each at its deepest enclosing HIR
+    /// node — by which point `cfg_attr` has resolved and a per-site
+    /// `#[allow]` applies. A candidate is dropped if the late pass already
+    /// saw a literal at the same source range (it survived lowering, so
+    /// `check_expr` owns it) or if an earlier candidate already covered
+    /// that range (the same literal reached through nested macro
+    /// invocations).
     fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
         let pending: Vec<PendingViolation> = {
             let mut guard = PENDING_VIOLATIONS
@@ -263,12 +303,26 @@ impl<'tcx> LateLintPass<'tcx> for PreferRawString {
                 .unwrap_or_else(|err| err.into_inner());
             std::mem::take(&mut *guard)
         };
-        if pending.is_empty() {
+        let visited: BTreeSet<(u32, u32)> = {
+            let mut guard = VISITED_LITERALS
+                .lock()
+                .unwrap_or_else(|err| err.into_inner());
+            std::mem::take(&mut *guard)
+        };
+        let mut emitted: BTreeSet<(u32, u32)> = BTreeSet::new();
+        let surviving: Vec<PendingViolation> = pending
+            .into_iter()
+            .filter(|violation| {
+                let range = (violation.span.lo().0, violation.span.hi().0);
+                !visited.contains(&range) && emitted.insert(range)
+            })
+            .collect();
+        if surviving.is_empty() {
             return;
         }
-        let target_spans: Vec<_> = pending.iter().map(|violation| violation.span).collect();
+        let target_spans: Vec<_> = surviving.iter().map(|violation| violation.span).collect();
         let best = find_enclosing_hir_ids(lint_context.tcx, &target_spans);
-        for (violation, &hir_id) in pending.into_iter().zip(best.iter()) {
+        for (violation, &hir_id) in surviving.into_iter().zip(best.iter()) {
             emit::emit_raw_string(lint_context, hir_id, violation.span, violation.suggestion);
         }
     }

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -32,23 +32,21 @@ declare_tool_lint! {
     /// `r"..."` / `r#"..."#`, picking the smallest hash count that
     /// avoids a delimiter collision.
     ///
-    /// This includes literals passed as arguments to macros such as
-    /// `println!`, `format!`, `vec!`, and `assert!` — even a `format!`
-    /// template carrying a `{...}` placeholder, which expansion would
-    /// otherwise split apart before the lint sees it. The rewrite is
-    /// value-preserving (a raw string still parses placeholders, and
-    /// `{{` / `}}` survive verbatim), so the literal's role doesn't
-    /// matter. Silence a site the usual way where the regular form is
-    /// deliberately preferred.
-    ///
     /// The scan does not respect macro-argument boundaries: it reaches
-    /// every string literal a macro receives, including ones used for
-    /// their *source spelling* rather than their value, such as
-    /// `stringify!` and `dbg!`. There the raw form carries the same
-    /// value but a different reflected text. That is intentional rather
-    /// than carved out of the lint: code whose behaviour depends on a
-    /// literal's exact spelling instead of its value is rare and a code
-    /// smell; suppress it per site with
+    /// every string literal a macro receives, even ones expansion would
+    /// otherwise consume before the late pass sees them — most visibly a
+    /// `format!`-family template carrying a `{...}` placeholder, which is
+    /// split into static pieces. The rewrite is value-preserving (a raw
+    /// string still parses placeholders, and `{{` / `}}` survive
+    /// verbatim), so the literal's role doesn't matter. Silence a site
+    /// the usual way where the regular form is deliberately preferred.
+    ///
+    /// That reach also covers literals used for their *source spelling*
+    /// rather than their value, such as `stringify!` and `dbg!`, where
+    /// the raw form has the same value but a different reflected text.
+    /// That is intentional rather than carved out of the lint: code
+    /// whose behaviour depends on a literal's exact spelling instead of
+    /// its value is rare and a code smell; suppress it per site with
     /// `#[expect(perfectionist::prefer_raw_string)]`.
     ///
     /// Pattern-position literals in ordinary code

--- a/src/rules/prefer_raw_string.rs
+++ b/src/rules/prefer_raw_string.rs
@@ -1,4 +1,5 @@
 use std::num::NonZeroUsize;
+use std::sync::Mutex;
 
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use rustc_ast::{LitKind, StrStyle};
@@ -7,13 +8,19 @@ use rustc_hir::{Expr, ExprKind};
 use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 
+mod early;
+mod emit;
 mod parser;
+mod queue;
 
+use early::PreferRawStringEarly;
 use parser::{
-    DEFAULT_ELIGIBLE_ESCAPES, is_supported_eligible_entry, minimal_hash_count, scan_body,
+    DEFAULT_ELIGIBLE_ESCAPES, build_raw_string_suggestion, is_supported_eligible_entry, scan_body,
 };
+use queue::PendingViolation;
 
 use crate::common::{DefaultState, resolved_state};
+use crate::enclosing_hir::find_enclosing_hir_ids;
 
 declare_tool_lint! {
     /// ### What it does
@@ -121,6 +128,36 @@ impl Default for Config {
     }
 }
 
+/// The rule's settings after parsing and validation, shared by the late
+/// `ExprKind::Lit` pass and the pre-expansion `format!`-template pass so
+/// both apply the same threshold and eligible-escape set.
+pub(super) struct ResolvedConfig {
+    pub(super) min_escapes_to_trigger: NonZeroUsize,
+    pub(super) eligible_escapes: Vec<String>,
+}
+
+/// Load and validate the rule's configuration once, from the shared
+/// `CONFIG_KEY` table.
+pub(super) fn resolved_config() -> ResolvedConfig {
+    let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
+    // Drop entries that aren't one of the three self-decoding
+    // escapes (`\"`, `\\`, `\'`). Anything else — `\n`, `\t`,
+    // `\xNN`, `\u{...}`, ill-formed shapes — would break
+    // the parser's "second char is the decoded form" contract
+    // and let the `MachineApplicable` autofix silently corrupt
+    // user code. Filter rather than reject so a stray entry in
+    // the config table doesn't take the whole rule offline.
+    let eligible_escapes = config
+        .eligible_escapes
+        .into_iter()
+        .filter(|entry| is_supported_eligible_entry(entry))
+        .collect();
+    ResolvedConfig {
+        min_escapes_to_trigger: config.min_escapes_to_trigger,
+        eligible_escapes,
+    }
+}
+
 pub struct PreferRawString {
     min_escapes_to_trigger: NonZeroUsize,
     eligible_escapes: Vec<String>,
@@ -128,27 +165,29 @@ pub struct PreferRawString {
 
 impl PreferRawString {
     fn new() -> Self {
-        let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-        // Drop entries that aren't one of the three self-decoding
-        // escapes (`\"`, `\\`, `\'`). Anything else — `\n`, `\t`,
-        // `\xNN`, `\u{...}`, ill-formed shapes — would break
-        // the parser's "second char is the decoded form" contract
-        // and let the `MachineApplicable` autofix silently corrupt
-        // user code. Filter rather than reject so a stray entry in
-        // the config table doesn't take the whole rule offline.
-        let eligible_escapes = config
-            .eligible_escapes
-            .into_iter()
-            .filter(|entry| is_supported_eligible_entry(entry))
-            .collect();
+        let resolved = resolved_config();
         Self {
-            min_escapes_to_trigger: config.min_escapes_to_trigger,
-            eligible_escapes,
+            min_escapes_to_trigger: resolved.min_escapes_to_trigger,
+            eligible_escapes: resolved.eligible_escapes,
         }
     }
 }
 
+/// Rewrites the pre-expansion pass has built, waiting for the late pass
+/// to anchor each at its enclosing HIR node and emit. A process-wide
+/// static is the same mechanism `print_macro_split` uses to bridge its
+/// pre-expansion and late halves; see [`mod@queue`].
+static PENDING_VIOLATIONS: Mutex<Vec<PendingViolation>> = Mutex::new(Vec::new());
+
+fn queue(violation: PendingViolation) {
+    let mut guard = PENDING_VIOLATIONS
+        .lock()
+        .unwrap_or_else(|err| err.into_inner());
+    guard.push(violation);
+}
+
 impl_lint_pass!(PreferRawString => [PREFER_RAW_STRING]);
+impl_lint_pass!(PreferRawStringEarly => [PREFER_RAW_STRING]);
 
 pub fn register_lint(lint_store: &mut LintStore) {
     lint_store.register_lints(&[PREFER_RAW_STRING]);
@@ -158,6 +197,11 @@ pub fn register_pass(lint_store: &mut LintStore) {
     if let DefaultState::Inactive = resolved_state("prefer_raw_string", DefaultState::Active) {
         return;
     }
+    // The pre-expansion pass sees `format!`-family templates while their
+    // source tokens are intact — before placeholder-carrying ones are
+    // split away from the HIR — and parks each rewrite for the late pass
+    // to anchor and emit. See [`mod@early`].
+    lint_store.register_pre_expansion_pass(|| Box::new(PreferRawStringEarly::new()));
     lint_store.register_late_pass(|_| Box::new(PreferRawString::new()));
 }
 
@@ -198,17 +242,34 @@ impl<'tcx> LateLintPass<'tcx> for PreferRawString {
         if scan.eliminable_count < self.min_escapes_to_trigger.get() {
             return;
         }
-        let n_hashes = minimal_hash_count(&scan.decoded);
-        let hashes = "#".repeat(n_hashes);
-        let suggestion = format!("r{hashes}\"{}\"{hashes}", scan.decoded);
         span_lint_and_sugg(
             lint_context,
             PREFER_RAW_STRING,
             literal.span,
             "string literal uses escapes that a raw string would avoid",
             "use a raw string",
-            suggestion,
+            build_raw_string_suggestion(&scan.decoded),
             Applicability::MachineApplicable,
         );
+    }
+
+    /// Drain the pre-expansion pass's queue of `format!`-template
+    /// rewrites and emit each at its deepest enclosing HIR node, by which
+    /// point `cfg_attr` has resolved and a per-site `#[allow]` applies.
+    fn check_crate_post(&mut self, lint_context: &LateContext<'tcx>) {
+        let pending: Vec<PendingViolation> = {
+            let mut guard = PENDING_VIOLATIONS
+                .lock()
+                .unwrap_or_else(|err| err.into_inner());
+            std::mem::take(&mut *guard)
+        };
+        if pending.is_empty() {
+            return;
+        }
+        let target_spans: Vec<_> = pending.iter().map(|violation| violation.span).collect();
+        let best = find_enclosing_hir_ids(lint_context.tcx, &target_spans);
+        for (violation, &hir_id) in pending.into_iter().zip(best.iter()) {
+            emit::emit_raw_string(lint_context, hir_id, violation.span, violation.suggestion);
+        }
     }
 }

--- a/src/rules/prefer_raw_string/early.rs
+++ b/src/rules/prefer_raw_string/early.rs
@@ -26,7 +26,7 @@ use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 
 use super::parser::{build_raw_string_suggestion, scan_body};
 use super::queue::PendingViolation;
-use super::{queue, resolved_config};
+use super::resolved_config;
 use crate::macro_template::find_all_cooked_str_literals;
 
 pub(super) struct PreferRawStringEarly {
@@ -66,7 +66,11 @@ impl EarlyLintPass for PreferRawStringEarly {
             if scan.eliminable_count < self.min_escapes_to_trigger.get() {
                 continue;
             }
-            queue(PendingViolation {
+            // Qualified rather than imported: the parent module also
+            // has a `queue` submodule (used above for `PendingViolation`),
+            // and naming the function through `super::` keeps the two
+            // `queue` spellings visibly distinct at a glance.
+            super::queue(PendingViolation {
                 span: literal_span,
                 suggestion: build_raw_string_suggestion(&scan.decoded),
             });

--- a/src/rules/prefer_raw_string/early.rs
+++ b/src/rules/prefer_raw_string/early.rs
@@ -1,0 +1,147 @@
+//! Pre-expansion pass that rescues `format!`-family templates the late
+//! `ExprKind::Lit` pass cannot see.
+//!
+//! A `format!`-family template that contains a `{...}` placeholder is
+//! lowered through `rustc_ast::FormatArgs`: by the time the HIR exists
+//! the template has been split into its static pieces and arguments, so
+//! it never survives as one `LitKind::Str` node for the late pass to
+//! visit. A placeholder-free template, by contrast, lowers to a single
+//! `&str` literal and is handled by the late pass as normal.
+//!
+//! This pass closes that gap. It runs before expansion, where the
+//! macro's source tokens are intact, finds the format template via
+//! [`crate::macro_template::find_template_literal`], and — *only* when
+//! the template carries a real placeholder (the exact case the late
+//! pass misses, which keeps the two passes from both firing on one
+//! literal) — scans it with the same eligible-escape parser the late
+//! pass uses and queues a raw-string rewrite. The queued rewrite is
+//! emitted by the late pass's `check_crate_post`, anchored at the
+//! enclosing HIR node so a `cfg_attr`-wrapped `#[allow]` resolves.
+
+use std::collections::BTreeSet;
+use std::num::NonZeroUsize;
+
+use rustc_ast::MacCall;
+use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
+
+use super::parser::{build_raw_string_suggestion, scan_body};
+use super::queue::PendingViolation;
+use super::{queue, resolved_config};
+use crate::macro_path::{matches_any, merge_with_builtins};
+use crate::macro_template::find_template_literal;
+
+/// `format!`-family macros whose template argument is routed through
+/// `format_args!` and therefore split away from the HIR once it carries
+/// a placeholder. Matched by final path segment, so `format` covers
+/// `std::format!` / `core::format!`, and `info` covers `log::info!` /
+/// `tracing::info!`.
+///
+/// The `assert_eq!` / `assert_ne!` family is deliberately absent: their
+/// leading arguments are *compared values* that may themselves be lone
+/// string literals, which the "first lone cooked literal" template
+/// search would misread as the message template. Their message argument
+/// is reachable, but pinning it down robustly is out of scope for this
+/// false-negative fix.
+const FORMAT_TEMPLATE_MACROS: &[&str] = &[
+    "format",
+    "format_args",
+    "print",
+    "println",
+    "eprint",
+    "eprintln",
+    "write",
+    "writeln",
+    "panic",
+    "todo",
+    "unimplemented",
+    "unreachable",
+    "assert",
+    "debug_assert",
+    "log",
+    "error",
+    "warn",
+    "info",
+    "debug",
+    "trace",
+];
+
+pub(super) struct PreferRawStringEarly {
+    min_escapes_to_trigger: NonZeroUsize,
+    eligible_escapes: Vec<String>,
+    target_macros: BTreeSet<Vec<String>>,
+}
+
+impl PreferRawStringEarly {
+    pub(super) fn new() -> Self {
+        let resolved = resolved_config();
+        Self {
+            min_escapes_to_trigger: resolved.min_escapes_to_trigger,
+            eligible_escapes: resolved.eligible_escapes,
+            target_macros: merge_with_builtins(FORMAT_TEMPLATE_MACROS, &BTreeSet::new()),
+        }
+    }
+}
+
+impl EarlyLintPass for PreferRawStringEarly {
+    fn check_mac(&mut self, lint_context: &EarlyContext<'_>, mac_call: &MacCall) {
+        if !matches_any(&mac_call.path, &self.target_macros) {
+            return;
+        }
+        let Some(template_span) = find_template_literal(&mac_call.args.tokens) else {
+            return;
+        };
+        let source_map = lint_context.sess().source_map();
+        let Ok(snippet) = source_map.span_to_snippet(template_span) else {
+            return;
+        };
+        // Synthesised spans and any non-cooked spelling that slips
+        // through bail here, mirroring the late pass's belt-and-braces
+        // quote-stripping guard.
+        let Some(body) = snippet
+            .strip_prefix('"')
+            .and_then(|rest| rest.strip_suffix('"'))
+        else {
+            return;
+        };
+        let Some(scan) = scan_body(body, &self.eligible_escapes) else {
+            return;
+        };
+        // Only placeholder-carrying templates are split away from the
+        // HIR; a placeholder-free one survives as a single literal and
+        // is the late pass's job. Skipping it here is what keeps the two
+        // passes from both flagging the same literal.
+        if !has_format_placeholder(&scan.decoded) {
+            return;
+        }
+        if scan.eliminable_count < self.min_escapes_to_trigger.get() {
+            return;
+        }
+        queue(PendingViolation {
+            span: template_span,
+            suggestion: build_raw_string_suggestion(&scan.decoded),
+        });
+    }
+}
+
+/// Whether a format-string body contains a real `{...}` placeholder, as
+/// opposed to only the escaped braces `{{` / `}}`. Switching to a raw
+/// string leaves placeholder parsing untouched (`{` is still a
+/// placeholder, `{{` still an escaped brace), so this only gates *which
+/// pass* handles the literal — it never changes the rewrite.
+///
+/// Braces are ASCII, so a byte scan is correct over UTF-8 text; and a
+/// `\` never escapes a brace in a Rust string literal, so the decoded
+/// body carries the same braces as the source.
+fn has_format_placeholder(body: &str) -> bool {
+    let bytes = body.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'{' if bytes.get(index + 1) == Some(&b'{') => index += 2,
+            b'{' => return true,
+            b'}' if bytes.get(index + 1) == Some(&b'}') => index += 2,
+            _ => index += 1,
+        }
+    }
+    false
+}

--- a/src/rules/prefer_raw_string/early.rs
+++ b/src/rules/prefer_raw_string/early.rs
@@ -1,24 +1,24 @@
-//! Pre-expansion pass that rescues `format!`-family templates the late
+//! Pre-expansion pass that rescues string literals the late
 //! `ExprKind::Lit` pass cannot see.
 //!
-//! A `format!`-family template that contains a `{...}` placeholder is
-//! lowered through `rustc_ast::FormatArgs`: by the time the HIR exists
-//! the template has been split into its static pieces and arguments, so
-//! it never survives as one `LitKind::Str` node for the late pass to
-//! visit. A placeholder-free template, by contrast, lowers to a single
-//! `&str` literal and is handled by the late pass as normal.
+//! Some macros consume a string literal during expansion so that it
+//! never survives into the HIR as one `LitKind::Str` node: a `format!`
+//! template carrying a `{...}` placeholder is split into its static
+//! pieces, `stringify!`/`dbg!` reflect it as source text, and so on. The
+//! late pass, which only walks the HIR, can't reach those.
 //!
-//! This pass closes that gap. It runs before expansion, where the
-//! macro's source tokens are intact, finds the format template via
-//! [`crate::macro_template::find_template_literal`], and — *only* when
-//! the template carries a real placeholder (the exact case the late
-//! pass misses, which keeps the two passes from both firing on one
-//! literal) — scans it with the same eligible-escape parser the late
-//! pass uses and queues a raw-string rewrite. The queued rewrite is
-//! emitted by the late pass's `check_crate_post`, anchored at the
-//! enclosing HIR node so a `cfg_attr`-wrapped `#[allow]` resolves.
+//! This pass runs before expansion, where the macro's source tokens are
+//! intact, and collects *every* cooked string literal in every macro
+//! invocation (via [`crate::macro_template::find_all_cooked_str_literals`]).
+//! The raw-string rewrite is value-preserving for any literal, so there
+//! is no need to single out "the template" or restrict to a macro
+//! allowlist. Each eligible literal is queued; the late pass drains the
+//! queue at `check_crate_post`, **skipping any literal it already saw in
+//! the HIR** (recorded by byte range — see [`super::VISITED_LITERALS`]).
+//! That dedup is what keeps the two passes disjoint: literals that
+//! survive lowering belong to the late pass, and only the consumed ones
+//! are emitted here.
 
-use std::collections::BTreeSet;
 use std::num::NonZeroUsize;
 
 use rustc_ast::MacCall;
@@ -27,48 +27,11 @@ use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use super::parser::{build_raw_string_suggestion, scan_body};
 use super::queue::PendingViolation;
 use super::{queue, resolved_config};
-use crate::macro_path::{matches_any, merge_with_builtins};
-use crate::macro_template::find_template_literal;
-
-/// `format!`-family macros whose template argument is routed through
-/// `format_args!` and therefore split away from the HIR once it carries
-/// a placeholder. Matched by final path segment, so `format` covers
-/// `std::format!` / `core::format!`, and `info` covers `log::info!` /
-/// `tracing::info!`.
-///
-/// The `assert_eq!` / `assert_ne!` family is deliberately absent: their
-/// leading arguments are *compared values* that may themselves be lone
-/// string literals, which the "first lone cooked literal" template
-/// search would misread as the message template. Their message argument
-/// is reachable, but pinning it down robustly is out of scope for this
-/// false-negative fix.
-const FORMAT_TEMPLATE_MACROS: &[&str] = &[
-    "format",
-    "format_args",
-    "print",
-    "println",
-    "eprint",
-    "eprintln",
-    "write",
-    "writeln",
-    "panic",
-    "todo",
-    "unimplemented",
-    "unreachable",
-    "assert",
-    "debug_assert",
-    "log",
-    "error",
-    "warn",
-    "info",
-    "debug",
-    "trace",
-];
+use crate::macro_template::find_all_cooked_str_literals;
 
 pub(super) struct PreferRawStringEarly {
     min_escapes_to_trigger: NonZeroUsize,
     eligible_escapes: Vec<String>,
-    target_macros: BTreeSet<Vec<String>>,
 }
 
 impl PreferRawStringEarly {
@@ -77,71 +40,36 @@ impl PreferRawStringEarly {
         Self {
             min_escapes_to_trigger: resolved.min_escapes_to_trigger,
             eligible_escapes: resolved.eligible_escapes,
-            target_macros: merge_with_builtins(FORMAT_TEMPLATE_MACROS, &BTreeSet::new()),
         }
     }
 }
 
 impl EarlyLintPass for PreferRawStringEarly {
     fn check_mac(&mut self, lint_context: &EarlyContext<'_>, mac_call: &MacCall) {
-        if !matches_any(&mac_call.path, &self.target_macros) {
-            return;
-        }
-        let Some(template_span) = find_template_literal(&mac_call.args.tokens) else {
-            return;
-        };
         let source_map = lint_context.sess().source_map();
-        let Ok(snippet) = source_map.span_to_snippet(template_span) else {
-            return;
-        };
-        // Synthesised spans and any non-cooked spelling that slips
-        // through bail here, mirroring the late pass's belt-and-braces
-        // quote-stripping guard.
-        let Some(body) = snippet
-            .strip_prefix('"')
-            .and_then(|rest| rest.strip_suffix('"'))
-        else {
-            return;
-        };
-        let Some(scan) = scan_body(body, &self.eligible_escapes) else {
-            return;
-        };
-        // Only placeholder-carrying templates are split away from the
-        // HIR; a placeholder-free one survives as a single literal and
-        // is the late pass's job. Skipping it here is what keeps the two
-        // passes from both flagging the same literal.
-        if !has_format_placeholder(&scan.decoded) {
-            return;
-        }
-        if scan.eliminable_count < self.min_escapes_to_trigger.get() {
-            return;
-        }
-        queue(PendingViolation {
-            span: template_span,
-            suggestion: build_raw_string_suggestion(&scan.decoded),
-        });
-    }
-}
-
-/// Whether a format-string body contains a real `{...}` placeholder, as
-/// opposed to only the escaped braces `{{` / `}}`. Switching to a raw
-/// string leaves placeholder parsing untouched (`{` is still a
-/// placeholder, `{{` still an escaped brace), so this only gates *which
-/// pass* handles the literal — it never changes the rewrite.
-///
-/// Braces are ASCII, so a byte scan is correct over UTF-8 text; and a
-/// `\` never escapes a brace in a Rust string literal, so the decoded
-/// body carries the same braces as the source.
-fn has_format_placeholder(body: &str) -> bool {
-    let bytes = body.as_bytes();
-    let mut index = 0;
-    while index < bytes.len() {
-        match bytes[index] {
-            b'{' if bytes.get(index + 1) == Some(&b'{') => index += 2,
-            b'{' => return true,
-            b'}' if bytes.get(index + 1) == Some(&b'}') => index += 2,
-            _ => index += 1,
+        for literal_span in find_all_cooked_str_literals(&mac_call.args.tokens) {
+            let Ok(snippet) = source_map.span_to_snippet(literal_span) else {
+                continue;
+            };
+            // Synthesised spans and any non-cooked spelling that slips
+            // through bail here, mirroring the late pass's belt-and-braces
+            // quote-stripping guard.
+            let Some(body) = snippet
+                .strip_prefix('"')
+                .and_then(|rest| rest.strip_suffix('"'))
+            else {
+                continue;
+            };
+            let Some(scan) = scan_body(body, &self.eligible_escapes) else {
+                continue;
+            };
+            if scan.eliminable_count < self.min_escapes_to_trigger.get() {
+                continue;
+            }
+            queue(PendingViolation {
+                span: literal_span,
+                suggestion: build_raw_string_suggestion(&scan.decoded),
+            });
         }
     }
-    false
 }

--- a/src/rules/prefer_raw_string/emit.rs
+++ b/src/rules/prefer_raw_string/emit.rs
@@ -12,7 +12,7 @@ use rustc_hir as hir;
 use rustc_lint::LateContext;
 use rustc_span::Span;
 
-use super::PREFER_RAW_STRING;
+use super::{PREFER_RAW_STRING, SUGGESTION_LABEL, VIOLATION_MESSAGE};
 
 pub(super) fn emit_raw_string(
     lint_context: &LateContext<'_>,
@@ -25,11 +25,11 @@ pub(super) fn emit_raw_string(
         PREFER_RAW_STRING,
         hir_id,
         span,
-        "string literal uses escapes that a raw string would avoid",
+        VIOLATION_MESSAGE,
         |diag| {
             diag.span_suggestion(
                 span,
-                "use a raw string",
+                SUGGESTION_LABEL,
                 suggestion,
                 Applicability::MachineApplicable,
             );

--- a/src/rules/prefer_raw_string/emit.rs
+++ b/src/rules/prefer_raw_string/emit.rs
@@ -1,7 +1,7 @@
-//! Diagnostic emission for the `format!`-template violations the
-//! pre-expansion pass discovers. The late `ExprKind::Lit` path emits
-//! its own diagnostics inline via `span_lint_and_sugg`; this helper is
-//! the HIR-anchored counterpart for the queued ones, drained at
+//! Diagnostic emission for the consumed-literal violations the
+//! pre-expansion pass discovers. The late `ExprKind::Lit` path emits its
+//! own diagnostics inline via `span_lint_and_sugg`; this helper is the
+//! HIR-anchored counterpart for the queued ones, drained at
 //! `check_crate_post`. Message, label, and applicability match the
 //! inline path exactly so the two firing routes are indistinguishable
 //! to the user.

--- a/src/rules/prefer_raw_string/emit.rs
+++ b/src/rules/prefer_raw_string/emit.rs
@@ -1,0 +1,38 @@
+//! Diagnostic emission for the `format!`-template violations the
+//! pre-expansion pass discovers. The late `ExprKind::Lit` path emits
+//! its own diagnostics inline via `span_lint_and_sugg`; this helper is
+//! the HIR-anchored counterpart for the queued ones, drained at
+//! `check_crate_post`. Message, label, and applicability match the
+//! inline path exactly so the two firing routes are indistinguishable
+//! to the user.
+
+use clippy_utils::diagnostics::span_lint_hir_and_then;
+use rustc_errors::Applicability;
+use rustc_hir as hir;
+use rustc_lint::LateContext;
+use rustc_span::Span;
+
+use super::PREFER_RAW_STRING;
+
+pub(super) fn emit_raw_string(
+    lint_context: &LateContext<'_>,
+    hir_id: hir::HirId,
+    span: Span,
+    suggestion: String,
+) {
+    span_lint_hir_and_then(
+        lint_context,
+        PREFER_RAW_STRING,
+        hir_id,
+        span,
+        "string literal uses escapes that a raw string would avoid",
+        |diag| {
+            diag.span_suggestion(
+                span,
+                "use a raw string",
+                suggestion,
+                Applicability::MachineApplicable,
+            );
+        },
+    );
+}

--- a/src/rules/prefer_raw_string/parser.rs
+++ b/src/rules/prefer_raw_string/parser.rs
@@ -91,6 +91,16 @@ fn take_literal_char(input: &str) -> Option<(&str, &str)> {
     Some(input.split_at(first.len_utf8()))
 }
 
+/// Build the raw-string replacement for a decoded literal body: the
+/// `r`-prefixed form with the smallest hash count that avoids a
+/// delimiter collision. Shared by the late `ExprKind::Lit` pass and the
+/// pre-expansion `format!`-template pass so the two emit byte-identical
+/// suggestions.
+pub(super) fn build_raw_string_suggestion(decoded: &str) -> String {
+    let hashes = "#".repeat(minimal_hash_count(decoded));
+    format!(r#"r{hashes}"{decoded}"{hashes}"#)
+}
+
 /// Smallest number of `#` characters needed so that the closing
 /// `"<n #s>` sequence does not appear inside `decoded`.
 ///

--- a/src/rules/prefer_raw_string/queue.rs
+++ b/src/rules/prefer_raw_string/queue.rs
@@ -1,0 +1,18 @@
+//! The pre-expansion pass parks one of these per `format!`-family
+//! template it rewrites, for the late pass to emit after `cfg_attr` has
+//! resolved, at the deepest enclosing HIR node.
+//!
+//! As with `print_macro_split`, the rewrite is computed up front (it
+//! needs the source map, available pre-expansion) and carried as a
+//! ready `String`. `Span` is `Copy + Send + Sync` and `String` is
+//! `Send`, so the queue is safe to hold in a process-wide static.
+
+use rustc_span::Span;
+
+pub(super) struct PendingViolation {
+    /// Span of the template string literal — both the diagnostic anchor
+    /// and the region the suggestion replaces.
+    pub(super) span: Span,
+    /// The raw-string replacement for `span`.
+    pub(super) suggestion: String,
+}

--- a/src/rules/prefer_raw_string/queue.rs
+++ b/src/rules/prefer_raw_string/queue.rs
@@ -1,6 +1,6 @@
-//! The pre-expansion pass parks one of these per `format!`-family
-//! template it rewrites, for the late pass to emit after `cfg_attr` has
-//! resolved, at the deepest enclosing HIR node.
+//! The pre-expansion pass parks one of these per macro-embedded string
+//! literal it rewrites, for the late pass to dedup and emit after
+//! `cfg_attr` has resolved, at the deepest enclosing HIR node.
 //!
 //! As with `print_macro_split`, the rewrite is computed up front (it
 //! needs the source map, available pre-expansion) and carried as a
@@ -10,8 +10,8 @@
 use rustc_span::Span;
 
 pub(super) struct PendingViolation {
-    /// Span of the template string literal — both the diagnostic anchor
-    /// and the region the suggestion replaces.
+    /// Span of the string literal — both the diagnostic anchor and the
+    /// region the suggestion replaces.
     pub(super) span: Span,
     /// The raw-string replacement for `span`.
     pub(super) suggestion: String,

--- a/src/rules/print_macro_split.rs
+++ b/src/rules/print_macro_split.rs
@@ -5,6 +5,7 @@ use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 
 use crate::common::{DefaultState, resolved_state};
+use crate::macro_template::find_template_literal;
 
 mod config;
 mod emit;
@@ -15,7 +16,7 @@ mod scan;
 use config::PrintMacroSplit;
 use late::PrintMacroSplitLate;
 use queue::PendingViolation;
-use scan::{build_fold_suggestion, find_template_literal};
+use scan::build_fold_suggestion;
 
 declare_tool_lint! {
     /// ### What it does

--- a/src/rules/print_macro_split/scan.rs
+++ b/src/rules/print_macro_split/scan.rs
@@ -11,8 +11,8 @@
 //! source newline and indentation it introduced.
 
 use rustc_ast::MacCall;
-use rustc_ast::token::{LitKind, TokenKind};
-use rustc_ast::tokenstream::{TokenStream, TokenTree};
+use rustc_ast::token::TokenKind;
+use rustc_ast::tokenstream::TokenTree;
 use rustc_span::Span;
 use rustc_span::source_map::SourceMap;
 
@@ -23,59 +23,6 @@ use crate::literal_scan::take_string_escape;
 /// one level past the line the invocation starts on; four spaces
 /// matches rustfmt's default.
 const INDENT_STEP: &str = "    ";
-
-/// Span of the first top-level argument that is, on its own, a single
-/// cooked string literal — the format template. Returns `None` when no
-/// such argument exists (a runtime-expression template, a `concat!`
-/// result, or a template that is the second argument behind a writer
-/// expression that itself isn't a lone string literal, etc.).
-///
-/// "First lone cooked string literal" is what makes the same scan work
-/// across the whole target set: `println!`'s template is the first
-/// argument, `write!`'s is the second (the writer comes first and
-/// isn't a bare literal), `log!`'s is the second (the level comes
-/// first), and `log::info!`'s is the first.
-pub(super) fn find_template_literal(tokens: &TokenStream) -> Option<Span> {
-    let mut argument_len: usize = 0;
-    let mut argument_lead_literal: Option<Span> = None;
-    let mut found: Option<Span> = None;
-    let finish_argument = |len: usize, lead: Option<Span>, found: &mut Option<Span>| {
-        if found.is_none() && len == 1 {
-            *found = lead;
-        }
-    };
-    for tree in tokens.iter() {
-        if is_top_level_comma(tree) {
-            finish_argument(argument_len, argument_lead_literal, &mut found);
-            argument_len = 0;
-            argument_lead_literal = None;
-            continue;
-        }
-        if argument_len == 0 {
-            argument_lead_literal = cooked_str_literal_span(tree);
-        }
-        argument_len += 1;
-    }
-    finish_argument(argument_len, argument_lead_literal, &mut found);
-    found
-}
-
-fn is_top_level_comma(tree: &TokenTree) -> bool {
-    matches!(tree, TokenTree::Token(token, _) if token.kind == TokenKind::Comma)
-}
-
-fn cooked_str_literal_span(tree: &TokenTree) -> Option<Span> {
-    let TokenTree::Token(token, _) = tree else {
-        return None;
-    };
-    let TokenKind::Literal(literal) = token.kind else {
-        return None;
-    };
-    // Cooked (`"..."`) only. A raw string (`r"..."`) treats `\` as an
-    // ordinary character, so the escape-aware fold below must never run
-    // over one.
-    matches!(literal.kind, LitKind::Str).then_some(token.span)
-}
 
 /// Build the `(call_span, replacement)` for the wrapped,
 /// continuation-folded form, or `None` if the invocation should be
@@ -110,7 +57,7 @@ pub(super) fn build_fold_suggestion(
         .strip_prefix('"')
         .and_then(|rest| rest.strip_suffix('"'))?;
     let folded_body = fold_template_body(body, &inner_indent)?;
-    let folded_literal = format!("\"{folded_body}\"");
+    let folded_literal = format!(r#""{folded_body}""#);
 
     // Splice the folded literal back into the delimited argument list,
     // keeping every other argument verbatim.

--- a/tools/deploy-check/src/contract.rs
+++ b/tools/deploy-check/src/contract.rs
@@ -136,8 +136,8 @@ pub(crate) fn assert_version_only_diff(
     if before_lines.len() != after_lines.len() {
         return Err(RuntimeError::LineCountChanged(file.to_owned()));
     }
-    let expected_before = format!("version = \"{before_ver}\"");
-    let expected_after = format!("version = \"{after_ver}\"");
+    let expected_before = format!(r#"version = "{before_ver}""#);
+    let expected_after = format!(r#"version = "{after_ver}""#);
     let mut diffs = before_lines
         .iter()
         .zip(&after_lines)

--- a/tools/gen-docs/src/render/config.rs
+++ b/tools/gen-docs/src/render/config.rs
@@ -38,7 +38,7 @@ pub(crate) fn config_section(config: &ConfigDoc) -> Markup {
             summary.config-summary { "Configuration" }
             p {
                 "Configure via " code { "dylint.toml" } " under "
-                code { r#"["# (config.key) r#""]"# } "."
+                code { r#"[""# (config.key) r#""]"# } "."
             }
             dl.config {
                 @for field in &config.fields {

--- a/tools/gen-docs/src/render/config.rs
+++ b/tools/gen-docs/src/render/config.rs
@@ -38,7 +38,7 @@ pub(crate) fn config_section(config: &ConfigDoc) -> Markup {
             summary.config-summary { "Configuration" }
             p {
                 "Configure via " code { "dylint.toml" } " under "
-                code { "[\"" (config.key) "\"]" } "."
+                code { r#"["# (config.key) r#""]"# } "."
             }
             dl.config {
                 @for field in &config.fields {
@@ -95,7 +95,7 @@ fn custom_type_block(ty: &TypeDoc) -> Markup {
                         dl.config {
                             @for variant in variants {
                                 dt {
-                                    code.config-key { "\"" (variant.serialized) "\"" }
+                                    code.config-key { r#"""# (variant.serialized) r#"""# }
                                     @if variant.rust_name != variant.serialized {
                                         " "
                                         span.config-default {

--- a/tools/gen-docs/src/render/markdown.rs
+++ b/tools/gen-docs/src/render/markdown.rs
@@ -105,7 +105,7 @@ fn lang_class_attr(lang: &str) -> String {
             char.is_ascii_alphanumeric() || matches!(char, '_' | '-' | '+' | '#' | '.')
         });
     if safe {
-        format!(" class=\"language-{lang}\"")
+        format!(r#" class="language-{lang}""#)
     } else {
         String::new()
     }

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use super::*;
-use crate::model::ConfigDoc;
+use crate::model::{ConfigDoc, ConfigField, Optionality};
 
 fn fake_rule(name: &str) -> Rule {
     Rule {
@@ -578,4 +578,30 @@ fn nav_toggle_script_is_a_single_iife() {
     // a future edit can't reintroduce the same bug silently.
     assert_eq!(NAV_TOGGLE_SCRIPT.matches("(function () {").count(), 1);
     assert_eq!(NAV_TOGGLE_SCRIPT.matches("})();").count(), 1);
+}
+
+#[test]
+fn config_section_keeps_both_quotes_around_the_dylint_toml_key() {
+    // Regression guard: the `["<key>"]` TOML table header is built from
+    // two quote-bearing string fragments in `config_section`. A
+    // value-dropping raw-string rewrite of either (e.g. `r#"[""#`
+    // mistyped as `r#"["#`, which parses as `[` and loses the quote)
+    // silently renders `[key"]`. Assert both quotes survive around the
+    // key. Only rules with at least one field render this header, so the
+    // `fake_rule` fixtures elsewhere never covered it.
+    let config = ConfigDoc {
+        key: "perfectionist::demo".to_owned(),
+        fields: vec![ConfigField {
+            name: "some_field".to_owned(),
+            type_label: "bool".to_owned(),
+            doc_markdown: String::new(),
+            optionality: Optionality::Optional,
+        }],
+        custom_types: Vec::new(),
+    };
+    let html = crate::render::config::config_section(&config).into_string();
+    assert!(
+        html.contains("[&quot;perfectionist::demo&quot;]"),
+        "config heading must wrap the key in both quotes, got: {html}",
+    );
 }

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -172,7 +172,7 @@ fn page_links_each_stylesheet_individually() {
     // its cascade position matches the old single `<style>`.
     for &(name, _) in STYLESHEETS {
         assert!(
-            html.contains(&format!("<link rel=\"stylesheet\" href=\"{name}\">")),
+            html.contains(&format!(r#"<link rel="stylesheet" href="{name}">"#)),
             "expected a dedicated <link> for {name}",
         );
     }
@@ -275,7 +275,7 @@ fn page_does_not_inline_the_anchor_icon_svg() {
 fn style_references_rule_anchor_icon() {
     // The CSS `url(...)` and the written filename must agree, or the
     // icon 404s.
-    let expected = format!("url(\"{RULE_ANCHOR_ICON_FILENAME}\")");
+    let expected = format!(r#"url("{RULE_ANCHOR_ICON_FILENAME}")"#);
     assert!(
         stylesheet("rules.css").contains(&expected),
         "rules.css must reference the anchor icon as {expected}",
@@ -375,7 +375,7 @@ fn page_does_not_inline_theme_icon_svgs() {
     let settings = stylesheet("settings.css");
     for (name, _) in THEME_ICONS {
         assert!(
-            settings.contains(&format!("url(\"{name}\")")),
+            settings.contains(&format!(r#"url("{name}")"#)),
             "settings.css must reference the theme icon {name} as a mask",
         );
     }

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -143,7 +143,7 @@ fn page_links_nav_toggle_script_externally() {
     // out of sync with `NAV_TOGGLE_SCRIPT_FILENAME`) is caught.
     assert!(
         html.contains(&format!(
-            "<script src=\"{NAV_TOGGLE_SCRIPT_FILENAME}\"></script>"
+            r#"<script src="{NAV_TOGGLE_SCRIPT_FILENAME}"></script>"#
         )),
         "expected the nav script to be referenced via <script src>",
     );
@@ -180,13 +180,13 @@ fn page_links_each_stylesheet_individually() {
     // emits two, so a regression that drops the dark one must fail here.
     assert!(
         html.contains(&format!(
-            "<link rel=\"stylesheet\" href=\"{HIGHLIGHT_CSS_LIGHT_FILENAME}\">"
+            r#"<link rel="stylesheet" href="{HIGHLIGHT_CSS_LIGHT_FILENAME}">"#
         )),
         "expected a dedicated <link> for the light highlight CSS",
     );
     assert!(
         html.contains(&format!(
-            "<link rel=\"stylesheet\" href=\"{HIGHLIGHT_CSS_DARK_FILENAME}\">"
+            r#"<link rel="stylesheet" href="{HIGHLIGHT_CSS_DARK_FILENAME}">"#
         )),
         "expected a dedicated <link> for the dark highlight CSS",
     );
@@ -337,7 +337,7 @@ fn page_links_theme_toggle_script_externally() {
     // src>`, not inlined — same contract as the nav script.
     assert!(
         html.contains(&format!(
-            "<script src=\"{THEME_TOGGLE_SCRIPT_FILENAME}\"></script>"
+            r#"<script src="{THEME_TOGGLE_SCRIPT_FILENAME}"></script>"#
         )),
         "expected the theme script to be referenced via <script src>",
     );

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -385,7 +385,7 @@ fn page_links_config_toggle_script_externally() {
     // scripts.
     assert!(
         html.contains(&format!(
-            "<script src=\"{CONFIG_TOGGLE_SCRIPT_FILENAME}\"></script>"
+            r#"<script src="{CONFIG_TOGGLE_SCRIPT_FILENAME}"></script>"#
         )),
         "expected the config-toggle script to be referenced via <script src>",
     );

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -173,7 +173,7 @@ fn render_config_section(config: &ConfigDoc, out: &mut String) {
     };
     let _ = writeln!(
         out,
-        "Configure via `dylint.toml` under `[\"{}\"]`. {optionality_note}.",
+        r#"Configure via `dylint.toml` under `["{}"]`. {optionality_note}."#,
         config.key,
     );
     out.push('\n');
@@ -234,11 +234,11 @@ fn render_type(ty: &TypeDoc, out: &mut String) {
 
 fn render_variant(variant: &EnumVariant, out: &mut String) {
     if variant.rust_name == variant.serialized {
-        let _ = writeln!(out, "##### `\"{}\"`", variant.serialized);
+        let _ = writeln!(out, r#"##### `"{}"`"#, variant.serialized);
     } else {
         let _ = writeln!(
             out,
-            "##### `\"{}\"` (Rust: `{}`)",
+            r#"##### `"{}"` (Rust: `{}`)"#,
             variant.serialized, variant.rust_name,
         );
     }

--- a/ui/prefer_raw_string.rs
+++ b/ui/prefer_raw_string.rs
@@ -39,6 +39,29 @@ fn _inside_core_macro() {
     println!("path: \"foo\"");
 }
 
+// Bad: `format!` template carrying a `{...}` placeholder. The
+// placeholder splits the template away from the HIR during format-args
+// lowering, so the late `ExprKind::Lit` pass never sees it; the
+// pre-expansion pass rescues it. (issue #219)
+fn _format_with_inline_placeholder() {
+    let name = "x";
+    let _ = format!("url(\"{name}\")");
+}
+
+// Bad: same split reached through `println!` with a positional
+// placeholder rather than an inline-captured one.
+fn _println_with_positional_placeholder() {
+    println!("path: \"{}\"", "x");
+}
+
+// Not flagged: a placeholder template that also contains a non-raw
+// escape (`\n`). The literal is ineligible as a whole, and the static
+// pieces the compiler splits it into are not rewritten either.
+fn _placeholder_with_newline_escape() {
+    let value = 1;
+    let _ = format!("a\"b{value}\nc");
+}
+
 // Not flagged: contains a required non-raw escape (`\n`).
 fn _has_newline_escape() {
     let _ = "name:\tvalue\n";
@@ -86,6 +109,9 @@ fn main() {
     _mixed_eligible_escapes();
     _hash_count_grows();
     _inside_core_macro();
+    _format_with_inline_placeholder();
+    _println_with_positional_placeholder();
+    _placeholder_with_newline_escape();
     _has_newline_escape();
     _line_continuation();
     _mixed_eligible_and_non_raw();

--- a/ui/prefer_raw_string.rs
+++ b/ui/prefer_raw_string.rs
@@ -54,6 +54,32 @@ fn _println_with_positional_placeholder() {
     println!("path: \"{}\"", "x");
 }
 
+// Bad: `assert_eq!`'s message is the *third* argument, with no macro
+// allowlist or argument-position bookkeeping — the pre-expansion scan
+// reaches every literal. The message carries a placeholder, so it is
+// split away from the HIR; the comparison operands (`value`) are not
+// literals here, so nothing competes for the diagnostic.
+fn _assert_eq_message_placeholder() {
+    let value = 1;
+    assert_eq!(value, value, "v = \"{value}\"");
+}
+
+// Bad, exactly once: a string-literal *operand* of `assert_eq!`
+// survives lowering as an ordinary value, so the late pass flags it. The
+// pre-expansion scan also sees it, but the byte-range dedup drops the
+// duplicate — this fixture pins that there is no double diagnostic.
+fn _assert_eq_string_operand() {
+    assert_eq!("a\"b".len(), 3);
+}
+
+// Bad: `stringify!` reflects its argument's source spelling, so the
+// literal is consumed rather than surviving into the HIR. The rewrite is
+// still value-preserving; the project deliberately flags it (suppress
+// with `#[allow]` in the rare case the exact `stringify!` text matters).
+fn _stringify_argument() {
+    let _ = stringify!("a\"b");
+}
+
 // Not flagged: a placeholder template that also contains a non-raw
 // escape (`\n`). The literal is ineligible as a whole, and the static
 // pieces the compiler splits it into are not rewritten either.
@@ -111,6 +137,9 @@ fn main() {
     _inside_core_macro();
     _format_with_inline_placeholder();
     _println_with_positional_placeholder();
+    _assert_eq_message_placeholder();
+    _assert_eq_string_operand();
+    _stringify_argument();
     _placeholder_with_newline_escape();
     _has_newline_escape();
     _line_continuation();

--- a/ui/prefer_raw_string.rs
+++ b/ui/prefer_raw_string.rs
@@ -80,6 +80,16 @@ fn _stringify_argument() {
     let _ = stringify!("a\"b");
 }
 
+// Bad: `dbg!`'s argument *survives* lowering as the `match` scrutinee,
+// so the late pass flags it (the pre-expansion scan also sees it, but the
+// byte-range dedup drops the duplicate). The rewritten value is
+// identical; only the `stringify!`-reflected debug label printed at
+// runtime changes — the same deliberately-accepted trade-off as
+// `stringify!`.
+fn _dbg_argument() {
+    let _ = dbg!("a\"b");
+}
+
 // Not flagged: a placeholder template that also contains a non-raw
 // escape (`\n`). The literal is ineligible as a whole, and the static
 // pieces the compiler splits it into are not rewritten either.
@@ -140,6 +150,7 @@ fn main() {
     _assert_eq_message_placeholder();
     _assert_eq_string_operand();
     _stringify_argument();
+    _dbg_argument();
     _placeholder_with_newline_escape();
     _has_newline_escape();
     _line_continuation();

--- a/ui/prefer_raw_string.stderr
+++ b/ui/prefer_raw_string.stderr
@@ -42,5 +42,17 @@ warning: string literal uses escapes that a raw string would avoid
 LL |     println!("path: /"foo/"");
    |              ^^^^^^^^^^^^^^^ help: use a raw string: `r#"path: "foo""#`
 
-warning: 7 warnings emitted
+warning: string literal uses escapes that a raw string would avoid
+  --> $DIR/prefer_raw_string.rs:54:14
+   |
+LL |     println!("path: /"{}/"", "x");
+   |              ^^^^^^^^^^^^^^ help: use a raw string: `r#"path: "{}""#`
+
+warning: string literal uses escapes that a raw string would avoid
+  --> $DIR/prefer_raw_string.rs:48:21
+   |
+LL |     let _ = format!("url(/"{name}/")");
+   |                     ^^^^^^^^^^^^^^^^^ help: use a raw string: `r#"url("{name}")"#`
+
+warning: 9 warnings emitted
 

--- a/ui/prefer_raw_string.stderr
+++ b/ui/prefer_raw_string.stderr
@@ -55,6 +55,12 @@ LL |     assert_eq!("a/"b".len(), 3);
    |                ^^^^^^ help: use a raw string: `r#"a"b"#`
 
 warning: string literal uses escapes that a raw string would avoid
+  --> $DIR/prefer_raw_string.rs:90:18
+   |
+LL |     let _ = dbg!("a/"b");
+   |                  ^^^^^^ help: use a raw string: `r#"a"b"#`
+
+warning: string literal uses escapes that a raw string would avoid
   --> $DIR/prefer_raw_string.rs:48:21
    |
 LL |     let _ = format!("url(/"{name}/")");
@@ -72,5 +78,5 @@ warning: string literal uses escapes that a raw string would avoid
 LL |     let _ = stringify!("a/"b");
    |                        ^^^^^^ help: use a raw string: `r#"a"b"#`
 
-warning: 12 warnings emitted
+warning: 13 warnings emitted
 

--- a/ui/prefer_raw_string.stderr
+++ b/ui/prefer_raw_string.stderr
@@ -49,10 +49,28 @@ LL |     println!("path: /"{}/"", "x");
    |              ^^^^^^^^^^^^^^ help: use a raw string: `r#"path: "{}""#`
 
 warning: string literal uses escapes that a raw string would avoid
+  --> $DIR/prefer_raw_string.rs:72:16
+   |
+LL |     assert_eq!("a/"b".len(), 3);
+   |                ^^^^^^ help: use a raw string: `r#"a"b"#`
+
+warning: string literal uses escapes that a raw string would avoid
   --> $DIR/prefer_raw_string.rs:48:21
    |
 LL |     let _ = format!("url(/"{name}/")");
    |                     ^^^^^^^^^^^^^^^^^ help: use a raw string: `r#"url("{name}")"#`
 
-warning: 9 warnings emitted
+warning: string literal uses escapes that a raw string would avoid
+  --> $DIR/prefer_raw_string.rs:64:30
+   |
+LL |     assert_eq!(value, value, "v = /"{value}/"");
+   |                              ^^^^^^^^^^^^^^^^^ help: use a raw string: `r#"v = "{value}""#`
+
+warning: string literal uses escapes that a raw string would avoid
+  --> $DIR/prefer_raw_string.rs:80:24
+   |
+LL |     let _ = stringify!("a/"b");
+   |                        ^^^^^^ help: use a raw string: `r#"a"b"#`
+
+warning: 12 warnings emitted
 


### PR DESCRIPTION
Fixes a false negative in `perfectionist::prefer_raw_string`: string literals that macro expansion **consumes** — most visibly a `format!` template carrying a `{...}` placeholder — never reach the HIR, so the late `ExprKind::Lit` pass never saw them.

**Approach.** A pre-expansion `EarlyLintPass` scans every cooked string literal in every macro invocation (descending into delimited groups) and queues a raw-string rewrite for each. The late pass records the source byte range of every literal it visits and, at `check_crate_post`, emits only the queued candidates the HIR walk never saw — the consumed ones. That byte-range dedup keeps the two passes disjoint **without** a macro allowlist or a placeholder heuristic: the raw-string rewrite is value-preserving for any literal (raw strings still parse `{...}`; `{{`/`}}` survive verbatim; braces are never backslash-escaped), so there is no need to identify "the template."

**Consequences.** `assert_eq!`/`assert!` messages and custom format wrappers are now covered, with no per-macro argument bookkeeping. `stringify!`/`dbg!` arguments are rewritten too — the value is unchanged, only the reflected source text differs, and `#[allow]` covers the rare case where that matters. Adds `find_all_cooked_str_literals` to `src/macro_template.rs` (shared with `print_macro_split`) and rewrites the literals across the codebase the broader scan now flags (maud templates and multiline `format!`/`assert!` messages in the docs generator).

`just all` passes locally (fmt, build, doc, clippy, test, self-lint).

Fixes <https://github.com/KSXGitHub/perfectionist/issues/219>.