### PR TITLE
docs(config): defaults live in field docs, not type docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,42 @@ has two consequences for the implementer:
    docstring — a generic HIR walker, a per-character emit loop, a
    path-set parser — earns its own file.
 
+## Defaults live in field docs, not type or variant docs
+
+A config field's default value is documented on the **field**, never
+on the field's **type** or on an **enum variant**. The default is a
+property of the field, not of the type: the same type could back
+another field with a different default, so a default stated on the
+type (or one of its variants) is misattributed and goes stale the
+moment a second field reuses it. The field doc is also where readers
+look — `tools/gen-docs/` renders it under "Configuration", the
+section a reader scans for defaults.
+
+So a field doc states the default in the config-file value form, and
+the type / variant docs describe only what each value *means*:
+
+```rust
+/// How inline test code is handled. Defaults to `external_when_long`.
+inline_style: InlineStyle,           // field doc carries the default
+
+enum InlineStyle {
+    /// Every inline test item is flagged; all test code must move out.
+    ExternalOnly,
+    /// Inline test code is allowed up to the configured budget.
+    ExternalWhenLong,                // variant doc: meaning only, no "the default"
+}
+```
+
+The wrong placement — `ExternalWhenLong`'s doc reading "… the
+default." or `InlineStyle`'s own doc reading "Defaults to
+`external_when_long`." — is the recurring mistake this convention
+exists to stop. It already had to be corrected once for
+`ReferenceScope::Crate` in
+<https://github.com/KSXGitHub/perfectionist/pull/218>. The `#[default]`
+*attribute* on a variant is fine — it is code expressing the
+`Default` impl, not prose claiming a default. Only the prose is
+governed here.
+
 ## When the implementation is complete
 
 If a PR fully implements a rule — every sub-check, every

--- a/rules/inline_test_footprint.md
+++ b/rules/inline_test_footprint.md
@@ -105,4 +105,4 @@ external `mod <name>;`. Matches pacquet's strict policy.
 
 Inline test code is allowed up to the configured budget; beyond
 that it must move to a file. Matches parallel-disk-usage's
-guidance. The default.
+guidance.

--- a/rules/macro_argument_binding.md
+++ b/rules/macro_argument_binding.md
@@ -106,7 +106,7 @@ Configure via `dylint.toml` under `["perfectionist::macro_argument_binding"]`. E
 
 ### `mode`: `Mode` (optional)
 
-Eligibility mode.
+Eligibility mode. Defaults to `allow_and_deny`.
 
 ### `deny_extra`: `[string]` (optional)
 
@@ -175,7 +175,7 @@ Checked after the merge, so this knob always wins.
 
 #### `Mode` (enum)
 
-Eligibility mode. The default is `AllowAndDeny`.
+Eligibility mode.
 
 ##### `"deny_only"` (Rust: `DenyOnly`)
 

--- a/src/rules/inline_test_footprint/config.rs
+++ b/src/rules/inline_test_footprint/config.rs
@@ -12,7 +12,7 @@ pub(super) enum InlineStyle {
     ExternalOnly,
     /// Inline test code is allowed up to the configured budget; beyond
     /// that it must move to a file. Matches parallel-disk-usage's
-    /// guidance. The default.
+    /// guidance.
     ExternalWhenLong,
 }
 

--- a/src/rules/macro_argument_binding/config.rs
+++ b/src/rules/macro_argument_binding/config.rs
@@ -194,7 +194,7 @@ const BUILTIN_PURE_METHODS: &[&str] = &[
     "as_bytes", "as_deref", "as_mut", "as_ref", "as_slice", "as_str", "is_empty", "len",
 ];
 
-/// Eligibility mode. The default is `AllowAndDeny`.
+/// Eligibility mode.
 #[derive(Debug, Clone, Copy, Default, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum Mode {
@@ -219,7 +219,7 @@ pub(super) enum Mode {
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 pub(super) struct Config {
-    /// Eligibility mode.
+    /// Eligibility mode. Defaults to `allow_and_deny`.
     pub mode: Mode,
     /// Macros added to the built-in deny set. Each entry is a
     /// fully-qualified macro path (no trailing `!`) or a bare macro


### PR DESCRIPTION
A config field's default value belongs on the field doc, not on the field's type doc or an enum variant doc. The default is a property of the field (the same type can back another field with a different default) and field docs are where gen-docs renders the "Configuration" section readers scan for defaults.

Document the convention in CLAUDE.md (picked up by the AGENTS.md / copilot-instructions symlinks), and fix the two existing violations:

- inline_test_footprint: `InlineStyle::ExternalWhenLong`'s variant doc claimed "The default."; the `inline_style` field already states it.
- macro_argument_binding: the `Mode` type doc claimed "The default is `AllowAndDeny`."; moved to the `mode` field as "Defaults to `allow_and_deny`."

Regenerate the affected rules/*.md catalogue entries.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/229>.