### PR TITLE
docs(prefer-derive-more-over-thiserror): fix the example code

### DIFF
--- a/rules/prefer_derive_more_over_thiserror.md
+++ b/rules/prefer_derive_more_over_thiserror.md
@@ -71,7 +71,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum MyError {
     #[error("missing field {0}")]
-    MissingField(String),
+    MissingField(MissingFieldError),
 }
 ```
 
@@ -83,7 +83,7 @@ use derive_more::{Display, Error};
 #[derive(Debug, Display, Error)]
 pub enum MyError {
     #[display("missing field {_0}")]
-    MissingField(String),
+    MissingField(MissingFieldError),
 }
 ```
 

--- a/src/rules/prefer_derive_more_over_thiserror.rs
+++ b/src/rules/prefer_derive_more_over_thiserror.rs
@@ -76,7 +76,7 @@ declare_tool_lint! {
     /// #[derive(Debug, Error)]
     /// pub enum MyError {
     ///     #[error("missing field {0}")]
-    ///     MissingField(String),
+    ///     MissingField(MissingFieldError),
     /// }
     /// ```
     ///
@@ -88,7 +88,7 @@ declare_tool_lint! {
     /// #[derive(Debug, Display, Error)]
     /// pub enum MyError {
     ///     #[display("missing field {_0}")]
-    ///     MissingField(String),
+    ///     MissingField(MissingFieldError),
     /// }
     /// ```
     pub perfectionist::PREFER_DERIVE_MORE_OVER_THISERROR,


### PR DESCRIPTION
The "Prefer" example for `perfectionist::prefer_derive_more_over_thiserror` did not compile: `derive_more::Error` treats a single-field variant's field as the error source, so `MissingField(String)` required `String: Error`, which doesn't hold.

Per the issue, both examples now use a pretend `MissingFieldError` as the variant payload — no `#[error(not(source))]` workaround, no spelled-out type definition. Changing the "Avoid" side too keeps the before/after a pure derive/attribute migration.

Edited the rustdoc in `src/rules/prefer_derive_more_over_thiserror.rs` and regenerated `rules/prefer_derive_more_over_thiserror.md` via `just gen-rules-md`. `just all` (including `self-lint`) passes.

Fixes <https://github.com/KSXGitHub/perfectionist/issues/237>.