### PR TITLE
fix(deploy-check/commit-msg): ignore section after scissor line

### DIFF
--- a/tools/deploy-check/src/hook.rs
+++ b/tools/deploy-check/src/hook.rs
@@ -38,8 +38,19 @@ fn git_comment_char(root: &Path) -> char {
     }
 }
 
-/// Parse the commit-message file's effective content (after stripping
-/// `comment`-prefixed lines and leading blanks). Returns:
+/// The body of Git's default "scissors" line — everything after the
+/// comment char and its following space. `git commit --verbose`
+/// appends the staged diff below a line of the form
+/// `"<commentChar> {SCISSORS_BODY}"`, and Git strips that line and
+/// everything after it before creating the commit. The hook must do
+/// the same: the diff's lines aren't comment-prefixed, so without
+/// this cut a release-shaped subject followed by a `-v` diff looks
+/// like a forbidden commit body and trips `MessageHasExtraContent`.
+const SCISSORS_BODY: &str = "------------------------ >8 ------------------------";
+
+/// Parse the commit-message file's effective content (after cutting at
+/// the verbose-diff scissors line and stripping `comment`-prefixed
+/// lines and leading blanks). Returns:
 ///
 /// * `Ok(Some(subject))` when the message is a release-shaped one
 ///   (`X.Y.Z(-<suffix>)?` only, no body).
@@ -51,8 +62,10 @@ pub(crate) fn extract_release_subject(
     content: &str,
     comment: char,
 ) -> Result<Option<&str>, RuntimeError> {
+    let scissors = format!("{comment} {SCISSORS_BODY}");
     let effective: Vec<&str> = content
         .lines()
+        .take_while(|line| line.trim_end() != scissors)
         .filter(|line| !line.starts_with(comment))
         .map(str::trim_end)
         .skip_while(|line| line.is_empty())

--- a/tools/deploy-check/src/tests.rs
+++ b/tools/deploy-check/src/tests.rs
@@ -227,6 +227,35 @@ fn commit_msg_honours_a_configured_semicolon_comment_char() {
 }
 
 #[test]
+fn commit_msg_ignores_the_verbose_diff_below_the_scissors_line() {
+    // `git commit -v` appends the staged diff below the scissors
+    // line. Its lines aren't comment-prefixed, so the pre-fix code
+    // mistook them for a commit body and rejected the release commit
+    // with `MessageHasExtraContent`. The hook must cut at the
+    // scissors line just as Git does before committing.
+    let content = text_block_fnl! {
+        "0.0.0-rc.19"
+        "# Please enter the commit message for your changes. Lines starting"
+        "# with '#' will be ignored, and an empty message aborts the commit."
+        "#"
+        "# ------------------------ >8 ------------------------"
+        "# Do not modify or remove the line above."
+        "# Everything below it will be ignored."
+        "diff --git a/Cargo.toml b/Cargo.toml"
+        "index afbb122..b4b6303 100644"
+        "--- a/Cargo.toml"
+        "+++ b/Cargo.toml"
+        r#"@@ -4,7 +4,7 @@ members = ["tools/*", "utils"]"#
+        r#"-version = "0.0.0-rc.18""#
+        r#"+version = "0.0.0-rc.19""#
+    };
+    assert_eq!(
+        extract_release_subject(content, '#').unwrap(),
+        Some("0.0.0-rc.19"),
+    );
+}
+
+#[test]
 fn commit_msg_returns_none_when_subject_is_not_a_version() {
     assert_eq!(
         extract_release_subject("fix: something\n", '#').unwrap(),


### PR DESCRIPTION
`git commit -v` appends the staged diff below the scissors line (`# ------------------------ >8 ------------------------`). `extract_release_subject` dropped only comment-prefixed lines, so the diff body — whose lines are not comment-prefixed — survived as apparent commit-body content and tripped `MessageHasExtraContent`, rejecting an otherwise valid version-bump commit.

Cut the message at the scissors line before parsing, mirroring what Git itself strips before creating the commit. Add a regression test built from a real `commit -v` message.