### PR TITLE
feat(config/import-grouping)!: change `style` type into `"single_block" | "multi_block"`

### DIFF
--- a/rules/import_grouping.md
+++ b/rules/import_grouping.md
@@ -11,9 +11,9 @@
 
 Enforces a single project-wide *grouping* style for the run of
 `use` statements at the top of a module body, chosen via `style`:
-- `single_group` — every `use` sits in one contiguous block with
+- `single_block` — every `use` sits in one contiguous block with
   no blank lines between imports.
-- `grouped` (default) — imports are partitioned into ordered
+- `multi_block` (default) — imports are partitioned into ordered
   groups separated by exactly `blank_line_count` blank lines. The
   default group set, in order, is std (`std` / `core` / `alloc`),
   internal (`super` / `self` / `crate`), then third-party (every
@@ -38,7 +38,7 @@ projects a hard CI check instead of a silent reformat.
 
 ## Example
 
-### Style: Grouped (default)
+### Style: Multi block (default)
 
 **Avoid:**
 
@@ -58,7 +58,7 @@ use crate::args::Args;
 use clap::Parser;
 ```
 
-### Style: Single group
+### Style: Single block
 
 **Avoid:**
 
@@ -84,7 +84,7 @@ Configure via `dylint.toml` under `["perfectionist::import_grouping"]`. Every fi
 
 ### `style`: `Style` (optional)
 
-Partitioning style to enforce. Defaults to `grouped`.
+Partitioning style to enforce. Defaults to `multi_block`.
 
 ### `order`: `[Group]` (optional)
 
@@ -111,7 +111,7 @@ How `#[cfg(...)]`-gated imports are grouped. Defaults to
 ### `blank_line_count`: `unsigned integer` (optional)
 
 Exact number of blank lines separating adjacent groups (strict
-equality). Defaults to `1`. Ignored under `single_group`.
+equality). Defaults to `1`. Ignored under `single_block`.
 
 ### Types
 
@@ -119,12 +119,12 @@ equality). Defaults to `1`. Ignored under `single_group`.
 
 How `use` statements are partitioned into blocks.
 
-##### `"single_group"` (Rust: `SingleGroup`)
+##### `"single_block"` (Rust: `SingleBlock`)
 
 Every `use` statement sits in one contiguous block, with no
 blank lines between imports.
 
-##### `"grouped"` (Rust: `Grouped`)
+##### `"multi_block"` (Rust: `MultiBlock`)
 
 Imports are partitioned into ordered groups separated by exactly
 `blank_line_count` blank lines. The default group set is

--- a/src/rules/import_grouping.rs
+++ b/src/rules/import_grouping.rs
@@ -24,9 +24,9 @@ declare_tool_lint! {
     ///
     /// Enforces a single project-wide *grouping* style for the run of
     /// `use` statements at the top of a module body, chosen via `style`:
-    /// - `single_group` — every `use` sits in one contiguous block with
+    /// - `single_block` — every `use` sits in one contiguous block with
     ///   no blank lines between imports.
-    /// - `grouped` (default) — imports are partitioned into ordered
+    /// - `multi_block` (default) — imports are partitioned into ordered
     ///   groups separated by exactly `blank_line_count` blank lines. The
     ///   default group set, in order, is std (`std` / `core` / `alloc`),
     ///   internal (`super` / `self` / `crate`), then third-party (every
@@ -51,7 +51,7 @@ declare_tool_lint! {
     ///
     /// ### Example
     ///
-    /// #### Style: Grouped (default)
+    /// #### Style: Multi block (default)
     ///
     /// **Avoid:**
     ///
@@ -71,7 +71,7 @@ declare_tool_lint! {
     /// use clap::Parser;
     /// ```
     ///
-    /// #### Style: Single group
+    /// #### Style: Single block
     ///
     /// **Avoid:**
     ///
@@ -96,8 +96,8 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. `grouped` is the shipped baseline; a project that
-/// prefers one contiguous block sets `style = "single_group"` in
+/// Active by default. `multi_block` is the shipped baseline; a project
+/// that prefers one contiguous block sets `style = "single_block"` in
 /// `dylint.toml`. Read by [`register_pass`]; gen-docs picks the constant
 /// up to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
@@ -353,12 +353,13 @@ impl ImportGrouping {
 
         // A comment sitting between two statements is dropped by the
         // re-render (only each statement's own text is reproduced) and,
-        // under `grouped`, may end up describing a statement that moved.
-        // A leading comment immediately above the first statement is left
-        // in place by the rewrite but is stranded above a *different*
-        // statement when `grouped` reorders the first one downward. Either
-        // way, drop to `MaybeIncorrect` so the fix isn't applied unreviewed.
-        let first_statement_moves = matches!(self.config.style, Style::Grouped)
+        // under `multi_block`, may end up describing a statement that
+        // moved. A leading comment immediately above the first statement
+        // is left in place by the rewrite but is stranded above a
+        // *different* statement when `multi_block` reorders the first one
+        // downward. Either way, drop to `MaybeIncorrect` so the fix isn't
+        // applied unreviewed.
+        let first_statement_moves = matches!(self.config.style, Style::MultiBlock)
             && run.iter().any(|stmt| stmt.rank < first.rank);
         let applicability = if self.run_has_interstatement_comment(lint_context, run)
             || (first_statement_moves && self.has_leading_comment(lint_context, first))
@@ -418,10 +419,10 @@ impl ImportGrouping {
 
     fn message(&self) -> &'static str {
         match self.config.style {
-            Style::SingleGroup => {
-                "blank lines split the imports; this project keeps them in a single group"
+            Style::SingleBlock => {
+                "blank lines split the imports; this project keeps them in a single block"
             }
-            Style::Grouped => "imports are not partitioned into ordered groups",
+            Style::MultiBlock => "imports are not partitioned into ordered groups",
         }
     }
 }

--- a/src/rules/import_grouping.rs
+++ b/src/rules/import_grouping.rs
@@ -322,7 +322,7 @@ impl ImportGrouping {
         run: &[UseStmt<'_>],
         violations: &mut Vec<Pending>,
     ) {
-        // A run of one statement is a single group either way, so it
+        // A run of one statement is a single block either way, so it
         // can never violate.
         if run.len() < 2 {
             return;

--- a/src/rules/import_grouping/check.rs
+++ b/src/rules/import_grouping/check.rs
@@ -72,21 +72,21 @@ pub(super) fn is_compliant(
     blanks: &[usize],
 ) -> bool {
     match style {
-        Style::SingleGroup => single_group_compliant(blanks),
-        Style::Grouped => grouped_compliant(blank_line_count, stmts, blanks),
+        Style::SingleBlock => single_block_compliant(blanks),
+        Style::MultiBlock => multi_block_compliant(blank_line_count, stmts, blanks),
     }
 }
 
-/// `single_group`: no blank line may sit between any two statements in
+/// `single_block`: no blank line may sit between any two statements in
 /// the run.
-fn single_group_compliant(blanks: &[usize]) -> bool {
+fn single_block_compliant(blanks: &[usize]) -> bool {
     blanks.iter().all(|&blanks| blanks == 0)
 }
 
-/// `grouped`: ranks are non-decreasing in the configured order;
+/// `multi_block`: ranks are non-decreasing in the configured order;
 /// statements sharing a rank carry no blank line between them; a step
 /// up to a later group carries exactly `blank_line_count` blank lines.
-fn grouped_compliant(blank_line_count: usize, stmts: &[UseStmt<'_>], blanks: &[usize]) -> bool {
+fn multi_block_compliant(blank_line_count: usize, stmts: &[UseStmt<'_>], blanks: &[usize]) -> bool {
     stmts
         .windows(2)
         .zip(blanks)

--- a/src/rules/import_grouping/config.rs
+++ b/src/rules/import_grouping/config.rs
@@ -10,13 +10,13 @@
 pub(super) enum Style {
     /// Every `use` statement sits in one contiguous block, with no
     /// blank lines between imports.
-    SingleGroup,
+    SingleBlock,
     /// Imports are partitioned into ordered groups separated by exactly
     /// `blank_line_count` blank lines. The default group set is
     /// std (`std` / `core` / `alloc`), internal (`super` / `self` /
     /// `crate`), and third-party (every other crate).
     #[default]
-    Grouped,
+    MultiBlock,
 }
 
 /// One of the three groups a `use` statement is classified into. The
@@ -48,7 +48,7 @@ pub(super) enum CfgBlockHandling {
 #[derive(Debug, serde::Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 pub(super) struct Config {
-    /// Partitioning style to enforce. Defaults to `grouped`.
+    /// Partitioning style to enforce. Defaults to `multi_block`.
     pub(super) style: Style,
     /// The order the groups appear in, top to bottom. Defaults to
     /// `["std", "internal", "thirdparty"]`.
@@ -65,7 +65,7 @@ pub(super) struct Config {
     /// `trailing`.
     pub(super) cfg_block_handling: CfgBlockHandling,
     /// Exact number of blank lines separating adjacent groups (strict
-    /// equality). Defaults to `1`. Ignored under `single_group`.
+    /// equality). Defaults to `1`. Ignored under `single_block`.
     pub(super) blank_line_count: usize,
 }
 

--- a/src/rules/import_grouping/render.rs
+++ b/src/rules/import_grouping/render.rs
@@ -21,9 +21,9 @@ pub(super) fn replacement(
 ) -> String {
     let ordered: Vec<&UseStmt<'_>> = match style {
         // Keep source order; the fix only collapses blank lines.
-        Style::SingleGroup => stmts.iter().collect(),
+        Style::SingleBlock => stmts.iter().collect(),
         // Stable-partition by group rank; order within a group stands.
-        Style::Grouped => {
+        Style::MultiBlock => {
             let mut ordered: Vec<&UseStmt<'_>> = stmts.iter().collect();
             ordered.sort_by_key(|stmt| stmt.rank);
             ordered
@@ -34,9 +34,9 @@ pub(super) fn replacement(
     for (index, stmt) in ordered.iter().enumerate() {
         if index > 0 {
             let blanks = match style {
-                Style::SingleGroup => 0,
-                Style::Grouped if ordered[index - 1].rank == stmt.rank => 0,
-                Style::Grouped => blank_line_count,
+                Style::SingleBlock => 0,
+                Style::MultiBlock if ordered[index - 1].rank == stmt.rank => 0,
+                Style::MultiBlock => blank_line_count,
             };
             // One newline ends the previous statement; `blanks` more
             // produce that many empty lines; then the shared indent.

--- a/tests/import_grouping.rs
+++ b/tests/import_grouping.rs
@@ -1,5 +1,5 @@
 //! UI tests for `import_grouping`'s configuration knobs. The
-//! default-config (`style = "grouped"`) sweep lives in
+//! default-config (`style = "multi_block"`) sweep lives in
 //! `ui/import_grouping.rs` and is picked up by `tests/ui.rs`; these
 //! tests each point at their own one-fixture directory under
 //! `ui-toml/import_grouping/` and pass a per-rule `dylint.toml` to
@@ -56,14 +56,14 @@ fn run(src_base: &str, config: RuleConfig) {
 }
 
 #[test]
-fn single_group_collapses_blank_lines() {
-    // Under `style = "single_group"`, every blank line between imports
+fn single_block_collapses_blank_lines() {
+    // Under `style = "single_block"`, every blank line between imports
     // is flagged and the block is re-rendered as one contiguous run in
     // source order.
     run(
-        "ui-toml/import_grouping/single_group",
+        "ui-toml/import_grouping/single_block",
         RuleConfig {
-            style: Some("single_group"),
+            style: Some("single_block"),
             ..Default::default()
         },
     );

--- a/ui-toml/import_granularity/respect_cfg_blocks/fixture.rs
+++ b/ui-toml/import_granularity/respect_cfg_blocks/fixture.rs
@@ -13,7 +13,7 @@
 // lint fires but withholds an autofix.
 
 // `import_grouping` (active by default) is allowed here: under its
-// `grouped` style the cfg-gated import forms a trailing group, which
+// `multi_block` style the cfg-gated import forms a trailing group, which
 // this fixture places first to exercise granularity's cfg handling.
 #[allow(perfectionist::import_grouping, reason = "exercises import_granularity")]
 mod m {

--- a/ui-toml/import_grouping/single_block/fixture.rs
+++ b/ui-toml/import_grouping/single_block/fixture.rs
@@ -7,7 +7,7 @@
     reason = "ui fixture"
 )]
 
-// Under `style = "single_group"`: every `use` sits in one contiguous
+// Under `style = "single_block"`: every `use` sits in one contiguous
 // block. A blank line between imports is the violation; the fix
 // re-renders the run in source order with no blank lines.
 

--- a/ui-toml/import_grouping/single_block/fixture.stderr
+++ b/ui-toml/import_grouping/single_block/fixture.stderr
@@ -1,4 +1,4 @@
-warning: blank lines split the imports; this project keeps them in a single group
+warning: blank lines split the imports; this project keeps them in a single block
   --> $DIR/fixture.rs:22:1
    |
 LL | / use std::time::Duration;

--- a/ui/import_granularity.rs
+++ b/ui/import_granularity.rs
@@ -67,7 +67,7 @@ mod visibility_respected {
 
 // Good: under default `respect_cfg_blocks`, a platform-gated import
 // stays on its own line rather than merging with an unconditional one.
-// `import_grouping` is allowed here: under its default `grouped` style
+// `import_grouping` is allowed here: under its default `multi_block` style
 // the cfg-gated import forms a trailing group, which this fixture
 // deliberately places first to exercise granularity, not grouping.
 #[allow(perfectionist::import_grouping, reason = "exercises import_granularity")]

--- a/ui/import_grouping.rs
+++ b/ui/import_grouping.rs
@@ -7,7 +7,7 @@
     reason = "ui fixture"
 )]
 
-// Default style is `grouped`: imports partitioned into std, internal,
+// Default style is `multi_block`: imports partitioned into std, internal,
 // then third-party groups, each separated by exactly one blank line.
 // A `#[cfg(...)]`-gated import forms an always-last (trailing) group.
 //


### PR DESCRIPTION
Renames `import_grouping`'s `Style` enum variants from `SingleGroup` / `Grouped` to **`SingleBlock` / `MultiBlock`**.

## Why

The old pair was unconvincing: non-parallel grammar (count+noun vs. participle), and both echoed "group" — the rule's own name — even though `single_group` is precisely the variant where imports are *not* grouped. `SingleBlock` / `MultiBlock` is parallel, drops the rule-name echo, and describes the observable result (block count) without implying the variant is an off-switch.

## What changed

- **Config:** variants + serde values `single_group` → `single_block`, `grouped` → `multi_block`; field-doc defaults.
- **Logic:** match arms and helpers (`*_compliant`, render), plus the `SingleBlock` diagnostic wording.
- **Tests/fixtures:** renamed test, `ui-toml/import_grouping/single_group/` → `single_block/`, and prose references in sibling `import_granularity` fixtures.
- **Docs:** `rules/import_grouping.md` catalogue entry.

> [!WARNING]
> **Breaking change** to the config surface: `import_grouping.style` values `single_group` / `grouped` are now `single_block` / `multi_block`.

## Validation caveat

`just all` / `self-lint` could not run in this environment — outbound network is blocked, so the `cargo-dylint` dev-tools can't install and there are no vendored deps to build offline. I therefore **hand-synced** `rules/import_grouping.md` (normally `just gen-rules-md`'s job) and **manually self-linted** the diff. CI should confirm `check-rules-md` and the `.stderr` fixtures agree.