### PR TITLE
feat(pages): preload and prefetch

### DIFF
--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -101,6 +101,12 @@ pub(crate) const THEME_ICONS: &[(&str, &str)] = &[
     ("theme-system.svg", include_str!("assets/theme-system.svg")),
 ];
 
+/// `id` of the inert `<template>` (see [`theme_icon_prefetch_template`])
+/// that carries the colour-scheme icons' `<link rel="prefetch">` hints.
+/// `theme_toggle.js` looks the template up by this same id and clones its
+/// contents into `<head>` to fire the prefetch, so the two must agree.
+pub(crate) const THEME_ICON_PREFETCH_TEMPLATE_ID: &str = "theme-icon-prefetch";
+
 /// The chain-link glyph for the rule-name heading anchors, shipped as
 /// a standalone file beside `index.html` rather than inlined.
 pub(crate) const RULE_ANCHOR_ICON: &str = include_str!("assets/rule-anchor.svg");
@@ -141,6 +147,7 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
                 h1 id="catalogue" { "perfectionist lints" }
                 (nav_drawer(rules))
                 (settings_panel())
+                (theme_icon_prefetch_template())
                 div.banner {
                     "Showing docs for " code { (git_ref) } "."
                 }
@@ -251,6 +258,28 @@ fn config_controls() -> Markup {
             div.config-actions {
                 button.config-action type="button" data-config-open="true" { "Expand all" }
                 button.config-action type="button" data-config-open="false" { "Collapse all" }
+            }
+        }
+    }
+}
+
+/// The inert `<template>` carrying one `<link rel="prefetch" as="image">`
+/// per colour-scheme icon. The colour-scheme icons are reachable only
+/// through settings.css mask `url(...)`s — invisible to the browser's
+/// preload scanner — so without a hint the first panel-open fetches them
+/// cold. The hints can't be static `<link>`s, though: a reader who never
+/// opens Settings (and every reader with JS disabled, for whom the panel
+/// is permanently inert) would fetch them for nothing. A `<template>`'s
+/// contents are parsed but never loaded, so the links lie dormant until
+/// `theme_toggle.js` clones them into `<head>` at idle time (it finds the
+/// template via [`THEME_ICON_PREFETCH_TEMPLATE_ID`]). Built from
+/// [`THEME_ICONS`] so the warmed URLs are the same files settings.css
+/// masks and can't drift from them.
+fn theme_icon_prefetch_template() -> Markup {
+    html! {
+        template id=(THEME_ICON_PREFETCH_TEMPLATE_ID) {
+            @for &(name, _) in THEME_ICONS {
+                link rel="prefetch" as="image" href=(name);
             }
         }
     }

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -74,6 +74,25 @@ pub(crate) const CONFIG_TOGGLE_SCRIPT: &str = include_str!("config_toggle.js");
 /// `<script src>` references the same name, so they must agree.
 pub(crate) const CONFIG_TOGGLE_SCRIPT_FILENAME: &str = "config_toggle.js";
 
+/// The page scripts, in the order `<body>` loads them, driving the
+/// single `<script src>` loop at the foot of the document and the
+/// matching `<link rel="preload" as="script">` block in `<head>`.
+/// The two are generated from this one slice so they can't drift: a
+/// script added here is both preloaded and loaded. The scripts sit at
+/// the very end of `<body>`, so without the preload hints the browser
+/// wouldn't start fetching them until it had parsed the whole page;
+/// the hints let it pull them down in parallel with the stylesheets
+/// instead. (The CSS-referenced assets — the hover-revealed
+/// `rule-anchor.svg` and the settings-panel theme icons — are
+/// deliberately *not* preloaded: both are decorative and hidden until
+/// the reader interacts, so preloading them would contend with the
+/// critical resources for bytes most visitors never render.)
+pub(crate) const PAGE_SCRIPTS: &[&str] = &[
+    NAV_TOGGLE_SCRIPT_FILENAME,
+    THEME_TOGGLE_SCRIPT_FILENAME,
+    CONFIG_TOGGLE_SCRIPT_FILENAME,
+];
+
 /// The colour-scheme icons (Octicons, MIT), shipped beside `index.html`
 /// and referenced from settings.css. Each tuple is `(filename, contents)`.
 pub(crate) const THEME_ICONS: &[(&str, &str)] = &[
@@ -111,6 +130,12 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
                 }
                 link rel="stylesheet" href=(HIGHLIGHT_CSS_LIGHT_FILENAME);
                 link rel="stylesheet" href=(HIGHLIGHT_CSS_DARK_FILENAME);
+                // The scripts load at the foot of <body>; preload them
+                // here so the browser fetches them in parallel with the
+                // stylesheets rather than waiting until it parses there.
+                @for &src in PAGE_SCRIPTS {
+                    link rel="preload" as="script" href=(src);
+                }
             }
             body {
                 h1 id="catalogue" { "perfectionist lints" }
@@ -158,9 +183,9 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
                     "Generated from " code { "src/rules/" }
                     " at " code { (commit_sha) } "."
                 }
-                script src=(NAV_TOGGLE_SCRIPT_FILENAME) {}
-                script src=(THEME_TOGGLE_SCRIPT_FILENAME) {}
-                script src=(CONFIG_TOGGLE_SCRIPT_FILENAME) {}
+                @for &src in PAGE_SCRIPTS {
+                    script src=(src) {}
+                }
             }
         }
     };

--- a/tools/gen-docs/src/render.rs
+++ b/tools/gen-docs/src/render.rs
@@ -74,19 +74,10 @@ pub(crate) const CONFIG_TOGGLE_SCRIPT: &str = include_str!("config_toggle.js");
 /// `<script src>` references the same name, so they must agree.
 pub(crate) const CONFIG_TOGGLE_SCRIPT_FILENAME: &str = "config_toggle.js";
 
-/// The page scripts, in the order `<body>` loads them, driving the
-/// single `<script src>` loop at the foot of the document and the
-/// matching `<link rel="preload" as="script">` block in `<head>`.
-/// The two are generated from this one slice so they can't drift: a
-/// script added here is both preloaded and loaded. The scripts sit at
-/// the very end of `<body>`, so without the preload hints the browser
-/// wouldn't start fetching them until it had parsed the whole page;
-/// the hints let it pull them down in parallel with the stylesheets
-/// instead. (The CSS-referenced assets — the hover-revealed
-/// `rule-anchor.svg` and the settings-panel theme icons — are
-/// deliberately *not* preloaded: both are decorative and hidden until
-/// the reader interacts, so preloading them would contend with the
-/// critical resources for bytes most visitors never render.)
+/// The page scripts, in the order `<body>` loads them. Both the
+/// foot-of-`<body>` `<script src>` tags and the `<head>`
+/// `<link rel="preload" as="script">` hints are generated from this slice,
+/// so they can't drift.
 pub(crate) const PAGE_SCRIPTS: &[&str] = &[
     NAV_TOGGLE_SCRIPT_FILENAME,
     THEME_TOGGLE_SCRIPT_FILENAME,
@@ -101,10 +92,9 @@ pub(crate) const THEME_ICONS: &[(&str, &str)] = &[
     ("theme-system.svg", include_str!("assets/theme-system.svg")),
 ];
 
-/// `id` of the inert `<template>` (see [`theme_icon_prefetch_template`])
-/// that carries the colour-scheme icons' `<link rel="prefetch">` hints.
-/// `theme_toggle.js` looks the template up by this same id and clones its
-/// contents into `<head>` to fire the prefetch, so the two must agree.
+/// `id` shared by the inert prefetch `<template>`
+/// ([`theme_icon_prefetch_template`]) and the `theme_toggle.js` lookup that
+/// activates it; the two must agree.
 pub(crate) const THEME_ICON_PREFETCH_TEMPLATE_ID: &str = "theme-icon-prefetch";
 
 /// The chain-link glyph for the rule-name heading anchors, shipped as
@@ -136,9 +126,6 @@ pub(crate) fn render_page(rules: &[Rule], context: &RenderContext<'_>) -> String
                 }
                 link rel="stylesheet" href=(HIGHLIGHT_CSS_LIGHT_FILENAME);
                 link rel="stylesheet" href=(HIGHLIGHT_CSS_DARK_FILENAME);
-                // The scripts load at the foot of <body>; preload them
-                // here so the browser fetches them in parallel with the
-                // stylesheets rather than waiting until it parses there.
                 @for &src in PAGE_SCRIPTS {
                     link rel="preload" as="script" href=(src);
                 }
@@ -263,18 +250,11 @@ fn config_controls() -> Markup {
     }
 }
 
-/// The inert `<template>` carrying one `<link rel="prefetch" as="image">`
-/// per colour-scheme icon. The colour-scheme icons are reachable only
-/// through settings.css mask `url(...)`s — invisible to the browser's
-/// preload scanner — so without a hint the first panel-open fetches them
-/// cold. The hints can't be static `<link>`s, though: a reader who never
-/// opens Settings (and every reader with JS disabled, for whom the panel
-/// is permanently inert) would fetch them for nothing. A `<template>`'s
-/// contents are parsed but never loaded, so the links lie dormant until
-/// `theme_toggle.js` clones them into `<head>` at idle time (it finds the
-/// template via [`THEME_ICON_PREFETCH_TEMPLATE_ID`]). Built from
-/// [`THEME_ICONS`] so the warmed URLs are the same files settings.css
-/// masks and can't drift from them.
+/// The inert `<template>` of `<link rel="prefetch" as="image">` hints, one
+/// per [`THEME_ICONS`] entry, warming the cache for the colour-scheme icons
+/// (reachable only through settings.css masks). The `<template>` keeps the
+/// links dormant until `theme_toggle.js` clones them into `<head>`, so they
+/// load only once the Settings panel is used.
 fn theme_icon_prefetch_template() -> Markup {
     html! {
         template id=(THEME_ICON_PREFETCH_TEMPLATE_ID) {

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -380,6 +380,62 @@ fn page_links_theme_toggle_script_externally() {
 }
 
 #[test]
+fn page_ships_theme_icon_prefetch_hints_in_an_inert_template() {
+    let html = render_page(&[fake_rule("alpha")], &fake_context());
+    // The colour-scheme icons are reachable only through settings.css masks,
+    // invisible to the preload scanner. Instead of hardcoding their names in
+    // JS, the page renders the prefetch hints from THEME_ICONS into an inert
+    // <template>, so the warmed URLs are the same files settings.css masks —
+    // testable here against the real output, not a string-match on the script.
+    let open = format!(r#"<template id="{THEME_ICON_PREFETCH_TEMPLATE_ID}">"#);
+    let template_start = html.find(&open).expect("prefetch <template> not rendered");
+    let template_end = template_start
+        + html[template_start..]
+            .find("</template>")
+            .expect("<template> unterminated")
+        + "</template>".len();
+    let template = &html[template_start..template_end];
+    for (name, _) in THEME_ICONS {
+        assert!(
+            template.contains(&format!(
+                r#"<link rel="prefetch" as="image" href="{name}">"#
+            )),
+            "the prefetch template must carry an inert link for {name}",
+        );
+    }
+    // Inertness is the whole point: the links must live *inside* the
+    // <template> (parsed but not loaded) and nowhere else, or a reader who
+    // never opens the panel — or who has JS disabled — would fetch them for
+    // nothing. So every rel=prefetch on the page must fall within the
+    // template, and there must be exactly one per icon.
+    assert_eq!(
+        html.matches(r#"rel="prefetch""#).count(),
+        template.matches(r#"rel="prefetch""#).count(),
+        "prefetch links must appear only inside the inert <template>",
+    );
+    assert_eq!(
+        template.matches(r#"rel="prefetch""#).count(),
+        THEME_ICONS.len(),
+    );
+}
+
+#[test]
+fn theme_toggle_script_activates_the_prefetch_template_at_idle() {
+    // The script reaches the inert template by the shared id and clones its
+    // links into <head> to fire the prefetch. Pin the id agreement — a rename
+    // on either side would silently no-op the warm-up — and that activation is
+    // deferred to idle time so it never contends with first-paint work.
+    assert!(
+        THEME_TOGGLE_SCRIPT.contains(THEME_ICON_PREFETCH_TEMPLATE_ID),
+        "theme script must look up the prefetch template by its shared id",
+    );
+    assert!(
+        THEME_TOGGLE_SCRIPT.contains("requestIdleCallback"),
+        "the prefetch activation must be scheduled off the critical path",
+    );
+}
+
+#[test]
 fn page_emits_config_controls_section_hidden_with_two_buttons() {
     let html = render_page(&[fake_rule("alpha")], &fake_context());
     // The Configuration section is a <fieldset> emitted with the HTML

--- a/tools/gen-docs/src/render/tests.rs
+++ b/tools/gen-docs/src/render/tests.rs
@@ -164,6 +164,39 @@ fn page_links_nav_toggle_script_externally() {
 }
 
 #[test]
+fn page_preloads_each_script_in_head() {
+    let html = render_page(&[fake_rule("alpha")], &fake_context());
+    // Every page script gets a `<link rel="preload" as="script">` so the
+    // browser fetches it in parallel with the stylesheets instead of
+    // waiting until it parses to the `<script src>` tags at the foot of
+    // <body>. Pin the exact tag for each script in `PAGE_SCRIPTS`.
+    for &src in PAGE_SCRIPTS {
+        assert!(
+            html.contains(&format!(r#"<link rel="preload" as="script" href="{src}">"#)),
+            "expected a <link rel=preload as=script> for {src}",
+        );
+    }
+    // The preload hints must live in <head>, ahead of <body>, or they
+    // can't front-run the foot-of-body `<script src>` discovery.
+    let head_end = html.find("</head>").expect("no </head>");
+    let first_preload = html
+        .find(r#"<link rel="preload""#)
+        .expect("no preload link emitted");
+    assert!(
+        first_preload < head_end,
+        "preload hints must be emitted inside <head>",
+    );
+    // Both forms reference the same files, so the count of preload links
+    // matches the count of loaded scripts — a script added to one loop
+    // but not the other (were they ever to diverge) would skew this.
+    assert_eq!(
+        html.matches(r#"<link rel="preload" as="script""#).count(),
+        PAGE_SCRIPTS.len(),
+    );
+    assert_eq!(html.matches("<script src=").count(), PAGE_SCRIPTS.len());
+}
+
+#[test]
 fn page_links_each_stylesheet_individually() {
     let html = render_page(&[fake_rule("alpha")], &fake_context());
     // Every static sheet gets its own `<link>`, in slice order,

--- a/tools/gen-docs/src/theme_toggle.js
+++ b/tools/gen-docs/src/theme_toggle.js
@@ -21,9 +21,13 @@
 //      `hidden` attribute; clearing it is how the button appears).
 //   3. Read `perfectionist-color-scheme-override` from localStorage and
 //      apply it.
+//   4. Activate the colour-scheme icons' prefetch hints: clone the inert
+//      <template> the Rust side ships into <head> at idle time, warming
+//      the HTTP cache so the first panel-open paints them from cache
+//      rather than fetching them cold.
 //
 // If step 1 throws — the likely cause being a browser too old for the
-// APIs used — execution stops before steps 2 and 3, so the gear stays
+// APIs used — execution stops before steps 2–4, so the gear stays
 // hidden rather than appearing as a dead control. This is the same
 // "reveal only once wired up" contract the nav hamburger uses, and the
 // absence of a try/catch is deliberate: a half-supported browser should
@@ -154,5 +158,33 @@
   } else {
     applyScheme(null);
     selectRadio("system");
+  }
+
+  // ---- (4) warm the theme-icon cache ------------------------------------
+  //
+  // The three colour-scheme icons are referenced only from settings.css,
+  // as CSS masks on `.theme-icon`. The preload scanner never sees inside
+  // CSS, so without help the browser wouldn't fetch any of them until the
+  // reader opens the panel and the masked tiles first render — a cold
+  // request right when the UI appears. They matter only when this script
+  // runs (the panel is `hidden` and inert otherwise), so the Rust side
+  // ships the `<link rel="prefetch">` hints inside an inert `<template>`
+  // (built from its THEME_ICONS list — the same files settings.css masks)
+  // rather than as live <link>s the no-JS page would also fetch: a
+  // template's contents are parsed but never loaded until cloned into a
+  // live document. Cloning them into <head> here makes the browser process
+  // them; Chrome and Firefox then serve the later CSS mask load from that
+  // same HTTP cache. Done at idle time (requestIdleCallback, setTimeout
+  // fallback) so it never blocks setup. The id must match the template's.
+  var prefetchTemplate = document.getElementById("theme-icon-prefetch");
+  function warmThemeIcons() {
+    if (prefetchTemplate && "content" in prefetchTemplate) {
+      document.head.appendChild(prefetchTemplate.content.cloneNode(true));
+    }
+  }
+  if (window.requestIdleCallback) {
+    window.requestIdleCallback(warmThemeIcons);
+  } else {
+    window.setTimeout(warmThemeIcons, 0);
   }
 })();


### PR DESCRIPTION
Two resource-loading hints for the generated docs page (`tools/gen-docs/`).

## Preload the page scripts

The three toggle scripts (`nav_toggle.js`, `theme_toggle.js`, `config_toggle.js`) load via `<script src>` at the foot of `<body>`, so the browser wouldn't begin fetching them until it parsed that far. Each now also gets a `<link rel="preload" as="script">` in `<head>` so they download in parallel with the stylesheets. Both the preload links and the bottom-of-body `<script>` tags are generated from one `PAGE_SCRIPTS` slice, so they can't drift.

## Prefetch the theme icons

The three colour-scheme icons are referenced only from `settings.css` (as CSS masks), so the preload scanner never sees them and the first Settings-panel open fetches them cold. They're warmed ahead of time — but only for readers who can use the panel, since it's JS-driven and `hidden` by default and a no-JS reader must never pay for the fetch:

- Rust renders the `<link rel="prefetch" as="image">` hints into an **inert `<template>`**, built from the same `THEME_ICONS` list `settings.css` masks (single source of truth, no drift). A `<template>`'s contents are parsed but never loaded.
- `theme_toggle.js` clones the template into `<head>` at idle time (`requestIdleCallback`, `setTimeout` fallback) to fire the prefetch. Chrome and Firefox then serve the later CSS mask load from the same HTTP cache.

Rendering the hints from Rust keeps the behaviour testable against the real HTML: the tests pin one inert prefetch link per icon, that they live only inside the template, and that the script activates it by the shared id at idle.

## Notes

The CSS-referenced assets are warmed via prefetch rather than preload deliberately: preload is for late-discovered *critical* resources used on the current load, whereas these are decorative and gated behind interaction. The hover-revealed `rule-anchor.svg` is left untouched for the same reason.

Validated with the full `just all` gate (fmt, build, doc, clippy, test, self-lint).