### PR TITLE
ci(pages): minify CSS/JS/SVG assets after rendering

### DIFF
--- a/.github/workflows/pages-preview.yaml
+++ b/.github/workflows/pages-preview.yaml
@@ -100,9 +100,6 @@ jobs:
         with:
           tool: just
 
-      # Provision the pinned pnpm that `just minify-docs` shells out to.
-      # The recipe deliberately doesn't install pnpm, so the workflow
-      # owns the version.
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -113,10 +110,6 @@ jobs:
         shell: bash
         run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
-      # Cache the content-addressable store so the pinned minifiers
-      # (lightningcss-cli, terser, svgo) aren't re-downloaded each run.
-      # Keyed on the justfile because the tool versions live there, so a
-      # bump invalidates the cache automatically.
       - name: Cache pnpm store
         uses: actions/cache@v5
         timeout-minutes: 1
@@ -135,8 +128,6 @@ jobs:
         shell: bash
         run: cargo run --package _gen_docs --bin gen-docs -- --root "$(pwd)" html gh-pages --git-ref="${{ github.event.pull_request.head.sha }}"
 
-      # Minify the rendered CSS/JS/SVG in place so the preview matches
-      # what production publishes (see pages.yaml).
       - name: Minify site
         shell: bash
         run: just minify-docs gh-pages

--- a/.github/workflows/pages-preview.yaml
+++ b/.github/workflows/pages-preview.yaml
@@ -5,9 +5,10 @@ on:
   # preview is only worth building when the PR changes something the
   # rendered site is derived from (rule sources under `src/`, the
   # gen-docs renderer + assets, `Cargo.toml`) or a build input (lockfile,
-  # toolchain, linker config in `.cargo/`). PRs that only touch
-  # `planned-rules/`, the generated `rules/` markdown mirror, or
-  # `README.md` don't change the page, so they skip the Cloudflare deploy.
+  # toolchain, linker config in `.cargo/`, the pinned minifier versions
+  # in `justfile`). PRs that only touch `planned-rules/`, the generated
+  # `rules/` markdown mirror, or `README.md` don't change the page, so
+  # they skip the Cloudflare deploy.
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -17,6 +18,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain'
       - '.cargo/**'
+      - 'justfile'
       - '.github/workflows/pages-preview.yaml'
 
 permissions:
@@ -93,6 +95,38 @@ jobs:
         with:
           tool: dylint-link
 
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      # Provision the pinned pnpm that `just minify-docs` shells out to.
+      # The recipe deliberately doesn't install pnpm, so the workflow
+      # owns the version.
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.2
+
+      - name: Locate pnpm store
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      # Cache the content-addressable store so the pinned minifiers
+      # (lightningcss-cli, terser, svgo) aren't re-downloaded each run.
+      # Keyed on the justfile because the tool versions live there, so a
+      # bump invalidates the cache automatically.
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        timeout-minutes: 1
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-minify-${{ runner.os }}-${{ hashFiles('justfile') }}
+          restore-keys: |
+            pnpm-minify-${{ runner.os }}-
+
       # Pass the PR head SHA as `--git-ref` so the rendered
       # "Source:" links permalink the exact commit being previewed
       # rather than `master` (which `gen-docs` defaults to but
@@ -100,6 +134,12 @@ jobs:
       - name: Render site
         shell: bash
         run: cargo run --package _gen_docs --bin gen-docs -- --root "$(pwd)" html gh-pages --git-ref="${{ github.event.pull_request.head.sha }}"
+
+      # Minify the rendered CSS/JS/SVG in place so the preview matches
+      # what production publishes (see pages.yaml).
+      - name: Minify site
+        shell: bash
+        run: just minify-docs gh-pages
 
       # Wrangler's `--branch` flag drives the alias subdomain
       # Cloudflare assigns to the deployment

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -6,12 +6,13 @@ on:
   # under `src/`, its own renderer + assets under `tools/gen-docs/`, and
   # `Cargo.toml` (crate version + repo URL); the build additionally
   # depends on the pinned toolchain, the lockfile, and the linker config
-  # in `.cargo/`. Pure docs that never reach the page — `planned-rules/`,
-  # the generated `rules/` markdown mirror, `README.md` — are excluded.
-  # An allow-list fits a deploy workflow: a path missed here just leaves
-  # the live site untouched (the previous deploy stands), never broken.
-  # `workflow_dispatch` stays available for manual redeploys regardless
-  # of which paths changed.
+  # in `.cargo/`, and the post-render minify pass on the pinned tool
+  # versions in `justfile`. Pure docs that never reach the page —
+  # `planned-rules/`, the generated `rules/` markdown mirror, `README.md`
+  # — are excluded. An allow-list fits a deploy workflow: a path missed
+  # here just leaves the live site untouched (the previous deploy
+  # stands), never broken. `workflow_dispatch` stays available for manual
+  # redeploys regardless of which paths changed.
   push:
     branches:
       - master
@@ -22,6 +23,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain'
       - '.cargo/**'
+      - 'justfile'
       - '.github/workflows/pages.yaml'
   workflow_dispatch:
 
@@ -74,9 +76,48 @@ jobs:
         with:
           tool: dylint-link
 
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      # Provision the pinned pnpm that `just minify-docs` shells out to.
+      # The recipe deliberately doesn't install pnpm, so the workflow
+      # owns the version.
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.2
+
+      - name: Locate pnpm store
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      # Cache the content-addressable store so the pinned minifiers
+      # (lightningcss-cli, terser, svgo) aren't re-downloaded each run.
+      # Keyed on the justfile because the tool versions live there, so a
+      # bump invalidates the cache automatically.
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        timeout-minutes: 1
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-minify-${{ runner.os }}-${{ hashFiles('justfile') }}
+          restore-keys: |
+            pnpm-minify-${{ runner.os }}-
+
       - name: Render site
         shell: bash
         run: cargo run --package _gen_docs --bin gen-docs -- --root "$(pwd)" html gh-pages
+
+      # Minify the rendered CSS/JS/SVG in place before upload so the
+      # published site ships compressed assets. GitHub Pages then gzips
+      # them on the wire on top of this.
+      - name: Minify site
+        shell: bash
+        run: just minify-docs gh-pages
 
       - name: Configure Pages
         uses: actions/configure-pages@v6

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -81,9 +81,6 @@ jobs:
         with:
           tool: just
 
-      # Provision the pinned pnpm that `just minify-docs` shells out to.
-      # The recipe deliberately doesn't install pnpm, so the workflow
-      # owns the version.
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -94,10 +91,6 @@ jobs:
         shell: bash
         run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
-      # Cache the content-addressable store so the pinned minifiers
-      # (lightningcss-cli, terser, svgo) aren't re-downloaded each run.
-      # Keyed on the justfile because the tool versions live there, so a
-      # bump invalidates the cache automatically.
       - name: Cache pnpm store
         uses: actions/cache@v5
         timeout-minutes: 1
@@ -112,9 +105,6 @@ jobs:
         shell: bash
         run: cargo run --package _gen_docs --bin gen-docs -- --root "$(pwd)" html gh-pages
 
-      # Minify the rendered CSS/JS/SVG in place before upload so the
-      # published site ships compressed assets. GitHub Pages then gzips
-      # them on the wire on top of this.
       - name: Minify site
         shell: bash
         run: just minify-docs gh-pages

--- a/justfile
+++ b/justfile
@@ -113,21 +113,24 @@ svgo_version := "4.0.1"
 minify-docs site_dir="gh-pages":
   #!/usr/bin/env bash
   set -euo pipefail
+  cd "{{site_dir}}"
   shopt -s nullglob
-  # CSS: lightningcss minifies every file in place. `--targets` keeps the
-  # output legacy — without it lightningcss rewrites media queries to MQ4
-  # range syntax and `rgba()` to `#rrggbbaa`, neither of which Trident/IE
-  # parses, silently dropping the desktop sidebar and every alpha colour.
-  css=("{{site_dir}}"/*.css)
+  # CSS: lightningcss minifies every file in place, beside a sourcemap with
+  # the original embedded. `--targets` keeps the output legacy — without it
+  # lightningcss rewrites media queries to MQ4 range syntax and `rgba()` to
+  # `#rrggbbaa`, neither of which Trident/IE parses, silently dropping the
+  # desktop sidebar and every alpha colour.
+  css=(*.css)
   if [ "${#css[@]}" -gt 0 ]; then
-    pnpm dlx lightningcss-cli@{{lightningcss_cli_version}} --minify --targets 'ie 11' --output-dir "{{site_dir}}" "${css[@]}"
+    pnpm dlx lightningcss-cli@{{lightningcss_cli_version}} --minify --targets 'ie 11' --sourcemap --output-dir . "${css[@]}"
   fi
-  # JS: terser minifies every file in place.
-  for js in "{{site_dir}}"/*.js; do
-    pnpm dlx terser@{{terser_version}} "$js" --compress --mangle --output "$js"
+  # JS: terser minifies every file in place, beside a sourcemap with the
+  # original embedded.
+  for js in *.js; do
+    pnpm dlx terser@{{terser_version}} "$js" --compress --mangle --source-map "url='$js.map',includeSources=true" --output "$js"
   done
-  # SVG: svgo minifies every file in place.
-  svg=("{{site_dir}}"/*.svg)
+  # SVG: svgo minifies every file in place (SVG has no sourcemap format).
+  svg=(*.svg)
   if [ "${#svg[@]}" -gt 0 ]; then
-    pnpm dlx svgo@{{svgo_version}} --quiet --folder "{{site_dir}}"
+    pnpm dlx svgo@{{svgo_version}} --quiet --folder .
   fi

--- a/justfile
+++ b/justfile
@@ -115,21 +115,16 @@ minify-docs site_dir="gh-pages":
   set -euo pipefail
   cd "{{site_dir}}"
   shopt -s nullglob
-  # CSS: lightningcss minifies every file in place, beside a sourcemap with
-  # the original embedded. `--targets` keeps the output legacy — without it
-  # lightningcss rewrites media queries to MQ4 range syntax and `rgba()` to
-  # `#rrggbbaa`, neither of which Trident/IE parses, silently dropping the
-  # desktop sidebar and every alpha colour.
+  # CSS: lightningcss minifies every file in place.
   css=(*.css)
   if [ "${#css[@]}" -gt 0 ]; then
     pnpm dlx lightningcss-cli@{{lightningcss_cli_version}} --minify --targets 'ie 11' --sourcemap --output-dir . "${css[@]}"
   fi
-  # JS: terser minifies every file in place, beside a sourcemap with the
-  # original embedded.
+  # JS: terser minifies every file in place.
   for js in *.js; do
     pnpm dlx terser@{{terser_version}} "$js" --compress --mangle --source-map "url='$js.map',includeSources=true" --output "$js"
   done
-  # SVG: svgo minifies every file in place (SVG has no sourcemap format).
+  # SVG: svgo minifies every file in place.
   svg=(*.svg)
   if [ "${#svg[@]}" -gt 0 ]; then
     pnpm dlx svgo@{{svgo_version}} --quiet --folder .

--- a/justfile
+++ b/justfile
@@ -104,3 +104,41 @@ gen-rules-md rules_dir="rules":
 # Verify the in-tree markdown catalogue is in sync with `src/rules/`.
 check-rules-md rules_dir="rules":
   cargo run {{locked}} --package _gen_docs --bin gen-docs -- --root "$(pwd)" check-md "{{rules_dir}}"
+
+# Minifier versions, pinned. `minify-docs` fetches each on demand with
+# `pnpm dlx <tool>@<version>`, so there is no `package.json` or
+# `node_modules` in the tree and bumping a tool is a one-line edit here.
+# The Pages CI caches the pnpm store keyed on this file, so a bump
+# re-warms the cache.
+lightningcss_cli_version := "1.32.0"
+terser_version := "5.48.0"
+svgo_version := "4.0.1"
+
+# Minify a gen-docs output directory's CSS, JS, and SVG assets in place.
+# Run after `gen-docs`; the two Pages CI workflows do exactly this so the
+# published site ships compressed assets without pulling a JS minifier
+# into the Rust build. Needs `pnpm` on PATH — provisioning it is the
+# caller's job (CI installs a pinned pnpm), so this recipe never installs
+# pnpm itself. Each tool is version-pinned above and fetched on demand by
+# `pnpm dlx`.
+minify-docs out_dir="gh-pages":
+  #!/usr/bin/env bash
+  set -euo pipefail
+  shopt -s nullglob
+  # CSS: a single lightningcss run rewrites every sheet in place, because
+  # `--output-dir` points back at the directory the inputs came from.
+  css=("{{out_dir}}"/*.css)
+  if [ "${#css[@]}" -gt 0 ]; then
+    pnpm dlx lightningcss-cli@{{lightningcss_cli_version}} --minify --output-dir "{{out_dir}}" "${css[@]}"
+  fi
+  # JS: terser reads each file fully before emitting, so writing back to
+  # the same path is safe; `--compress --mangle` drops comments and
+  # shortens identifiers.
+  for js in "{{out_dir}}"/*.js; do
+    pnpm dlx terser@{{terser_version}} "$js" --compress --mangle --output "$js"
+  done
+  # SVG: svgo rewrites every `.svg` in the folder in place.
+  svg=("{{out_dir}}"/*.svg)
+  if [ "${#svg[@]}" -gt 0 ]; then
+    pnpm dlx svgo@{{svgo_version}} --quiet --folder "{{out_dir}}"
+  fi

--- a/justfile
+++ b/justfile
@@ -105,40 +105,26 @@ gen-rules-md rules_dir="rules":
 check-rules-md rules_dir="rules":
   cargo run {{locked}} --package _gen_docs --bin gen-docs -- --root "$(pwd)" check-md "{{rules_dir}}"
 
-# Minifier versions, pinned. `minify-docs` fetches each on demand with
-# `pnpm dlx <tool>@<version>`, so there is no `package.json` or
-# `node_modules` in the tree and bumping a tool is a one-line edit here.
-# The Pages CI caches the pnpm store keyed on this file, so a bump
-# re-warms the cache.
 lightningcss_cli_version := "1.32.0"
 terser_version := "5.48.0"
 svgo_version := "4.0.1"
 
 # Minify a gen-docs output directory's CSS, JS, and SVG assets in place.
-# Run after `gen-docs`; the two Pages CI workflows do exactly this so the
-# published site ships compressed assets without pulling a JS minifier
-# into the Rust build. Needs `pnpm` on PATH — provisioning it is the
-# caller's job (CI installs a pinned pnpm), so this recipe never installs
-# pnpm itself. Each tool is version-pinned above and fetched on demand by
-# `pnpm dlx`.
-minify-docs out_dir="gh-pages":
+minify-docs site_dir="gh-pages":
   #!/usr/bin/env bash
   set -euo pipefail
   shopt -s nullglob
-  # CSS: a single lightningcss run rewrites every sheet in place, because
-  # `--output-dir` points back at the directory the inputs came from.
-  css=("{{out_dir}}"/*.css)
+  # CSS: lightningcss minifies every file in place.
+  css=("{{site_dir}}"/*.css)
   if [ "${#css[@]}" -gt 0 ]; then
-    pnpm dlx lightningcss-cli@{{lightningcss_cli_version}} --minify --output-dir "{{out_dir}}" "${css[@]}"
+    pnpm dlx lightningcss-cli@{{lightningcss_cli_version}} --minify --output-dir "{{site_dir}}" "${css[@]}"
   fi
-  # JS: terser reads each file fully before emitting, so writing back to
-  # the same path is safe; `--compress --mangle` drops comments and
-  # shortens identifiers.
-  for js in "{{out_dir}}"/*.js; do
+  # JS: terser minifies every file in place.
+  for js in "{{site_dir}}"/*.js; do
     pnpm dlx terser@{{terser_version}} "$js" --compress --mangle --output "$js"
   done
-  # SVG: svgo rewrites every `.svg` in the folder in place.
-  svg=("{{out_dir}}"/*.svg)
+  # SVG: svgo minifies every file in place.
+  svg=("{{site_dir}}"/*.svg)
   if [ "${#svg[@]}" -gt 0 ]; then
-    pnpm dlx svgo@{{svgo_version}} --quiet --folder "{{out_dir}}"
+    pnpm dlx svgo@{{svgo_version}} --quiet --folder "{{site_dir}}"
   fi

--- a/justfile
+++ b/justfile
@@ -114,10 +114,13 @@ minify-docs site_dir="gh-pages":
   #!/usr/bin/env bash
   set -euo pipefail
   shopt -s nullglob
-  # CSS: lightningcss minifies every file in place.
+  # CSS: lightningcss minifies every file in place. `--targets` keeps the
+  # output legacy — without it lightningcss rewrites media queries to MQ4
+  # range syntax and `rgba()` to `#rrggbbaa`, neither of which Trident/IE
+  # parses, silently dropping the desktop sidebar and every alpha colour.
   css=("{{site_dir}}"/*.css)
   if [ "${#css[@]}" -gt 0 ]; then
-    pnpm dlx lightningcss-cli@{{lightningcss_cli_version}} --minify --output-dir "{{site_dir}}" "${css[@]}"
+    pnpm dlx lightningcss-cli@{{lightningcss_cli_version}} --minify --targets 'ie 11' --output-dir "{{site_dir}}" "${css[@]}"
   fi
   # JS: terser minifies every file in place.
   for js in "{{site_dir}}"/*.js; do


### PR DESCRIPTION
Minify the generated Pages assets (CSS / JS / SVG) before publishing, so the live catalogue ships compressed — without adding any dependency to the Rust build.

**How**
- New `just minify-docs` recipe rewrites a gen-docs output directory in place with `lightningcss-cli`, `terser`, and `svgo`. Tools are version-pinned and fetched on demand via `pnpm dlx`, so there's no `package.json` / `node_modules` in the tree.
- Both Pages workflows (production + preview) install a pinned pnpm, cache the pnpm store (keyed on `justfile`), and run `just minify-docs` after the render step. Provisioning pnpm is CI's job — the recipe never installs it.
- `justfile` is added to each workflow's path filter so bumping a tool version re-triggers the deploy.
- lightningcss runs with `--targets 'ie 11'` so it keeps legacy syntax. Without it, lightningcss rewrites media queries to MQ4 range syntax and `rgba()` to 8-digit `#rrggbbaa`, which Trident/IE can't parse — that dropped the desktop sidebar entirely. The source deliberately avoids `var()` for pre-custom-property engines, and this keeps the minified output on the same footing.
- CSS and JS are emitted with **embedded sourcemaps** (`sourcesContent`), so devtools can map the minified assets back to the original even though the recipe overwrites it in place — no unminified copies need publishing. The `.map` files ride along with the existing upload and are only fetched when devtools is open, so visitors pay nothing. SVG has no sourcemap format and is skipped.

**Effect:** assets shrink ~63% gzipped overall (what GitHub Pages serves) — see the table. CSS/JS/SVG only; `index.html` is left as-is (maud already emits near-minimal HTML).

**Measured sizes** — gzip level 9 (what GitHub Pages serves over the wire). "Minified" is the served asset and includes the trailing `sourceMappingURL` comment; the devtools-only `.map` files are excluded.

| File                | Original (gzip B) | Minified (gzip B) | Reduction (B) | Reduction |
| :------------------ | ----------------: | ----------------: | ------------: | --------: |
| base.css            |              3067 |               678 |          2389 |     77.9% |
| dark.css            |              2006 |              1289 |           717 |     35.7% |
| highlight-dark.css  |              1224 |              1181 |            43 |      3.5% |
| highlight-light.css |              1229 |              1186 |            43 |      3.5% |
| light.css           |              1727 |               843 |           884 |     51.2% |
| nav.css             |              2243 |               763 |          1480 |     66.0% |
| rules.css           |              1818 |              1084 |           734 |     40.4% |
| settings.css        |              2384 |               764 |          1620 |     68.0% |
| config_toggle.js    |              2620 |               431 |          2189 |     83.5% |
| nav_toggle.js       |              6548 |              1004 |          5544 |     84.7% |
| theme_toggle.js     |              2980 |               760 |          2220 |     74.5% |
| rule-anchor.svg     |               500 |               271 |           229 |     45.8% |
| theme-dark.svg      |               479 |               199 |           280 |     58.5% |
| theme-light.svg     |               640 |               355 |           285 |     44.5% |
| theme-system.svg    |               617 |               300 |           317 |     51.4% |
| **Total**           |         **30082** |         **11108** |     **18974** | **63.1%** |

https://claude.ai/code/session_017zXezU3Z4Z96mj11KKihCD