### PR TITLE
build: use TypeScript to ensure JavaScript files' correctness

### DIFF
--- a/.github/workflows/check-js-types.yaml
+++ b/.github/workflows/check-js-types.yaml
@@ -1,0 +1,76 @@
+name: Check JS Types
+
+# Type-checks the docs-site browser scripts (tools/gen-docs/src/*.js) from
+# their JSDoc annotations with the TypeScript compiler (`tsc --noEmit`, driven
+# by tsconfig.json).
+#
+# This workflow is intentionally independent of every other CI:
+#
+#   * It is a standalone workflow with its own job, not a `needs:` dependency
+#     of the Test or Pages workflows and not invoked via `workflow_call`, so it
+#     can never gate them — a red run here leaves Test and the Pages deploy
+#     free to pass and publish.
+#   * It only installs Node tooling (pnpm + the pinned TypeScript), never the
+#     Rust toolchain, so it shares no cache or step with the Rust suite.
+#
+# An allow-list of trigger paths keeps it from running on unrelated changes.
+# Because it gates nothing, a path missed here only means a JS/JSDoc change
+# went unchecked by CI — never a blocked merge or a broken deploy.
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'tools/gen-docs/src/*.js'
+      - 'tsconfig.json'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/check-js-types.yaml'
+  pull_request:
+    paths:
+      - 'tools/gen-docs/src/*.js'
+      - 'tsconfig.json'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/check-js-types.yaml'
+  workflow_dispatch:
+
+# Type-checking only reads the repository.
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check JS types
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Locate pnpm store
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        timeout-minutes: 1
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-tscheck-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-tscheck-${{ runner.os }}-
+
+      - name: Install packages
+        shell: bash
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check JavaScript
+        shell: bash
+        run: pnpm exec tsc --noEmit --project tsconfig.json

--- a/justfile
+++ b/justfile
@@ -105,6 +105,17 @@ gen-rules-md rules_dir="rules":
 check-rules-md rules_dir="rules":
   cargo run {{locked}} --package _gen_docs --bin gen-docs -- --root "$(pwd)" check-md "{{rules_dir}}"
 
+# Type-check the docs-site JavaScript (tools/gen-docs/src/*.js) from its
+# JSDoc annotations with the TypeScript compiler. Emits nothing; tsconfig.json
+# drives the check. Not part of `just all` — it has no Rust toolchain
+# dependency and runs in its own CI (.github/workflows/check-js-types.yaml).
+check-js-types:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  root_dir="{{justfile_directory()}}"
+  pnpm --dir "$root_dir" install --frozen-lockfile
+  pnpm --dir "$root_dir" exec tsc --noEmit --project "$root_dir/tsconfig.json"
+
 # Minify a gen-docs output directory's CSS, JS, and SVG assets in place.
 minify-docs site_dir="gh-pages":
   #!/usr/bin/env bash

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "@perfectionist/minify-docs",
   "version": "0.0.0",
   "private": true,
-  "description": "Pinned docs-site tooling: CSS/JS/SVG minifiers (justfile `minify-docs`) and the Cloudflare Pages deploy CLI (wrangler).",
+  "description": "Pinned docs-site tooling: CSS/JS/SVG minifiers (justfile `minify-docs`), the TypeScript compiler that type-checks the docs-site JS via JSDoc (justfile `check-js-types`), and the Cloudflare Pages deploy CLI (wrangler).",
   "devDependencies": {
     "lightningcss-cli": "1.32.0",
     "svgo": "4.0.1",
     "terser": "5.48.0",
+    "typescript": "6.0.3",
     "wrangler": "4.98.0"
   },
   "packageManager": "pnpm@11.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       terser:
         specifier: 5.48.0
         version: 5.48.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
       wrangler:
         specifier: 4.98.0
         version: 4.98.0
@@ -638,6 +641,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
@@ -1162,6 +1170,8 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  typescript@6.0.3: {}
 
   undici@7.24.8: {}
 

--- a/tools/gen-docs/src/config_toggle.js
+++ b/tools/gen-docs/src/config_toggle.js
@@ -39,24 +39,37 @@
 // ============================================================================
 
 (function () {
-  var section = document.querySelector(".config-controls");
+  var section = /** @type {HTMLElement | null} */ (
+    document.querySelector(".config-controls")
+  );
   if (!section) return;
 
-  var expandButton = section.querySelector('button[data-config-open="true"]');
-  var collapseButton = section.querySelector('button[data-config-open="false"]');
+  // Non-null casts (not `HTMLButtonElement | null`): the guard below still
+  // rejects a missing button at runtime, but TypeScript won't carry that
+  // narrowing into the reflectState closure below for a `var`, so it would
+  // otherwise read the buttons as nullable.
+  var expandButton = /** @type {HTMLButtonElement} */ (
+    section.querySelector('button[data-config-open="true"]')
+  );
+  var collapseButton = /** @type {HTMLButtonElement} */ (
+    section.querySelector('button[data-config-open="false"]')
+  );
   if (!expandButton || !collapseButton) return;
 
   // The Configuration panels. A generated catalogue is static after render
   // (nothing adds or removes panels at runtime), so query once and reuse the
   // NodeList everywhere rather than re-scanning the DOM per call — the same
   // cache-the-query approach theme_toggle.js takes with its radios.
-  var panels = document.querySelectorAll("details.config-details");
+  var panels = /** @type {NodeListOf<HTMLDetailsElement>} */ (
+    document.querySelectorAll("details.config-details")
+  );
 
   // Nothing to toggle means nothing to reveal: a catalogue with no
   // configurable rule renders no `details.config-details`, so leaving the
   // section hidden avoids two buttons that would silently do nothing.
   if (panels.length === 0) return;
 
+  /** @param {boolean} open */
   function setAllOpen(open) {
     for (var i = 0; i < panels.length; i++) {
       panels[i].open = open;

--- a/tools/gen-docs/src/nav_toggle.js
+++ b/tools/gen-docs/src/nav_toggle.js
@@ -128,8 +128,16 @@
 // ============================================================================
 
 (function () {
-  var toggle = document.querySelector(".nav-toggle");
-  var sidebar = document.querySelector(".nav-sidebar");
+  // Cast to the non-null element type rather than `HTMLElement | null`: the
+  // `if (!toggle || !sidebar) return;` guard below still catches a missing
+  // element at runtime, but TypeScript does not carry guard-based narrowing of
+  // a `var` into the closures further down (this file deliberately avoids
+  // `const`, see the trailing-comma note in config_toggle.js), so every event
+  // handler that reads `toggle`/`sidebar` would otherwise see them as nullable.
+  var toggle = /** @type {HTMLElement} */ (document.querySelector(".nav-toggle"));
+  var sidebar = /** @type {HTMLElement} */ (
+    document.querySelector(".nav-sidebar")
+  );
   if (!toggle || !sidebar) return;
 
   // ---- Hamburger fade ---------------------------------------------------
@@ -224,11 +232,12 @@
   // the toggle and the sidebar while the drawer is open; restore on
   // close. `inert` removes focusability and AT exposure of the
   // subtree without needing a manual focus trap or aria-hidden dance.
+  /** @type {HTMLElement[]} */
   var inertedChildren = [];
   function setBackgroundInert() {
     inertedChildren = [];
     for (var i = 0; i < document.body.children.length; i++) {
-      var el = document.body.children[i];
+      var el = /** @type {HTMLElement} */ (document.body.children[i]);
       if (el === toggle || el === sidebar) continue;
       if (el.inert) continue;
       el.inert = true;
@@ -269,7 +278,9 @@
     }
   });
 
-  var closeBtn = sidebar.querySelector(".nav-sidebar-close");
+  var closeBtn = /** @type {HTMLElement | null} */ (
+    sidebar.querySelector(".nav-sidebar-close")
+  );
   if (closeBtn) closeBtn.addEventListener("click", closeSidebar);
 
   // ---- Focus trap fallback ----------------------------------------------
@@ -289,8 +300,8 @@
   document.addEventListener("keydown", function (event) {
     if (event.key !== "Tab") return;
     if (toggle.getAttribute("aria-expanded") !== "true") return;
-    var focusable = sidebar.querySelectorAll(
-      "a[href], button:not([disabled])"
+    var focusable = /** @type {NodeListOf<HTMLElement>} */ (
+      sidebar.querySelectorAll("a[href], button:not([disabled])")
     );
     if (focusable.length === 0) return;
     var first = focusable[0];
@@ -321,7 +332,7 @@
   // the catalogue heading aren't focusable by default, so set
   // tabindex="-1" before .focus().
   sidebar.addEventListener("click", function (event) {
-    var link = event.target.closest("a");
+    var link = /** @type {Element} */ (event.target).closest("a");
     if (!link) return;
     if (event.button !== 0) return;
     if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;

--- a/tools/gen-docs/src/theme_toggle.js
+++ b/tools/gen-docs/src/theme_toggle.js
@@ -47,16 +47,27 @@
   var STORAGE_KEY = "perfectionist-color-scheme-override";
   var ATTRIBUTE = "color-scheme-override";
 
-  var toggle = document.querySelector(".settings-toggle");
-  var panel = document.querySelector(".settings-panel");
+  // Non-null casts (not `HTMLElement | null`): the guard below still rejects a
+  // missing element at runtime, but TypeScript won't carry that narrowing into
+  // the event-handler closures below for a `var`, so they would otherwise read
+  // `toggle`/`panel` as nullable. See the matching note in nav_toggle.js.
+  var toggle = /** @type {HTMLElement} */ (
+    document.querySelector(".settings-toggle")
+  );
+  var panel = /** @type {HTMLElement} */ (
+    document.querySelector(".settings-panel")
+  );
   if (!toggle || !panel) return;
 
-  var radios = panel.querySelectorAll('input[name="color-scheme"]');
+  var radios = /** @type {NodeListOf<HTMLInputElement>} */ (
+    panel.querySelectorAll('input[name="color-scheme"]')
+  );
   if (radios.length === 0) return;
 
   // Apply a choice to the live page. "dark"/"light" set the override
   // attribute (tier 3); anything else ("system") removes it so the
   // page falls back to tiers 1–2.
+  /** @param {string | null} value */
   function applyScheme(value) {
     if (value === "dark" || value === "light") {
       html.setAttribute(ATTRIBUTE, value);
@@ -67,6 +78,7 @@
 
   // Persist a choice. "system" clears the key (its absence IS the
   // default), keeping the stored set to exactly {dark, light, unset}.
+  /** @param {string} value */
   function persistScheme(value) {
     if (value === "dark" || value === "light") {
       window.localStorage.setItem(STORAGE_KEY, value);
@@ -75,6 +87,7 @@
     }
   }
 
+  /** @param {string} value */
   function selectRadio(value) {
     for (var i = 0; i < radios.length; i++) {
       radios[i].checked = radios[i].value === value;
@@ -103,8 +116,9 @@
 
   for (var i = 0; i < radios.length; i++) {
     radios[i].addEventListener("change", function (event) {
-      applyScheme(event.target.value);
-      persistScheme(event.target.value);
+      var radio = /** @type {HTMLInputElement} */ (event.target);
+      applyScheme(radio.value);
+      persistScheme(radio.value);
     });
   }
 
@@ -114,7 +128,8 @@
   // behaviour for this kind of menu.
   document.addEventListener("click", function (event) {
     if (toggle.getAttribute("aria-expanded") !== "true") return;
-    if (toggle.contains(event.target) || panel.contains(event.target)) return;
+    var clickTarget = /** @type {Node | null} */ (event.target);
+    if (toggle.contains(clickTarget) || panel.contains(clickTarget)) return;
     closePanel();
   });
 
@@ -176,7 +191,9 @@
   // them; Chrome and Firefox then serve the later CSS mask load from that
   // same HTTP cache. Done at idle time (requestIdleCallback, setTimeout
   // fallback) so it never blocks setup. The id must match the template's.
-  var prefetchTemplate = document.getElementById("theme-icon-prefetch");
+  var prefetchTemplate = /** @type {HTMLTemplateElement | null} */ (
+    document.getElementById("theme-icon-prefetch")
+  );
   function warmThemeIcons() {
     if (prefetchTemplate && "content" in prefetchTemplate) {
       document.head.appendChild(prefetchTemplate.content.cloneNode(true));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": [],
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["tools/gen-docs/src/*.js"]
+}


### PR DESCRIPTION
Type-checks the docs-site browser scripts (`tools/gen-docs/src/*.js`) with the TypeScript compiler, driven from JSDoc annotations.

## Changes

- **JSDoc annotations** on the three scripts — narrow element/event casts (`HTMLButtonElement`, `NodeListOf<HTMLDetailsElement>`, `HTMLTemplateElement`, …) and `@param`s, for the tightest types `tsc` can enforce.
- **`tsconfig.json`** — no-emit, strict `tsc` over those files (`checkJs`/`allowJs`, DOM libs, `types: []`).
- **`typescript` pinned** in `package.json` (+ `pnpm-lock.yaml`).
- **`check-js-types`** justfile task (frozen install + `tsc --noEmit`).
- **Standalone "Check JS Types" workflow** — installs pnpm, caches the store, frozen install, runs `tsc`.

The workflow is independent of the Test and Pages workflows: it is not a `needs:`/`workflow_call` target and installs only Node tooling, so it can never gate the Rust suite or the Pages deploy.

> [!NOTE]
> TypeScript 7 — the Go-based native port (`@typescript/native-preview`, `tsgo`) — is **not** adopted here: it's still a dev preview, and its speed advantage is irrelevant for three small files. Stable `typescript` is the right choice; revisit once TS 7 ships stable.

https://claude.ai/code/session_018se8hYQuBWfnBYwVLx5ejh