### PR TITLE
chore(git/hooks): reject bare "#NNN" issue references in commit messages

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,27 +1,85 @@
 #!/usr/bin/env bash
-# commit-msg hook: reject release-shaped commit messages (X.Y.Z or
-# X.Y.Z-<suffix>) whose staged diff fails the version-bump contract
-# enforced by tools/deploy-check.
+# commit-msg hook. Two independent checks:
+#
+#   1. Reject any commit message that contains a bare "#NNN" issue/PR
+#      reference (see "Reject bare #NNN" below). This guards against the
+#      most common AI mis-reference: a number that resolves against the
+#      wrong repository, or "#1"/"#2" used to enumerate list items. Pure
+#      text, runs for every commit.
+#   2. Reject release-shaped commit messages (X.Y.Z or X.Y.Z-<suffix>)
+#      whose staged diff fails the version-bump contract enforced by
+#      tools/deploy-check.
 set -euo pipefail
 
 msg_file="$1"
 
-# Cheap pre-filter so non-release commits don't pay the cost of
-# spawning cargo. Find the first non-blank, non-comment line and
-# check whether it matches the version-literal grammar.
-#
-# Honour `core.commentChar` (default `#`) so a user with a
-# non-default comment char doesn't have template comment lines
-# leak through and get picked as the subject — that would
-# otherwise let a malformed release commit slip past the hook.
-# Fall back to `#` on unset, `auto`, or any non-single-char
-# value, matching the Rust side's fallback.
+# Honour `core.commentChar` (default `#`) so a user with a non-default
+# comment char doesn't have template comment lines leak through — that
+# would otherwise let a malformed release commit slip past check 2, and
+# make check 1 skip lines it should scan. Fall back to `#` on unset,
+# `auto`, or any non-single-char value, matching the Rust side's
+# fallback. Both checks below share this value.
 comment_char=$(git config --get core.commentChar 2>/dev/null || true)
 case "$comment_char" in
   '') comment_char='#' ;;
   ?) ;;
   *) comment_char='#' ;;
 esac
+
+# --- Reject bare "#NNN" issue / PR references -------------------------
+# A bare "#123" is resolved by GitHub against *this* repository, so it
+# is a frequent source of mis-references: a number copied from another
+# project silently links to the wrong issue here, and "#1"/"#2" used to
+# enumerate list items reads as issue/PR 1 and 2. Qualified
+# ("owner/repo#123") and absolute-URL forms are unambiguous, so we
+# reject only the bare form. See CLAUDE.md, "Issue and PR references in
+# commit messages", for the full rationale.
+#
+# Scan only the human-authored text: drop comment-char lines and stop
+# at the `git commit -v` scissors marker (a comment line carrying `>8`)
+# so a diff hunk in the verbose template never trips the check. A "#"
+# counts as bare unless the character before it could be the tail of a
+# qualifying "owner/repo" (`[0-9A-Za-z._/-]`); the trailing-boundary
+# group keeps "#123abc" and URL fragments like "#L123" / "#issuecomment-1"
+# from matching.
+bare_refs=$(
+  awk -v cc="$comment_char" '
+    index($0, cc) == 1 { if (index($0, ">8") > 0) exit; next }
+    { print }
+  ' "$msg_file" | grep -E '(^|[^0-9A-Za-z._/-])#[0-9]+([^0-9A-Za-z]|$)' || true
+)
+if [ -n "$bare_refs" ]; then
+  cat >&2 <<EOF
+✖ Commit message rejected: it contains a bare "#NNN" reference.
+
+$(printf '%s\n' "$bare_refs" | sed 's/^/    /')
+
+A bare "#123" is ambiguous and a common way to mis-reference an issue:
+
+  • Used to enumerate list items ("#1", "#2", "#3"), it instead reads
+    as issue/PR 1, 2, 3. Number the items another way, e.g. "item 1",
+    "1.", or "(1)".
+
+  • Used for a real issue or PR, GitHub resolves a bare "#123" against
+    THIS repository, so a number meant for another repo silently links
+    to the wrong issue here.
+
+Use an unambiguous form instead:
+
+  • Same repo:    KSXGitHub/perfectionist#123
+  • Another repo: owner/repo#123
+  • Absolute URL: https://github.com/owner/repo/issues/123
+
+Qualified ("owner/repo#123") and URL forms are always accepted, so it
+is safe to qualify even same-repo references.
+EOF
+  exit 1
+fi
+
+# --- Reject malformed release commits --------------------------------
+# Cheap pre-filter so non-release commits don't pay the cost of
+# spawning cargo. Find the first non-blank, non-comment line and
+# check whether it matches the version-literal grammar.
 subject=$(awk -v cc="$comment_char" 'index($0, cc) != 1 && NF { print; exit }' "$msg_file")
 if ! [[ "$subject" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[^[:space:]]+)?$ ]]; then
   exit 0

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -27,8 +27,6 @@ case "$comment_char" in
 esac
 
 # --- Reject bare "#NNN" issue / PR references -------------------------
-# Rationale and the accepted forms are in the rejection message below.
-#
 # Scan only the human-authored text: drop comment-char lines and stop
 # at the `git commit -v` scissors marker (a comment line carrying `>8`).
 #

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -37,16 +37,22 @@ esac
 #
 # Scan only the human-authored text: drop comment-char lines and stop
 # at the `git commit -v` scissors marker (a comment line carrying `>8`)
-# so a diff hunk in the verbose template never trips the check. A "#"
-# counts as bare unless the character before it could be the tail of a
-# qualifying "owner/repo" (`[0-9A-Za-z._/-]`); the trailing-boundary
-# group keeps "#123abc" and URL fragments like "#L123" / "#issuecomment-1"
-# from matching.
+# so a diff hunk in the verbose template never trips the check.
+#
+# The "#" is bracketed by word boundaries, matching GitHub's own
+# autolink rule: it autolinks "#NNN" exactly when the "#" is not
+# preceded by a word character `[0-9A-Za-z_]`. So only a word char
+# before the "#" exempts it — that is the tail of the "repo" in a
+# qualifying "owner/repo#123" (where the char before "#" is
+# alphanumeric). Anything else before the "#" — whitespace, "(", ".",
+# "/", "-", … — leaves it bare, so "path/#123" and "foo.#123" are
+# caught too. The trailing word boundary keeps "#123abc" and URL
+# fragments like "#L123" / "#issuecomment-1" from matching.
 bare_refs=$(
   awk -v cc="$comment_char" '
     index($0, cc) == 1 { if (index($0, ">8") > 0) exit; next }
     { print }
-  ' "$msg_file" | grep -E '(^|[^0-9A-Za-z._/-])#[0-9]+([^0-9A-Za-z]|$)' || true
+  ' "$msg_file" | grep -E '(^|[^0-9A-Za-z_])#[0-9]+([^0-9A-Za-z_]|$)' || true
 )
 if [ -n "$bare_refs" ]; then
   cat >&2 <<EOF

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -27,27 +27,15 @@ case "$comment_char" in
 esac
 
 # --- Reject bare "#NNN" issue / PR references -------------------------
-# A bare "#123" is resolved by GitHub against *this* repository, so it
-# is a frequent source of mis-references: a number copied from another
-# project silently links to the wrong issue here, and "#1"/"#2" used to
-# enumerate list items reads as issue/PR 1 and 2. Qualified
-# ("owner/repo#123") and absolute-URL forms are unambiguous, so we
-# reject only the bare form. See CLAUDE.md, "Issue and PR references in
-# commit messages", for the full rationale.
+# Rationale and the accepted forms are in the rejection message below.
 #
 # Scan only the human-authored text: drop comment-char lines and stop
-# at the `git commit -v` scissors marker (a comment line carrying `>8`)
-# so a diff hunk in the verbose template never trips the check.
+# at the `git commit -v` scissors marker (a comment line carrying `>8`).
 #
-# The "#" is bracketed by word boundaries, matching GitHub's own
-# autolink rule: it autolinks "#NNN" exactly when the "#" is not
-# preceded by a word character `[0-9A-Za-z_]`. So only a word char
-# before the "#" exempts it — that is the tail of the "repo" in a
-# qualifying "owner/repo#123" (where the char before "#" is
-# alphanumeric). Anything else before the "#" — whitespace, "(", ".",
-# "/", "-", … — leaves it bare, so "path/#123" and "foo.#123" are
-# caught too. The trailing word boundary keeps "#123abc" and URL
-# fragments like "#L123" / "#issuecomment-1" from matching.
+# The regex matches GitHub's autolink boundary: "#NNN" is bare unless
+# the "#" is preceded by a word char `[0-9A-Za-z_]` (the tail of the
+# "repo" in "owner/repo#123"). The trailing boundary keeps "#123abc"
+# and fragments like "#L123" / "#issuecomment-1" from matching.
 bare_refs=$(
   awk -v cc="$comment_char" '
     index($0, cc) == 1 { if (index($0, ">8") > 0) exit; next }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,44 @@ The single exception is version-bump commits, whose subject is
 just the version itself (e.g. `0.0.0-rc.6`). Use this form only
 for commits that do nothing other than bump the version.
 
+## Issue and PR references in commit messages
+
+Never write a **bare** `#NNN` reference (a `#` immediately
+followed by digits) anywhere in a commit message — not in the
+subject, not in the body. The [`commit-msg` hook](.githooks/commit-msg)
+installed by `just install-git-hooks` rejects any commit message
+that contains one. This rule is blanket: it applies to every
+commit, and it is always safe to satisfy because the accepted
+forms work for this repository's own issues too.
+
+The bare form is banned because it is the single most common way
+references go wrong:
+
+- **Enumerating list items.** Writing "`#1`", "`#2`", "`#3`" to
+  number the items of a list reads, on GitHub, as a link to
+  issue/PR 1, 2, and 3. Number the items some other way —
+  "item 1", "1.", or "(1)".
+- **Wrong-repository links.** GitHub resolves a bare `#123`
+  against *this* repository. A number that actually belongs to a
+  different project (a dependency, an upstream tool, a tracking
+  issue elsewhere) silently links to whatever issue happens to
+  carry that number here.
+
+Use an unambiguous form instead. All three are accepted by the
+hook:
+
+- **Same repository (qualified):** `KSXGitHub/perfectionist#123`
+- **Another repository (qualified):** `owner/repo#123`
+- **Absolute URL:** `https://github.com/owner/repo/issues/123`
+
+Qualifying a same-repo reference is never wrong, so prefer the
+qualified or URL form unconditionally rather than reaching for the
+bare `#123` and relying on the reader inferring the repository.
+(The hook only inspects the human-authored message: it skips
+comment lines and the `git commit -v` diff, and it does not flag
+`#123abc` or URL fragments such as `#L123` / `#issuecomment-1`,
+since those are not bare issue references.)
+
 ## Markdown links
 
 `README.md` uses absolute links throughout, because it is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,16 @@ that contains one. This rule is blanket: it applies to every
 commit, and it is always safe to satisfy because the accepted
 forms work for this repository's own issues too.
 
+**Install the hook before you commit.** On every fresh checkout,
+run `just install-git-hooks` as a setup step (it points this
+checkout's `core.hooksPath` at `.githooks/`). The hook is what
+catches the bare-reference mistake — and the malformed-release
+mistake — locally, before a bad message is ever recorded. Do not
+skip it on the assumption that you will get the message right by
+hand; the whole point of the hook is that this mistake is easy to
+make and easy to miss. If you cannot run `just`, set it up
+directly with `git config core.hooksPath .githooks`.
+
 The bare form is banned because it is the single most common way
 references go wrong:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,11 +431,17 @@ for commits that do nothing other than bump the version.
 
 ## Issue and PR references in commit messages
 
-Never write a **bare** `#NNN` reference (a `#` immediately
-followed by digits) anywhere in a commit message — not in the
-subject, not in the body. The [`commit-msg` hook](.githooks/commit-msg)
-installed by `just install-git-hooks` rejects any commit message
-that contains one. This rule is blanket: it applies to every
+Never write a **bare** `#NNN` reference anywhere in a commit
+message — not in the subject, not in the body. A reference is
+*bare* when a `#` followed by digits is **not** immediately
+preceded by an ASCII word character (`[0-9A-Za-z_]`) — exactly
+the form GitHub autolinks against *this* repository. So `#123`,
+`(#123)`, `path/#123`, and `foo.#123` are all bare, whereas
+`owner/repo#123` is not (the `#` follows the word character `o`);
+likewise a non-reference such as `C#123` or `foo#123` is left
+alone. The [`commit-msg` hook](.githooks/commit-msg) installed by
+`just install-git-hooks` rejects any commit message that contains
+a bare reference. This rule is blanket: it applies to every
 commit, and it is always safe to satisfy because the accepted
 forms work for this repository's own issues too.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,57 +431,26 @@ for commits that do nothing other than bump the version.
 
 ## Issue and PR references in commit messages
 
-Never write a **bare** `#NNN` reference anywhere in a commit
-message — not in the subject, not in the body. A reference is
-*bare* when a `#` followed by digits is **not** immediately
-preceded by an ASCII word character (`[0-9A-Za-z_]`) — exactly
-the form GitHub autolinks against *this* repository. So `#123`,
-`(#123)`, `path/#123`, and `foo.#123` are all bare, whereas
-`owner/repo#123` is not (the `#` follows the word character `o`);
-likewise a non-reference such as `C#123` or `foo#123` is left
-alone. The [`commit-msg` hook](.githooks/commit-msg) installed by
-`just install-git-hooks` rejects any commit message that contains
-a bare reference. This rule is blanket: it applies to every
-commit, and it is always safe to satisfy because the accepted
-forms work for this repository's own issues too.
+Never write a **bare** `#NNN` reference in a commit message. A
+reference is *bare* when a `#` followed by digits is not
+immediately preceded by an ASCII word char (`[0-9A-Za-z_]`) — the
+form GitHub autolinks against *this* repo, so a number meant for
+another project links to the wrong issue. Thus `#123`, `(#123)`,
+`path/#123` are bare; `owner/repo#123`, `C#123`, `foo#123` are
+not. The [`commit-msg` hook](.githooks/commit-msg) rejects any
+commit containing one; install it on a fresh checkout with
+`just install-git-hooks` (or `git config core.hooksPath .githooks`).
 
-**Install the hook before you commit.** On every fresh checkout,
-run `just install-git-hooks` as a setup step (it points this
-checkout's `core.hooksPath` at `.githooks/`). The hook is what
-catches the bare-reference mistake — and the malformed-release
-mistake — locally, before a bad message is ever recorded. Do not
-skip it on the assumption that you will get the message right by
-hand; the whole point of the hook is that this mistake is easy to
-make and easy to miss. If you cannot run `just`, set it up
-directly with `git config core.hooksPath .githooks`.
+Use an unambiguous form instead:
 
-The bare form is banned because it is the single most common way
-references go wrong:
-
-- **Enumerating list items.** Writing "`#1`", "`#2`", "`#3`" to
-  number the items of a list reads, on GitHub, as a link to
-  issue/PR 1, 2, and 3. Number the items some other way —
-  "item 1", "1.", or "(1)".
-- **Wrong-repository links.** GitHub resolves a bare `#123`
-  against *this* repository. A number that actually belongs to a
-  different project (a dependency, an upstream tool, a tracking
-  issue elsewhere) silently links to whatever issue happens to
-  carry that number here.
-
-Use an unambiguous form instead. All three are accepted by the
-hook:
-
-- **Same repository (qualified):** `KSXGitHub/perfectionist#123`
-- **Another repository (qualified):** `owner/repo#123`
+- **Same repo:** `KSXGitHub/perfectionist#123`
+- **Another repo:** `owner/repo#123`
 - **Absolute URL:** `https://github.com/owner/repo/issues/123`
 
-Qualifying a same-repo reference is never wrong, so prefer the
-qualified or URL form unconditionally rather than reaching for the
-bare `#123` and relying on the reader inferring the repository.
-(The hook only inspects the human-authored message: it skips
-comment lines and the `git commit -v` diff, and it does not flag
-`#123abc` or URL fragments such as `#L123` / `#issuecomment-1`,
-since those are not bare issue references.)
+To enumerate list items, number them without `#` ("item 1", "1.",
+"(1)") — "`#1`"/"`#2`" otherwise autolink as issue 1/2. The hook
+skips comment lines and the `git commit -v` diff, and ignores
+non-bare forms like `#123abc` / `#L123` / `#issuecomment-1`.
 
 ## Markdown links
 


### PR DESCRIPTION
Adds a `commit-msg` hook check that rejects any commit message containing a **bare** issue reference — a `#` directly followed by digits.

### Why

A bare reference resolves against *this* repository, so a number copied from another project links to the wrong issue, and a `#` plus a small list index used to enumerate items reads as a link to those issue/PR numbers. The qualified (`owner/repo#123`) and absolute-URL forms are unambiguous, so the check rejects only the bare form — making it safe to apply to every commit. The rejection message explains the problem and lists the accepted alternatives.

### What's here

- **`.githooks/commit-msg`** gains the bare-reference check. It is pure text and runs for every commit: it skips comment lines and the `git commit -v` diff, and does not flag `#123abc` or URL fragments like `#L123` / `#issuecomment-1`. The existing malformed-release check is unchanged.
- **`CLAUDE.md`** documents the rule and accepted forms, and instructs agents to install the hook via `just install-git-hooks`.