### PR TITLE
fix(unpinned-repo-ref)!: restrict version-suffix characters

### DIFF
--- a/rules/unpinned_repo_ref.md
+++ b/rules/unpinned_repo_ref.md
@@ -74,7 +74,8 @@ pure-hex ref as a SHA.
 ### `allow_version_patterns`: `boolean` (optional)
 
 Whether refs shaped like version patterns (`1.2.3`, `v1.2.3`, or
-either form with a non-empty `-suffix`) are accepted without a
+either form with a non-empty `-suffix` of ASCII letters, ASCII
+digits, `.`, `-`, and `_`) are accepted without a
 commit SHA. Defaults to `false`; tags can move, and a
 version-shaped branch name is valid Git, so projects must opt in
 to this convenience explicitly.

--- a/src/rules/unpinned_repo_ref/config.rs
+++ b/src/rules/unpinned_repo_ref/config.rs
@@ -96,7 +96,8 @@ pub(super) struct Config {
     /// pure-hex ref as a SHA.
     pub(super) sha_recognition_length: usize,
     /// Whether refs shaped like version patterns (`1.2.3`, `v1.2.3`, or
-    /// either form with a non-empty `-suffix`) are accepted without a
+    /// either form with a non-empty `-suffix` of ASCII letters, ASCII
+    /// digits, `.`, `-`, and `_`) are accepted without a
     /// commit SHA. Defaults to `false`; tags can move, and a
     /// version-shaped branch name is valid Git, so projects must opt in
     /// to this convenience explicitly.

--- a/src/rules/unpinned_repo_ref/parse.rs
+++ b/src/rules/unpinned_repo_ref/parse.rs
@@ -144,14 +144,17 @@ fn is_commit_sha(text: &str, sha_recognition_length: usize) -> bool {
 }
 
 /// Whether `text` looks like a version pattern (`1.2.3`, `v1.2.3`, or
-/// either form with a non-empty `-suffix`). This intentionally avoids a
-/// regex dependency because the lint is compiled from source by users.
+/// either form with a non-empty `-suffix` of version-suffix characters,
+/// per [`is_version_suffix_byte`]). This intentionally avoids a regex
+/// dependency because the lint is compiled from source by users.
 fn is_version_pattern_ref(text: &str) -> bool {
     let text = text.strip_prefix('v').unwrap_or(text);
     let (version, suffix) = text
         .split_once('-')
         .map_or((text, None), |(version, suffix)| (version, Some(suffix)));
-    if suffix.is_some_and(str::is_empty) {
+    if let Some(suffix) = suffix
+        && (suffix.is_empty() || !suffix.bytes().all(is_version_suffix_byte))
+    {
         return false;
     }
 
@@ -164,6 +167,14 @@ fn is_version_pattern_ref(text: &str) -> bool {
     [major, minor, patch]
         .into_iter()
         .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+/// Whether `byte` may appear in a version-pattern suffix: ASCII
+/// letters, ASCII digits, `.`, `-`, and `_`. Anything else (`$`, `,`,
+/// `;`, `&`, ...) is not a versioning suffix, so a ref containing it
+/// is not exempted by `allow_version_patterns`.
+fn is_version_suffix_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_')
 }
 
 /// Split `url` into the byte offset of its path and the path text

--- a/src/rules/unpinned_repo_ref/parse/tests.rs
+++ b/src/rules/unpinned_repo_ref/parse/tests.rs
@@ -177,7 +177,14 @@ fn ref_problem_accepts_sha_and_rejects_short_or_non_hex() {
 
 #[test]
 fn ref_problem_accepts_version_patterns_when_configured() {
-    for reference in ["1.2.3", "1.2.3-rc.1", "v1.2.3", "v1.2.3-suffix"] {
+    for reference in [
+        "1.2.3",
+        "1.2.3-rc.1",
+        "v1.2.3",
+        "v1.2.3-suffix",
+        "1.2.3-rc_1",
+        "v1.2.3-alpha-2",
+    ] {
         assert_eq!(
             ref_problem(reference, RefOutcome::MustBeSha, 4, true),
             None,
@@ -195,7 +202,17 @@ fn ref_problem_accepts_version_patterns_when_configured() {
         );
     }
 
-    for reference in ["v1.2", "1.2.3-", "release-1.2.3"] {
+    for reference in [
+        "v1.2",
+        "1.2.3-",
+        "release-1.2.3",
+        // A suffix may only contain ASCII letters, ASCII digits, `.`,
+        // `-`, and `_`; anything else is not a versioning suffix.
+        "1.2.3-abc$def&ghi",
+        "1.2.3-abc,def",
+        "1.2.3-abc;def",
+        "v1.2.3-abc/def",
+    ] {
         assert_eq!(
             ref_problem(reference, RefOutcome::MustBeSha, 4, true),
             Some(RefProblem::NotSha),

--- a/ui-toml/unpinned_repo_ref/allow_version_patterns/fixture.rs
+++ b/ui-toml/unpinned_repo_ref/allow_version_patterns/fixture.rs
@@ -16,4 +16,9 @@ fn _comment_gitea_version_pattern() {}
 /// <https://github.com/owner/repo/blob/main/src/lib.rs>.
 fn _doc_github_branch() {}
 
+/// Bad: a suffix with characters outside ASCII letters, ASCII digits,
+/// `.`, `-`, and `_` is not a version pattern:
+/// <https://github.com/owner/repo/blob/v1.2.3-abc$def/src/lib.rs>.
+fn _doc_github_invalid_suffix() {}
+
 fn main() {}

--- a/ui-toml/unpinned_repo_ref/allow_version_patterns/fixture.stderr
+++ b/ui-toml/unpinned_repo_ref/allow_version_patterns/fixture.stderr
@@ -7,5 +7,13 @@ LL | /// <https://github.com/owner/repo/blob/main/src/lib.rs>.
    = help: pin the URL to a commit SHA so the linked file or directory cannot change without warning
    = note: `#[warn(perfectionist::unpinned_repo_ref)]` on by default
 
-warning: 1 warning emitted
+warning: repository URL ref `v1.2.3-abc$def` is not a pinned commit SHA
+  --> $DIR/fixture.rs:21:41
+   |
+LL | /// <https://github.com/owner/repo/blob/v1.2.3-abc$def/src/lib.rs>.
+   |                                         ^^^^^^^^^^^^^^
+   |
+   = help: pin the URL to a commit SHA so the linked file or directory cannot change without warning
+
+warning: 2 warnings emitted
 


### PR DESCRIPTION
## Problem

The `allow_version_patterns` exemption (introduced in https://github.com/KSXGitHub/perfectionist/pull/273) accepted any non-empty `-suffix` after the `major.minor.patch` core, so refs that are not versioning suffixes at all — `1.2.3-abc$def&ghi`, `1.2.3-abc,def`, `1.2.3-abc;def` — were exempted from pinning.

## Change

A suffix now only matches when every character is ASCII alphabetic, ASCII numeric, `.` (dot), `-` (dash), or `_` (underscore). This covers the real-world suffix vocabulary (`-rc.1`, `-alpha-2`, `-beta_3`) while rejecting arbitrary punctuation. (For comparison, semver pre-release identifiers allow only ASCII alphanumerics, `-`, and `.` separators; `_` is additionally accepted here.)

- `is_version_pattern_ref` validates the suffix bytes against the new `is_version_suffix_byte` set.
- The `allow_version_patterns` config field doc and the regenerated `rules/unpinned_repo_ref.md` state the allowed character set.
- New unit-test cases cover accepted (`1.2.3-rc_1`, `v1.2.3-alpha-2`) and rejected (`1.2.3-abc$def&ghi`, `1.2.3-abc,def`, `1.2.3-abc;def`, `v1.2.3-abc/def`) suffixes, and the `allow_version_patterns` UI fixture gains a flagged invalid-suffix URL.

## Validation

`just all` passes (fmt, build, doc, lint, test, self-lint).

https://claude.ai/code/session_01GTJ6pfLHGg7cESh73Du6k4

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTJ6pfLHGg7cESh73Du6k4)_