### PR TITLE
docs(unpinned-repo-ref): keep "Why restrict this?" to the rationale

### DIFF
--- a/rules/unpinned_repo_ref.md
+++ b/rules/unpinned_repo_ref.md
@@ -17,25 +17,21 @@ version-shaped refs can opt into accepting those patterns via
 `allow_version_patterns`. Scans doc comments, regular comments, and
 string literals.
 
+This rule only concerns whether the ref is mutable; the
+*length* of an accepted SHA is `perfectionist::commit_id_length`'s
+concern, and `perfectionist::bare_url` ensures the URL is
+wrapped. The three lints layer rather than overlap.
+
 ## Why restrict this?
 
 This is a stylistic preference, not a correctness issue. A
 branch ref such as `/blob/main/...` resolves to whatever that
 branch currently points at, so the linked content can change —
 or disappear — without warning after the link is written. A tag
-ref is steadier but still not pinned: a tag can be moved, and
-the lint can't tell a tag from a branch by name alone (a branch
-named `v1.2.3` is valid Git), so version-shaped refs are rejected
-by default. If that is too strict for a project's version links,
-`allow_version_patterns = true` accepts refs shaped like `1.2.3`,
-`1.2.3-suffix`, `v1.2.3`, or `v1.2.3-suffix`. A commit SHA is
-still the only ref that always denotes the exact content the
-author linked to.
-
-This rule only concerns whether the ref is mutable; the
-*length* of an accepted SHA is `perfectionist::commit_id_length`'s
-concern, and `perfectionist::bare_url` ensures the URL is
-wrapped. The three lints layer rather than overlap.
+ref is steadier but still not pinned: a tag can be removed, and
+a version-shaped name is not even guaranteed to be a tag (a
+branch named `v1.2.3` is valid Git). A commit SHA is the only
+ref that always denotes the exact content the author linked to.
 
 ## Example
 

--- a/src/rules/unpinned_repo_ref.rs
+++ b/src/rules/unpinned_repo_ref.rs
@@ -27,25 +27,21 @@ declare_tool_lint! {
     /// `allow_version_patterns`. Scans doc comments, regular comments, and
     /// string literals.
     ///
+    /// This rule only concerns whether the ref is mutable; the
+    /// *length* of an accepted SHA is `perfectionist::commit_id_length`'s
+    /// concern, and `perfectionist::bare_url` ensures the URL is
+    /// wrapped. The three lints layer rather than overlap.
+    ///
     /// ### Why restrict this?
     ///
     /// This is a stylistic preference, not a correctness issue. A
     /// branch ref such as `/blob/main/...` resolves to whatever that
     /// branch currently points at, so the linked content can change —
     /// or disappear — without warning after the link is written. A tag
-    /// ref is steadier but still not pinned: a tag can be moved, and
-    /// the lint can't tell a tag from a branch by name alone (a branch
-    /// named `v1.2.3` is valid Git), so version-shaped refs are rejected
-    /// by default. If that is too strict for a project's version links,
-    /// `allow_version_patterns = true` accepts refs shaped like `1.2.3`,
-    /// `1.2.3-suffix`, `v1.2.3`, or `v1.2.3-suffix`. A commit SHA is
-    /// still the only ref that always denotes the exact content the
-    /// author linked to.
-    ///
-    /// This rule only concerns whether the ref is mutable; the
-    /// *length* of an accepted SHA is `perfectionist::commit_id_length`'s
-    /// concern, and `perfectionist::bare_url` ensures the URL is
-    /// wrapped. The three lints layer rather than overlap.
+    /// ref is steadier but still not pinned: a tag can be removed, and
+    /// a version-shaped name is not even guaranteed to be a tag (a
+    /// branch named `v1.2.3` is valid Git). A commit SHA is the only
+    /// ref that always denotes the exact content the author linked to.
     ///
     /// ### Example
     ///


### PR DESCRIPTION
## Problem

The "Why restrict this?" section of `perfectionist::unpinned_repo_ref` was over-explaining. A rationale section should state why the practice is restricted — not how the rule works or how to configure it. Specifically:

- It explained the `allow_version_patterns` config mechanism ("...so version-shaped refs are rejected by default. If that is too strict for a project's version links, `allow_version_patterns = true` accepts refs shaped like..."). The Configuration section already covers this.
- The paragraph "This rule only concerns whether the ref is mutable; ..." describes the mechanism/scope of the rule, not the rationale.
- It claimed "a tag can be moved". The accepted convention is that a published tag is fixed (GitHub Actions' floating `v1` / `v2` style being the notable exception); the unpinned risk worth stating is that **a tag can be removed**.

## Change

- "Why restrict this?" now contains only the rationale: branch refs float, tags can be removed, version-shaped names aren't even guaranteed to be tags, and only a commit SHA always denotes the exact linked content.
- The lint-layering note (`commit_id_length` / `bare_url`) moves to "What it does", where rule scope belongs.
- The config-mechanism prose is dropped.
- `rules/unpinned_repo_ref.md` regenerated.

## Validation

`just all` passes (including `check-rules-md`).

https://claude.ai/code/session_01GTJ6pfLHGg7cESh73Du6k4

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTJ6pfLHGg7cESh73Du6k4)_