### PR TITLE
docs(plan): `needless_utf8_conversion`

### DIFF
--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -59,19 +59,23 @@ pattern that several rules call out by reference — live in
   to cover the full owned-vs-borrowed trade-off from the pacquet
   guide.
 
-### OS strings and paths
-- [`needless-os-str-utf8-conversion.md`](./needless-os-str-utf8-conversion.md)
-  — flag a fidelity-destroying UTF-8 conversion of an OS string
-  (`OsStr` / `OsString` / `Path` / `PathBuf`) — `to_string_lossy()`,
-  `to_str().unwrap()`, `display().to_string()` — whose result feeds a
-  sink that already accepts the OS-string form (`AsRef<OsStr>` /
+### OS strings, paths, and bytes
+- [`needless-utf8-conversion.md`](./needless-utf8-conversion.md)
+  — flag a fidelity-destroying UTF-8 conversion of a value whose
+  native form is not UTF-8 — an OS string (`OsStr` / `OsString` /
+  `Path` / `PathBuf`: `to_string_lossy()`, `to_str().unwrap()`,
+  `display().to_string()`) or a byte buffer (`[u8]` / `Vec<u8>`:
+  `String::from_utf8_lossy()`, `from_utf8().unwrap()`) — whose result
+  feeds a sink that already accepts the native form (`AsRef<OsStr>` /
   `AsRef<Path>`: `Command::arg`, `command-extra`'s `CommandExtra`
   builder, `Path::join`, `File::open`, …). The lossy form silently
-  corrupts non-UTF-8 paths; the `unwrap` form panics on them. Byte
-  sinks (`fs::write`) are opt-in behind `include_byte_sinks`;
-  conversions whose non-UTF-8 case is *handled* (`?` / `ok_or` /
-  let-else) but still feed an OsStr sink are exempt by default and
-  opt-in behind `include_handled_conversions`. Active by default.
+  corrupts non-UTF-8 input; the `unwrap` form panics on it. Byte
+  sinks (`fs::write`, plus byte-buffer sources) are opt-in behind
+  `include_byte_sinks`; conversions whose non-UTF-8 case is *handled*
+  (`?` / `ok_or` / let-else) but still feed a sink are exempt by
+  default and opt-in behind `include_handled_conversions`.
+  `CStr`/`CString` are out of scope (FFI-shaped; satisfy no sink
+  bound). Active by default.
 
 ### Derives and error types
 - [`error-type-derives.md`](./error-type-derives.md) — derive

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -68,8 +68,10 @@ pattern that several rules call out by reference — live in
   `AsRef<Path>`: `Command::arg`, `command-extra`'s `CommandExtra`
   builder, `Path::join`, `File::open`, …). The lossy form silently
   corrupts non-UTF-8 paths; the `unwrap` form panics on them. Byte
-  sinks (`fs::write`) are opt-in behind `include_byte_sinks`. Active
-  by default.
+  sinks (`fs::write`) are opt-in behind `include_byte_sinks`;
+  conversions whose non-UTF-8 case is *handled* (`?` / `ok_or` /
+  let-else) but still feed an OsStr sink are exempt by default and
+  opt-in behind `include_handled_conversions`. Active by default.
 
 ### Derives and error types
 - [`error-type-derives.md`](./error-type-derives.md) — derive

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -59,6 +59,17 @@ pattern that several rules call out by reference — live in
   to cover the full owned-vs-borrowed trade-off from the pacquet
   guide.
 
+### OS strings and paths
+- [`needless-os-str-utf8-conversion.md`](./needless-os-str-utf8-conversion.md)
+  — flag a fidelity-destroying UTF-8 conversion of an OS string
+  (`OsStr` / `OsString` / `Path` / `PathBuf`) — `to_string_lossy()`,
+  `to_str().unwrap()`, `display().to_string()` — whose result feeds a
+  sink that already accepts the OS-string form (`AsRef<OsStr>` /
+  `AsRef<Path>`: `Command::arg`, `Path::join`, `File::open`, …). The
+  lossy form silently corrupts non-UTF-8 paths; the `unwrap` form
+  panics on them. Byte sinks (`fs::write`) are opt-in behind
+  `include_byte_sinks`. Active by default.
+
 ### Derives and error types
 - [`error-type-derives.md`](./error-type-derives.md) — derive
   `derive_more::Display` / `Error` only when needed; flag superfluous

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -65,10 +65,11 @@ pattern that several rules call out by reference — live in
   (`OsStr` / `OsString` / `Path` / `PathBuf`) — `to_string_lossy()`,
   `to_str().unwrap()`, `display().to_string()` — whose result feeds a
   sink that already accepts the OS-string form (`AsRef<OsStr>` /
-  `AsRef<Path>`: `Command::arg`, `Path::join`, `File::open`, …). The
-  lossy form silently corrupts non-UTF-8 paths; the `unwrap` form
-  panics on them. Byte sinks (`fs::write`) are opt-in behind
-  `include_byte_sinks`. Active by default.
+  `AsRef<Path>`: `Command::arg`, `command-extra`'s `CommandExtra`
+  builder, `Path::join`, `File::open`, …). The lossy form silently
+  corrupts non-UTF-8 paths; the `unwrap` form panics on them. Byte
+  sinks (`fs::write`) are opt-in behind `include_byte_sinks`. Active
+  by default.
 
 ### Derives and error types
 - [`error-type-derives.md`](./error-type-derives.md) — derive

--- a/planned-rules/needless-os-str-utf8-conversion.md
+++ b/planned-rules/needless-os-str-utf8-conversion.md
@@ -118,8 +118,10 @@ on the HIR (no string parsing required):
   non-literal piece of a `format!` / `write!` template
   (`format!("{}", recv.display())`).
 - `recv.to_str()` followed by `.unwrap()` / `.expect(...)`.
-- `OsString::into_string()` / `PathBuf::into_os_string` chains
-  ending in `.unwrap()` / `.expect(...)` that yield a `String`.
+- `OsString::into_string()` followed by `.unwrap()` / `.expect(...)`
+  (a `PathBuf` reaches this via `.into_os_string().into_string()`).
+  Its infallible cousin `PathBuf::into_os_string()` is *not* a
+  trigger — it yields an `OsString`, losing nothing.
 
 A faithful, fully-handled conversion is **not** flagged: a
 `match recv.to_str() { Some(s) => …, None => … }` that copes with

--- a/planned-rules/needless-os-str-utf8-conversion.md
+++ b/planned-rules/needless-os-str-utf8-conversion.md
@@ -77,6 +77,26 @@ fn build(mut command: Command, file: &Path) -> Command {
 }
 ```
 
+**Prefer** — the same fix through `command-extra`'s builder, which
+perfectionist recognizes as a sink in its own right (see
+[(c) The sink](#c-the-sink)):
+
+```rust
+use command_extra::CommandExtra;
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+use std::process::Command;
+
+fn build(command: Command, file: &Path) -> Command {
+    let flag = OsStr::new("--some-flag=");
+    let file = file.as_os_str();
+    let mut arg = OsString::with_capacity(flag.len() + file.len());
+    arg.push(flag);
+    arg.push(file);
+    command.with_arg(arg)
+}
+```
+
 ## Why is this bad?
 
 This is a correctness issue, not a stylistic preference.
@@ -151,13 +171,50 @@ site rather than a hard-coded function allowlist, so third-party and
 in-house wrappers are covered for free:
 
 - **`AsRef<OsStr>`** — `Command::{arg, args, env, envs}`,
-  `command_extra::CommandExtra::{with_arg, with_args, with_env, …}`,
-  `OsString::push`, and any user function with the same bound.
+  `OsString::push`, and any function with the same bound (including
+  `command-extra`'s builder, called out below).
 - **`AsRef<Path>`** — `Path::join`, `PathBuf::push`, `File::open`,
   `fs::{read, read_to_string, metadata, canonicalize, …}`.
 
 `&Path`, `&OsStr`, `OsString`, `PathBuf`, and `Cow<OsStr>` all
 satisfy both bounds, so the conversion is provably droppable.
+
+#### `command-extra` is a recognized sink by default
+
+`command_extra::CommandExtra` is the subprocess-builder crate by
+perfectionist's own author, and the rule recognizes it as a
+first-class sink — *not* merely as an incidental match of the
+bound-based detection. Its builder methods, which mirror std's
+`Command` setters, are recognized by default:
+
+- `with_arg`, `with_args`, `with_env`, `with_envs` — the
+  `AsRef<OsStr>` family.
+- `with_current_dir` — the `AsRef<Path>` family.
+
+Two things make the explicit recognition worth stating rather than
+leaving implicit:
+
+- **Precedent.** Building in knowledge of a specific well-known
+  third-party crate is established in this catalogue —
+  `perfectionist::manual_json_string` (`serde_json`),
+  the `derive_more` rule family, `perfectionist::thiserror_usage`,
+  the `clap`-help rules, `perfectionist::escaped_multiline_string`
+  (`text_block`), and `perfectionist::macro_trailing_comma`'s curated
+  core/std-plus-third-party list all do it. `command-extra` is the
+  natural OS-string-sink analogue.
+- **Shape.** `with_*` are *consuming builder methods* — they take
+  the `Command` by value and return it — so a converted argument
+  sits inside a `Command`-returning method chain
+  (`command.with_arg(file.to_string_lossy().into_owned())`). The
+  detection treats that argument position no differently from
+  `Command::arg`; the recognition just guarantees the call is on the
+  default sink set so coverage does not hinge on the bound-based
+  path reaching a trait method's bound.
+
+The recognition is unconditional and costs nothing when a consumer
+does not depend on `command-extra` — the `with_*` calls simply never
+appear. A project may still drop specific methods through
+`ignore_sinks`.
 
 A third category is **opt-in** behind `include_byte_sinks` (see
 [Configuration](#configuration)):

--- a/planned-rules/needless-os-str-utf8-conversion.md
+++ b/planned-rules/needless-os-str-utf8-conversion.md
@@ -1,0 +1,363 @@
+# `needless_os_str_utf8_conversion`
+
+**Source:** project-maintainer report. Not drawn from the
+`parallel-disk-usage` / `pacquet` style guides the rest of this
+catalogue extends; it captures a recurring footgun in code that
+shells out to subprocesses or stores paths.
+
+## Statement
+
+An OS string (`OsStr`, `OsString`, `Path`, `PathBuf`) routed into a
+sink that already accepts the OS-string form should be passed
+through **without** a UTF-8 conversion. The two conversions this
+rule fires on both throw away fidelity for nothing:
+
+- **`to_string_lossy()`** (and `Path::display().to_string()`,
+  `format!("{}", path.display())`) silently replaces every
+  non-UTF-8 byte with U+FFFD. The path that comes out the other end
+  names a *different* file — or no file at all.
+- **`to_str().unwrap()` / `.expect(...)`** (and
+  `OsString::into_string().unwrap()`) panics on a perfectly valid
+  filesystem path. On Unix a path is arbitrary bytes; on Windows it
+  is arbitrary UTF-16; neither is guaranteed to be UTF-8.
+
+Both are needless because the destination — `Command::arg`,
+`Path::join`, `File::open`, `command_extra::CommandExtra::with_arg`,
+and every other API bounded by `AsRef<OsStr>` or `AsRef<Path>` —
+takes the OS string directly. `&Path`, `&OsStr`, `OsString`, and
+`PathBuf` all satisfy those bounds, so the conversion can simply be
+dropped (or, when a literal prefix is involved, replaced by an
+`OsString` built with `OsString::push`).
+
+The motivating shapes, corrected from the report:
+
+**Avoid** — lossy conversion corrupts a non-UTF-8 path en route to
+a subprocess argument:
+
+```rust
+use std::path::Path;
+use std::process::Command;
+
+fn build(mut command: Command, file: &Path) -> Command {
+    let mut arg = "--some-flag=".to_owned();
+    arg.push_str(&file.to_string_lossy()); // silent corruption
+    command.arg(arg);
+    command
+}
+```
+
+**Avoid** — `to_str().unwrap()` panics on a valid path:
+
+```rust
+use command_extra::CommandExtra; // crate by perfectionist's author
+use std::path::Path;
+use std::process::Command;
+
+fn build(command: Command, file: &Path) -> Command {
+    command.with_arg(format!("--some-flag={}", file.to_str().unwrap()))
+}
+```
+
+**Prefer** — build the argument as an `OsString`; nothing is lost
+and nothing panics:
+
+```rust
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+use std::process::Command;
+
+fn build(mut command: Command, file: &Path) -> Command {
+    let flag = OsStr::new("--some-flag=");
+    let file = file.as_os_str();
+    let mut arg = OsString::with_capacity(flag.len() + file.len());
+    arg.push(flag);
+    arg.push(file);
+    command.arg(arg);
+    command
+}
+```
+
+## Why is this bad?
+
+This is a correctness issue, not a stylistic preference.
+
+- **Silent target corruption (lossy form).** `to_string_lossy()`
+  maps every ill-formed byte sequence to U+FFFD. When the result is
+  handed to `Command::arg`, `File::open`, or `fs::write`, the OS
+  receives a path that differs from the one the program holds.
+  Best case the operation fails with "file not found" after wasting
+  the work that led up to it; worst case it silently reads or writes
+  the *wrong* file. The corruption is invisible at the call site —
+  the program compiles, runs, and quietly does the wrong thing on
+  exactly the inputs (non-UTF-8 paths) that the OS-string types
+  exist to handle.
+- **Needless panic (unwrap form).** `to_str().unwrap()` turns a
+  representable path into a process abort. A directory walk that
+  hits one non-UTF-8 entry takes down the whole program, even though
+  the path could have been forwarded untouched.
+
+Neither failure mode is hypothetical on Unix, where filenames are
+arbitrary `[u8]` and non-UTF-8 names occur in the wild (legacy
+encodings, deliberately adversarial names, binary-derived paths).
+
+## What to lint
+
+Fire on an expression that is **(a)** a fidelity-destroying
+UTF-8 conversion of **(b)** a value of OS-string type, sitting in
+**(c)** an argument position that accepts the OS-string form
+directly.
+
+### (a) The conversion
+
+Recognised lossy / panicking conversions, all detected structurally
+on the HIR (no string parsing required):
+
+- `recv.to_string_lossy()`, plus a trailing `.into_owned()` /
+  `.to_string()`.
+- `recv.display()` consumed by `.to_string()` or as the sole
+  non-literal piece of a `format!` / `write!` template
+  (`format!("{}", recv.display())`).
+- `recv.to_str()` followed by `.unwrap()` / `.expect(...)`.
+- `OsString::into_string()` / `PathBuf::into_os_string` chains
+  ending in `.unwrap()` / `.expect(...)` that yield a `String`.
+
+A faithful, fully-handled conversion is **not** flagged: a
+`match recv.to_str() { Some(s) => …, None => … }` that copes with
+the `None` arm keeps the fidelity decision explicit and is out of
+scope. Only the lossy and the unwrap-on-`None` forms qualify.
+
+### (b) The source type
+
+The conversion's receiver must resolve (via `typeck_results`) to
+`OsStr`, `OsString`, `Path`, or `PathBuf` (or a reference to one).
+This guard is what makes the lossless pass-through *possible* — the
+value already is an OS string, so the sink can take it as-is. It
+also keeps the lint off `str`/`String` receivers that happen to
+share a method name.
+
+### (c) The sink
+
+The argument's **formal parameter** must accept the OS string
+losslessly. Detected by the parameter's trait bound at the call
+site rather than a hard-coded function allowlist, so third-party and
+in-house wrappers are covered for free:
+
+- **`AsRef<OsStr>`** — `Command::{arg, args, env, envs}`,
+  `command_extra::CommandExtra::{with_arg, with_args, with_env, …}`,
+  `OsString::push`, and any user function with the same bound.
+- **`AsRef<Path>`** — `Path::join`, `PathBuf::push`, `File::open`,
+  `fs::{read, read_to_string, metadata, canonicalize, …}`.
+
+`&Path`, `&OsStr`, `OsString`, `PathBuf`, and `Cow<OsStr>` all
+satisfy both bounds, so the conversion is provably droppable.
+
+A third category is **opt-in** behind `include_byte_sinks` (see
+[Configuration](#configuration)):
+
+- **`AsRef<[u8]>`** — `fs::write`, `io::Write::write_all`, when the
+  byte argument is a converted OS string (writing a path *as file
+  content*). The lossless replacement is
+  `os_str.as_os_str().as_encoded_bytes()`. This is gated because the
+  byte encoding of an `OsStr` is platform-specific (raw bytes on
+  Unix, WTF-8 on Windows), so whether `as_encoded_bytes()` is the
+  *intended* on-disk form is a judgement the rule cannot make for
+  the consumer; opting in asserts "these files hold OS-string path
+  data, not UTF-8 text."
+
+### Exemptions
+
+- Faithful, fully-handled conversions (the `match` / `?` / `ok_or`
+  forms) — see (a).
+- A receiver whose type is not an OS-string type — the lossless
+  path does not exist, so there is nothing to suggest.
+- Proc-macro-synthesised nodes (see
+  [Implementation notes](#implementation-notes)).
+
+## Examples
+
+**Avoid** — bare lossy conversion as the argument:
+
+```rust
+command.arg(file.to_string_lossy());
+```
+
+**Prefer** — `&Path` is already `AsRef<OsStr>`:
+
+```rust
+command.arg(file);
+```
+
+**Avoid** — `format!` + `unwrap` building a flag:
+
+```rust
+command.arg(format!("--input={}", file.to_str().unwrap()));
+```
+
+**Prefer** — assemble the flag as an `OsString`:
+
+```rust
+let mut arg = OsString::from("--input=");
+arg.push(file);
+command.arg(arg);
+```
+
+**Avoid** — lossy round-trip into a path-joining sink:
+
+```rust
+base.join(name.to_string_lossy().as_ref())
+```
+
+**Prefer** — `join` already takes `AsRef<Path>`:
+
+```rust
+base.join(name)
+```
+
+**Avoid** — writing a path as file content (only with
+`include_byte_sinks = true`):
+
+```rust
+fs::write(out, target.to_string_lossy().as_bytes())?;
+```
+
+**Prefer** — write the OS string's bytes directly:
+
+```rust
+fs::write(out, target.as_os_str().as_encoded_bytes())?;
+```
+
+**Not flagged** — the `None` arm is handled, so the conversion is a
+deliberate fidelity decision:
+
+```rust
+let Some(text) = file.to_str() else {
+    return Err(NonUtf8Path(file.to_owned()));
+};
+command.arg(text);
+```
+
+## Suggested fix
+
+- **Bare conversion as the argument.** Drop the conversion. Prefer
+  `recv.as_os_str()` (for `Path`/`PathBuf`) or the receiver itself
+  (for `OsStr`/`OsString`) so the edit never turns a borrow into a
+  move. `Applicability::MachineApplicable` when the receiver is
+  already a reference; `MaybeIncorrect` when dropping the conversion
+  would move an owned value used later.
+- **`format!` / concatenation with a literal prefix.** Suggest the
+  `OsString` + `push` rewrite, emitted as help text rather than an
+  auto-applied edit: it restructures one expression into several
+  statements, which `MachineApplicable` cannot express cleanly.
+- **Byte sink (opt-in).** Suggest
+  `recv.as_os_str().as_encoded_bytes()`, `MaybeIncorrect` (the
+  platform-encoding caveat above).
+
+## Configuration
+
+```toml
+[perfectionist::needless_os_str_utf8_conversion]
+# Extend or restrict the sink set beyond bound-based detection.
+# Function paths are absolute, so each carries a leading `::`
+# per the leading-`::` convention in IMPLEMENTATION_CONVENTIONS.md.
+extra_sinks = ["::my_crate::exec::spawn_with_path"]
+ignore_sinks = ["::my_crate::log::record_display_path"]
+
+# Extend / restrict the recognised conversion methods.
+extra_conversion_methods = []
+ignore_conversion_methods = []
+
+# Opt into `AsRef<[u8]>` sinks (fs::write & friends). Off by
+# default because the on-disk byte encoding of an OsStr is
+# platform-specific; see "What to lint > (c)".
+include_byte_sinks = false
+```
+
+Bound-based detection (`AsRef<OsStr>` / `AsRef<Path>`) is the
+default and needs no list; `extra_sinks` / `ignore_sinks` exist for
+the cases the bound check misses (a sink that takes an already-built
+`OsString` by value) or over-matches (a logging helper that
+*wants* the lossy text). The extras-plus-ignore shape mirrors
+`perfectionist::needless_borrowed_parameters`.
+
+## Implementation notes
+
+- **`LateLintPass`.** Type information is mandatory: the rule reads
+  the receiver type (b) and the formal parameter's trait bound (c)
+  from `cx.typeck_results()` / `cx.tcx.fn_sig`. An `EarlyLintPass`
+  cannot see either.
+- **Walk `ExprKind::MethodCall` / `ExprKind::Call`.** For each call,
+  inspect each argument expression: peel a trailing `.unwrap()` /
+  `.expect(...)` / `.into_owned()` / `.to_string()` / `.as_ref()` /
+  `.as_bytes()`, then test whether the core is a recognised
+  conversion (a) on an OS-string receiver (b).
+- **Sink check (c).** Resolve the callee `DefId`, take its
+  `fn_sig`, find the formal parameter index for this argument, and
+  test the parameter type: either a generic param whose
+  `predicates_of` include `AsRef<OsStr>` / `AsRef<Path>` (and, when
+  `include_byte_sinks`, `AsRef<[u8]>`), or a concrete
+  `&OsStr` / `OsString` / `Cow<OsStr>` / `&Path` / `PathBuf`.
+  Supplement with the `extra_sinks` / `ignore_sinks` path lists via
+  `src/macro_path.rs`-style matching against the callee path.
+- **No string parser needed.** Unlike the markdown / serde-literal
+  rules, every trigger is an HIR shape. The `format!` case inspects
+  the desugared `FormatArgs` (a literal template whose only dynamic
+  argument is a flagged conversion), not the source text, so the
+  parser-combinator convention in
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  does not apply here.
+- **Proc-macro suppression.** The diagnostic span is the conversion
+  sub-expression, which is narrower than the enclosing call, so the
+  built-in `report_in_external_macro: false` filter is *not*
+  sufficient on its own — add the late-pass
+  `crate::common::hir_in_external_macro(cx, hir_id, span)` guard per
+  the "Suppressing proc-macro-synthesised violations" section of
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md).
+  A derive that shells out via a synthesised `Command::arg` with a
+  lossy path is unlikely but cheap to guard; record the call at the
+  span-selection site and add a `ui/needless_os_str_utf8_conversion_proc_macro.rs`
+  fixture only if a non-vacuous, mutation-checked trigger can be
+  constructed (delete the guard, confirm the fixture turns red).
+
+### Difficulty
+
+**Medium** for the core: the direct-argument case
+(`command.arg(file.to_string_lossy())`, `base.join(p.to_str().unwrap())`)
+is a local HIR-shape match plus two type queries. A conservative
+first pass can ship just this — the conversion *is* the argument
+expression, no dataflow.
+
+**Hard** follow-ups, deferrable:
+
+- The `format!` / `write!` template case (code block 2): inspect the
+  desugared `FormatArgs` to confirm the template is literal apart
+  from one flagged conversion.
+- The build-a-`String`-then-pass case (code block 1): the conversion
+  feeds a local `String` via `push_str` / `+`, and that local is
+  later handed to the sink. Needs local dataflow from the
+  `let mut s = String::…` binding to the sink call.
+
+## Default state
+
+Active by default. The `AsRef<OsStr>` / `AsRef<Path>` trigger does
+not false-positive in practice — deliberately passing a lossily
+corrupted path to a subprocess or filesystem call is essentially
+never intended. The platform-nuanced byte-sink branch is held back
+behind `include_byte_sinks` rather than the whole rule, so the
+default policy stays purely on the objective-defect cases.
+
+## Interaction with clippy and sibling rules
+
+- **No clippy counterpart.** Clippy has no lint for an OS-string →
+  UTF-8 conversion feeding an `AsRef<OsStr>` / `AsRef<Path>` sink,
+  so this rule takes its own anti-pattern name rather than mirroring
+  one.
+- **`perfectionist::needless_borrowed_parameters`** shares the
+  "needless conversion" theme but is orthogonal: it removes a
+  `&T → T` owning conversion in a *function signature*, whereas this
+  rule removes an `OsStr → str` *fidelity-destroying* conversion at
+  a *call site*. Neither subsumes the other.
+
+- See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  for cross-cutting conventions that apply to every rule in this
+  catalogue, in particular the lint-name namespacing
+  (`perfectionist::*`) that every registered lint follows.

--- a/planned-rules/needless-os-str-utf8-conversion.md
+++ b/planned-rules/needless-os-str-utf8-conversion.md
@@ -149,10 +149,23 @@ a lossy `Cow<str>` fit an `AsRef<OsStr>` / `AsRef<[u8]>` parameter
 (the `join` and `fs::write` examples below rely on them), so the
 implementation peels any such adapter to reach the core conversion.
 
-A faithful, fully-handled conversion is **not** flagged: a
-`match recv.to_str() { Some(s) => …, None => … }` that copes with
-the `None` arm keeps the fidelity decision explicit and is out of
-scope. Only the lossy and the unwrap-on-`None` forms qualify.
+By **default**, a faithful, fully-handled conversion is *not*
+flagged — a `match recv.to_str() { Some(s) => …, None => … }`, a
+`recv.to_str().ok_or(e)?`, or a
+`let Some(s) = recv.to_str() else { … }` that copes with the
+non-UTF-8 case. Only the lossy and the unwrap-on-`None` forms qualify
+out of the box.
+
+The `include_handled_conversions` knob (off by default — see
+[Configuration](#configuration)) extends the rule to flag the handled
+forms too, because "handling" the error is frequently *not* a
+decision to reject non-UTF-8: it is a reflex — a developer, or an
+assistant told to "replace `.unwrap()` with proper error handling",
+mechanically turning `path.to_str().unwrap()` into
+`path.to_str().ok_or(e)?` — that still missed the real fix, which is
+not to convert at all and pass the `OsStr` through. The knob's
+default and the tension behind it are explained under
+[Configuration](#configuration).
 
 ### (b) The source type
 
@@ -233,10 +246,12 @@ A third category is **opt-in** behind `include_byte_sinks` (see
 
 ### Exemptions
 
-- Faithful, fully-handled conversions (the `match` / `?` / `ok_or`
-  forms) — see (a).
 - A receiver whose type is not an OS-string type — the lossless
   path does not exist, so there is nothing to suggest.
+- Faithful, fully-handled conversions (`match` / `?` / `ok_or` /
+  let-else) — exempt **only by default**; flagged when
+  `include_handled_conversions` is enabled (see (a) and
+  [Configuration](#configuration)).
 - Proc-macro-synthesised nodes (see
   [Implementation notes](#implementation-notes)).
 
@@ -293,8 +308,11 @@ fs::write(out, target.to_string_lossy().as_bytes())?;
 fs::write(out, target.as_os_str().as_encoded_bytes())?;
 ```
 
-**Not flagged** — the `None` arm is handled, so the conversion is a
-deliberate fidelity decision:
+**Not flagged by default** — the `None` arm is handled. With
+`include_handled_conversions = true` this *is* flagged, because the
+handling could have been avoided entirely by passing the `OsStr`
+(`command.arg(file)`); the rule then suggests dropping both the
+conversion and its error path:
 
 ```rust
 let Some(text) = file.to_str() else {
@@ -338,6 +356,12 @@ ignore_conversion_methods = []
 # default because the on-disk byte encoding of an OsStr is
 # platform-specific; see "What to lint > (c)".
 include_byte_sinks = false
+
+# Also flag conversions whose non-UTF-8 case is *handled* (`?`,
+# `ok_or`, `match`, let-else) but still feeds an OsStr/Path sink —
+# the handling was avoidable by passing the OsStr. Off by default;
+# see the rationale below.
+include_handled_conversions = false
 ```
 
 Bound-based detection (`AsRef<OsStr>` / `AsRef<Path>`) is the
@@ -346,6 +370,45 @@ the cases the bound check misses (a sink that takes an already-built
 `OsString` by value) or over-matches (a logging helper that
 *wants* the lossy text). The extras-plus-ignore shape mirrors
 `perfectionist::needless_borrowed_parameters`.
+
+### Why `include_handled_conversions` is off by default
+
+The knob sits on a genuine tension. A conversion whose non-UTF-8
+case is *handled* — `path.to_str().ok_or(e)?`, a `match`, a let-else
+that returns an error — and whose `&str` then feeds an OsStr/Path
+sink achieved nothing the `OsStr` would not have achieved for free:
+the error path is dead weight, the fix is `command.arg(path)`. That
+is the case for flagging it. But the opposite reading is also
+legitimate: a developer who deliberately propagated the error may
+have *meant* to reject non-UTF-8 input at that boundary, in which
+case the handling is intentional and the lint would be noise.
+
+Because the two readings are indistinguishable from the syntax
+alone, this is a configuration choice rather than a fixed default —
+and the default follows **detection difficulty**:
+
+- Robust, low-false-positive detection of the handled case is
+  **hard**. Unlike the core trigger (where the conversion *is* the
+  sink argument, a local expression match), the handled form binds
+  a `&str` and feeds it to the sink later — so the rule must trace
+  the binding to the sink (the same local-dataflow problem as the
+  deferred "build-a-`String`-then-pass" case below) *and* prove the
+  `&str` is consumed **only** by OsStr/Path sinks. If the `&str` is
+  also used as text (printed, parsed, compared, stored), the
+  conversion is genuinely needed and flagging it is a false
+  positive. Establishing "only fed to a sink" needs whole-binding
+  use-analysis.
+- Per the project's policy for difficult, false-positive-prone
+  triggers, a check this hard to get right ships **off by default**.
+  (Had the handled case been a cheap local match with no
+  false-positive risk, the opposite policy would apply and it would
+  be on by default.)
+
+An implementation may first cover the easy subset where the handling
+is **inline in the argument** (`command.arg(path.to_str().ok_or(e)?)`),
+which needs no dataflow and carries no other-use risk, while leaving
+the out-of-line binding case for later — but the knob stays off by
+default until the general case is handled soundly.
 
 ## Implementation notes
 
@@ -410,6 +473,13 @@ expression, no dataflow.
   feeds a local `String` via `push_str` / `+`, and that local is
   later handed to the sink. Needs local dataflow from the
   `let mut s = String::…` binding to the sink call.
+- The `include_handled_conversions` case (off by default): same
+  binding-to-sink dataflow as above, *plus* proving the bound `&str`
+  is consumed only by OsStr/Path sinks (else the conversion is
+  genuinely needed). The inline-handling subset
+  (`command.arg(path.to_str().ok_or(e)?)`) is the easy slice of this
+  and can land first. See
+  ["Why `include_handled_conversions` is off by default"](#why-include_handled_conversions-is-off-by-default).
 
 ## Default state
 

--- a/planned-rules/needless-os-str-utf8-conversion.md
+++ b/planned-rules/needless-os-str-utf8-conversion.md
@@ -180,7 +180,7 @@ A third category is **opt-in** behind `include_byte_sinks` (see
 **Avoid** — bare lossy conversion as the argument:
 
 ```rust
-command.arg(file.to_string_lossy());
+command.arg(file.to_string_lossy().into_owned());
 ```
 
 **Prefer** — `&Path` is already `AsRef<OsStr>`:
@@ -329,7 +329,7 @@ sending the implementer down an unverified path.
 ### Difficulty
 
 **Medium** for the core: the direct-argument case
-(`command.arg(file.to_string_lossy())`, `base.join(p.to_str().unwrap())`)
+(`command.arg(file.to_string_lossy().into_owned())`, `base.join(p.to_str().unwrap())`)
 is a local HIR-shape match plus two type queries. A conservative
 first pass can ship just this — the conversion *is* the argument
 expression, no dataflow.

--- a/planned-rules/needless-os-str-utf8-conversion.md
+++ b/planned-rules/needless-os-str-utf8-conversion.md
@@ -112,8 +112,7 @@ directly.
 Recognised lossy / panicking conversions, all detected structurally
 on the HIR (no string parsing required):
 
-- `recv.to_string_lossy()`, plus a trailing `.into_owned()` /
-  `.to_string()`.
+- `recv.to_string_lossy()` (returns `Cow<str>`).
 - `recv.display()` consumed by `.to_string()` or as the sole
   non-literal piece of a `format!` / `write!` template
   (`format!("{}", recv.display())`).
@@ -122,6 +121,13 @@ on the HIR (no string parsing required):
   (a `PathBuf` reaches this via `.into_os_string().into_string()`).
   Its infallible cousin `PathBuf::into_os_string()` is *not* a
   trigger — it yields an `OsString`, losing nothing.
+
+The core conversion is often followed by a trailing coercion that
+adapts its result to the sink — `.into_owned()`, `.to_string()`,
+`.as_str()`, `.as_ref()`, `.as_bytes()`. These are exactly what make
+a lossy `Cow<str>` fit an `AsRef<OsStr>` / `AsRef<[u8]>` parameter
+(the `join` and `fs::write` examples below rely on them), so the
+implementation peels any such adapter to reach the core conversion.
 
 A faithful, fully-handled conversion is **not** flagged: a
 `match recv.to_str() { Some(s) => …, None => … }` that copes with
@@ -158,8 +164,10 @@ A third category is **opt-in** behind `include_byte_sinks` (see
 
 - **`AsRef<[u8]>`** — `fs::write`, `io::Write::write_all`, when the
   byte argument is a converted OS string (writing a path *as file
-  content*). The lossless replacement is
-  `os_str.as_os_str().as_encoded_bytes()`. This is gated because the
+  content*). The lossless replacement writes the receiver's
+  `as_encoded_bytes()` — reached through `.as_os_str()` for a
+  `Path` / `PathBuf` receiver (as in the `fs::write` example below),
+  or called directly on an `&OsStr`. This is gated because the
   byte encoding of an `OsStr` is platform-specific (raw bytes on
   Unix, WTF-8 on Windows), so whether `as_encoded_bytes()` is the
   *intended* on-disk form is a judgement the rule cannot make for
@@ -250,8 +258,9 @@ command.arg(text);
   `OsString` + `push` rewrite, emitted as help text rather than an
   auto-applied edit: it restructures one expression into several
   statements, which `MachineApplicable` cannot express cleanly.
-- **Byte sink (opt-in).** Suggest
-  `recv.as_os_str().as_encoded_bytes()`, `MaybeIncorrect` (the
+- **Byte sink (opt-in).** Suggest writing the receiver's
+  `as_encoded_bytes()` (reached via `.as_os_str()` for a `Path` /
+  `PathBuf`, as in the `fs::write` example), `MaybeIncorrect` (the
   platform-encoding caveat above).
 
 ## Configuration
@@ -295,9 +304,10 @@ sending the implementer down an unverified path.
   confirming the sink argument accepts the OS-string form (c). An
   early pass has no types and cannot decide either.
 - **Triggers are HIR expression shapes, not source text.** Every
-  conversion in (a) is a method call (possibly wrapped in a trailing
-  `.unwrap()` / `.expect(...)` / `.into_owned()` / `.to_string()`),
-  and each sink is a call argument. Nothing here scans source text,
+  conversion in (a) is a method call (possibly wrapped in `.unwrap()`
+  / `.expect(...)` and a trailing coercion such as `.into_owned()` /
+  `.to_string()` / `.as_ref()` / `.as_bytes()`), and each sink is a
+  call argument. Nothing here scans source text,
   so — unlike the markdown / serde-literal rules — the
   parser-combinator convention in
   [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)

--- a/planned-rules/needless-os-str-utf8-conversion.md
+++ b/planned-rules/needless-os-str-utf8-conversion.md
@@ -281,42 +281,48 @@ the cases the bound check misses (a sink that takes an already-built
 
 ## Implementation notes
 
-- **`LateLintPass`.** Type information is mandatory: the rule reads
-  the receiver type (b) and the formal parameter's trait bound (c)
-  from `cx.typeck_results()` / `cx.tcx.fn_sig`. An `EarlyLintPass`
-  cannot see either.
-- **Walk `ExprKind::MethodCall` / `ExprKind::Call`.** For each call,
-  inspect each argument expression: peel a trailing `.unwrap()` /
-  `.expect(...)` / `.into_owned()` / `.to_string()` / `.as_ref()` /
-  `.as_bytes()`, then test whether the core is a recognised
-  conversion (a) on an OS-string receiver (b).
-- **Sink check (c).** Resolve the callee `DefId`, take its
-  `fn_sig`, find the formal parameter index for this argument, and
-  test the parameter type: either a generic param whose
-  `predicates_of` include `AsRef<OsStr>` / `AsRef<Path>` (and, when
-  `include_byte_sinks`, `AsRef<[u8]>`), or a concrete
-  `&OsStr` / `OsString` / `Cow<OsStr>` / `&Path` / `PathBuf`.
-  Supplement with the `extra_sinks` / `ignore_sinks` path lists via
-  `src/macro_path.rs`-style matching against the callee path.
-- **No string parser needed.** Unlike the markdown / serde-literal
-  rules, every trigger is an HIR shape. The `format!` case inspects
-  the desugared `FormatArgs` (a literal template whose only dynamic
-  argument is a flagged conversion), not the source text, so the
+These notes record what is certain about the rule's *shape*. The
+exact `rustc` / `clippy_utils` API calls are deliberately left to
+the implementer to choose and verify — they have not been written or
+compiled against here, so pinning specific function names would risk
+sending the implementer down an unverified path.
+
+- **`LateLintPass`, not `EarlyLintPass`.** Both halves of the
+  trigger need type information that only exists after type-checking:
+  confirming the conversion's receiver is an OS-string type (b), and
+  confirming the sink argument accepts the OS-string form (c). An
+  early pass has no types and cannot decide either.
+- **Triggers are HIR expression shapes, not source text.** Every
+  conversion in (a) is a method call (possibly wrapped in a trailing
+  `.unwrap()` / `.expect(...)` / `.into_owned()` / `.to_string()`),
+  and each sink is a call argument. Nothing here scans source text,
+  so — unlike the markdown / serde-literal rules — the
   parser-combinator convention in
   [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
-  does not apply here.
-- **Proc-macro suppression.** The diagnostic span is the conversion
-  sub-expression, which is narrower than the enclosing call, so the
-  built-in `report_in_external_macro: false` filter is *not*
-  sufficient on its own — add the late-pass
-  `crate::common::hir_in_external_macro(cx, hir_id, span)` guard per
-  the "Suppressing proc-macro-synthesised violations" section of
-  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md).
-  A derive that shells out via a synthesised `Command::arg` with a
-  lossy path is unlikely but cheap to guard; record the call at the
-  span-selection site and add a `ui/needless_os_str_utf8_conversion_proc_macro.rs`
-  fixture only if a non-vacuous, mutation-checked trigger can be
-  constructed (delete the guard, confirm the fixture turns red).
+  does not apply.
+- **Detect the sink by what its parameter accepts, not by a fixed
+  name list.** Recognising any argument position whose parameter
+  takes the OS string losslessly (an `AsRef<OsStr>` / `AsRef<Path>`
+  bound, or a concrete `&OsStr` / `OsString` / `&Path` / `PathBuf` /
+  `Cow<OsStr>` parameter) is what lets std, `command-extra`, and
+  in-house wrappers all be covered without an enumerated allowlist.
+  `extra_sinks` / `ignore_sinks` then exist only for what this
+  bound-based detection misses or over-matches. (Whether the bound
+  is read off the callee signature, or approximated some other way,
+  is an implementation choice to validate against real code.)
+- **Proc-macro suppression.** The natural diagnostic span — the
+  conversion sub-expression — is narrower than the enclosing call,
+  which is exactly the case the "Suppressing proc-macro-synthesised
+  violations" section of
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  flags as *not* covered by the built-in
+  `report_in_external_macro: false` filter. Apply the late-pass
+  `crate::common::hir_in_external_macro` guard it prescribes. A
+  trigger that is realistically derive-generated is hard to
+  construct, so add a `ui/needless_os_str_utf8_conversion_proc_macro.rs`
+  fixture only if a non-vacuous, mutation-checked one can be built
+  (delete the guard, confirm the fixture turns red); otherwise record
+  at the span-selection site why it is omitted.
 
 ### Difficulty
 
@@ -328,9 +334,9 @@ expression, no dataflow.
 
 **Hard** follow-ups, deferrable:
 
-- The `format!` / `write!` template case (code block 2): inspect the
-  desugared `FormatArgs` to confirm the template is literal apart
-  from one flagged conversion.
+- The `format!` / `write!` template case (code block 2): confirm the
+  template is literal apart from one flagged conversion, by
+  inspecting the macro's expanded arguments.
 - The build-a-`String`-then-pass case (code block 1): the conversion
   feeds a local `String` via `push_str` / `+`, and that local is
   later handed to the sink. Needs local dataflow from the

--- a/planned-rules/needless-utf8-conversion.md
+++ b/planned-rules/needless-utf8-conversion.md
@@ -1,16 +1,21 @@
-# `needless_os_str_utf8_conversion`
+# `needless_utf8_conversion`
 
 **Source:** project-maintainer report. Not drawn from the
 `parallel-disk-usage` / `pacquet` style guides the rest of this
 catalogue extends; it captures a recurring footgun in code that
-shells out to subprocesses or stores paths.
+shells out to subprocesses, stores paths, or writes byte buffers.
 
 ## Statement
 
-An OS string (`OsStr`, `OsString`, `Path`, `PathBuf`) routed into a
-sink that already accepts the OS-string form should be passed
-through **without** a UTF-8 conversion. The two conversions this
-rule fires on both throw away fidelity for nothing:
+A value whose native representation is *not* UTF-8 — an OS string
+(`OsStr`, `OsString`, `Path`, `PathBuf`) or a byte buffer (`[u8]`,
+`Vec<u8>`, `Box<[u8]>`) — routed into a sink that already accepts
+that native form should be passed through **without** a UTF-8
+conversion. The OS-string case is the rule's default and the running
+example below; the byte-buffer case (same anti-pattern, against byte
+sinks) is covered under [(b)](#b-the-source-type) and
+[(c)](#c-the-sink). The conversions this rule fires on all throw away
+fidelity for nothing:
 
 - **`to_string_lossy()`** (and `Path::display().to_string()`,
   `format!("{}", path.display())`) silently replaces every
@@ -123,8 +128,8 @@ encodings, deliberately adversarial names, binary-derived paths).
 ## What to lint
 
 Fire on an expression that is **(a)** a fidelity-destroying
-UTF-8 conversion of **(b)** a value of OS-string type, sitting in
-**(c)** an argument position that accepts the OS-string form
+UTF-8 conversion of **(b)** a value whose native form is not UTF-8,
+sitting in **(c)** an argument position that accepts that native form
 directly.
 
 ### (a) The conversion
@@ -141,6 +146,14 @@ on the HIR (no string parsing required):
   (a `PathBuf` reaches this via `.into_os_string().into_string()`).
   Its infallible cousin `PathBuf::into_os_string()` is *not* a
   trigger — it yields an `OsString`, losing nothing.
+
+For **byte-buffer** sources the conversions are the same idea in
+associated-function form — the value is the *argument*, not the
+receiver:
+
+- `String::from_utf8_lossy(bytes)` (lossy; returns `Cow<str>`).
+- `String::from_utf8(vec)` / `str::from_utf8(bytes)` followed by
+  `.unwrap()` / `.expect(...)`.
 
 The core conversion is often followed by a trailing coercion that
 adapts its result to the sink — `.into_owned()`, `.to_string()`,
@@ -169,12 +182,33 @@ default and the tension behind it are explained under
 
 ### (b) The source type
 
-The conversion's receiver must resolve (via `typeck_results`) to
-`OsStr`, `OsString`, `Path`, or `PathBuf` (or a reference to one).
-This guard is what makes the lossless pass-through *possible* — the
-value already is an OS string, so the sink can take it as-is. It
-also keeps the lint off `str`/`String` receivers that happen to
-share a method name.
+The converted value must resolve (via `typeck_results`) to a type
+whose native form is not UTF-8, so the lossless pass-through is
+actually *possible*:
+
+- **OS strings** — `OsStr`, `OsString`, `Path`, `PathBuf` (or a
+  reference). The default sources; they reach the `AsRef<OsStr>` /
+  `AsRef<Path>` sinks in (c) directly.
+- **Byte buffers** — `[u8]`, `&[u8]`, `Vec<u8>`, `Box<[u8]>`. A byte
+  buffer satisfies `AsRef<[u8]>` but **not** `AsRef<OsStr>` /
+  `AsRef<Path>`, so it is flaggable only for the **byte sinks** gated
+  behind `include_byte_sinks` (see (c)). There the
+  `String::from_utf8_lossy(&bytes)` round-trip is pure waste and the
+  fix (`fs::write(p, &bytes)`) has no platform nuance at all — the
+  cleanest case the rule has.
+
+The type guard also keeps the lint off genuine `str` / `String`
+values that merely share a method name.
+
+**Out of scope: `CStr` / `CString`.** They carry the same lossy /
+panicking conversions (`to_string_lossy`, `to_str().unwrap()`,
+`into_string().unwrap()`), but they satisfy *none* of the rule's sink
+bounds — `CString: AsRef<[u8]>` does not hold, nor `AsRef<OsStr>` /
+`AsRef<Path>` — and their natural consumer is FFI: a `*const c_char`
+reached through `as_ptr()`, which the AsRef-bounded sink model does
+not cover. A C string fed to a byte sink would have to go through its
+lossless `to_bytes()` view, and "with or without the trailing NUL?"
+is a real ambiguity, so the case is left out rather than guessed at.
 
 ### (c) The sink
 
@@ -232,17 +266,24 @@ appear. A project may still drop specific methods through
 A third category is **opt-in** behind `include_byte_sinks` (see
 [Configuration](#configuration)):
 
-- **`AsRef<[u8]>`** — `fs::write`, `io::Write::write_all`, when the
-  byte argument is a converted OS string (writing a path *as file
-  content*). The lossless replacement writes the receiver's
-  `as_encoded_bytes()` — reached through `.as_os_str()` for a
-  `Path` / `PathBuf` receiver (as in the `fs::write` example below),
-  or called directly on an `&OsStr`. This is gated because the
-  byte encoding of an `OsStr` is platform-specific (raw bytes on
-  Unix, WTF-8 on Windows), so whether `as_encoded_bytes()` is the
-  *intended* on-disk form is a judgement the rule cannot make for
-  the consumer; opting in asserts "these files hold OS-string path
-  data, not UTF-8 text."
+- **`AsRef<[u8]>`** — `fs::write`, `io::Write::write_all`. Two source
+  families reach these:
+  - **Byte buffers** (`&[u8]` / `Vec<u8>` / `Box<[u8]>`): the lossy
+    `fs::write(p, String::from_utf8_lossy(&bytes).into_owned())`
+    round-trip is pure waste; the fix is `fs::write(p, &bytes)`, with
+    **no** platform nuance.
+  - **OS strings** written *as file content*: the lossless
+    replacement writes the receiver's `as_encoded_bytes()` — reached
+    through `.as_os_str()` for a `Path` / `PathBuf` receiver (as in
+    the `fs::write` example below), or directly on an `&OsStr`.
+
+  The category is gated because of the OS-string source: the byte
+  encoding of an `OsStr` is platform-specific (raw bytes on Unix,
+  WTF-8 on Windows), so whether `as_encoded_bytes()` is the *intended*
+  on-disk form is a judgement the rule cannot make; opting in asserts
+  "these files hold path / raw bytes, not UTF-8 text." The
+  byte-buffer source carries no such ambiguity but rides the same
+  toggle, since it too only concerns byte sinks.
 
 ### Exemptions
 
@@ -308,6 +349,19 @@ fs::write(out, target.to_string_lossy().as_bytes())?;
 fs::write(out, target.as_os_str().as_encoded_bytes())?;
 ```
 
+**Avoid** — lossy round-trip writing a byte buffer (only with
+`include_byte_sinks = true`):
+
+```rust
+fs::write(out, String::from_utf8_lossy(&bytes).into_owned())?;
+```
+
+**Prefer** — the bytes are already what `fs::write` wants:
+
+```rust
+fs::write(out, &bytes)?;
+```
+
 **Not flagged by default** — the `None` arm is handled. With
 `include_handled_conversions = true` this *is* flagged, because the
 handling could have been avoided entirely by passing the `OsStr`
@@ -341,7 +395,7 @@ command.arg(text);
 ## Configuration
 
 ```toml
-[perfectionist::needless_os_str_utf8_conversion]
+[perfectionist::needless_utf8_conversion]
 # Extend or restrict the sink set beyond bound-based detection.
 # Function paths are absolute, so each carries a leading `::`
 # per the leading-`::` convention in IMPLEMENTATION_CONVENTIONS.md.
@@ -451,7 +505,7 @@ sending the implementer down an unverified path.
   `report_in_external_macro: false` filter. Apply the late-pass
   `crate::common::hir_in_external_macro` guard it prescribes. A
   trigger that is realistically derive-generated is hard to
-  construct, so add a `ui/needless_os_str_utf8_conversion_proc_macro.rs`
+  construct, so add a `ui/needless_utf8_conversion_proc_macro.rs`
   fixture only if a non-vacuous, mutation-checked one can be built
   (delete the guard, confirm the fixture turns red); otherwise record
   at the span-selection site why it is omitted.
@@ -492,10 +546,10 @@ default policy stays purely on the objective-defect cases.
 
 ## Interaction with clippy and sibling rules
 
-- **No clippy counterpart.** Clippy has no lint for an OS-string →
-  UTF-8 conversion feeding an `AsRef<OsStr>` / `AsRef<Path>` sink,
-  so this rule takes its own anti-pattern name rather than mirroring
-  one.
+- **No clippy counterpart.** Clippy has no lint for a non-UTF-8
+  value (OS string or byte buffer) being lossily converted to UTF-8
+  on its way into a sink that accepts the native form, so this rule
+  takes its own anti-pattern name rather than mirroring one.
 - **`perfectionist::needless_borrowed_parameters`** shares the
   "needless conversion" theme but is orthogonal: it removes a
   `&T → T` owning conversion in a *function signature*, whereas this

--- a/planned-rules/needless-utf8-conversion.md
+++ b/planned-rules/needless-utf8-conversion.md
@@ -102,6 +102,14 @@ fn build(command: Command, file: &Path) -> Command {
 }
 ```
 
+Both motivating shapes above — building a `String` with `push_str`,
+and interpolating the path through `format!` — are the rule's
+*fuller* targets: each needs dataflow or macro-template inspection
+and is a **Hard** tier in [Difficulty](#difficulty). The core,
+first-shippable trigger is the simpler shape where the conversion
+*is* the sink argument (e.g. `command.arg(file.to_string_lossy().into_owned())`),
+shown under [Examples](#examples). All three share the same fix.
+
 ## Why is this bad?
 
 This is a correctness issue, not a stylistic preference.
@@ -261,7 +269,10 @@ leaving implicit:
 The recognition is unconditional and costs nothing when a consumer
 does not depend on `command-extra` — the `with_*` calls simply never
 appear. A project may still drop specific methods through
-`ignore_sinks`.
+`ignore_sinks`: that list is matched against *every* sink — built-in
+(std and `command-extra`), bound-detected, and `extra_sinks` alike —
+and takes precedence, so an `ignore_sinks` entry naming a
+`CommandExtra` method suppresses even its built-in recognition.
 
 A third category is **opt-in** behind `include_byte_sinks` (see
 [Configuration](#configuration)):
@@ -404,7 +415,8 @@ command.arg(text);
 extra_sinks = ["::my_crate::exec::spawn_with_path"]
 ignore_sinks = ["::my_crate::log::record_display_path"]
 
-# Extend / restrict the recognised conversion methods.
+# Extend / restrict the recognised *core* conversions (see prose
+# below for how an entry maps onto the multi-step trigger shapes).
 extra_conversion_methods = []
 ignore_conversion_methods = []
 
@@ -426,6 +438,23 @@ the cases the bound check misses (a sink that takes an already-built
 `OsString` by value) or over-matches (a logging helper that
 *wants* the lossy text). The extras-plus-ignore shape mirrors
 `perfectionist::needless_borrowed_parameters`.
+
+An `extra_conversion_methods` / `ignore_conversion_methods` entry
+names the **core** conversion only — the fidelity-losing step listed
+in (a), e.g. the receiver method `to_string_lossy` / `to_str`, or an
+associated function by path (`::std::string::String::from_utf8`) for
+the byte forms. It does **not** name the surrounding `.unwrap()` /
+`.expect()` or the trailing coercions: those are matched (and peeled)
+by the rule's fixed machinery around whatever core conversion is
+recognised, so adding `"my_lossy"` makes `x.my_lossy().unwrap()` and
+`x.my_lossy().as_ref()` triggers without further configuration, and
+`ignore_conversion_methods = ["to_str"]` drops every `to_str`-rooted
+shape while leaving `to_string_lossy` active. Method-name entries are
+matched on the final segment (relative, no leading `::`); a
+multi-segment associated-function path follows the leading-`::`
+convention like the `*_sinks` lists. This keeps the conversion knobs
+symmetric with the sink knobs rather than leaving "conversion method"
+as an undefined flat string.
 
 ### Why `include_handled_conversions` is off by default
 

--- a/planned-rules/needless-utf8-conversion.md
+++ b/planned-rules/needless-utf8-conversion.md
@@ -277,8 +277,10 @@ and takes precedence, so an `ignore_sinks` entry naming a
 A third category is **opt-in** behind `include_byte_sinks` (see
 [Configuration](#configuration)):
 
-- **`AsRef<[u8]>`** — `fs::write`, `io::Write::write_all`. Two source
-  families reach these:
+- **Byte sinks** — `fs::write` (a true `AsRef<[u8]>` bound) and the
+  concrete `&[u8]` writers like `io::Write::{write_all, write}`
+  (reached via the concrete-parameter arm of the detection in (c), not
+  an `AsRef<[u8]>` bound). Two source families reach these:
   - **Byte buffers** (`&[u8]` / `Vec<u8>` / `Box<[u8]>`): the lossy
     `fs::write(p, String::from_utf8_lossy(&bytes).into_owned())`
     round-trip is pure waste; the fix is `fs::write(p, &bytes)`, with
@@ -422,7 +424,7 @@ ignore_sinks = ["::my_crate::log::record_display_path"]
 extra_conversion_methods = []
 ignore_conversion_methods = []
 
-# Opt into `AsRef<[u8]>` sinks (fs::write & friends). Off by
+# Opt into byte sinks (`fs::write`, `Write::write_all`, …). Off by
 # default because the on-disk byte encoding of an OsStr is
 # platform-specific; see "What to lint > (c)".
 include_byte_sinks = false

--- a/planned-rules/needless-utf8-conversion.md
+++ b/planned-rules/needless-utf8-conversion.md
@@ -287,8 +287,10 @@ A third category is **opt-in** behind `include_byte_sinks` (see
 
 ### Exemptions
 
-- A receiver whose type is not an OS-string type — the lossless
-  path does not exist, so there is nothing to suggest.
+- A converted value whose type is neither an OS string nor (for byte
+  sinks) a byte buffer — it has no non-UTF-8 native form to pass
+  through, so there is nothing to suggest. (This is the (b) source-type
+  guard; it also keeps the lint off genuine `str` / `String` values.)
 - Faithful, fully-handled conversions (`match` / `?` / `ok_or` /
   let-else) — exempt **only by default**; flagged when
   `include_handled_conversions` is enabled (see (a) and

--- a/planned-rules/needless-utf8-conversion.md
+++ b/planned-rules/needless-utf8-conversion.md
@@ -323,7 +323,9 @@ command.arg(file.to_string_lossy().into_owned());
 command.arg(file);
 ```
 
-**Avoid** — `format!` + `unwrap` building a flag:
+**Avoid** — `format!` + `unwrap` building a flag (the macro-template
+**Hard** tier — the conversion is inside the `format!`, not the sink
+argument; see [Difficulty](#difficulty)):
 
 ```rust
 command.arg(format!("--input={}", file.to_str().unwrap()));


### PR DESCRIPTION
## Summary

Adds a planning file for a new rule, **`needless_utf8_conversion`** (`planned-rules/needless-utf8-conversion.md`), plus its index entry in `planned-rules/README.md`. Docs only — no Rust touched.

## The anti-pattern

A fidelity-destroying UTF-8 conversion of a value whose **native form is not UTF-8**, whose result is then fed to a sink that already accepts the native form:

- **OS strings** (`OsStr` / `OsString` / `Path` / `PathBuf`) — `to_string_lossy()`, `to_str().unwrap()`, `display().to_string()`.
- **Byte buffers** (`[u8]` / `&[u8]` / `Vec<u8>` / `Box<[u8]>`) — `String::from_utf8_lossy()`, `String::from_utf8(..).unwrap()`, `str::from_utf8(..).unwrap()`.

The lossy form silently corrupts non-UTF-8 input (wrong file targeted, or silent failure); the `unwrap` form panics on valid non-UTF-8 input. Both are needless: `Command::arg`, `command-extra`'s `CommandExtra` builder, `Path::join`, `File::open` (and `fs::write` for bytes) take the native value directly.

## Scope decisions

- **Generalized from OS-strings-only to all non-UTF-8 native values.** Byte buffers share the exact anti-pattern; they satisfy `AsRef<[u8]>` (so they fit byte sinks) but not `AsRef<OsStr>`/`AsRef<Path>`, so they're flagged only for byte sinks — where the `bytes → from_utf8_lossy → bytes` round-trip has *no* platform nuance (the cleanest case). The rename to `needless_utf8_conversion` matches this broader invariant; the old `needless_os_str_…` name under-claimed.
- **`CStr`/`CString` are out of scope.** Same conversions exist, but they satisfy *no* sink bound (`CString: AsRef<[u8]>` does not hold) and their consumer is FFI (`as_ptr()` → `*const c_char`), outside the AsRef-bounded sink model. Documented with rationale.
- **`command-extra`** is a first-class recognized sink by default (catalogue precedent for special-casing known third-party crates).
- **Config knobs, each with a difficulty-driven default:** `include_byte_sinks` (off — gates byte sinks *and* byte-buffer sources), `include_handled_conversions` (off — also flag conversions whose non-UTF-8 case is *handled* via `?`/`ok_or`/let-else but still feed a sink; off because robust detection needs binding-to-sink dataflow + proving the `&str` is consumed only by sinks), plus `extra_sinks`/`ignore_sinks`/`extra_conversion_methods`/`ignore_conversion_methods`.

## Conventions

- **Name** — names the anti-pattern (Clippy `needless_*` idiom); claims no more than the trigger checks.
- **Rationale** — *"Why is this bad?"*: the lossy form is an objective silent-corruption defect.
- **Implementation notes** — restricted to what's certain about the rule's shape (LateLintPass, HIR-shape triggers incl. the associated-function byte forms, bound-based sink detection, proc-macro guard); unverified `rustc`/`clippy_utils` call-level details left to the implementer. Core direct-argument case rated Medium; `format!`/concat, build-a-`String`, and handled-conversion cases are Hard follow-ups.

All example code blocks (including byte buffers and the `command-extra` builder) verified to compile against `rustc`.

## Notes

- Git hooks installed before committing (`just` unavailable on this image, so the recipe's commands were run directly); the `commit-msg` hook validated the commits.
- Docs-only change, so the `just all` / `self-lint` gate does not apply.

https://claude.ai/code/session_01NDhxQ5Xwe7L6RmovPM97wg