### PR TITLE
feat(import-grouping-mismatch)!: honour `cfg_block_handling` under `single_block`

### DIFF
--- a/rules/import_grouping_mismatch.md
+++ b/rules/import_grouping_mismatch.md
@@ -13,7 +13,10 @@ Enforces a single project-wide *grouping* style for the run of
 `use` statements at the top of a module body. The rule is
 inactive by default; a project opts in and sets `style` to one of:
 - `single_block` — every `use` sits in one contiguous block with
-  no blank lines between imports.
+  no blank lines between imports. Setting `cfg_trailing_block`
+  carves the `#[cfg(...)]`-gated imports out into their own
+  trailing block, one (or `blank_line_count`) blank line below the
+  rest.
 - `multi_block` — imports are partitioned into ordered groups
   separated by exactly `blank_line_count` blank lines. The
   default group set, in order, is std (`std` / `core` / `alloc`),
@@ -89,6 +92,27 @@ use crate::args::Args;
 use std::time::Duration;
 ```
 
+### Style: Single block, `cfg_trailing_block = true`
+
+**Avoid:** (cfg-gated imports mixed into the one block)
+
+```rust,ignore
+use std::fs::Metadata;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+use super::size::Bytes;
+```
+
+**Prefer:** (cfg-gated imports kept in a trailing block)
+
+```rust,ignore
+use std::fs::Metadata;
+use super::size::Bytes;
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+```
+
 ## Configuration
 
 Configure via `dylint.toml` under `["perfectionist::import_grouping_mismatch"]`. A field marked mandatory must be set; an optional field can be omitted and the per-field prose below states its default.
@@ -118,13 +142,26 @@ re-export roots treated as part of the workspace.
 
 ### `cfg_block_handling`: `CfgBlockHandling` (optional)
 
-How `#[cfg(...)]`-gated imports are grouped. Defaults to
-`trailing`.
+How `#[cfg(...)]`-gated imports are grouped under `multi_block`.
+Defaults to `trailing`. Ignored under `single_block`, which keeps
+every import in one block unless `cfg_trailing_block` carves out a
+trailing cfg block.
+
+### `cfg_trailing_block`: `boolean` (optional)
+
+Under `single_block`, whether `#[cfg(...)]`-gated imports are
+separated into their own trailing block (`blank_line_count` blank
+lines below the main block). Defaults to `false`, keeping every
+import — cfg-gated or not — in one contiguous block. Ignored under
+`multi_block`, which routes cfg grouping through
+`cfg_block_handling`.
 
 ### `blank_line_count`: `unsigned integer` (optional)
 
 Exact number of blank lines separating adjacent groups (strict
-equality). Defaults to `1`. Ignored under `single_block`.
+equality). Defaults to `1`. Under `single_block` it is used only
+when `cfg_trailing_block` separates the trailing cfg block;
+otherwise `single_block` admits no blank lines at all.
 
 ### Types
 

--- a/rules/import_grouping_mismatch.md
+++ b/rules/import_grouping_mismatch.md
@@ -13,10 +13,10 @@ Enforces a single project-wide *grouping* style for the run of
 `use` statements at the top of a module body. The rule is
 inactive by default; a project opts in and sets `style` to one of:
 - `single_block` — every `use` sits in one contiguous block with
-  no blank lines between imports. Setting `cfg_trailing_block`
-  carves the `#[cfg(...)]`-gated imports out into their own
-  trailing block, one (or `blank_line_count`) blank line below the
-  rest.
+  no blank lines between imports, except that `#[cfg(...)]`-gated
+  imports are carved into their own trailing block (one, or
+  `blank_line_count`, blank line below the rest). Set
+  `cfg_block_handling = "merge"` to keep them in the one block.
 - `multi_block` — imports are partitioned into ordered groups
   separated by exactly `blank_line_count` blank lines. The
   default group set, in order, is std (`std` / `core` / `alloc`),
@@ -92,7 +92,7 @@ use crate::args::Args;
 use std::time::Duration;
 ```
 
-### Style: Single block, `cfg_trailing_block = true`
+### Style: Single block, `#[cfg]`-gated imports
 
 **Avoid:** (cfg-gated imports mixed into the one block)
 
@@ -142,26 +142,19 @@ re-export roots treated as part of the workspace.
 
 ### `cfg_block_handling`: `CfgBlockHandling` (optional)
 
-How `#[cfg(...)]`-gated imports are grouped under `multi_block`.
-Defaults to `trailing`. Ignored under `single_block`, which keeps
-every import in one block unless `cfg_trailing_block` carves out a
-trailing cfg block.
-
-### `cfg_trailing_block`: `boolean` (optional)
-
-Under `single_block`, whether `#[cfg(...)]`-gated imports are
-separated into their own trailing block (`blank_line_count` blank
-lines below the main block). Defaults to `false`, keeping every
-import — cfg-gated or not — in one contiguous block. Ignored under
-`multi_block`, which routes cfg grouping through
-`cfg_block_handling`.
+How `#[cfg(...)]`-gated imports are grouped. Defaults to
+`trailing`: a cfg-gated import forms its own trailing block under
+both styles. Set `merge` to keep cfg-gated imports with the rest —
+in their natural path group under `multi_block`, or in the single
+block under `single_block`.
 
 ### `blank_line_count`: `unsigned integer` (optional)
 
 Exact number of blank lines separating adjacent groups (strict
 equality). Defaults to `1`. Under `single_block` it is used only
-when `cfg_trailing_block` separates the trailing cfg block;
-otherwise `single_block` admits no blank lines at all.
+to separate the trailing cfg block (`cfg_block_handling =
+"trailing"`); a `merge`d `single_block` admits no blank lines at
+all.
 
 ### Types
 
@@ -204,10 +197,13 @@ How a `#[cfg(...)]`-gated import is grouped.
 
 ##### `"trailing"` (Rust: `Trailing`)
 
-Treat every `#[cfg(...)]`-gated import as a fourth,
-always-last group, regardless of the imported path.
+Give every `#[cfg(...)]`-gated import its own trailing block,
+regardless of the imported path: an always-last group under
+`multi_block`, a trailing block below the single block under
+`single_block`.
 
 ##### `"merge"` (Rust: `Merge`)
 
-Slot a cfg-gated import back into its natural group based on the
-imported path's first segment.
+Keep a cfg-gated import with the rest: slotted into its natural
+path group under `multi_block`, or left in the single block under
+`single_block`.

--- a/src/rules/import_grouping_mismatch.rs
+++ b/src/rules/import_grouping_mismatch.rs
@@ -24,7 +24,10 @@ declare_tool_lint! {
     /// `use` statements at the top of a module body. The rule is
     /// inactive by default; a project opts in and sets `style` to one of:
     /// - `single_block` — every `use` sits in one contiguous block with
-    ///   no blank lines between imports.
+    ///   no blank lines between imports. Setting `cfg_trailing_block`
+    ///   carves the `#[cfg(...)]`-gated imports out into their own
+    ///   trailing block, one (or `blank_line_count`) blank line below the
+    ///   rest.
     /// - `multi_block` — imports are partitioned into ordered groups
     ///   separated by exactly `blank_line_count` blank lines. The
     ///   default group set, in order, is std (`std` / `core` / `alloc`),
@@ -98,6 +101,27 @@ declare_tool_lint! {
     /// use clap::Parser;
     /// use crate::args::Args;
     /// use std::time::Duration;
+    /// ```
+    ///
+    /// #### Style: Single block, `cfg_trailing_block = true`
+    ///
+    /// **Avoid:** (cfg-gated imports mixed into the one block)
+    ///
+    /// ```rust,ignore
+    /// use std::fs::Metadata;
+    /// #[cfg(unix)]
+    /// use std::os::unix::fs::MetadataExt;
+    /// use super::size::Bytes;
+    /// ```
+    ///
+    /// **Prefer:** (cfg-gated imports kept in a trailing block)
+    ///
+    /// ```rust,ignore
+    /// use std::fs::Metadata;
+    /// use super::size::Bytes;
+    ///
+    /// #[cfg(unix)]
+    /// use std::os::unix::fs::MetadataExt;
     /// ```
     pub perfectionist::IMPORT_GROUPING_MISMATCH,
     Warn,
@@ -356,12 +380,7 @@ impl ImportGroupingMismatch {
             return;
         }
         let blanks = self.blank_counts(lint_context, run);
-        if check::is_compliant(
-            self.config.style,
-            self.config.blank_line_count,
-            run,
-            &blanks,
-        ) {
+        if check::is_compliant(self.config.blank_line_count, run, &blanks) {
             return;
         }
 
@@ -374,19 +393,20 @@ impl ImportGroupingMismatch {
             .with_hi(last.item.span.hi());
         let indent = indent_of(lint_context, first.item.span).unwrap_or(0);
         let pad = " ".repeat(indent);
-        let replacement =
-            render::replacement(self.config.style, self.config.blank_line_count, &pad, run);
+        let replacement = render::replacement(self.config.blank_line_count, &pad, run);
 
         // A comment sitting between two statements is dropped by the
         // re-render (only each statement's own text is reproduced) and,
-        // under `multi_block`, may end up describing a statement that
-        // moved. A leading comment immediately above the first statement
-        // is left in place by the rewrite but is stranded above a
-        // *different* statement when `multi_block` reorders the first one
-        // downward. Either way, drop to `MaybeIncorrect` so the fix isn't
-        // applied unreviewed.
-        let first_statement_moves = matches!(self.config.style, Style::MultiBlock)
-            && run.iter().any(|stmt| stmt.rank < first.rank);
+        // when the rewrite reorders statements, may end up describing a
+        // statement that moved. A leading comment immediately above the
+        // first statement is left in place by the rewrite but is stranded
+        // above a *different* statement when the first one is reordered
+        // downward — under `multi_block`, or under `single_block` when a
+        // leading cfg-gated import is hoisted into the trailing block.
+        // Either way, drop to `MaybeIncorrect` so the fix isn't applied
+        // unreviewed. The check is style-agnostic: any statement ranking
+        // ahead of the first means the first sorts down.
+        let first_statement_moves = run.iter().any(|stmt| stmt.rank < first.rank);
         let applicability = if self.run_has_interstatement_comment(lint_context, run)
             || (first_statement_moves && self.has_leading_comment(lint_context, first))
         {
@@ -445,6 +465,9 @@ impl ImportGroupingMismatch {
 
     fn message(&self) -> &'static str {
         match self.config.style {
+            Style::SingleBlock if self.config.cfg_trailing_block => {
+                "imports must form one block, with `#[cfg]`-gated imports in a trailing block"
+            }
             Style::SingleBlock => {
                 "blank lines split the imports; this project keeps them in a single block"
             }

--- a/src/rules/import_grouping_mismatch.rs
+++ b/src/rules/import_grouping_mismatch.rs
@@ -24,10 +24,10 @@ declare_tool_lint! {
     /// `use` statements at the top of a module body. The rule is
     /// inactive by default; a project opts in and sets `style` to one of:
     /// - `single_block` — every `use` sits in one contiguous block with
-    ///   no blank lines between imports. Setting `cfg_trailing_block`
-    ///   carves the `#[cfg(...)]`-gated imports out into their own
-    ///   trailing block, one (or `blank_line_count`) blank line below the
-    ///   rest.
+    ///   no blank lines between imports, except that `#[cfg(...)]`-gated
+    ///   imports are carved into their own trailing block (one, or
+    ///   `blank_line_count`, blank line below the rest). Set
+    ///   `cfg_block_handling = "merge"` to keep them in the one block.
     /// - `multi_block` — imports are partitioned into ordered groups
     ///   separated by exactly `blank_line_count` blank lines. The
     ///   default group set, in order, is std (`std` / `core` / `alloc`),
@@ -103,7 +103,7 @@ declare_tool_lint! {
     /// use std::time::Duration;
     /// ```
     ///
-    /// #### Style: Single block, `cfg_trailing_block = true`
+    /// #### Style: Single block, `#[cfg]`-gated imports
     ///
     /// **Avoid:** (cfg-gated imports mixed into the one block)
     ///
@@ -214,6 +214,8 @@ struct Pending {
     anchor: Span,
     /// Span the diagnostic points at and rewrites — the whole run.
     span: Span,
+    /// Warning header, chosen per run by [`ImportGroupingMismatch::message`].
+    message: &'static str,
     replacement: String,
     applicability: Applicability,
 }
@@ -242,6 +244,7 @@ impl<'tcx> LateLintPass<'tcx> for ImportGroupingMismatch {
         for (pending, hir_id) in violations.into_iter().zip(hir_ids) {
             let Pending {
                 span,
+                message,
                 replacement,
                 applicability,
                 ..
@@ -251,7 +254,7 @@ impl<'tcx> LateLintPass<'tcx> for ImportGroupingMismatch {
                 IMPORT_GROUPING_MISMATCH,
                 hir_id,
                 span,
-                self.message(),
+                message,
                 |diagnostic| {
                     diagnostic.span_suggestion(
                         span,
@@ -418,6 +421,7 @@ impl ImportGroupingMismatch {
         violations.push(Pending {
             anchor: first.item.span,
             span: replace_span,
+            message: self.message(run),
             replacement,
             applicability,
         });
@@ -463,15 +467,20 @@ impl ImportGroupingMismatch {
         })
     }
 
-    fn message(&self) -> &'static str {
+    /// The warning header for a violating `run`. Under `single_block` the
+    /// wording depends on the actual violation: a run that carries a
+    /// hoisted cfg-gated import (rank above the single block's `0`) is
+    /// about the trailing cfg block, while a run with none is just blank
+    /// lines splitting one block — the same violation `merge` reports.
+    fn message(&self, run: &[UseStmt<'_>]) -> &'static str {
         match self.config.style {
-            Style::SingleBlock if self.config.cfg_trailing_block => {
+            Style::MultiBlock => "imports are not partitioned into ordered groups",
+            Style::SingleBlock if run.iter().any(|stmt| stmt.rank > 0) => {
                 "imports must form one block, with `#[cfg]`-gated imports in a trailing block"
             }
             Style::SingleBlock => {
                 "blank lines split the imports; this project keeps them in a single block"
             }
-            Style::MultiBlock => "imports are not partitioned into ordered groups",
         }
     }
 }

--- a/src/rules/import_grouping_mismatch/check.rs
+++ b/src/rules/import_grouping_mismatch/check.rs
@@ -3,7 +3,6 @@
 //! canonical replacement.
 
 use super::UseStmt;
-use super::config::Style;
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
 
 /// Number of whitespace-only lines strictly between two source-adjacent
@@ -61,31 +60,24 @@ fn block_comment_ranges(text: &str) -> Vec<(usize, usize)> {
     ranges
 }
 
-/// Whether `stmts` (in source order) already matches `style`. `blanks`
-/// holds the blank-line count between each adjacent pair (so its length
-/// is `stmts.len() - 1`), as counted by [`count_blank_lines`].
+/// Whether `stmts` (in source order) already matches the configured
+/// style. `blanks` holds the blank-line count between each adjacent pair
+/// (so its length is `stmts.len() - 1`), as counted by
+/// [`count_blank_lines`].
+///
+/// Both styles reduce to one rule once each statement carries its group
+/// rank (assigned in [`super::classify::rank`]): ranks are non-decreasing
+/// down the run; statements sharing a rank carry no blank line between
+/// them; a step up to a later group carries exactly `blank_line_count`
+/// blank lines. The style lives entirely in the ranks — `single_block`
+/// gives every import rank `0` (so the rule degenerates to "no blank
+/// lines anywhere"), bar an opt-in trailing cfg block at a higher rank;
+/// `multi_block` assigns the std / internal / third-party / cfg ranks.
 pub(super) fn is_compliant(
-    style: Style,
     blank_line_count: usize,
     stmts: &[UseStmt<'_>],
     blanks: &[usize],
 ) -> bool {
-    match style {
-        Style::SingleBlock => single_block_compliant(blanks),
-        Style::MultiBlock => multi_block_compliant(blank_line_count, stmts, blanks),
-    }
-}
-
-/// `single_block`: no blank line may sit between any two statements in
-/// the run.
-fn single_block_compliant(blanks: &[usize]) -> bool {
-    blanks.iter().all(|&blanks| blanks == 0)
-}
-
-/// `multi_block`: ranks are non-decreasing in the configured order;
-/// statements sharing a rank carry no blank line between them; a step
-/// up to a later group carries exactly `blank_line_count` blank lines.
-fn multi_block_compliant(blank_line_count: usize, stmts: &[UseStmt<'_>], blanks: &[usize]) -> bool {
     stmts
         .windows(2)
         .zip(blanks)

--- a/src/rules/import_grouping_mismatch/classify.rs
+++ b/src/rules/import_grouping_mismatch/classify.rs
@@ -40,24 +40,23 @@ fn path_group(tree: &UseTree, config: &Config) -> Group {
     }
 }
 
-/// The rank a statement sorts by. The style decides the partition:
+/// The rank a statement sorts by. The style decides the partition;
+/// under both, a cfg-gated import is hoisted into a trailing block only
+/// when `cfg_block_handling` is [`CfgBlockHandling::Trailing`]:
 ///
 /// - `single_block` keeps every import in one block (rank `0`), so the
-///   run admits no blank lines — except that, with `cfg_trailing_block`
-///   set, a cfg-gated import takes a higher rank `1` and forms a single
-///   trailing block. Path origin is irrelevant here.
+///   run admits no blank lines — except a trailing cfg import, which
+///   takes a higher rank `1` and forms a single trailing block. Path
+///   origin is irrelevant here.
 /// - `multi_block` ranks by the path group's position in the configured
-///   order, except a cfg-gated import under [`CfgBlockHandling::Trailing`],
-///   which takes the always-last cfg rank regardless of its path.
+///   order, except a trailing cfg import, which takes the always-last
+///   cfg rank regardless of its path.
 pub(super) fn rank(tree: &UseTree, is_cfg_gated: bool, config: &Config) -> usize {
+    let cfg_trailing =
+        is_cfg_gated && matches!(config.cfg_block_handling, CfgBlockHandling::Trailing);
     match config.style {
-        Style::SingleBlock => usize::from(is_cfg_gated && config.cfg_trailing_block),
-        Style::MultiBlock => {
-            if is_cfg_gated && matches!(config.cfg_block_handling, CfgBlockHandling::Trailing) {
-                config.cfg_rank()
-            } else {
-                config.group_rank(path_group(tree, config))
-            }
-        }
+        Style::SingleBlock => usize::from(cfg_trailing),
+        Style::MultiBlock if cfg_trailing => config.cfg_rank(),
+        Style::MultiBlock => config.group_rank(path_group(tree, config)),
     }
 }

--- a/src/rules/import_grouping_mismatch/classify.rs
+++ b/src/rules/import_grouping_mismatch/classify.rs
@@ -6,7 +6,7 @@
 //! that same path (under [`CfgBlockHandling::Merge`]) or hoisted into a
 //! single trailing group (under [`CfgBlockHandling::Trailing`]).
 
-use super::config::{CfgBlockHandling, Config, Group};
+use super::config::{CfgBlockHandling, Config, Group, Style};
 use rustc_ast::UseTree;
 use rustc_span::kw;
 
@@ -40,13 +40,24 @@ fn path_group(tree: &UseTree, config: &Config) -> Group {
     }
 }
 
-/// The rank a statement sorts by: its path group's position in the
-/// configured order, except a cfg-gated import under
-/// [`CfgBlockHandling::Trailing`], which takes the always-last cfg
-/// rank regardless of its path.
+/// The rank a statement sorts by. The style decides the partition:
+///
+/// - `single_block` keeps every import in one block (rank `0`), so the
+///   run admits no blank lines — except that, with `cfg_trailing_block`
+///   set, a cfg-gated import takes a higher rank `1` and forms a single
+///   trailing block. Path origin is irrelevant here.
+/// - `multi_block` ranks by the path group's position in the configured
+///   order, except a cfg-gated import under [`CfgBlockHandling::Trailing`],
+///   which takes the always-last cfg rank regardless of its path.
 pub(super) fn rank(tree: &UseTree, is_cfg_gated: bool, config: &Config) -> usize {
-    if is_cfg_gated && matches!(config.cfg_block_handling, CfgBlockHandling::Trailing) {
-        return config.cfg_rank();
+    match config.style {
+        Style::SingleBlock => usize::from(is_cfg_gated && config.cfg_trailing_block),
+        Style::MultiBlock => {
+            if is_cfg_gated && matches!(config.cfg_block_handling, CfgBlockHandling::Trailing) {
+                config.cfg_rank()
+            } else {
+                config.group_rank(path_group(tree, config))
+            }
+        }
     }
-    config.group_rank(path_group(tree, config))
 }

--- a/src/rules/import_grouping_mismatch/config.rs
+++ b/src/rules/import_grouping_mismatch/config.rs
@@ -73,12 +73,24 @@ pub(super) struct Config {
     /// re-export roots treated as part of the workspace.
     #[serde(default = "default_internal_prefixes")]
     pub(super) internal_prefixes: Vec<String>,
-    /// How `#[cfg(...)]`-gated imports are grouped. Defaults to
-    /// `trailing`.
+    /// How `#[cfg(...)]`-gated imports are grouped under `multi_block`.
+    /// Defaults to `trailing`. Ignored under `single_block`, which keeps
+    /// every import in one block unless `cfg_trailing_block` carves out a
+    /// trailing cfg block.
     #[serde(default)]
     pub(super) cfg_block_handling: CfgBlockHandling,
+    /// Under `single_block`, whether `#[cfg(...)]`-gated imports are
+    /// separated into their own trailing block (`blank_line_count` blank
+    /// lines below the main block). Defaults to `false`, keeping every
+    /// import — cfg-gated or not — in one contiguous block. Ignored under
+    /// `multi_block`, which routes cfg grouping through
+    /// `cfg_block_handling`.
+    #[serde(default)]
+    pub(super) cfg_trailing_block: bool,
     /// Exact number of blank lines separating adjacent groups (strict
-    /// equality). Defaults to `1`. Ignored under `single_block`.
+    /// equality). Defaults to `1`. Under `single_block` it is used only
+    /// when `cfg_trailing_block` separates the trailing cfg block;
+    /// otherwise `single_block` admits no blank lines at all.
     #[serde(default = "default_blank_line_count")]
     pub(super) blank_line_count: usize,
 }
@@ -151,9 +163,8 @@ mod tests {
 
     #[test]
     fn missing_style_is_an_error() {
-        // `style` is required (bare `Style`, no `serde(default)`), so a
-        // table that omits it fails to deserialize rather than defaulting
-        // to a layout — even when another knob is present.
+        // `style` is required (bare `Style`, no `serde(default)`): a table
+        // omitting it errors rather than defaulting, even with another knob set.
         assert!(toml::from_str::<Config>("").is_err());
         assert!(toml::from_str::<Config>("blank_line_count = 2").is_err());
     }
@@ -167,6 +178,7 @@ mod tests {
         assert_eq!(config.std_crates, default_std_crates());
         assert_eq!(config.internal_prefixes, default_internal_prefixes());
         assert_eq!(config.cfg_block_handling, CfgBlockHandling::Trailing);
+        assert!(!config.cfg_trailing_block);
         assert_eq!(config.blank_line_count, 1);
     }
 

--- a/src/rules/import_grouping_mismatch/config.rs
+++ b/src/rules/import_grouping_mismatch/config.rs
@@ -35,12 +35,15 @@ pub(super) enum Group {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum CfgBlockHandling {
-    /// Treat every `#[cfg(...)]`-gated import as a fourth,
-    /// always-last group, regardless of the imported path.
+    /// Give every `#[cfg(...)]`-gated import its own trailing block,
+    /// regardless of the imported path: an always-last group under
+    /// `multi_block`, a trailing block below the single block under
+    /// `single_block`.
     #[default]
     Trailing,
-    /// Slot a cfg-gated import back into its natural group based on the
-    /// imported path's first segment.
+    /// Keep a cfg-gated import with the rest: slotted into its natural
+    /// path group under `multi_block`, or left in the single block under
+    /// `single_block`.
     Merge,
 }
 
@@ -73,24 +76,18 @@ pub(super) struct Config {
     /// re-export roots treated as part of the workspace.
     #[serde(default = "default_internal_prefixes")]
     pub(super) internal_prefixes: Vec<String>,
-    /// How `#[cfg(...)]`-gated imports are grouped under `multi_block`.
-    /// Defaults to `trailing`. Ignored under `single_block`, which keeps
-    /// every import in one block unless `cfg_trailing_block` carves out a
-    /// trailing cfg block.
+    /// How `#[cfg(...)]`-gated imports are grouped. Defaults to
+    /// `trailing`: a cfg-gated import forms its own trailing block under
+    /// both styles. Set `merge` to keep cfg-gated imports with the rest —
+    /// in their natural path group under `multi_block`, or in the single
+    /// block under `single_block`.
     #[serde(default)]
     pub(super) cfg_block_handling: CfgBlockHandling,
-    /// Under `single_block`, whether `#[cfg(...)]`-gated imports are
-    /// separated into their own trailing block (`blank_line_count` blank
-    /// lines below the main block). Defaults to `false`, keeping every
-    /// import — cfg-gated or not — in one contiguous block. Ignored under
-    /// `multi_block`, which routes cfg grouping through
-    /// `cfg_block_handling`.
-    #[serde(default)]
-    pub(super) cfg_trailing_block: bool,
     /// Exact number of blank lines separating adjacent groups (strict
     /// equality). Defaults to `1`. Under `single_block` it is used only
-    /// when `cfg_trailing_block` separates the trailing cfg block;
-    /// otherwise `single_block` admits no blank lines at all.
+    /// to separate the trailing cfg block (`cfg_block_handling =
+    /// "trailing"`); a `merge`d `single_block` admits no blank lines at
+    /// all.
     #[serde(default = "default_blank_line_count")]
     pub(super) blank_line_count: usize,
 }
@@ -163,8 +160,9 @@ mod tests {
 
     #[test]
     fn missing_style_is_an_error() {
-        // `style` is required (bare `Style`, no `serde(default)`): a table
-        // omitting it errors rather than defaulting, even with another knob set.
+        // `style` is required (bare `Style`, no `serde(default)`), so a
+        // table that omits it fails to deserialize rather than defaulting
+        // to a layout — even when another knob is present.
         assert!(toml::from_str::<Config>("").is_err());
         assert!(toml::from_str::<Config>("blank_line_count = 2").is_err());
     }
@@ -178,7 +176,6 @@ mod tests {
         assert_eq!(config.std_crates, default_std_crates());
         assert_eq!(config.internal_prefixes, default_internal_prefixes());
         assert_eq!(config.cfg_block_handling, CfgBlockHandling::Trailing);
-        assert!(!config.cfg_trailing_block);
         assert_eq!(config.blank_line_count, 1);
     }
 

--- a/src/rules/import_grouping_mismatch/render.rs
+++ b/src/rules/import_grouping_mismatch/render.rs
@@ -8,35 +8,29 @@
 //! sort is stable).
 
 use super::UseStmt;
-use super::config::Style;
 
 /// Build the replacement text for the whole run. `pad` is the run's
 /// indentation, prepended to every line after the first (the first
 /// line's indent is left in the source, outside the replaced span).
-pub(super) fn replacement(
-    style: Style,
-    blank_line_count: usize,
-    pad: &str,
-    stmts: &[UseStmt<'_>],
-) -> String {
-    let ordered: Vec<&UseStmt<'_>> = match style {
-        // Keep source order; the fix only collapses blank lines.
-        Style::SingleBlock => stmts.iter().collect(),
-        // Stable-partition by group rank; order within a group stands.
-        Style::MultiBlock => {
-            let mut ordered: Vec<&UseStmt<'_>> = stmts.iter().collect();
-            ordered.sort_by_key(|stmt| stmt.rank);
-            ordered
-        }
-    };
+///
+/// The run is stable-partitioned by group rank (assigned in
+/// [`super::classify::rank`]); order within a rank stands, so a
+/// `single_block` run with one rank keeps source order while a
+/// `multi_block` run keeps `cargo fmt`'s inner order. Adjacent
+/// statements are then separated by `blank_line_count` blank lines
+/// across a rank step and none within a rank — which, for a one-rank
+/// `single_block` run, collapses to one contiguous block.
+pub(super) fn replacement(blank_line_count: usize, pad: &str, stmts: &[UseStmt<'_>]) -> String {
+    let mut ordered: Vec<&UseStmt<'_>> = stmts.iter().collect();
+    ordered.sort_by_key(|stmt| stmt.rank);
 
     let mut out = String::new();
     for (index, stmt) in ordered.iter().enumerate() {
         if index > 0 {
-            let blanks = match style {
-                Style::SingleBlock => 0,
-                Style::MultiBlock if ordered[index - 1].rank == stmt.rank => 0,
-                Style::MultiBlock => blank_line_count,
+            let blanks = if ordered[index - 1].rank == stmt.rank {
+                0
+            } else {
+                blank_line_count
             };
             // One newline ends the previous statement; `blanks` more
             // produce that many empty lines; then the shared indent.

--- a/tests/import_grouping_mismatch.rs
+++ b/tests/import_grouping_mismatch.rs
@@ -35,6 +35,8 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     cfg_block_handling: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    cfg_trailing_block: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     blank_line_count: Option<usize>,
 }
 
@@ -67,6 +69,22 @@ fn single_block_collapses_blank_lines() {
         "ui-toml/import_grouping_mismatch/single_block",
         RuleConfig {
             style: Some("single_block"),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn single_block_cfg_trailing_block_separates_cfg() {
+    // Under `style = "single_block"` with `cfg_trailing_block = true`,
+    // the non-cfg imports stay in one contiguous block and every
+    // `#[cfg(...)]`-gated import is hoisted into a single trailing block
+    // one blank line below.
+    run(
+        "ui-toml/import_grouping_mismatch/single_block_cfg_trailing",
+        RuleConfig {
+            style: Some("single_block"),
+            cfg_trailing_block: Some(true),
             ..Default::default()
         },
     );

--- a/tests/import_grouping_mismatch.rs
+++ b/tests/import_grouping_mismatch.rs
@@ -35,8 +35,6 @@ struct RuleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     cfg_block_handling: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    cfg_trailing_block: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     blank_line_count: Option<usize>,
 }
 
@@ -75,16 +73,31 @@ fn single_block_collapses_blank_lines() {
 }
 
 #[test]
-fn single_block_cfg_trailing_block_separates_cfg() {
-    // Under `style = "single_block"` with `cfg_trailing_block = true`,
-    // the non-cfg imports stay in one contiguous block and every
-    // `#[cfg(...)]`-gated import is hoisted into a single trailing block
-    // one blank line below.
+fn single_block_separates_cfg_into_trailing_block_by_default() {
+    // Under `style = "single_block"`, `cfg_block_handling` defaults to
+    // `trailing`: the non-cfg imports stay in one contiguous block and
+    // every `#[cfg(...)]`-gated import is hoisted into a single trailing
+    // block one blank line below. No cfg knob is set, so this also
+    // asserts the default.
     run(
         "ui-toml/import_grouping_mismatch/single_block_cfg_trailing",
         RuleConfig {
             style: Some("single_block"),
-            cfg_trailing_block: Some(true),
+            ..Default::default()
+        },
+    );
+}
+
+#[test]
+fn single_block_cfg_merge_keeps_cfg_in_one_block() {
+    // Under `style = "single_block"` with `cfg_block_handling = "merge"`,
+    // cfg-gated imports are not separated: a blank line above one is a
+    // violation, and the fix collapses everything into one block.
+    run(
+        "ui-toml/import_grouping_mismatch/single_block_cfg_merge",
+        RuleConfig {
+            style: Some("single_block"),
+            cfg_block_handling: Some("merge"),
             ..Default::default()
         },
     );

--- a/ui-toml/import_grouping_mismatch/single_block_cfg_merge/fixture.rs
+++ b/ui-toml/import_grouping_mismatch/single_block_cfg_merge/fixture.rs
@@ -1,0 +1,28 @@
+#![feature(register_tool)]
+#![register_tool(perfectionist)]
+#![allow(
+    unknown_lints,
+    dead_code,
+    unused_imports,
+    reason = "ui fixture"
+)]
+
+// Under `style = "single_block"` with `cfg_block_handling = "merge"`:
+// cfg-gated imports are not separated. Every import — cfg-gated or not —
+// belongs in one contiguous block with no blank lines.
+
+// Bad: a blank line carves the cfg-gated import into its own block;
+// `merge` keeps it in the one block with no blank line.
+use std::time::Duration;
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+struct Sep1;
+
+// Good: the cfg-gated import sits directly in the one block.
+use std::io::stdin;
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+
+fn main() {}

--- a/ui-toml/import_grouping_mismatch/single_block_cfg_merge/fixture.stderr
+++ b/ui-toml/import_grouping_mismatch/single_block_cfg_merge/fixture.stderr
@@ -1,0 +1,19 @@
+warning: blank lines split the imports; this project keeps them in a single block
+  --> $DIR/fixture.rs:16:1
+   |
+LL | / use std::time::Duration;
+LL | |
+LL | | #[cfg(unix)]
+LL | | use std::os::unix::fs::MetadataExt;
+   | |___________________________________^
+   |
+   = note: `#[warn(perfectionist::import_grouping_mismatch)]` on by default
+help: regroup the imports
+   |
+LL + use std::time::Duration;
+LL + #[cfg(unix)]
+LL + use std::os::unix::fs::MetadataExt;
+   |
+
+warning: 1 warning emitted
+

--- a/ui-toml/import_grouping_mismatch/single_block_cfg_trailing/fixture.rs
+++ b/ui-toml/import_grouping_mismatch/single_block_cfg_trailing/fixture.rs
@@ -7,8 +7,8 @@
     reason = "ui fixture"
 )]
 
-// Under `style = "single_block"` with `cfg_trailing_block = true`: the
-// non-cfg imports stay in one contiguous block and every
+// Under `style = "single_block"`, `cfg_block_handling` defaults to
+// `trailing`: the non-cfg imports stay in one contiguous block and every
 // `#[cfg(...)]`-gated import is hoisted into a single trailing block one
 // blank line below. Path origin is irrelevant — only the cfg gate moves
 // an import.

--- a/ui-toml/import_grouping_mismatch/single_block_cfg_trailing/fixture.rs
+++ b/ui-toml/import_grouping_mismatch/single_block_cfg_trailing/fixture.rs
@@ -1,0 +1,42 @@
+#![feature(register_tool)]
+#![register_tool(perfectionist)]
+#![allow(
+    unknown_lints,
+    dead_code,
+    unused_imports,
+    reason = "ui fixture"
+)]
+
+// Under `style = "single_block"` with `cfg_trailing_block = true`: the
+// non-cfg imports stay in one contiguous block and every
+// `#[cfg(...)]`-gated import is hoisted into a single trailing block one
+// blank line below. Path origin is irrelevant — only the cfg gate moves
+// an import.
+
+// Bad: a cfg-gated import sits inside the main block. The fix keeps the
+// non-cfg imports in one block and moves the cfg-gated import into a
+// trailing block.
+use std::time::Duration;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+use std::cmp::Ordering;
+
+struct Sep1;
+
+// Bad: a blank line splits two non-cfg imports; single_block admits no
+// blank line within the main block.
+use std::io::stdin;
+
+use std::process::exit;
+
+struct Sep2;
+
+// Good: the non-cfg imports sit in one block and the cfg-gated import
+// trails one blank line below.
+use std::collections::HashMap;
+use std::env::args;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+fn main() {}

--- a/ui-toml/import_grouping_mismatch/single_block_cfg_trailing/fixture.stderr
+++ b/ui-toml/import_grouping_mismatch/single_block_cfg_trailing/fixture.stderr
@@ -1,0 +1,35 @@
+warning: imports must form one block, with `#[cfg]`-gated imports in a trailing block
+  --> $DIR/fixture.rs:19:1
+   |
+LL | / use std::time::Duration;
+LL | | #[cfg(unix)]
+LL | | use std::os::unix::fs::MetadataExt;
+LL | | use std::cmp::Ordering;
+   | |_______________________^
+   |
+   = note: `#[warn(perfectionist::import_grouping_mismatch)]` on by default
+help: regroup the imports
+   |
+LL + use std::time::Duration;
+LL + use std::cmp::Ordering;
+LL + 
+LL + #[cfg(unix)]
+LL + use std::os::unix::fs::MetadataExt;
+   |
+
+warning: imports must form one block, with `#[cfg]`-gated imports in a trailing block
+  --> $DIR/fixture.rs:28:1
+   |
+LL | / use std::io::stdin;
+LL | |
+LL | | use std::process::exit;
+   | |_______________________^
+   |
+help: regroup the imports
+   |
+LL + use std::io::stdin;
+LL + use std::process::exit;
+   |
+
+warning: 2 warnings emitted
+

--- a/ui-toml/import_grouping_mismatch/single_block_cfg_trailing/fixture.stderr
+++ b/ui-toml/import_grouping_mismatch/single_block_cfg_trailing/fixture.stderr
@@ -17,7 +17,7 @@ LL + #[cfg(unix)]
 LL + use std::os::unix::fs::MetadataExt;
    |
 
-warning: imports must form one block, with `#[cfg]`-gated imports in a trailing block
+warning: blank lines split the imports; this project keeps them in a single block
   --> $DIR/fixture.rs:28:1
    |
 LL | / use std::io::stdin;


### PR DESCRIPTION
`single_block` forbade every blank line between imports, so a project couldn't keep its `#[cfg(...)]`-gated imports in their own trailing block — the layout `multi_block` already offers via `cfg_block_handling = "trailing"`.

`single_block` now honours the existing **`cfg_block_handling`** enum (no separate knob):

- **`trailing`** (the default): non-cfg imports stay in one contiguous block and every `#[cfg(...)]`-gated import is hoisted into a single trailing block, `blank_line_count` blank lines below. So under `single_block`, cfg imports are separated by default — a behavior change for existing `single_block` users, who can restore the old layout with `merge`.
- **`merge`**: every import — cfg-gated or not — stays in the one contiguous block (the strict opt-out, and the pre-PR `single_block` behavior).

The enum semantics read the same under both styles: `trailing` = cfg imports form their own trailing block; `merge` = cfg imports stay with the rest (their path group under `multi_block`, the single block under `single_block`).

Internals: the style is now encoded entirely in each statement's rank, so `is_compliant` and `replacement` drop their `style` parameter and each collapse to one rank-based path. The `single_block` warning header is chosen per run — a run that hoists a cfg import names the trailing cfg block; a plain blank-line split keeps the original wording.

Covered by UI fixtures (`single_block_cfg_trailing` for the default, `single_block_cfg_merge` for the opt-out), a config-default unit assertion, regenerated `rules/` docs, and an updated rustdoc example.

Distinguishing *kinds* of cfg (`#[cfg(test)]` vs `#[cfg(unix)]` vs `#[cfg(feature)]`) is out of scope here; this PR keeps all cfg imports in one bucket. Tracked in #298.

Resolves <https://github.com/KSXGitHub/parallel-disk-usage/issues/436>