### PR TITLE
docs(plan): `dedented_multiline_string`

### DIFF
--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -115,13 +115,13 @@ pattern that several rules call out by reference — live in
   `text_block_fnl! { ... }` (default) or the
   `"line\n\<newline>line"` continuation form. Skips templates and
   attribute literals.
-- [`deindented-multiline-string.md`](./deindented-multiline-string.md) — the
+- [`dedented-multiline-string.md`](./dedented-multiline-string.md) — the
   source-layout complement: when a string literal is broken across
   source lines by *raw* line breaks that drop its body out of the
   surrounding indentation (flush to the left margin), prefer
   `include_str!` of a sibling fixture file, a `text_block_fnl! { ... }`
   re-indented block (default), or — for a single logical line — a
-  one-line `"…\n"`. Independent of `manual_json_string`: a de-indented
+  one-line `"…\n"`. Independent of `manual_json_string`: a dedented
   JSON literal trips both.
 - [`overly-long-print-macro.md`](./overly-long-print-macro.md) — when a
   splittable print macro (`println!`, `eprintln!`, `writeln!`,

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -120,9 +120,9 @@ pattern that several rules call out by reference — live in
   source lines by *raw* line breaks that drop its body out of the
   surrounding indentation (flush to the left margin), prefer
   `include_str!` of a sibling fixture file, a `text_block_fnl! { ... }`
-  re-indented block (default), or — for a single logical line — a
-  one-line `"…\n"`. Independent of `manual_json_string`: a dedented
-  JSON literal trips both.
+  re-indented block, or — for a single logical line — a one-line
+  `"…\n"`. Independent of `manual_json_string`: a dedented JSON
+  literal trips both.
 - [`overly-long-print-macro.md`](./overly-long-print-macro.md) — when a
   splittable print macro (`println!`, `eprintln!`, `writeln!`,
   log family, …) has an embedded-`\n` template *and* spans more

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -121,7 +121,8 @@ pattern that several rules call out by reference — live in
   surrounding indentation (flush to the left margin), prefer
   `include_str!` of a sibling fixture file, a `text_block_fnl! { ... }`
   re-indented block (default), or — for a single logical line — a
-  one-line `"…\n"`. Defers JSON content to `manual_json_string`.
+  one-line `"…\n"`. Independent of `manual_json_string`: a de-indented
+  JSON literal trips both.
 - [`overly-long-print-macro.md`](./overly-long-print-macro.md) — when a
   splittable print macro (`println!`, `eprintln!`, `writeln!`,
   log family, …) has an embedded-`\n` template *and* spans more

--- a/planned-rules/README.md
+++ b/planned-rules/README.md
@@ -115,6 +115,13 @@ pattern that several rules call out by reference — live in
   `text_block_fnl! { ... }` (default) or the
   `"line\n\<newline>line"` continuation form. Skips templates and
   attribute literals.
+- [`deindented-multiline-string.md`](./deindented-multiline-string.md) — the
+  source-layout complement: when a string literal is broken across
+  source lines by *raw* line breaks that drop its body out of the
+  surrounding indentation (flush to the left margin), prefer
+  `include_str!` of a sibling fixture file, a `text_block_fnl! { ... }`
+  re-indented block (default), or — for a single logical line — a
+  one-line `"…\n"`. Defers JSON content to `manual_json_string`.
 - [`overly-long-print-macro.md`](./overly-long-print-macro.md) — when a
   splittable print macro (`println!`, `eprintln!`, `writeln!`,
   log family, …) has an embedded-`\n` template *and* spans more

--- a/planned-rules/dedented-multiline-string.md
+++ b/planned-rules/dedented-multiline-string.md
@@ -137,9 +137,8 @@ least one body line after such a break begins at a column
      is a template the macro interprets. Configurable via
      `format_macros`.
    - Already inside a `text_block!` / `text_block_fnl!` invocation
-     (configurable via `text_block_macros_paths`) or an
-     `include_str!` / `include_bytes!` argument — avoids firing on
-     already-fixed code and on path arguments.
+     or an `include_str!` / `include_bytes!` argument — avoids firing
+     on already-fixed code and on path arguments.
    - Inside any attribute meta-item (`#[doc = "…"]`,
      `#[display("…")]`, `#[error("…")]`, …) — the literal is
      consumed by the attribute and reshaping it is not equivalent.
@@ -344,19 +343,6 @@ format_macros = [
   "debug_assert", "debug_assert_eq", "debug_assert_ne",
   "error", "warn", "info", "debug", "trace", "log",
 ]
-
-# text-block-macros invocations whose arguments are already the
-# rewritten form; skipped to avoid firing on the rule's own output.
-text_block_macros_paths = [
-  "text_block_macros::text_block",
-  "text_block_macros::text_block_fnl",
-]
-
-# Import paths the `text_block_macros` autofix suggests, if no such
-# import is already in scope. Override when the project re-exports
-# the macros from an internal prelude.
-text_block_import_path = "text_block_macros::text_block"
-text_block_fnl_import_path = "text_block_macros::text_block_fnl"
 ```
 
 ## Implementation notes
@@ -387,11 +373,9 @@ text_block_fnl_import_path = "text_block_macros::text_block_fnl"
   branch, otherwise the multi-suggestion branch. No content parsing
   (so no `serde_json` in this pass).
 - **Skip contexts.** Reuse the sibling rule's machinery: a
-  `Span::from_expansion()` check against `format_macros` /
-  `text_block_macros_paths` for the macro cases, and a
-  `tcx.hir_parents(...)` walk for the attribute case. `include_str!`
-  / `include_bytes!` arguments are caught by the same
-  expansion-path check.
+  `Span::from_expansion()` check against `format_macros` (plus a
+  built-in `text_block!` / `include_str!` path set) for the macro
+  cases, and a `tcx.hir_parents(...)` walk for the attribute case.
 - **Proc-macro suppression.** The diagnostic's primary span is the
   **whole literal**, which is wider than the synthesised-identifier
   spans the "Suppressing proc-macro-synthesised violations" section

--- a/planned-rules/dedented-multiline-string.md
+++ b/planned-rules/dedented-multiline-string.md
@@ -404,6 +404,10 @@ format_macros = [
   `ui/<rule>_proc_macro.rs` fixture is required. Record this
   reasoning at the span-selection site so the omission reads as
   deliberate.
+- See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  for cross-cutting conventions that apply to every rule in this
+  catalogue, in particular the lint-name namespacing
+  (`perfectionist::*`) that every registered lint follows.
 
 ### Difficulty
 
@@ -425,17 +429,6 @@ concentrates in the suggestions, all attached to one diagnostic:
   preserving the trailing `\n`(s). Value-preserving.
 - `include_str!` extraction is a **help note only** — it needs a new
   file, which a rustc suggestion cannot create.
-
-`MachineApplicable` requires *both* that exactly one suggestion is
-enabled in config *and* that the fix is intrinsically exact — only
-`concat!` and the single-line collapse qualify (and only when sole).
-Otherwise every suggestion is `MaybeIncorrect`, so `cargo dylint
---fix` never silently rewrites to one of several alternatives.
-
-- See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
-  for cross-cutting conventions that apply to every rule in this
-  catalogue, in particular the lint-name namespacing
-  (`perfectionist::*`) that every registered lint follows.
 
 ## Default state
 

--- a/planned-rules/dedented-multiline-string.md
+++ b/planned-rules/dedented-multiline-string.md
@@ -1,4 +1,4 @@
-# `deindented_multiline_string`
+# `dedented_multiline_string`
 
 **Source:** project convention.
 
@@ -79,7 +79,7 @@ what the literal *is*:
   let nvmrc = "24.0.0\n";
   ```
 
-This rule fires on the de-indented shape and points at the
+This rule fires on the dedented shape and points at the
 appropriate replacement. It is the source-layout complement of
 `perfectionist::escaped_multiline_string`, which targets the
 opposite spelling — newlines crammed onto one source line as `\n`
@@ -88,14 +88,14 @@ escapes (see [Interaction with sibling rules](#interaction-with-sibling-rules)).
 ## Why restrict this?
 
 This is a stylistic preference, not a correctness issue. The
-de-indented literal compiles and produces exactly the intended
+dedented literal compiles and produces exactly the intended
 bytes. The objection is to the *source*:
 
 - A reader scanning the indentation to follow control flow loses
   the thread the moment the body drops to column zero; the literal
   reads as if the function ended. Nesting (a `match` arm, a closure
   inside a method chain) makes the discontinuity worse.
-- The de-indented body cannot be moved, re-indented by an editor's
+- The dedented body cannot be moved, re-indented by an editor's
   reformat, or wrapped in another block without either corrupting
   the value or being left behind by the surrounding `cargo fmt` —
   rustfmt does not touch the interior of a string literal.
@@ -107,7 +107,7 @@ There is also a quiet footgun worth naming, though it is the
 secondary motivation: raw line breaks bake every leading space on
 each body line **into the value**. When the value's leading
 whitespace is significant (a Makefile/justfile recipe body, YAML),
-re-indenting the source to "fix" the de-indentation silently
+re-indenting the source to "fix" the dedented body silently
 changes the string. The cleaner forms make the value's whitespace
 explicit and independent of source layout.
 
@@ -147,28 +147,28 @@ enclosing statement's indentation column:
      (`text_block_macros` by default), and — when
      `suggest_include_str` is on — additionally surface
      "extract to a sibling file and `include_str!` it" as a help
-     note, since a de-indented block is usually a foreign-format
+     note, since a dedented block is usually a foreign-format
      fixture.
 
-The rule does **not** inspect what the content *is*. A de-indented
+The rule does **not** inspect what the content *is*. A dedented
 block whose content happens to be JSON still fires here on its
 layout, and `perfectionist::manual_json_string` independently fires
 on the same literal to suggest the `json!` construction — the two do
 different things and neither suppresses the other (see
 [Interaction](#interaction-with-sibling-rules)).
 
-The trigger is the **raw line break plus de-indentation**, not the
+The trigger is the **raw line break plus a dedented body**, not the
 decoded newline count. A literal whose newlines are all `\n`
 escapes on one source line does not span source lines and so does
 not match this rule's trigger (it is the domain of
 `perfectionist::escaped_multiline_string`). A raw/`\<newline>`
 literal whose body is indented to *match or exceed* the enclosing
-code (so nothing is de-indented) does not fire — see the gen-docs
+code (so nothing is dedented) does not fire — see the gen-docs
 boundary case below.
 
 ## Examples
 
-### De-indented block, foreign format
+### Dedented block, foreign format
 
 **Avoid:**
 
@@ -210,7 +210,7 @@ pub fn create_justfile() {
 }
 ```
 
-### De-indented raw string holding JSON
+### Dedented raw string holding JSON
 
 **Avoid:**
 
@@ -223,7 +223,7 @@ let tsconfig = r#"
 "#;
 ```
 
-This rule fires on the de-indented layout and suggests its own
+This rule fires on the dedented layout and suggests its own
 remedies — `include_str!("fixtures/create/tsconfig.json")` or a
 `text_block_fnl!` block. Separately,
 `perfectionist::manual_json_string` fires on the same literal and
@@ -265,7 +265,7 @@ flush-left literals — the `CONFIG` blocks even carry `\"` escapes
 that a raw `text_block!` line or an `include_str!`-ed `.toml` would
 shed:
 
-- `tests/import_grouping_mismatch_submodules.rs` — nine de-indented
+- `tests/import_grouping_mismatch_submodules.rs` — nine dedented
   blocks: a `const CONFIG: &str = "\` TOML block plus the `lib` /
   `separate` / `deep` Rust-source fixtures threaded into
   `run_project_with_sources_and_config`. For example:
@@ -313,7 +313,7 @@ write(
 )
 ```
 
-Nothing here is de-indented, so the rule stays silent. (The body
+Nothing here is dedented, so the rule stays silent. (The body
 indentation is baked into the value, but the consumer re-parses it
 as Rust where leading whitespace is irrelevant — a deliberate,
 acceptable trade-off, not the anti-pattern this rule targets.)
@@ -346,7 +346,7 @@ let s = include_str!("fixtures/create/justfile");
 ## Configuration
 
 ```toml
-[perfectionist::deindented_multiline_string]
+[perfectionist::dedented_multiline_string]
 # Which inline rewrite the autofix offers as its primary
 # suggestion. Defaults to `text_block_macros`.
 #   "text_block_macros"  -> text_block_fnl! / text_block! (one
@@ -359,7 +359,7 @@ style = "text_block_macros"
 
 # Whether to additionally surface "extract to a sibling file and
 # pull it in with `include_str!`" as a help note. Defaults to
-# `true`: a de-indented block is most often a foreign-format
+# `true`: a dedented block is most often a foreign-format
 # fixture that reads best as its own file. Set to `false` to keep
 # the suggestion purely inline.
 suggest_include_str = true
@@ -407,7 +407,7 @@ text_block_fnl_import_path = "text_block_macros::text_block_fnl"
   over the snippet per the parser-combinator convention in
   [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md);
   do not reach for a regex.
-- **De-indentation measurement.** Use the source map's
+- **Indentation measurement.** Use the source map's
   `lookup_char_pos` on the literal's span to get the enclosing
   statement's indentation column (the column of the first
   non-whitespace byte on the literal's opening line). For each body
@@ -443,7 +443,7 @@ text_block_fnl_import_path = "text_block_macros::text_block_fnl"
 
 ### Difficulty
 
-**Medium.** The raw-line-break-plus-de-indentation detection is a
+**Medium.** Detecting a raw line break whose body is dedented is a
 straightforward snippet scan against the decoded value and a
 column comparison through the source map. The context-skip logic is
 shared with `perfectionist::escaped_multiline_string`. The work
@@ -472,12 +472,12 @@ concentrates in the autofix:
 
 ## Default state
 
-Active by default. The de-indented shape is a broad, project-
+Active by default. The dedented shape is a broad, project-
 agnostic readability regression; the default `style =
 "text_block_macros"` matches the catalogue's preferred form, and
 projects that don't want the external-crate dependency switch to
 `line_continuation`. Suppress per-site with
-`#[allow(perfectionist::deindented_multiline_string)]` or globally
+`#[allow(perfectionist::dedented_multiline_string)]` or globally
 via `[perfectionist].disable`.
 
 ## Interaction with sibling rules
@@ -493,16 +493,16 @@ point at different defects, so both are appropriate.
   string, so in practice they rarely fire on the same literal:
   - `escaped_multiline_string` targets newlines crammed onto one
     (or few) source lines as `\n` escapes — *too compressed*.
-  - `deindented_multiline_string` targets newlines spelled as raw
+  - `dedented_multiline_string` targets newlines spelled as raw
     source breaks that drop the body out of the code's
     indentation — *too sprawling*.
 
-  This rule's trigger is the raw-line-break-with-de-indentation
+  This rule's trigger is the raw-line-break-with-dedented-body
   shape; a purely `\n`-escaped literal does not match it at all.
-- [`manual-json-string`](./manual-json-string.md) — a de-indented
+- [`manual-json-string`](./manual-json-string.md) — a dedented
   literal whose content is JSON triggers **both** rules, and that is
   intended. They address different defects: `manual_json_string`
   rewrites the *construction* (hand-rolled string → `serde_json::json!`),
-  while this rule flags the *source layout* (the de-indented body).
+  while this rule flags the *source layout* (the dedented body).
   This rule does no content parsing, so it neither knows nor cares
   that the body is JSON.

--- a/planned-rules/dedented-multiline-string.md
+++ b/planned-rules/dedented-multiline-string.md
@@ -142,17 +142,23 @@ least one body line after such a break begins at a column
    - Inside any attribute meta-item (`#[doc = "…"]`,
      `#[display("…")]`, `#[error("…")]`, …) — the literal is
      consumed by the attribute and reshaping it is not equivalent.
-2. Emit the diagnostic with **every** applicable alternative
-   suggestion attached — a single diagnostic carries several, each
-   shown as its own `help:` fix — chosen by the literal's **shape**,
+2. Emit the diagnostic with each **enabled** suggestion attached
+   (toggled in config — see below), chosen by the literal's **shape**
    with no content parsing:
    - **One non-empty line** (every line but one is empty — e.g.
-     `"24.0.0\n"` spread across source lines) → suggest collapsing to
-     one source line, preserving the trailing `\n`(s).
-   - **Multiple non-empty lines** → suggest all three of:
-     `include_str!` of a sibling fixture file; the `text_block_fnl!` /
-     `text_block!` form; and `concat!` (one quoted line per line, each
-     ending in `\n` as needed).
+     `"24.0.0\n"` spread across source lines) → the single-line
+     collapse, preserving the trailing `\n`(s).
+   - **Multiple non-empty lines** → `include_str!` of a sibling
+     fixture file, the `text_block_fnl!` / `text_block!` form, and
+     `concat!` (one quoted line per line, each ending in `\n` as
+     needed).
+
+   Applicability is keyed to the toggles, **not** the individual fix:
+   a structured suggestion is `MachineApplicable` only when exactly
+   one suggestion is enabled (so `cargo dylint --fix` applies that one
+   form deterministically). With two or more enabled, every
+   suggestion is `MaybeIncorrect`, so `--fix` leaves the choice to the
+   author instead of silently rewriting to one of them.
 
 The rule inspects only layout, never content: a dedented JSON block
 fires here on its layout and, independently, on
@@ -332,6 +338,17 @@ let s = include_str!("fixtures/create/justfile");
 
 ```toml
 [perfectionist::dedented_multiline_string]
+# Which fixes the diagnostic offers. All on by default, so the
+# diagnostic shows them as alternatives and `cargo dylint --fix`
+# applies none (each is `MaybeIncorrect`). Set exactly one to `true`
+# (the rest `false`) to make that form the single `MachineApplicable`
+# fix `--fix` applies. (`include_str` is a help note — it needs a new
+# file — so it is never auto-applied even when it is the only one on.)
+suggest_include_str = true   # multi-line: extract to a sibling file
+suggest_text_block  = true   # multi-line: text_block_fnl! / text_block!
+suggest_concat      = true   # multi-line: concat!("line\n", …)
+suggest_single_line = true   # one non-empty line: collapse to "…\n"
+
 # Format-family macros whose first positional argument is a
 # template and must not be reshaped. Mirrors
 # `perfectionist::escaped_multiline_string`.
@@ -399,19 +416,21 @@ concentrates in the suggestions, all attached to one diagnostic:
 - `text_block_macros`: split the decoded value on `\n`, emit one
   quoted line each (raw-quoting lines that contain `"`), choosing
   `text_block_fnl!` when the value ends in `\n` and `text_block!`
-  otherwise. `Applicability::MaybeIncorrect` (assumes the
-  `text-block-macros` dependency, may need an added `use`).
+  otherwise. Always `MaybeIncorrect` — it assumes the
+  `text-block-macros` dependency and may need an added `use`, so it
+  stays MaybeIncorrect even when it is the only enabled suggestion.
 - `concat!`: emit one quoted line literal per line, each ending in
-  `\n` where the value has one. Std-only and value-preserving;
-  `Applicability::MachineApplicable`.
+  `\n` where the value has one. Std-only and value-preserving.
 - single-line collapse: replace the source with a one-line `"…\n"`,
-  preserving the trailing `\n`(s). `Applicability::MachineApplicable`.
+  preserving the trailing `\n`(s). Value-preserving.
 - `include_str!` extraction is a **help note only** — it needs a new
   file, which a rustc suggestion cannot create.
 
-With several suggestions on one diagnostic, `cargo fix` does not
-auto-apply (the choice is the author's); each appears under its own
-`help:`.
+`MachineApplicable` requires *both* that exactly one suggestion is
+enabled in config *and* that the fix is intrinsically exact — only
+`concat!` and the single-line collapse qualify (and only when sole).
+Otherwise every suggestion is `MaybeIncorrect`, so `cargo dylint
+--fix` never silently rewrites to one of several alternatives.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
   for cross-cutting conventions that apply to every rule in this

--- a/planned-rules/dedented-multiline-string.md
+++ b/planned-rules/dedented-multiline-string.md
@@ -67,6 +67,19 @@ what the literal *is*:
   };
   ```
 
+- **A std-only inline form** is `concat!`, one quoted line per
+  source line, each ending in `\n` as needed:
+
+  ```rust
+  let justfile = concat!(
+      "clean:\n",
+      "    rm -rf ./dist\n",
+      "\n",
+      "build:\n",
+      "    tsc\n",
+  );
+  ```
+
 - **A JSON document** is better built with `serde_json::json!`
   (the domain of `perfectionist::manual_json_string`).
 
@@ -130,16 +143,17 @@ least one body line after such a break begins at a column
    - Inside any attribute meta-item (`#[doc = "…"]`,
      `#[display("…")]`, `#[error("…")]`, …) — the literal is
      consumed by the attribute and reshaping it is not equivalent.
-2. Pick the suggested remedy from the literal's **shape** — no
-   content parsing, which keeps the trigger simple:
-   - **Single logical line** (the decoded value has no interior
-     newline — at most a single trailing `\n`) → suggest collapsing
-     to one source line (`"24.0.0\n"`). This is the case the rule
-     exists to catch even though it "obviously" should be one line.
-   - **Otherwise** → suggest the inline `text_block_fnl!` /
-     `text_block!` form and, when `suggest_include_str` is on, also
-     surface "extract to a sibling file and `include_str!` it" as a
-     help note (a dedented block is usually a foreign-format fixture).
+2. Emit the diagnostic with **every** applicable alternative
+   suggestion attached — a single diagnostic carries several, each
+   shown as its own `help:` fix — chosen by the literal's **shape**,
+   with no content parsing:
+   - **One non-empty line** (every line but one is empty — e.g.
+     `"24.0.0\n"` spread across source lines) → suggest collapsing to
+     one source line, preserving the trailing `\n`(s).
+   - **Multiple non-empty lines** → suggest all three of:
+     `include_str!` of a sibling fixture file; the `text_block_fnl!` /
+     `text_block!` form; and `concat!` (one quoted line per line, each
+     ending in `\n` as needed).
 
 The rule inspects only layout, never content: a dedented JSON block
 fires here on its layout and, independently, on
@@ -319,13 +333,6 @@ let s = include_str!("fixtures/create/justfile");
 
 ```toml
 [perfectionist::dedented_multiline_string]
-# Whether to additionally surface "extract to a sibling file and
-# pull it in with `include_str!`" as a help note. Defaults to
-# `true`: a dedented block is most often a foreign-format
-# fixture that reads best as its own file. Set to `false` to keep
-# the suggestion purely inline.
-suggest_include_str = true
-
 # Format-family macros whose first positional argument is a
 # template and must not be reshaped. Mirrors
 # `perfectionist::escaped_multiline_string`.
@@ -375,9 +382,10 @@ text_block_fnl_import_path = "text_block_macros::text_block_fnl"
   least one body line is shallower. At column-zero indentation
   nothing is shallower, so a top-level flush-left `const` does not
   fire — the least-offensive case, left out deliberately.
-- **Shape classification.** Count interior newlines in the decoded
-  value to choose the single-line-collapse vs. block-reshape branch.
-  No content parsing (so no `serde_json` in this pass).
+- **Shape classification.** Split the decoded value on `\n`; if
+  exactly one line is non-empty, take the single-line-collapse
+  branch, otherwise the multi-suggestion branch. No content parsing
+  (so no `serde_json` in this pass).
 - **Skip contexts.** Reuse the sibling rule's machinery: a
   `Span::from_expansion()` check against `format_macros` /
   `text_block_macros_paths` for the macro cases, and a
@@ -402,20 +410,24 @@ text_block_fnl_import_path = "text_block_macros::text_block_fnl"
 straightforward snippet scan against the decoded value and a
 column comparison through the source map. The context-skip logic is
 shared with `perfectionist::escaped_multiline_string`. The work
-concentrates in the autofix:
+concentrates in the suggestions, all attached to one diagnostic:
 
-- `text_block_macros` autofix: split the decoded value on `\n`,
-  emit one quoted line each (raw-quoting lines that contain `"`),
-  choose `text_block_fnl!` when the value ends in `\n` and
-  `text_block!` otherwise — the same construction as
-  `escaped_multiline_string`. `Applicability::MaybeIncorrect`
-  (assumes the `text-block-macros` dependency and may need an added
-  `use`).
-- single-line collapse: replace the literal's source with a
-  one-line `"…\n"`. `Applicability::MachineApplicable`.
-- `include_str!` extraction is offered as a **help note only**, not
-  a structured suggestion — it requires creating a new file, which
-  a rustc suggestion cannot do.
+- `text_block_macros`: split the decoded value on `\n`, emit one
+  quoted line each (raw-quoting lines that contain `"`), choosing
+  `text_block_fnl!` when the value ends in `\n` and `text_block!`
+  otherwise. `Applicability::MaybeIncorrect` (assumes the
+  `text-block-macros` dependency, may need an added `use`).
+- `concat!`: emit one quoted line literal per line, each ending in
+  `\n` where the value has one. Std-only and value-preserving;
+  `Applicability::MachineApplicable`.
+- single-line collapse: replace the source with a one-line `"…\n"`,
+  preserving the trailing `\n`(s). `Applicability::MachineApplicable`.
+- `include_str!` extraction is a **help note only** — it needs a new
+  file, which a rustc suggestion cannot create.
+
+With several suggestions on one diagnostic, `cargo fix` does not
+auto-apply (the choice is the author's); each appears under its own
+`help:`.
 
 - See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
   for cross-cutting conventions that apply to every rule in this

--- a/planned-rules/dedented-multiline-string.md
+++ b/planned-rules/dedented-multiline-string.md
@@ -23,11 +23,10 @@ build:
 ```
 
 The leading `"\` swallows the first break so the body starts on a
-clean line, and every line after it is a literal newline in the
-value. The body *has* to sit at column zero (any leading
-whitespace would land inside the value), so the literal visually
-"falls out" of the function. The same shape appears with raw
-strings:
+clean line, and every later line is a literal newline in the value.
+Its leading whitespace lands in the value too, so to keep the value
+clean the author pushes the body flush-left and the literal visually
+"falls out" of the function. Raw strings take the same shape:
 
 ```rust
 pub fn create_tsconfig() {
@@ -92,35 +91,29 @@ dedented literal compiles and produces exactly the intended
 bytes. The objection is to the *source*:
 
 - A reader scanning the indentation to follow control flow loses
-  the thread the moment the body drops to column zero; the literal
-  reads as if the function ended. Nesting (a `match` arm, a closure
-  inside a method chain) makes the discontinuity worse.
-- The dedented body cannot be moved, re-indented by an editor's
-  reformat, or wrapped in another block without either corrupting
-  the value or being left behind by the surrounding `cargo fmt` —
-  rustfmt does not touch the interior of a string literal.
+  the thread the moment the body drops to column zero — the literal
+  reads as if the function ended.
+- The dedented body cannot be re-indented by `cargo fmt` or an
+  editor reformat without corrupting the value: rustfmt does not
+  touch a string literal's interior.
 - For genuine file fixtures, keeping the content inline forgoes
   syntax highlighting, format-specific tooling, and a diff that
-  reads as a change to *that file* rather than to a Rust string.
+  reads as a change to *that file*.
 
-There is also a quiet footgun worth naming, though it is the
-secondary motivation: raw line breaks bake every leading space on
-each body line **into the value**. When the value's leading
-whitespace is significant (a Makefile/justfile recipe body, YAML),
-re-indenting the source to "fix" the dedented body silently
-changes the string. The cleaner forms make the value's whitespace
-explicit and independent of source layout.
+Secondary: each body line's leading whitespace is part of the
+value, so re-indenting the source to "fix" the layout silently
+changes any whitespace-significant string (a justfile recipe body,
+YAML).
 
 ## What to lint
 
 For every string literal (`ExprKind::Lit` of `LitKind::Str` or
 `LitKind::StrRaw`) whose **source spelling contains at least one
 raw line break** — a `\n` byte inside the literal token that is
-*not* a `\<newline>` line-continuation escape (which rustc elides)
-and is therefore reflected as content/newline in the decoded
-value — and where at least one of the body lines following such a
-break begins at a source column **strictly less than** the
-enclosing statement's indentation column:
+*not* a `\<newline>` line-continuation escape (which rustc elides),
+so it is reflected as a newline in the decoded value — and where at
+least one body line after such a break begins at a column
+**shallower than the line on which the literal opens**:
 
 1. Skip the literal if it is in a context the sibling string-literal
    rules also exempt (the lists mirror
@@ -143,28 +136,20 @@ enclosing statement's indentation column:
      newline — at most a single trailing `\n`) → suggest collapsing
      to one source line (`"24.0.0\n"`). This is the case the rule
      exists to catch even though it "obviously" should be one line.
-   - **Otherwise** → suggest the configured inline `style`
-     (`text_block_macros` by default), and — when
-     `suggest_include_str` is on — additionally surface
-     "extract to a sibling file and `include_str!` it" as a help
-     note, since a dedented block is usually a foreign-format
-     fixture.
+   - **Otherwise** → suggest the inline `text_block_fnl!` /
+     `text_block!` form and, when `suggest_include_str` is on, also
+     surface "extract to a sibling file and `include_str!` it" as a
+     help note (a dedented block is usually a foreign-format fixture).
 
-The rule does **not** inspect what the content *is*. A dedented
-block whose content happens to be JSON still fires here on its
-layout, and `perfectionist::manual_json_string` independently fires
-on the same literal to suggest the `json!` construction — the two do
-different things and neither suppresses the other (see
-[Interaction](#interaction-with-sibling-rules)).
-
-The trigger is the **raw line break plus a dedented body**, not the
-decoded newline count. A literal whose newlines are all `\n`
-escapes on one source line does not span source lines and so does
-not match this rule's trigger (it is the domain of
-`perfectionist::escaped_multiline_string`). A raw/`\<newline>`
-literal whose body is indented to *match or exceed* the enclosing
-code (so nothing is dedented) does not fire — see the gen-docs
-boundary case below.
+The rule inspects only layout, never content: a dedented JSON block
+fires here on its layout and, independently, on
+`perfectionist::manual_json_string` for its construction (see
+[Interaction](#interaction-with-sibling-rules)). A literal whose
+newlines are all `\n` escapes on one source line has no raw line
+break and is the domain of `perfectionist::escaped_multiline_string`;
+a raw/`\<newline>` literal whose body is indented to match the
+surrounding code is not dedented and does not fire — see the
+gen-docs boundary case below.
 
 ## Examples
 
@@ -223,23 +208,10 @@ let tsconfig = r#"
 "#;
 ```
 
-This rule fires on the dedented layout and suggests its own
-remedies — `include_str!("fixtures/create/tsconfig.json")` or a
-`text_block_fnl!` block. Separately,
-`perfectionist::manual_json_string` fires on the same literal and
-suggests the `serde_json::json!` construction, which is the better
-end state for JSON specifically:
-
-```rust
-let tsconfig = serde_json::json!({
-    "compilerOptions": { "strict": true },
-    "include": ["**/*.ts"],
-})
-.to_string();
-```
-
-Both diagnostics are expected; they address different defects (one
-the source layout, one the hand-rolled JSON construction).
+This fires on the dedented layout; the remedies are
+`include_str!("fixtures/create/tsconfig.json")` or a `text_block_fnl!`
+block. (`perfectionist::manual_json_string` fires separately on the
+same literal to suggest `serde_json::json!` — see Interaction.)
 
 ### Accidentally multi-line single line
 
@@ -347,16 +319,6 @@ let s = include_str!("fixtures/create/justfile");
 
 ```toml
 [perfectionist::dedented_multiline_string]
-# Which inline rewrite the autofix offers as its primary
-# suggestion. Defaults to `text_block_macros`.
-#   "text_block_macros"  -> text_block_fnl! / text_block! (one
-#                           quoted line per source line, re-indented
-#                           with the code)
-#   "line_continuation"  -> a single literal whose raw breaks become
-#                           `\n\<newline><indent>` continuations,
-#                           preserving the value while re-indenting
-style = "text_block_macros"
-
 # Whether to additionally surface "extract to a sibling file and
 # pull it in with `include_str!`" as a help note. Defaults to
 # `true`: a dedented block is most often a foreign-format
@@ -407,22 +369,15 @@ text_block_fnl_import_path = "text_block_macros::text_block_fnl"
   over the snippet per the parser-combinator convention in
   [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md);
   do not reach for a regex.
-- **Indentation measurement.** Use the source map's
-  `lookup_char_pos` on the literal's span to get the enclosing
-  statement's indentation column (the column of the first
-  non-whitespace byte on the literal's opening line). For each body
-  line after a raw break, compute its leading-whitespace column.
-  Fire only when at least one body line's column is strictly less
-  than the statement indentation. At crate-root indentation (column
-  zero) nothing is shallower, so a top-level `const` with a
-  flush-left body does not fire — the least-offensive case, left
-  out deliberately.
+- **Indentation measurement.** With `lookup_char_pos`, find the
+  column where the literal's line opens (its first non-whitespace
+  byte) and each body line's leading-whitespace column. Fire when at
+  least one body line is shallower. At column-zero indentation
+  nothing is shallower, so a top-level flush-left `const` does not
+  fire — the least-offensive case, left out deliberately.
 - **Shape classification.** Count interior newlines in the decoded
-  value to pick the single-line-collapse vs. block-reshape branch.
-  No content parsing — the rule never inspects whether the body is
-  JSON, TOML, or anything else, which keeps it independent of
-  `perfectionist::manual_json_string` and avoids pulling
-  `serde_json` into this pass.
+  value to choose the single-line-collapse vs. block-reshape branch.
+  No content parsing (so no `serde_json` in this pass).
 - **Skip contexts.** Reuse the sibling rule's machinery: a
   `Span::from_expansion()` check against `format_macros` /
   `text_block_macros_paths` for the macro cases, and a
@@ -456,9 +411,6 @@ concentrates in the autofix:
   `escaped_multiline_string`. `Applicability::MaybeIncorrect`
   (assumes the `text-block-macros` dependency and may need an added
   `use`).
-- `line_continuation` autofix: rewrite each raw break to
-  `\n\<newline><indent>` matching the statement column. Pure
-  syntactic rewrite, `Applicability::MachineApplicable`.
 - single-line collapse: replace the literal's source with a
   one-line `"…\n"`. `Applicability::MachineApplicable`.
 - `include_str!` extraction is offered as a **help note only**, not
@@ -472,37 +424,21 @@ concentrates in the autofix:
 
 ## Default state
 
-Active by default. The dedented shape is a broad, project-
-agnostic readability regression; the default `style =
-"text_block_macros"` matches the catalogue's preferred form, and
-projects that don't want the external-crate dependency switch to
-`line_continuation`. Suppress per-site with
-`#[allow(perfectionist::dedented_multiline_string)]` or globally
-via `[perfectionist].disable`.
+Active by default. The dedented shape is a broad, project-agnostic
+readability regression. Suppress per-site with
+`#[allow(perfectionist::dedented_multiline_string)]` or globally via
+`[perfectionist].disable`.
 
 ## Interaction with sibling rules
 
-These rules each do their own thing on their own trigger; none
-suppresses, defers to, or coordinates with another. Cross-rule
-avoidance would only complicate every implementation, so a literal
-that happens to trip two of them simply gets two diagnostics — they
-point at different defects, so both are appropriate.
+Each rule fires on its own trigger; none defers to or suppresses
+another.
 
-- [`escaped-multiline-string`](./escaped-multiline-string.md) — the
-  two rules target different **source spellings** of a multi-line
-  string, so in practice they rarely fire on the same literal:
-  - `escaped_multiline_string` targets newlines crammed onto one
-    (or few) source lines as `\n` escapes — *too compressed*.
-  - `dedented_multiline_string` targets newlines spelled as raw
-    source breaks that drop the body out of the code's
-    indentation — *too sprawling*.
-
-  This rule's trigger is the raw-line-break-with-dedented-body
-  shape; a purely `\n`-escaped literal does not match it at all.
-- [`manual-json-string`](./manual-json-string.md) — a dedented
-  literal whose content is JSON triggers **both** rules, and that is
-  intended. They address different defects: `manual_json_string`
-  rewrites the *construction* (hand-rolled string → `serde_json::json!`),
-  while this rule flags the *source layout* (the dedented body).
-  This rule does no content parsing, so it neither knows nor cares
-  that the body is JSON.
+- [`escaped-multiline-string`](./escaped-multiline-string.md) —
+  targets the opposite spelling: newlines crammed onto one source
+  line as `\n` escapes. A purely `\n`-escaped literal has no raw
+  line break, so it never matches this rule; the two rarely meet.
+- [`manual-json-string`](./manual-json-string.md) — a dedented JSON
+  literal triggers **both**, by design: that rule rewrites the JSON
+  *construction* (string → `json!`), this one flags the *source
+  layout*. This rule does no content parsing.

--- a/planned-rules/deindented-multiline-string.md
+++ b/planned-rules/deindented-multiline-string.md
@@ -137,13 +137,8 @@ enclosing statement's indentation column:
    - Inside any attribute meta-item (`#[doc = "…"]`,
      `#[display("…")]`, `#[error("…")]`, …) — the literal is
      consumed by the attribute and reshaping it is not equivalent.
-2. Classify the content to choose the suggested remedy:
-   - **Structurally interesting JSON** (parses via
-     `serde_json::from_str` to an object/array carrying a non-empty
-     object, the same predicate as
-     `perfectionist::manual_json_string`) → defer to that rule (see
-     [Interaction](#interaction-with-sibling-rules)); emit nothing
-     here.
+2. Pick the suggested remedy from the literal's **shape** — no
+   content parsing, which keeps the trigger simple:
    - **Single logical line** (the decoded value has no interior
      newline — at most a single trailing `\n`) → suggest collapsing
      to one source line (`"24.0.0\n"`). This is the case the rule
@@ -155,10 +150,18 @@ enclosing statement's indentation column:
      note, since a de-indented block is usually a foreign-format
      fixture.
 
+The rule does **not** inspect what the content *is*. A de-indented
+block whose content happens to be JSON still fires here on its
+layout, and `perfectionist::manual_json_string` independently fires
+on the same literal to suggest the `json!` construction — the two do
+different things and neither suppresses the other (see
+[Interaction](#interaction-with-sibling-rules)).
+
 The trigger is the **raw line break plus de-indentation**, not the
 decoded newline count. A literal whose newlines are all `\n`
-escapes on one source line does not span source lines and is left
-to `perfectionist::escaped_multiline_string`. A raw/`\<newline>`
+escapes on one source line does not span source lines and so does
+not match this rule's trigger (it is the domain of
+`perfectionist::escaped_multiline_string`). A raw/`\<newline>`
 literal whose body is indented to *match or exceed* the enclosing
 code (so nothing is de-indented) does not fire — see the gen-docs
 boundary case below.
@@ -220,9 +223,12 @@ let tsconfig = r#"
 "#;
 ```
 
-**Prefer:** `include_str!("fixtures/create/tsconfig.json")`, or —
-because the content is JSON — `serde_json::json!` via
-`perfectionist::manual_json_string`:
+This rule fires on the de-indented layout and suggests its own
+remedies — `include_str!("fixtures/create/tsconfig.json")` or a
+`text_block_fnl!` block. Separately,
+`perfectionist::manual_json_string` fires on the same literal and
+suggests the `serde_json::json!` construction, which is the better
+end state for JSON specifically:
 
 ```rust
 let tsconfig = serde_json::json!({
@@ -231,6 +237,9 @@ let tsconfig = serde_json::json!({
 })
 .to_string();
 ```
+
+Both diagnostics are expected; they address different defects (one
+the source layout, one the hand-rolled JSON construction).
 
 ### Accidentally multi-line single line
 
@@ -408,13 +417,12 @@ text_block_fnl_import_path = "text_block_macros::text_block_fnl"
   zero) nothing is shallower, so a top-level `const` with a
   flush-left body does not fire — the least-offensive case, left
   out deliberately.
-- **Content classification.** Run `serde_json::from_str` on the
-  decoded value; if it parses to a structurally interesting
-  document (object/array with a non-empty object somewhere — reuse
-  the `perfectionist::manual_json_string` predicate), defer to that
-  rule and emit nothing. Otherwise count interior newlines in the
-  decoded value to pick the single-line-collapse vs. block-reshape
-  branch.
+- **Shape classification.** Count interior newlines in the decoded
+  value to pick the single-line-collapse vs. block-reshape branch.
+  No content parsing — the rule never inspects whether the body is
+  JSON, TOML, or anything else, which keeps it independent of
+  `perfectionist::manual_json_string` and avoids pulling
+  `serde_json` into this pass.
 - **Skip contexts.** Reuse the sibling rule's machinery: a
   `Span::from_expansion()` check against `format_macros` /
   `text_block_macros_paths` for the macro cases, and a
@@ -439,7 +447,7 @@ text_block_fnl_import_path = "text_block_macros::text_block_fnl"
 straightforward snippet scan against the decoded value and a
 column comparison through the source map. The context-skip logic is
 shared with `perfectionist::escaped_multiline_string`. The work
-concentrates in the autofix and the content classification:
+concentrates in the autofix:
 
 - `text_block_macros` autofix: split the decoded value on `\n`,
   emit one quoted line each (raw-quoting lines that contain `"`),
@@ -474,28 +482,27 @@ via `[perfectionist].disable`.
 
 ## Interaction with sibling rules
 
+These rules each do their own thing on their own trigger; none
+suppresses, defers to, or coordinates with another. Cross-rule
+avoidance would only complicate every implementation, so a literal
+that happens to trip two of them simply gets two diagnostics — they
+point at different defects, so both are appropriate.
+
 - [`escaped-multiline-string`](./escaped-multiline-string.md) — the
-  two rules split the multi-line-string-literal space by **source
-  spelling**, not by decoded value:
+  two rules target different **source spellings** of a multi-line
+  string, so in practice they rarely fire on the same literal:
   - `escaped_multiline_string` targets newlines crammed onto one
     (or few) source lines as `\n` escapes — *too compressed*.
   - `deindented_multiline_string` targets newlines spelled as raw
     source breaks that drop the body out of the code's
     indentation — *too sprawling*.
 
-  A literal can in principle satisfy both decoded-value triggers,
-  so they must not double-fire. `deindented_multiline_string` owns
-  the raw-line-break-with-de-indentation case and takes precedence
-  there (its remedy menu — `include_str!` extraction, single-line
-  collapse, `json!` deferral — is richer than a pure shape
-  rewrite); `escaped_multiline_string` defers on any literal whose
-  source contains a de-indenting raw line break. See the reciprocal
-  note in that rule's file.
-- [`manual-json-string`](./manual-json-string.md) — when the
-  de-indented literal's content parses as a structurally
-  interesting JSON document, this rule emits nothing and lets
-  `manual_json_string` suggest the `serde_json::json!` form, which
-  eliminates the string literal entirely and makes the
-  de-indentation moot.
-</content>
-</invoke>
+  This rule's trigger is the raw-line-break-with-de-indentation
+  shape; a purely `\n`-escaped literal does not match it at all.
+- [`manual-json-string`](./manual-json-string.md) — a de-indented
+  literal whose content is JSON triggers **both** rules, and that is
+  intended. They address different defects: `manual_json_string`
+  rewrites the *construction* (hand-rolled string → `serde_json::json!`),
+  while this rule flags the *source layout* (the de-indented body).
+  This rule does no content parsing, so it neither knows nor cares
+  that the body is JSON.

--- a/planned-rules/deindented-multiline-string.md
+++ b/planned-rules/deindented-multiline-string.md
@@ -1,0 +1,501 @@
+# `deindented_multiline_string`
+
+**Source:** project convention.
+
+## Statement
+
+A string literal whose source spelling is broken across physical
+lines by a **raw line break** — an un-escaped newline that is part
+of the literal token — pushes its body out of the surrounding
+indentation, flush against the left margin:
+
+```rust
+pub fn create_justfile() {
+    let justfile = "\
+clean:
+    rm -rf ./dist
+
+build:
+    tsc
+";
+    write_file("/tmp/fixtures/justfile", justfile).unwrap();
+}
+```
+
+The leading `"\` swallows the first break so the body starts on a
+clean line, and every line after it is a literal newline in the
+value. The body *has* to sit at column zero (any leading
+whitespace would land inside the value), so the literal visually
+"falls out" of the function. The same shape appears with raw
+strings:
+
+```rust
+pub fn create_tsconfig() {
+    let tsconfig = r#"
+{
+    "compilerOptions": {
+        "rootDir": ".",
+        "outDir": "dist"
+    }
+}
+"#;
+    write_file("/tmp/fixtures/tsconfig.json", tsconfig).unwrap();
+}
+```
+
+Several cleaner shapes exist, and which one is best depends on
+what the literal *is*:
+
+- **A real file in a foreign format** (a justfile, a `tsconfig.json`,
+  an `index.ts`) belongs in a sibling fixture file, pulled in with
+  `include_str!`:
+
+  ```rust
+  let justfile = include_str!("fixtures/create/justfile");
+  ```
+
+- **An inline block that must stay in the `.rs`** reads cleanly as
+  one quoted line per source line through the
+  [`text-block-macros`](https://crates.io/crates/text-block-macros)
+  crate, which re-indents with the code:
+
+  ```rust
+  use text_block_macros::text_block_fnl;
+
+  let js = text_block_fnl! {
+      "#! /usr/bin/env node"
+      r#"console.log("Hello, World!");"#
+  };
+  ```
+
+- **A JSON document** is better built with `serde_json::json!`
+  (the domain of `perfectionist::manual_json_string`).
+
+- **A single logical line** that only *looks* multi-line because a
+  trailing newline was spelled with a raw break collapses back to
+  one source line:
+
+  ```rust
+  let nvmrc = "24.0.0\n";
+  ```
+
+This rule fires on the de-indented shape and points at the
+appropriate replacement. It is the source-layout complement of
+`perfectionist::escaped_multiline_string`, which targets the
+opposite spelling — newlines crammed onto one source line as `\n`
+escapes (see [Interaction with sibling rules](#interaction-with-sibling-rules)).
+
+## Why restrict this?
+
+This is a stylistic preference, not a correctness issue. The
+de-indented literal compiles and produces exactly the intended
+bytes. The objection is to the *source*:
+
+- A reader scanning the indentation to follow control flow loses
+  the thread the moment the body drops to column zero; the literal
+  reads as if the function ended. Nesting (a `match` arm, a closure
+  inside a method chain) makes the discontinuity worse.
+- The de-indented body cannot be moved, re-indented by an editor's
+  reformat, or wrapped in another block without either corrupting
+  the value or being left behind by the surrounding `cargo fmt` —
+  rustfmt does not touch the interior of a string literal.
+- For genuine file fixtures, keeping the content inline forgoes
+  syntax highlighting, format-specific tooling, and a diff that
+  reads as a change to *that file* rather than to a Rust string.
+
+There is also a quiet footgun worth naming, though it is the
+secondary motivation: raw line breaks bake every leading space on
+each body line **into the value**. When the value's leading
+whitespace is significant (a Makefile/justfile recipe body, YAML),
+re-indenting the source to "fix" the de-indentation silently
+changes the string. The cleaner forms make the value's whitespace
+explicit and independent of source layout.
+
+## What to lint
+
+For every string literal (`ExprKind::Lit` of `LitKind::Str` or
+`LitKind::StrRaw`) whose **source spelling contains at least one
+raw line break** — a `\n` byte inside the literal token that is
+*not* a `\<newline>` line-continuation escape (which rustc elides)
+and is therefore reflected as content/newline in the decoded
+value — and where at least one of the body lines following such a
+break begins at a source column **strictly less than** the
+enclosing statement's indentation column:
+
+1. Skip the literal if it is in a context the sibling string-literal
+   rules also exempt (the lists mirror
+   `perfectionist::escaped_multiline_string`):
+   - The first positional argument of a recognised format-family
+     macro (`format!`, `println!`, `panic!`, the `assert*` /
+     `debug_assert*` family, the `log::*!` family, …): the literal
+     is a template the macro interprets. Configurable via
+     `format_macros`.
+   - Already inside a `text_block!` / `text_block_fnl!` invocation
+     (configurable via `text_block_macros_paths`) or an
+     `include_str!` / `include_bytes!` argument — avoids firing on
+     already-fixed code and on path arguments.
+   - Inside any attribute meta-item (`#[doc = "…"]`,
+     `#[display("…")]`, `#[error("…")]`, …) — the literal is
+     consumed by the attribute and reshaping it is not equivalent.
+2. Classify the content to choose the suggested remedy:
+   - **Structurally interesting JSON** (parses via
+     `serde_json::from_str` to an object/array carrying a non-empty
+     object, the same predicate as
+     `perfectionist::manual_json_string`) → defer to that rule (see
+     [Interaction](#interaction-with-sibling-rules)); emit nothing
+     here.
+   - **Single logical line** (the decoded value has no interior
+     newline — at most a single trailing `\n`) → suggest collapsing
+     to one source line (`"24.0.0\n"`). This is the case the rule
+     exists to catch even though it "obviously" should be one line.
+   - **Otherwise** → suggest the configured inline `style`
+     (`text_block_macros` by default), and — when
+     `suggest_include_str` is on — additionally surface
+     "extract to a sibling file and `include_str!` it" as a help
+     note, since a de-indented block is usually a foreign-format
+     fixture.
+
+The trigger is the **raw line break plus de-indentation**, not the
+decoded newline count. A literal whose newlines are all `\n`
+escapes on one source line does not span source lines and is left
+to `perfectionist::escaped_multiline_string`. A raw/`\<newline>`
+literal whose body is indented to *match or exceed* the enclosing
+code (so nothing is de-indented) does not fire — see the gen-docs
+boundary case below.
+
+## Examples
+
+### De-indented block, foreign format
+
+**Avoid:**
+
+```rust
+pub fn create_justfile() {
+    let justfile = "\
+clean:
+    rm -rf ./dist
+
+build:
+    tsc
+";
+    write_file("/tmp/fixtures/justfile", justfile).unwrap();
+}
+```
+
+**Prefer:** move the content to `fixtures/create/justfile` and
+include it —
+
+```rust
+pub fn create_justfile() {
+    let justfile = include_str!("fixtures/create/justfile");
+    write_file("/tmp/fixtures/justfile", justfile).unwrap();
+}
+```
+
+or, to keep it inline, one quoted line per source line —
+
+```rust
+pub fn create_justfile() {
+    let justfile = text_block_fnl! {
+        "clean:"
+        "    rm -rf ./dist"
+        ""
+        "build:"
+        "    tsc"
+    };
+    write_file("/tmp/fixtures/justfile", justfile).unwrap();
+}
+```
+
+### De-indented raw string holding JSON
+
+**Avoid:**
+
+```rust
+let tsconfig = r#"
+{
+    "compilerOptions": { "strict": true },
+    "include": ["**/*.ts"]
+}
+"#;
+```
+
+**Prefer:** `include_str!("fixtures/create/tsconfig.json")`, or —
+because the content is JSON — `serde_json::json!` via
+`perfectionist::manual_json_string`:
+
+```rust
+let tsconfig = serde_json::json!({
+    "compilerOptions": { "strict": true },
+    "include": ["**/*.ts"],
+})
+.to_string();
+```
+
+### Accidentally multi-line single line
+
+**Avoid:**
+
+```rust
+let nvmrc = "\
+24.0.0
+";
+```
+
+**Prefer:**
+
+```rust
+let nvmrc = "24.0.0\n";
+```
+
+### Real occurrences in this repository
+
+The TIP that prompted this rule was right: the pattern has already
+slipped into `perfectionist`'s own test suite. Both files embed
+configuration and Rust-source fixtures as flush-left literals — the
+`CONFIG` blocks even carry `\"` escapes that a raw `text_block!`
+line or an `include_str!`-ed `.toml` would shed:
+
+- `tests/import_grouping_mismatch_submodules.rs` — nine de-indented
+  blocks: a `const CONFIG: &str = "\` TOML block plus the `lib` /
+  `separate` / `deep` Rust-source fixtures threaded into
+  `run_project_with_sources_and_config`. For example:
+
+  ```rust
+  const CONFIG: &str = "\
+  [perfectionist]
+  enable = [\"import_grouping_mismatch\"]
+
+  [\"perfectionist::import_grouping_mismatch\"]
+  style = \"multi_block\"
+  ";
+  ```
+
+  → either a sibling `fixtures/.../config.toml` behind
+  `include_str!`, or a raw-line `text_block_fnl!` that drops the
+  `\"` noise:
+
+  ```rust
+  const CONFIG: &str = text_block_fnl! {
+      "[perfectionist]"
+      r#"enable = ["import_grouping_mismatch"]"#
+      ""
+      r#"["perfectionist::import_grouping_mismatch"]"#
+      r#"style = "multi_block""#
+  };
+  ```
+
+- `tests/uncombined_self_import_submodules.rs` — the analogous
+  `const CONFIG: &str = "\` TOML block.
+
+### Boundary case — indented raw string is *not* flagged
+
+`tools/gen-docs/src/extract/shared/tests.rs` embeds Rust-source
+fixtures in raw strings whose body is **indented to match the
+surrounding code**:
+
+```rust
+write(
+    base.join("common.rs"),
+    r#"
+        struct One;
+        struct Two;
+    "#,
+)
+```
+
+Nothing here is de-indented, so the rule stays silent. (The body
+indentation is baked into the value, but the consumer re-parses it
+as Rust where leading whitespace is irrelevant — a deliberate,
+acceptable trade-off, not the anti-pattern this rule targets.)
+
+### Skipped contexts
+
+**Not flagged:**
+
+```rust
+// format template — the macro interprets it
+println!("\
+line one {x}
+line two
+", x = 42);
+
+// attribute literal
+#[doc = "\
+first line
+second line
+"]
+fn documented() {}
+
+// already inside text_block!
+let _ = text_block_fnl! { "foo" "bar" };
+
+// path argument, not content
+let s = include_str!("fixtures/create/justfile");
+```
+
+## Configuration
+
+```toml
+[perfectionist::deindented_multiline_string]
+# Which inline rewrite the autofix offers as its primary
+# suggestion. Defaults to `text_block_macros`.
+#   "text_block_macros"  -> text_block_fnl! / text_block! (one
+#                           quoted line per source line, re-indented
+#                           with the code)
+#   "line_continuation"  -> a single literal whose raw breaks become
+#                           `\n\<newline><indent>` continuations,
+#                           preserving the value while re-indenting
+style = "text_block_macros"
+
+# Whether to additionally surface "extract to a sibling file and
+# pull it in with `include_str!`" as a help note. Defaults to
+# `true`: a de-indented block is most often a foreign-format
+# fixture that reads best as its own file. Set to `false` to keep
+# the suggestion purely inline.
+suggest_include_str = true
+
+# Format-family macros whose first positional argument is a
+# template and must not be reshaped. Mirrors
+# `perfectionist::escaped_multiline_string`.
+format_macros = [
+  "format", "println", "eprintln", "format_args",
+  "write", "writeln", "print", "eprint",
+  "panic", "unimplemented", "todo", "unreachable",
+  "assert", "assert_eq", "assert_ne",
+  "debug_assert", "debug_assert_eq", "debug_assert_ne",
+  "error", "warn", "info", "debug", "trace", "log",
+]
+
+# text-block-macros invocations whose arguments are already the
+# rewritten form; skipped to avoid firing on the rule's own output.
+text_block_macros_paths = [
+  "text_block_macros::text_block",
+  "text_block_macros::text_block_fnl",
+]
+
+# Import paths the `text_block_macros` autofix suggests, if no such
+# import is already in scope. Override when the project re-exports
+# the macros from an internal prelude.
+text_block_import_path = "text_block_macros::text_block"
+text_block_fnl_import_path = "text_block_macros::text_block_fnl"
+```
+
+## Implementation notes
+
+- **Pass kind.** `LateLintPass::check_expr` on
+  `ExprKind::Lit`. The decoded value comes from rustc
+  (`lit.symbol_unescaped`); the *source spelling* needed to detect
+  raw line breaks and to measure indentation comes from
+  `cx.sess().source_map().span_to_snippet(lit.span)`.
+- **Raw-line-break detection.** A raw line break is a newline that
+  survives into the value. Compare source spelling against decoded
+  value: walk the snippet's bytes, and treat a source `\n` as a raw
+  break unless it is immediately preceded by an un-escaped `\`
+  (a `\<newline>` continuation, which rustc elides). Raw strings
+  (`r"…"`, `r#"…"#`) have no escapes, so every source `\n` inside
+  them is a raw break. Implement this as a small `take_*` scanner
+  over the snippet per the parser-combinator convention in
+  [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md);
+  do not reach for a regex.
+- **De-indentation measurement.** Use the source map's
+  `lookup_char_pos` on the literal's span to get the enclosing
+  statement's indentation column (the column of the first
+  non-whitespace byte on the literal's opening line). For each body
+  line after a raw break, compute its leading-whitespace column.
+  Fire only when at least one body line's column is strictly less
+  than the statement indentation. At crate-root indentation (column
+  zero) nothing is shallower, so a top-level `const` with a
+  flush-left body does not fire — the least-offensive case, left
+  out deliberately.
+- **Content classification.** Run `serde_json::from_str` on the
+  decoded value; if it parses to a structurally interesting
+  document (object/array with a non-empty object somewhere — reuse
+  the `perfectionist::manual_json_string` predicate), defer to that
+  rule and emit nothing. Otherwise count interior newlines in the
+  decoded value to pick the single-line-collapse vs. block-reshape
+  branch.
+- **Skip contexts.** Reuse the sibling rule's machinery: a
+  `Span::from_expansion()` check against `format_macros` /
+  `text_block_macros_paths` for the macro cases, and a
+  `tcx.hir_parents(...)` walk for the attribute case. `include_str!`
+  / `include_bytes!` arguments are caught by the same
+  expansion-path check.
+- **Proc-macro suppression.** The diagnostic's primary span is the
+  **whole literal**, which is wider than the synthesised-identifier
+  spans the "Suppressing proc-macro-synthesised violations" section
+  of [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  warns about. By the "vulnerable exactly when the diagnostic span
+  is narrower than the offending node" test, this rule is **not**
+  vulnerable: `declare_tool_lint! { … report_in_external_macro: false }`
+  alone suffices and no `hir_in_external_macro` guard or
+  `ui/<rule>_proc_macro.rs` fixture is required. Record this
+  reasoning at the span-selection site so the omission reads as
+  deliberate.
+
+### Difficulty
+
+**Medium.** The raw-line-break-plus-de-indentation detection is a
+straightforward snippet scan against the decoded value and a
+column comparison through the source map. The context-skip logic is
+shared with `perfectionist::escaped_multiline_string`. The work
+concentrates in the autofix and the content classification:
+
+- `text_block_macros` autofix: split the decoded value on `\n`,
+  emit one quoted line each (raw-quoting lines that contain `"`),
+  choose `text_block_fnl!` when the value ends in `\n` and
+  `text_block!` otherwise — the same construction as
+  `escaped_multiline_string`. `Applicability::MaybeIncorrect`
+  (assumes the `text-block-macros` dependency and may need an added
+  `use`).
+- `line_continuation` autofix: rewrite each raw break to
+  `\n\<newline><indent>` matching the statement column. Pure
+  syntactic rewrite, `Applicability::MachineApplicable`.
+- single-line collapse: replace the literal's source with a
+  one-line `"…\n"`. `Applicability::MachineApplicable`.
+- `include_str!` extraction is offered as a **help note only**, not
+  a structured suggestion — it requires creating a new file, which
+  a rustc suggestion cannot do.
+
+- See [`IMPLEMENTATION_CONVENTIONS.md`](./IMPLEMENTATION_CONVENTIONS.md)
+  for cross-cutting conventions that apply to every rule in this
+  catalogue, in particular the lint-name namespacing
+  (`perfectionist::*`) that every registered lint follows.
+
+## Default state
+
+Active by default. The de-indented shape is a broad, project-
+agnostic readability regression; the default `style =
+"text_block_macros"` matches the catalogue's preferred form, and
+projects that don't want the external-crate dependency switch to
+`line_continuation`. Suppress per-site with
+`#[allow(perfectionist::deindented_multiline_string)]` or globally
+via `[perfectionist].disable`.
+
+## Interaction with sibling rules
+
+- [`escaped-multiline-string`](./escaped-multiline-string.md) — the
+  two rules split the multi-line-string-literal space by **source
+  spelling**, not by decoded value:
+  - `escaped_multiline_string` targets newlines crammed onto one
+    (or few) source lines as `\n` escapes — *too compressed*.
+  - `deindented_multiline_string` targets newlines spelled as raw
+    source breaks that drop the body out of the code's
+    indentation — *too sprawling*.
+
+  A literal can in principle satisfy both decoded-value triggers,
+  so they must not double-fire. `deindented_multiline_string` owns
+  the raw-line-break-with-de-indentation case and takes precedence
+  there (its remedy menu — `include_str!` extraction, single-line
+  collapse, `json!` deferral — is richer than a pure shape
+  rewrite); `escaped_multiline_string` defers on any literal whose
+  source contains a de-indenting raw line break. See the reciprocal
+  note in that rule's file.
+- [`manual-json-string`](./manual-json-string.md) — when the
+  de-indented literal's content parses as a structurally
+  interesting JSON document, this rule emits nothing and lets
+  `manual_json_string` suggest the `serde_json::json!` form, which
+  eliminates the string literal entirely and makes the
+  de-indentation moot.
+</content>
+</invoke>

--- a/planned-rules/deindented-multiline-string.md
+++ b/planned-rules/deindented-multiline-string.md
@@ -259,11 +259,11 @@ let nvmrc = "24.0.0\n";
 
 ### Real occurrences in this repository
 
-The TIP that prompted this rule was right: the pattern has already
-slipped into `perfectionist`'s own test suite. Both files embed
-configuration and Rust-source fixtures as flush-left literals — the
-`CONFIG` blocks even carry `\"` escapes that a raw `text_block!`
-line or an `include_str!`-ed `.toml` would shed:
+The pattern has already slipped into `perfectionist`'s own test
+suite. Both files embed configuration and Rust-source fixtures as
+flush-left literals — the `CONFIG` blocks even carry `\"` escapes
+that a raw `text_block!` line or an `include_str!`-ed `.toml` would
+shed:
 
 - `tests/import_grouping_mismatch_submodules.rs` — nine de-indented
   blocks: a `const CONFIG: &str = "\` TOML block plus the `lib` /

--- a/planned-rules/escaped-multiline-string.md
+++ b/planned-rules/escaped-multiline-string.md
@@ -374,14 +374,14 @@ Both rules are independent and neither suppresses the other.
 
 ## Interaction with `perfectionist::deindented_multiline_string`
 
-The two rules partition the multi-line-string-literal space by
-*source spelling*. This rule targets newlines compressed onto one
-(or few) source lines as `\n` escapes; its sibling
+The two rules do different things on different source spellings and
+stay fully independent — neither defers to or suppresses the other.
+This rule targets newlines compressed onto one (or few) source lines
+as `\n` escapes;
 [`deindented-multiline-string`](./deindented-multiline-string.md)
 targets newlines spelled as *raw* source breaks that drop the
-literal's body out of the surrounding indentation. A literal can
-satisfy both decoded-value triggers, so to avoid double-firing
-`escaped_multiline_string` defers on any literal whose source
-contains a de-indenting raw line break — `deindented_multiline_string`
-owns that case and offers the richer remedy menu (`include_str!`
-extraction, single-line collapse, `json!` deferral).
+literal's body out of the surrounding indentation. Because this
+rule's motivating shape is the `\n`-escaped form and the sibling's
+is the raw-break form, they rarely fire on the same literal in
+practice; keeping each trigger self-contained (no cross-rule
+avoidance) keeps both implementations simple.

--- a/planned-rules/escaped-multiline-string.md
+++ b/planned-rules/escaped-multiline-string.md
@@ -371,3 +371,17 @@ text_block! {
 ```
 
 Both rules are independent and neither suppresses the other.
+
+## Interaction with `perfectionist::deindented_multiline_string`
+
+The two rules partition the multi-line-string-literal space by
+*source spelling*. This rule targets newlines compressed onto one
+(or few) source lines as `\n` escapes; its sibling
+[`deindented-multiline-string`](./deindented-multiline-string.md)
+targets newlines spelled as *raw* source breaks that drop the
+literal's body out of the surrounding indentation. A literal can
+satisfy both decoded-value triggers, so to avoid double-firing
+`escaped_multiline_string` defers on any literal whose source
+contains a de-indenting raw line break — `deindented_multiline_string`
+owns that case and offers the richer remedy menu (`include_str!`
+extraction, single-line collapse, `json!` deferral).

--- a/planned-rules/escaped-multiline-string.md
+++ b/planned-rules/escaped-multiline-string.md
@@ -372,13 +372,13 @@ text_block! {
 
 Both rules are independent and neither suppresses the other.
 
-## Interaction with `perfectionist::deindented_multiline_string`
+## Interaction with `perfectionist::dedented_multiline_string`
 
 The two rules do different things on different source spellings and
 stay fully independent — neither defers to or suppresses the other.
 This rule targets newlines compressed onto one (or few) source lines
 as `\n` escapes;
-[`deindented-multiline-string`](./deindented-multiline-string.md)
+[`dedented-multiline-string`](./dedented-multiline-string.md)
 targets newlines spelled as *raw* source breaks that drop the
 literal's body out of the surrounding indentation. Because this
 rule's motivating shape is the `\n`-escaped form and the sibling's

--- a/planned-rules/manual-json-string.md
+++ b/planned-rules/manual-json-string.md
@@ -534,3 +534,9 @@ entirely.
   should defer to this rule, since the `json!` rewrite
   eliminates the `format!` invocation entirely and the wrap
   question becomes moot.
+- [`deindented-multiline-string`](./deindented-multiline-string.md) —
+  same direction: when a de-indented multi-line literal's content
+  parses as a structurally interesting JSON document,
+  `deindented_multiline_string` emits nothing and lets this rule
+  suggest the `json!` form, which removes the literal — and its
+  de-indentation — entirely.

--- a/planned-rules/manual-json-string.md
+++ b/planned-rules/manual-json-string.md
@@ -535,8 +535,9 @@ entirely.
   eliminates the `format!` invocation entirely and the wrap
   question becomes moot.
 - [`deindented-multiline-string`](./deindented-multiline-string.md) —
-  same direction: when a de-indented multi-line literal's content
-  parses as a structurally interesting JSON document,
-  `deindented_multiline_string` emits nothing and lets this rule
-  suggest the `json!` form, which removes the literal — and its
-  de-indentation — entirely.
+  *not* a deferral, unlike the two above: a de-indented multi-line
+  literal whose content is JSON triggers **both** rules, and that is
+  intended. They do different things — this rule rewrites the JSON
+  *construction* (string → `json!`), that one flags the *source
+  layout* (the de-indented body) and does no content parsing — so
+  both diagnostics are appropriate and neither avoids the other.

--- a/planned-rules/manual-json-string.md
+++ b/planned-rules/manual-json-string.md
@@ -534,10 +534,10 @@ entirely.
   should defer to this rule, since the `json!` rewrite
   eliminates the `format!` invocation entirely and the wrap
   question becomes moot.
-- [`deindented-multiline-string`](./deindented-multiline-string.md) —
-  *not* a deferral, unlike the two above: a de-indented multi-line
+- [`dedented-multiline-string`](./dedented-multiline-string.md) —
+  *not* a deferral, unlike the two above: a dedented multi-line
   literal whose content is JSON triggers **both** rules, and that is
   intended. They do different things — this rule rewrites the JSON
   *construction* (string → `json!`), that one flags the *source
-  layout* (the de-indented body) and does no content parsing — so
+  layout* (the dedented body) and does no content parsing — so
   both diagnostics are appropriate and neither avoids the other.


### PR DESCRIPTION
## What

Adds a planning document for a new lint, **`dedented_multiline_string`** (`planned-rules/dedented-multiline-string.md`).

The rule flags string literals broken across source lines by *raw* line breaks, which push the body flush to the left margin and out of the surrounding indentation:

```rust
let justfile = "\
clean:
    rm -rf ./dist
";
```

The diagnostic attaches every applicable alternative fix: for a multi-line value, `include_str!` of a sibling fixture file, a re-indented `text_block_fnl! { ... }` block, and a `concat!`; for a value with a single non-empty line, a one-line `"…\n"`.

## Notes

- It is the source-layout complement of `escaped_multiline_string` (which targets the opposite spelling: `\n` escapes crammed onto one source line). The rules stay **independent** — none defers to or suppresses another. A dedented JSON literal trips both this rule and `manual_json_string`, by design; they flag different defects (source layout vs. hand-rolled JSON construction).
- The pattern already exists in this repo's own test suite; the doc cites the real occurrences (`tests/import_grouping_mismatch_submodules.rs`, `tests/uncombined_self_import_submodules.rs`) and contrasts them with an *indented* raw-string boundary case that does not fire.

## Changed files

- `planned-rules/dedented-multiline-string.md` — new planning doc.
- `planned-rules/README.md` — index entry.
- `planned-rules/escaped-multiline-string.md`, `planned-rules/manual-json-string.md` — reciprocal "independent, no cross-rule avoidance" interaction notes.

Docs only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)