### PR TITLE
feat(config)!: replace `targets` array with boolean fields

### DIFF
--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -633,54 +633,32 @@ correctly-spelled one (`"crate::internals"`) never does.
 
 ## Config shape: boolean fields, not an array of toggles
 
-A fixed, small set of *independent* on/off switches is modelled as
-one boolean field per switch — never as a multi-select array of
-keywords backed by a `Vec<enum>`. The tell-tale signs that an array
-is the wrong shape: the parsed list is flattened into N booleans
-before the rule uses it; an empty array is overloaded to mean
-"none"; duplicate entries are meaningless; and the variant set is
-fixed and tiny. Separate `bool` fields say exactly that — N
-orthogonal toggles, each defaulting on its own — and they drop the
-empty-vs-absent ambiguity and the dead dedup logic the array form
-drags along. This was settled in
-<https://github.com/KSXGitHub/perfectionist/pull/255> (which
-replaced `wildcard_imports`' `exceptions = ["prelude",
-"root_reexport"]` array with the booleans `prelude_exception` /
-`root_reexport_exception`) and applies catalogue-wide.
+A fixed, small set of *independent* on/off switches is one boolean
+field per switch — never a multi-select array backed by a
+`Vec<enum>`. The tell-tale signs the array is wrong: it gets
+flattened into N booleans before use, an empty array is overloaded
+to mean "none", and duplicates are meaningless. Separate `bool`s say
+exactly that and drop the empty-vs-absent ambiguity. Settled in
+<https://github.com/KSXGitHub/perfectionist/pull/255> (which replaced
+`wildcard_imports`' `exceptions = ["prelude", "root_reexport"]` with
+the booleans `prelude_exception` / `root_reexport_exception`).
 
-This is distinct from three shapes that *are* correctly arrays or
-enums, and must not be "fixed" into booleans:
-
-- A genuine **single mutually-exclusive choice** — a `style` /
-  direction enum such as `import_granularity` (`crate` / `module` /
-  `item`) or `serde_wrapper_form_mismatch` (`transparent` /
-  `from_into`). One field, one value; the variants exclude each
-  other.
-- An **open-ended list of user-supplied strings** —
-  `allowed_paths`, `prelude_segment_names`, `extra_*`, `ignore`,
-  and the clap-help `forbid` / `override_keys` sets. The set is
-  not fixed, so a `Vec<String>` is right.
-- A **meaningful permutation**, where order carries information —
-  `import_grouping`'s `order`. It is not a set of toggles; the
-  sequence is the data.
-
-The dividing line is membership-fixedness and independence, not
-length. A five-member fixed set of independent toggles is still the
-anti-pattern in principle, but five members read acceptably as a
-list, so a borderline case may keep the array as a *deliberate*,
-documented call rather than an accident —
-`path_qualification_mismatch`'s `contexts` array
-(`["call", "type", "derive", "macro", "trait_bound"]`) is the
-catalogue's one such exception.
+Three shapes are *not* this anti-pattern and stay as arrays/enums: a
+single mutually-exclusive **choice** (a `style` / direction enum like
+`import_granularity`); an **open-ended list** of user strings
+(`allowed_paths`, `extra_*`, `ignore`); and a **permutation** where
+order is the data (`import_grouping`'s `order`). The dividing line is
+fixed-membership-and-independence, not length — so a borderline case
+may keep the array as a *deliberate*, documented call:
+`path_qualification_mismatch`'s `contexts` array is the catalogue's
+one such exception.
 
 ### Scan-surface toggles
 
-Text-scanning rules — those that look for a pattern in comments and
-string literals — share one concrete instance of the convention:
-the *where do I scan?* surfaces are three independent booleans, not
-a `targets` array. Reach for the same three field names and
-`true` defaults every time, so the config reads identically across
-rules:
+The recurring concrete instance: a text-scanning rule's *where do I
+scan?* surfaces are three independent booleans, not a `targets`
+array. Reuse the same field names and `true` defaults so the config
+reads identically across rules:
 
 ```rust
 /// Scan doc comments (`///`, `//!`, `/** */`, `/*! */`).
@@ -692,11 +670,9 @@ scan_regular_comments: bool,
 scan_string_literals: bool,
 ```
 
-`perfectionist::bare_email` (`src/rules/bare_email.rs`, doc +
-regular comments) and `perfectionist::unpinned_repo_ref`
-(`src/rules/unpinned_repo_ref/config.rs`, all three) already follow
-this; a rule that scans only a subset omits the surfaces it can't
-reach rather than renaming the ones it keeps.
+`perfectionist::bare_email` and `perfectionist::unpinned_repo_ref`
+already follow this; a rule scanning only a subset omits the surfaces
+it can't reach rather than renaming the ones it keeps.
 
 ## Suppressing proc-macro-synthesised violations
 

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -631,6 +631,73 @@ correctly-spelled one (`"crate::internals"`) never does.
 - `perfectionist::unpinned_repo_ref`'s `hosts` / `skip_hosts` /
   `hostname` are forge hostnames, not Rust module paths.
 
+## Config shape: boolean fields, not an array of toggles
+
+A fixed, small set of *independent* on/off switches is modelled as
+one boolean field per switch — never as a multi-select array of
+keywords backed by a `Vec<enum>`. The tell-tale signs that an array
+is the wrong shape: the parsed list is flattened into N booleans
+before the rule uses it; an empty array is overloaded to mean
+"none"; duplicate entries are meaningless; and the variant set is
+fixed and tiny. Separate `bool` fields say exactly that — N
+orthogonal toggles, each defaulting on its own — and they drop the
+empty-vs-absent ambiguity and the dead dedup logic the array form
+drags along. This was settled in
+<https://github.com/KSXGitHub/perfectionist/pull/255> (which
+replaced `wildcard_imports`' `exceptions = ["prelude",
+"root_reexport"]` array with the booleans `prelude_exception` /
+`root_reexport_exception`) and applies catalogue-wide.
+
+This is distinct from three shapes that *are* correctly arrays or
+enums, and must not be "fixed" into booleans:
+
+- A genuine **single mutually-exclusive choice** — a `style` /
+  direction enum such as `import_granularity` (`crate` / `module` /
+  `item`) or `serde_wrapper_form_mismatch` (`transparent` /
+  `from_into`). One field, one value; the variants exclude each
+  other.
+- An **open-ended list of user-supplied strings** —
+  `allowed_paths`, `prelude_segment_names`, `extra_*`, `ignore`,
+  and the clap-help `forbid` / `override_keys` sets. The set is
+  not fixed, so a `Vec<String>` is right.
+- A **meaningful permutation**, where order carries information —
+  `import_grouping`'s `order`. It is not a set of toggles; the
+  sequence is the data.
+
+The dividing line is membership-fixedness and independence, not
+length. A five-member fixed set of independent toggles is still the
+anti-pattern in principle, but five members read acceptably as a
+list, so a borderline case may keep the array as a *deliberate*,
+documented call rather than an accident —
+`path_qualification_mismatch`'s `contexts` array
+(`["call", "type", "derive", "macro", "trait_bound"]`) is the
+catalogue's one such exception.
+
+### Scan-surface toggles
+
+Text-scanning rules — those that look for a pattern in comments and
+string literals — share one concrete instance of the convention:
+the *where do I scan?* surfaces are three independent booleans, not
+a `targets` array. Reach for the same three field names and
+`true` defaults every time, so the config reads identically across
+rules:
+
+```rust
+/// Scan doc comments (`///`, `//!`, `/** */`, `/*! */`).
+/// Defaults to `true`.
+scan_doc_comments: bool,
+/// Scan regular comments (`//`, `/* */`). Defaults to `true`.
+scan_regular_comments: bool,
+/// Scan string literals (`"..."`, `r"..."`). Defaults to `true`.
+scan_string_literals: bool,
+```
+
+`perfectionist::bare_email` (`src/rules/bare_email.rs`, doc +
+regular comments) and `perfectionist::unpinned_repo_ref`
+(`src/rules/unpinned_repo_ref/config.rs`, all three) already follow
+this; a rule that scans only a subset omits the surfaces it can't
+reach rather than renaming the ones it keeps.
+
 ## Suppressing proc-macro-synthesised violations
 
 `declare_tool_lint! { ... report_in_external_macro: false }` is the

--- a/planned-rules/commit-id-length-mismatch.md
+++ b/planned-rules/commit-id-length-mismatch.md
@@ -38,8 +38,13 @@ codebase.
 
 ```toml
 [commit_id_length_mismatch]
-# Where the lint scans. Subset of these.
-targets = ["doc", "comment", "string_literal"]
+# Where the lint scans. Three independent on/off switches, mirroring
+# `perfectionist::bare_email` and `perfectionist::unpinned_repo_ref`
+# (see the "Scan-surface toggles" convention in
+# IMPLEMENTATION_CONVENTIONS.md). Each defaults to `true`.
+scan_doc_comments = true       # `///`, `//!`, `/** */`, `/*! */`
+scan_regular_comments = true   # `//`, `/* */`
+scan_string_literals = true    # `"..."`, `r"..."`
 
 # Range for the SHA length, inclusive.
 #

--- a/planned-rules/commit-id-length-mismatch.md
+++ b/planned-rules/commit-id-length-mismatch.md
@@ -38,10 +38,7 @@ codebase.
 
 ```toml
 [commit_id_length_mismatch]
-# Where the lint scans. Three independent on/off switches, mirroring
-# `perfectionist::bare_email` and `perfectionist::unpinned_repo_ref`
-# (see the "Scan-surface toggles" convention in
-# IMPLEMENTATION_CONVENTIONS.md). Each defaults to `true`.
+# Where the lint scans. Each defaults to `true`.
 scan_doc_comments = true       # `///`, `//!`, `/** */`, `/*! */`
 scan_regular_comments = true   # `//`, `/* */`
 scan_string_literals = true    # `"..."`, `r"..."`

--- a/planned-rules/path-qualification-mismatch.md
+++ b/planned-rules/path-qualification-mismatch.md
@@ -68,6 +68,15 @@ style = "unqualified"
 #                  the full path and removal of the `use`.
 
 # Where the lint applies. Each context can be toggled independently.
+#
+# This is a fixed set of independent on/off toggles, the shape the
+# "Config shape: boolean fields, not an array of toggles" convention
+# in IMPLEMENTATION_CONVENTIONS.md otherwise turns into separate
+# `bool` fields. Keeping it an array here is a deliberate exception,
+# not an oversight: at five members the list still reads cleanly,
+# and "the set of contexts" is a natural unit to name. It is the
+# catalogue's one sanctioned array-of-toggles; do not copy the shape
+# into a new rule without the same explicit justification.
 contexts = ["call", "type", "derive", "macro", "trait_bound"]
 
 # Prefixes that the `unqualified` style leaves alone. Defaults to

--- a/planned-rules/path-qualification-mismatch.md
+++ b/planned-rules/path-qualification-mismatch.md
@@ -68,15 +68,9 @@ style = "unqualified"
 #                  the full path and removal of the `use`.
 
 # Where the lint applies. Each context can be toggled independently.
-#
-# This is a fixed set of independent on/off toggles, the shape the
-# "Config shape: boolean fields, not an array of toggles" convention
-# in IMPLEMENTATION_CONVENTIONS.md otherwise turns into separate
-# `bool` fields. Keeping it an array here is a deliberate exception,
-# not an oversight: at five members the list still reads cleanly,
-# and "the set of contexts" is a natural unit to name. It is the
-# catalogue's one sanctioned array-of-toggles; do not copy the shape
-# into a new rule without the same explicit justification.
+# Deliberately an array, not per-context bools: at five members it
+# still reads cleanly, and it's the catalogue's one sanctioned
+# array-of-toggles (see IMPLEMENTATION_CONVENTIONS.md).
 contexts = ["call", "type", "derive", "macro", "trait_bound"]
 
 # Prefixes that the `unqualified` style leaves alone. Defaults to

--- a/rules/unpinned_repo_ref.md
+++ b/rules/unpinned_repo_ref.md
@@ -51,11 +51,18 @@ ref that always denotes the exact content the author linked to.
 
 Configure via `dylint.toml` under `["perfectionist::unpinned_repo_ref"]`. Every field is optional; the per-field prose below states the default.
 
-### `targets`: `[Target]` (optional)
+### `scan_doc_comments`: `boolean` (optional)
 
-Surfaces to scan, any subset of `doc`, `comment`, and
-`string_literal`. Defaults to
-`["doc", "comment", "string_literal"]`.
+Scan doc comments (`///`, `//!`, `/** */`, `/*! */`).
+Defaults to `true`.
+
+### `scan_regular_comments`: `boolean` (optional)
+
+Scan regular comments (`//`, `/* */`). Defaults to `true`.
+
+### `scan_string_literals`: `boolean` (optional)
+
+Scan string literals (`"..."`, `r"..."`). Defaults to `true`.
 
 ### `sha_recognition_length`: `unsigned integer` (optional)
 
@@ -94,23 +101,6 @@ pattern here is ignored even when it also appears in `hosts`.
 Defaults to `[]`.
 
 ### Types
-
-#### `Target` (enum)
-
-Which text surfaces the rule scans. Each value names one of the
-three places a forge URL is written.
-
-##### `"doc"` (Rust: `Doc`)
-
-Doc comments (`///`, `//!`, `/** */`, `/*! */`).
-
-##### `"comment"` (Rust: `Comment`)
-
-Regular comments (`//`, `/* */`).
-
-##### `"string_literal"` (Rust: `StringLiteral`)
-
-String literals (`"..."`, `r"..."`).
 
 #### `HostEntry` (struct)
 

--- a/src/rules/unpinned_repo_ref.rs
+++ b/src/rules/unpinned_repo_ref.rs
@@ -3,7 +3,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::string_literal_quote_lengths;
 use crate::markdown::{SkipRange, scan_code_regions};
-use config::{Config, ForgeKind, Target, glob_match};
+use config::{Config, ForgeKind, glob_match};
 use emit::{Violation, emit_diagnostic};
 use rustc_ast::LitKind;
 use rustc_hir::{Expr, ExprKind};
@@ -67,9 +67,9 @@ use config::CONFIG_KEY;
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 pub struct UnpinnedRepoRef {
-    scan_doc: bool,
-    scan_comment: bool,
-    scan_string_literal: bool,
+    scan_doc_comments: bool,
+    scan_regular_comments: bool,
+    scan_string_literals: bool,
     pub(super) sha_recognition_length: usize,
     pub(super) allow_version_patterns: bool,
     /// Hostname globs paired with the forge kind they map to, in
@@ -92,9 +92,9 @@ impl UnpinnedRepoRef {
             .map(|entry| (entry.hostname, entry.kind))
             .collect();
         Self {
-            scan_doc: config.targets.contains(&Target::Doc),
-            scan_comment: config.targets.contains(&Target::Comment),
-            scan_string_literal: config.targets.contains(&Target::StringLiteral),
+            scan_doc_comments: config.scan_doc_comments,
+            scan_regular_comments: config.scan_regular_comments,
+            scan_string_literals: config.scan_string_literals,
             sha_recognition_length: config.sha_recognition_length,
             allow_version_patterns: config.allow_version_patterns,
             hosts,
@@ -120,13 +120,13 @@ impl UnpinnedRepoRef {
     }
 
     fn scans_any_comment(&self) -> bool {
-        self.scan_doc || self.scan_comment
+        self.scan_doc_comments || self.scan_regular_comments
     }
 
     fn scan_chunk(&self, chunk: &CommentChunk<'_>, out: &mut Vec<(Span, Violation)>) {
         let scan = match chunk.surface {
-            CommentSurface::DocBlock | CommentSurface::DocBlockBlock => self.scan_doc,
-            CommentSurface::PlainLine | CommentSurface::PlainBlock => self.scan_comment,
+            CommentSurface::DocBlock | CommentSurface::DocBlockBlock => self.scan_doc_comments,
+            CommentSurface::PlainLine | CommentSurface::PlainBlock => self.scan_regular_comments,
         };
         if !scan {
             return;
@@ -191,7 +191,7 @@ impl<'tcx> LateLintPass<'tcx> for UnpinnedRepoRef {
     }
 
     fn check_expr(&mut self, lint_context: &LateContext<'tcx>, expr: &Expr<'tcx>) {
-        if !self.scan_string_literal {
+        if !self.scan_string_literals {
             return;
         }
         let ExprKind::Lit(literal) = expr.kind else {

--- a/src/rules/unpinned_repo_ref/config.rs
+++ b/src/rules/unpinned_repo_ref/config.rs
@@ -11,19 +11,6 @@
 
 pub(super) const CONFIG_KEY: &str = "perfectionist::unpinned_repo_ref";
 
-/// Which text surfaces the rule scans. Each value names one of the
-/// three places a forge URL is written.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub(super) enum Target {
-    /// Doc comments (`///`, `//!`, `/** */`, `/*! */`).
-    Doc,
-    /// Regular comments (`//`, `/* */`).
-    Comment,
-    /// String literals (`"..."`, `r"..."`).
-    StringLiteral,
-}
-
 /// The forge a hostname maps to. The variant fixes the URL shape the
 /// per-kind matcher in [`super::parse`] applies; it does not vary per
 /// host, so a self-hosted instance reuses an existing variant.
@@ -61,10 +48,6 @@ pub(super) struct HostEntry {
     pub(super) kind: ForgeKind,
 }
 
-/// Surfaces scanned when `targets` is omitted: every surface.
-pub(super) const DEFAULT_TARGETS: &[Target] =
-    &[Target::Doc, Target::Comment, Target::StringLiteral];
-
 /// Minimum hex length recognised as a SHA when `sha_recognition_length`
 /// is omitted — Git's own minimum abbreviated-SHA length.
 pub(super) const DEFAULT_SHA_RECOGNITION_LENGTH: usize = 4;
@@ -83,10 +66,13 @@ pub(super) const DEFAULT_HOSTS: &[(&str, ForgeKind)] = &[
 #[derive(Debug, serde::Deserialize)]
 #[serde(default, deny_unknown_fields, rename_all = "snake_case")]
 pub(super) struct Config {
-    /// Surfaces to scan, any subset of `doc`, `comment`, and
-    /// `string_literal`. Defaults to
-    /// `["doc", "comment", "string_literal"]`.
-    pub(super) targets: Vec<Target>,
+    /// Scan doc comments (`///`, `//!`, `/** */`, `/*! */`).
+    /// Defaults to `true`.
+    pub(super) scan_doc_comments: bool,
+    /// Scan regular comments (`//`, `/* */`). Defaults to `true`.
+    pub(super) scan_regular_comments: bool,
+    /// Scan string literals (`"..."`, `r"..."`). Defaults to `true`.
+    pub(super) scan_string_literals: bool,
     /// Minimum hex length for a ref to be recognised as a commit SHA.
     /// A pure-hex ref shorter than this is treated as a branch and
     /// rejected. Defaults to `4` (Git's own minimum SHA length),
@@ -120,7 +106,9 @@ pub(super) struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            targets: DEFAULT_TARGETS.to_vec(),
+            scan_doc_comments: true,
+            scan_regular_comments: true,
+            scan_string_literals: true,
             sha_recognition_length: DEFAULT_SHA_RECOGNITION_LENGTH,
             allow_version_patterns: false,
             hosts: DEFAULT_HOSTS

--- a/ui/unpinned_repo_ref.rs
+++ b/ui/unpinned_repo_ref.rs
@@ -1,9 +1,9 @@
 // Default-config sweep for `unpinned_repo_ref`: every surface (doc
 // comment, plain comment, string literal) and every built-in forge
 // kind. Run by `tests/ui.rs` with an empty `dylint.toml`, so the
-// defaults apply (all three targets, the built-in host table,
-// `sha_recognition_length = 4`, `allow_version_patterns = false`, no
-// skipped hosts).
+// defaults apply (all three scan surfaces enabled, the built-in host
+// table, `sha_recognition_length = 4`,
+// `allow_version_patterns = false`, no skipped hosts).
 //
 // URLs are wrapped in `<...>` throughout: that is the realistic case
 // (`perfectionist::bare_url` already requires wrapping, and this rule


### PR DESCRIPTION
Replaces the `Vec<enum>` multi-select config for fixed sets of independent on/off toggles with separate boolean fields.

## Implemented rule

`perfectionist::unpinned_repo_ref` shipped with the anti-pattern: `targets = ["doc", "comment", "string_literal"]` was a `Vec<Target>` flattened into three internal booleans, an empty array meant "scan nothing", and duplicates were meaningless. It now exposes three boolean fields — `scan_doc_comments`, `scan_regular_comments`, `scan_string_literals` (each defaulting to `true`) — mirroring `perfectionist::bare_email`. The `Target` enum and `DEFAULT_TARGETS` are gone, and the generated `rules/unpinned_repo_ref.md` is regenerated.

## Planning specs

- **`commit-id-length-mismatch.md`** — its identical `targets` array is replaced with the same three booleans.
- **`path-qualification-mismatch.md`** — its five-member `contexts` array is kept, now documented as the catalogue's one deliberate array-of-toggles exception (a borderline call, not the anti-pattern).
- **`IMPLEMENTATION_CONVENTIONS.md`** — adds a "Config shape: boolean fields, not an array of toggles" section with a shared "Scan-surface toggles" subsection.

`just all` passes (fmt, build, doc incl. `check-rules-md`, clippy, test, self-lint).

Resolves <https://github.com/KSXGitHub/perfectionist/issues/258>.