### PR TITLE
docs: do not describe pass machinery in user-facing lint docs

### DIFF
--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -892,33 +892,23 @@ out of scope for the catalogue.
 
 ## `declare_tool_lint!` docs describe behaviour, not pass machinery
 
-The rustdoc on a rule's `declare_tool_lint!` block is **user-facing**:
-`tools/gen-docs/` renders it verbatim into the in-tree catalogue
-(`rules/<rule>.md`) and the docs site. It must describe *what* the
-rule flags and *why* — never *how* the pass is implemented. Terms
-like "late pass", "early pass", "pre-expansion", "lowering", "name
-resolution", "HIR node", "the scan", or the queue/anchor mechanism
-are implementation details that mean nothing to a reader of the
-catalogue, so they do not belong in that block.
+`tools/gen-docs/` renders a rule's `declare_tool_lint!` rustdoc
+verbatim into the in-tree catalogue (`rules/<rule>.md`) and the docs
+site, so that block must describe *what* the rule flags and *why* —
+never *how* the pass is implemented. "Late pass", "pre-expansion",
+"lowering", "name resolution", "HIR node", the queue/anchor mechanism,
+and the like mean nothing to a catalogue reader. A user-observable
+limitation that *stems* from the implementation is stated
+behaviourally instead: `perfectionist::thiserror_usage` resolves the
+bare `#[derive(Error)]` short-hand crate-wide rather than per-module,
+and says exactly that rather than "the pass runs pre-expansion and
+does not consult name resolution".
 
-When a real, user-observable limitation happens to *stem* from the
-implementation, document the limitation in behavioural terms and drop
-the mechanism. For example, `perfectionist::thiserror_usage` resolves
-the bare `#[derive(Error)]` short-hand crate-wide rather than
-per-module — a genuine false-positive surface worth stating — but the
-doc states that behaviour directly instead of explaining it via "the
-pass runs pre-expansion and does not consult name resolution".
-
-This convention is scoped to the `declare_tool_lint!` block only. Docs
-on *internal* items — `Pending`/queue structs, `register_pass` /
-`register_lint`, `emit` helpers, process-wide statics, source-walking
-combinators — legitimately describe implementation and are never
-rendered to users; keep the pass machinery there and in ordinary code
-comments.
-
-A borderline case is a doc that names a *rustc* mechanism the user can
-observe directly — `unfulfilled_lint_expectations` notes in their build
-output, rustc's own `unknown_lints` lint, the category a lint name
-falls into. Those describe behaviour the consumer sees, not this
-plugin's pass internals, so they may stay.
+The convention is scoped to the `declare_tool_lint!` block. Docs on
+*internal* items (queue structs, `register_pass`/`register_lint`,
+`emit` helpers, source walkers) describe implementation freely — they
+never reach users. And a doc may name a *rustc* mechanism the user
+observes directly (`unfulfilled_lint_expectations` notes,
+`unknown_lints`): that is behaviour the consumer sees, not this
+plugin's pass internals.
 

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -897,12 +897,11 @@ verbatim into the in-tree catalogue (`rules/<rule>.md`) and the docs
 site, so that block must describe *what* the rule flags and *why* —
 never *how* the pass is implemented. "Late pass", "pre-expansion",
 "lowering", "name resolution", "HIR node", the queue/anchor mechanism,
-and the like mean nothing to a catalogue reader. A user-observable
-limitation that *stems* from the implementation is stated
-behaviourally instead: `perfectionist::thiserror_usage` resolves the
-bare `#[derive(Error)]` short-hand crate-wide rather than per-module,
-and says exactly that rather than "the pass runs pre-expansion and
-does not consult name resolution".
+and the like mean nothing to a catalogue reader. When a
+user-observable limitation *stems* from the implementation, state the
+limitation behaviourally (e.g. "resolved crate-wide rather than
+per-module") and drop the mechanism that causes it ("the pass runs
+pre-expansion and does not consult name resolution").
 
 The convention is scoped to the `declare_tool_lint!` block. Docs on
 *internal* items (queue structs, `register_pass`/`register_lint`,

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -890,3 +890,35 @@ clippy and rustdoc lints. The planning file does not document
 which projects should escalate; that is project-side policy and
 out of scope for the catalogue.
 
+## `declare_tool_lint!` docs describe behaviour, not pass machinery
+
+The rustdoc on a rule's `declare_tool_lint!` block is **user-facing**:
+`tools/gen-docs/` renders it verbatim into the in-tree catalogue
+(`rules/<rule>.md`) and the docs site. It must describe *what* the
+rule flags and *why* — never *how* the pass is implemented. Terms
+like "late pass", "early pass", "pre-expansion", "lowering", "name
+resolution", "HIR node", "the scan", or the queue/anchor mechanism
+are implementation details that mean nothing to a reader of the
+catalogue, so they do not belong in that block.
+
+When a real, user-observable limitation happens to *stem* from the
+implementation, document the limitation in behavioural terms and drop
+the mechanism. For example, `perfectionist::thiserror_usage` resolves
+the bare `#[derive(Error)]` short-hand crate-wide rather than
+per-module — a genuine false-positive surface worth stating — but the
+doc states that behaviour directly instead of explaining it via "the
+pass runs pre-expansion and does not consult name resolution".
+
+This convention is scoped to the `declare_tool_lint!` block only. Docs
+on *internal* items — `Pending`/queue structs, `register_pass` /
+`register_lint`, `emit` helpers, process-wide statics, source-walking
+combinators — legitimately describe implementation and are never
+rendered to users; keep the pass machinery there and in ordinary code
+comments.
+
+A borderline case is a doc that names a *rustc* mechanism the user can
+observe directly — `unfulfilled_lint_expectations` notes in their build
+output, rustc's own `unknown_lints` lint, the category a lint name
+falls into. Those describe behaviour the consumer sees, not this
+plugin's pass internals, so they may stay.
+

--- a/rules/import_grouping_mismatch.md
+++ b/rules/import_grouping_mismatch.md
@@ -23,9 +23,9 @@ inactive by default; a project opts in and sets `style` to one of:
   internal (`crate` / `super` / `self`), then third-party (every
   other crate). A bare-path import of a first-party submodule
   (`mod error; use error::Foo;`) is classified as internal, not
-  third-party: the rule reads source without name resolution, so it
-  recognises a bare first segment that names a `mod` declared in
-  the same module scope. The `order` and `cfg_block_handling`
+  third-party: a bare first segment that names a `mod` declared in
+  the same module scope is recognised as first-party. The `order`
+  and `cfg_block_handling`
   knobs tune the partition; the inner ordering within each group
   is left to `cargo fmt`.
 

--- a/rules/thiserror_usage.md
+++ b/rules/thiserror_usage.md
@@ -42,11 +42,10 @@ format-string positional translation (`thiserror`'s `{0}` ↔
 `#[backtrace]`) whose mechanical rewrite is too risky to apply
 without review.
 
-Because the pass runs pre-expansion and does not consult
-name resolution, alias collection is crate-wide rather than
-per-module: a `use thiserror::Error;` anywhere in the crate
-makes the bare `#[derive(Error)]` short-hand resolve as
-thiserror everywhere. In practice that overlap is rare and
+Alias collection is crate-wide rather than per-module: a
+`use thiserror::Error;` anywhere in the crate makes the bare
+`#[derive(Error)]` short-hand resolve as thiserror everywhere.
+In practice that overlap is rare and
 the rule treats it as acceptable false-positive surface; a
 project that hits it can suppress individual sites with
 `#[allow(perfectionist::thiserror_usage)]`.

--- a/src/rules/import_grouping_mismatch.rs
+++ b/src/rules/import_grouping_mismatch.rs
@@ -34,9 +34,9 @@ declare_tool_lint! {
     ///   internal (`crate` / `super` / `self`), then third-party (every
     ///   other crate). A bare-path import of a first-party submodule
     ///   (`mod error; use error::Foo;`) is classified as internal, not
-    ///   third-party: the rule reads source without name resolution, so it
-    ///   recognises a bare first segment that names a `mod` declared in
-    ///   the same module scope. The `order` and `cfg_block_handling`
+    ///   third-party: a bare first segment that names a `mod` declared in
+    ///   the same module scope is recognised as first-party. The `order`
+    ///   and `cfg_block_handling`
     ///   knobs tune the partition; the inner ordering within each group
     ///   is left to `cargo fmt`.
     ///

--- a/src/rules/thiserror_usage.rs
+++ b/src/rules/thiserror_usage.rs
@@ -46,11 +46,10 @@ declare_tool_lint! {
     /// `#[backtrace]`) whose mechanical rewrite is too risky to apply
     /// without review.
     ///
-    /// Because the pass runs pre-expansion and does not consult
-    /// name resolution, alias collection is crate-wide rather than
-    /// per-module: a `use thiserror::Error;` anywhere in the crate
-    /// makes the bare `#[derive(Error)]` short-hand resolve as
-    /// thiserror everywhere. In practice that overlap is rare and
+    /// Alias collection is crate-wide rather than per-module: a
+    /// `use thiserror::Error;` anywhere in the crate makes the bare
+    /// `#[derive(Error)]` short-hand resolve as thiserror everywhere.
+    /// In practice that overlap is rare and
     /// the rule treats it as acceptable false-positive surface; a
     /// project that hits it can suppress individual sites with
     /// `#[allow(perfectionist::thiserror_usage)]`.


### PR DESCRIPTION
Keeps the `declare_tool_lint!` rustdoc — which renders into the user-facing catalogue (`rules/*.md` and the docs site) — describing *what* a rule flags and *why*, not *how* the pass is implemented.

## Leaks fixed

- **`thiserror_usage`** — drops "the pass runs pre-expansion and does not consult name resolution"; keeps the user-relevant limitation (alias resolution is crate-wide, so one `use thiserror::Error;` makes a bare `#[derive(Error)]` read as thiserror everywhere), restated behaviourally.
- **`import_grouping_mismatch`** — drops "the rule reads source without name resolution" from the same-scope-`mod` classification note.

`rules/thiserror_usage.md` and `rules/import_grouping_mismatch.md` are regenerated to match.

## Convention

Adds a section to `planned-rules/IMPLEMENTATION_CONVENTIONS.md`: the `declare_tool_lint!` block must describe behaviour, with the internal-item exception (queue structs, `register_pass`/`register_lint`, `emit` helpers) and a carve-out for docs naming a user-observable *rustc* mechanism (`unfulfilled_lint_expectations`, `unknown_lints`).

The borderline cases the issue listed (`allow_attributes_without_reason`, `unknown_perfectionist_lints`, `allow_attributes`) were reviewed and kept — they describe rustc behaviour the consumer sees, not this plugin's pass internals.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/240>.