### PR TITLE
fix(excessive-inline-tests): stop misclassifying `cfg(any(test, …))` as test-only

### DIFF
--- a/src/rules/excessive_inline_tests/cfg_test.rs
+++ b/src/rules/excessive_inline_tests/cfg_test.rs
@@ -8,8 +8,8 @@ use rustc_hir::{HirId, find_attr};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::sym;
 
-/// Whether the item at `id` carries a `#[cfg(...)]` whose predicate
-/// mentions `test` in a positive position — a bare `#[cfg(test)]` or a
+/// Whether the item at `id` carries a `#[cfg(...)]` whose predicate is
+/// satisfiable *only* when `test` is set — a bare `#[cfg(test)]` or a
 /// compound `#[cfg(all(test, unix))]`, `#[cfg(all(test, feature =
 /// "..."))]`, and so on.
 ///
@@ -20,24 +20,34 @@ use rustc_span::sym;
 /// false positive of <https://github.com/KSXGitHub/perfectionist/issues/187>).
 /// This reads the parsed `CfgTrace` predicate rustc leaves on the item
 /// after configuration and walks every `all(...)` / `any(...)` nesting.
-pub(super) fn cfg_predicate_mentions_test(tcx: TyCtxt<'_>, id: HirId) -> bool {
+pub(super) fn cfg_predicate_implies_test(tcx: TyCtxt<'_>, id: HirId) -> bool {
     find_attr!(tcx, id, CfgTrace(cfgs) => cfgs)
-        .is_some_and(|cfgs| cfgs.iter().any(|(cfg, _)| entry_mentions_test(cfg)))
+        .is_some_and(|cfgs| cfgs.iter().any(|(cfg, _)| entry_implies_test(cfg)))
 }
 
-/// Whether `test` appears as a predicate atom in a positive position.
-/// `all(...)` and `any(...)` are searched recursively; `not(...)` is
-/// deliberately *not* descended into. A `test` under a negation gates
-/// the item *away* from test builds — the opposite of what the caller
-/// asks — and an item whose only mention of `test` sits under a `not`
-/// is configured out of a `cfg(test)` build entirely, so this rule
-/// (which runs in that build) never sees it.
-fn entry_mentions_test(cfg: &CfgEntry) -> bool {
+/// Whether the predicate `cfg` holds *only* in a `test` build — i.e. it
+/// implies `test`. `not(...)` is deliberately *not* descended into: a
+/// `test` under a negation gates the item *away* from test builds — the
+/// opposite of what the caller asks — and an item whose only mention of
+/// `test` sits under a `not` is configured out of a `cfg(test)` build
+/// entirely, so this rule (which runs in that build) never sees it.
+///
+/// `all(...)` and `any(...)` compose the implication differently:
+///
+/// - `all(e1, ..., en)` implies `test` ⟺ **some** `ei` implies `test`;
+///   the others only further restrict when the item compiles.
+/// - `any(e1, ..., en)` implies `test` ⟺ **every** `ei` implies `test`.
+///   If even one branch can hold without `test` (e.g. `any(test, unix)`
+///   on a `unix` build), the item is real production code, not
+///   test-only.
+///
+/// This composes correctly through nesting — e.g. `all(any(test, foo),
+/// bar)` is *not* test-only, because `any(test, foo)` is not.
+fn entry_implies_test(cfg: &CfgEntry) -> bool {
     match cfg {
         CfgEntry::NameValue { name, .. } => *name == sym::test,
-        CfgEntry::All(entries, _) | CfgEntry::Any(entries, _) => {
-            entries.iter().any(entry_mentions_test)
-        }
+        CfgEntry::All(entries, _) => entries.iter().any(entry_implies_test),
+        CfgEntry::Any(entries, _) => entries.iter().all(entry_implies_test),
         CfgEntry::Not(..) | CfgEntry::Bool(..) | CfgEntry::Version(..) => false,
     }
 }

--- a/src/rules/excessive_inline_tests/scan.rs
+++ b/src/rules/excessive_inline_tests/scan.rs
@@ -2,7 +2,7 @@
 //! test, accumulates each source file's inline-test footprint, and
 //! emits the inline-style diagnostics once per file.
 
-use super::cfg_test::cfg_predicate_mentions_test;
+use super::cfg_test::cfg_predicate_implies_test;
 use super::config::{ExcessiveInlineTests, InlineStyle};
 use super::{EXCESSIVE_INLINE_TESTS, paths};
 use clippy_utils::diagnostics::span_lint_and_help;
@@ -76,7 +76,7 @@ fn classify(cx: &LateContext<'_>, item: &Item<'_>, files: &mut HashMap<BytePos, 
         return;
     }
 
-    let cfg_test = cfg_predicate_mentions_test(cx.tcx, item.hir_id());
+    let cfg_test = cfg_predicate_implies_test(cx.tcx, item.hir_id());
     let is_test = cfg_test
         || (matches!(item.kind, ItemKind::Fn { .. })
             && is_test_function(cx.tcx, item.owner_id.def_id));

--- a/tests/excessive_inline_tests.rs
+++ b/tests/excessive_inline_tests.rs
@@ -159,18 +159,17 @@ fn does_not_flag_external_module_gated_by_compound_cfg() {
 /// pass under the bug too (vacuous).
 #[test]
 fn does_not_flag_production_module_gated_by_any_test_cfg() {
-    let mut foo = String::from(
-        "pub fn keeps_file_production() -> i32 {\n    1\n}\n\n#[cfg(any(test, unix))]\nmod gated {\n",
-    );
-    for index in 0..60 {
-        foo.push_str(&format!("    pub fn item_{index}() -> i32 {{ {index} }}\n"));
-    }
-    foo.push_str("}\n");
     let (_temp, stderr, success) = run_project_with_config(
         "fixture_itf_any_test_cfg_production",
         cargo_manifest_dir(),
         &shared_target_dir(),
-        &[("src/lib.rs", "pub mod foo;\n"), ("src/foo.rs", &foo)],
+        &[
+            ("src/lib.rs", "pub mod foo;\n"),
+            (
+                "src/foo.rs",
+                include_str!("fixtures/excessive_inline_tests/any_test_cfg_production.rs"),
+            ),
+        ],
         "",
     );
     assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");
@@ -197,18 +196,17 @@ fn does_not_flag_production_module_gated_by_any_test_cfg() {
 /// <https://github.com/KSXGitHub/perfectionist/issues/211>.
 #[test]
 fn does_not_flag_production_module_gated_by_nested_any_in_all_cfg() {
-    let mut foo = String::from(
-        "pub fn keeps_file_production() -> i32 {\n    1\n}\n\n#[cfg(all(any(test, unix), unix))]\nmod gated {\n",
-    );
-    for index in 0..60 {
-        foo.push_str(&format!("    pub fn item_{index}() -> i32 {{ {index} }}\n"));
-    }
-    foo.push_str("}\n");
     let (_temp, stderr, success) = run_project_with_config(
         "fixture_itf_nested_any_in_all_cfg_production",
         cargo_manifest_dir(),
         &shared_target_dir(),
-        &[("src/lib.rs", "pub mod foo;\n"), ("src/foo.rs", &foo)],
+        &[
+            ("src/lib.rs", "pub mod foo;\n"),
+            (
+                "src/foo.rs",
+                include_str!("fixtures/excessive_inline_tests/nested_any_in_all_cfg_production.rs"),
+            ),
+        ],
         "",
     );
     assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");

--- a/tests/excessive_inline_tests.rs
+++ b/tests/excessive_inline_tests.rs
@@ -149,9 +149,19 @@ fn does_not_flag_external_module_gated_by_compound_cfg() {
 /// uncounted, and the whole module reported as "inline test code spans
 /// N lines". Regression for
 /// <https://github.com/KSXGitHub/perfectionist/issues/211>.
+///
+/// The file carries a separate top-level production item so the
+/// `production_count == 0` early-return in `emit_inline_style` cannot
+/// mask the regression: under the old bug the gated module is charged
+/// as a >50-line inline-test footprint *and* the file has production,
+/// so the lint fires; the fix records the module as production instead,
+/// so it stays silent. Without the extra production item the test would
+/// pass under the bug too (vacuous).
 #[test]
 fn does_not_flag_production_module_gated_by_any_test_cfg() {
-    let mut foo = String::from("#[cfg(any(test, unix))]\nmod gated {\n");
+    let mut foo = String::from(
+        "pub fn keeps_file_production() -> i32 {\n    1\n}\n\n#[cfg(any(test, unix))]\nmod gated {\n",
+    );
     for index in 0..60 {
         foo.push_str(&format!("    pub fn item_{index}() -> i32 {{ {index} }}\n"));
     }
@@ -168,6 +178,44 @@ fn does_not_flag_production_module_gated_by_any_test_cfg() {
         !stderr.contains(LINT),
         "a production module gated by `cfg(any(test, ...))` must not be \
          flagged as inline test code; stderr was:\n{stderr}",
+    );
+}
+
+/// Nested composition: `#[cfg(all(any(test, unix), unix))]` gates real
+/// production code. The inner `any(test, unix)` does *not* imply test
+/// (it holds on a non-test `unix` build), so neither does the enclosing
+/// `all(...)` — the module is production and must be descended into, not
+/// charged against the inline-test budget. This locks in the nested
+/// case the `entry_implies_test` docstring claims: before the fix, both
+/// `all` and `any` reduced with `.any(... mentions test)`, so the inner
+/// `any(test, unix)` was read as test-only and propagated up through the
+/// `all`, mis-flagging the whole module as inline test code. The flat
+/// `any`/`all` tests alone do not exercise this recursion. As above, a
+/// separate top-level production item keeps `production_count` non-zero
+/// so the bug surfaces as a fired lint rather than being masked by the
+/// `emit_inline_style` early-return. Regression for
+/// <https://github.com/KSXGitHub/perfectionist/issues/211>.
+#[test]
+fn does_not_flag_production_module_gated_by_nested_any_in_all_cfg() {
+    let mut foo = String::from(
+        "pub fn keeps_file_production() -> i32 {\n    1\n}\n\n#[cfg(all(any(test, unix), unix))]\nmod gated {\n",
+    );
+    for index in 0..60 {
+        foo.push_str(&format!("    pub fn item_{index}() -> i32 {{ {index} }}\n"));
+    }
+    foo.push_str("}\n");
+    let (_temp, stderr, success) = run_project_with_config(
+        "fixture_itf_nested_any_in_all_cfg_production",
+        cargo_manifest_dir(),
+        &shared_target_dir(),
+        &[("src/lib.rs", "pub mod foo;\n"), ("src/foo.rs", &foo)],
+        "",
+    );
+    assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");
+    assert!(
+        !stderr.contains(LINT),
+        "a production module gated by `cfg(all(any(test, ...), ...))` must \
+         not be flagged as inline test code; stderr was:\n{stderr}",
     );
 }
 

--- a/tests/excessive_inline_tests.rs
+++ b/tests/excessive_inline_tests.rs
@@ -140,6 +140,37 @@ fn does_not_flag_external_module_gated_by_compound_cfg() {
     );
 }
 
+/// A compound cfg that does *not* imply test — `#[cfg(any(test,
+/// unix))]` — gates real production code: the item is compiled in a
+/// non-test `unix` build too, so it is not test-only. The rule must
+/// descend into such a module and count its body as production, never
+/// charge it against the inline-test budget. With the `any`/`all`
+/// composition bug it was misread as test-only, its (large) body left
+/// uncounted, and the whole module reported as "inline test code spans
+/// N lines". Regression for
+/// <https://github.com/KSXGitHub/perfectionist/issues/211>.
+#[test]
+fn does_not_flag_production_module_gated_by_any_test_cfg() {
+    let mut foo = String::from("#[cfg(any(test, unix))]\nmod gated {\n");
+    for index in 0..60 {
+        foo.push_str(&format!("    pub fn item_{index}() -> i32 {{ {index} }}\n"));
+    }
+    foo.push_str("}\n");
+    let (_temp, stderr, success) = run_project_with_config(
+        "fixture_itf_any_test_cfg_production",
+        cargo_manifest_dir(),
+        &shared_target_dir(),
+        &[("src/lib.rs", "pub mod foo;\n"), ("src/foo.rs", &foo)],
+        "",
+    );
+    assert!(success, "`cargo dylint` failed; stderr was:\n{stderr}");
+    assert!(
+        !stderr.contains(LINT),
+        "a production module gated by `cfg(any(test, ...))` must not be \
+         flagged as inline test code; stderr was:\n{stderr}",
+    );
+}
+
 /// The on-disk position of an extracted test file is not the rule's
 /// concern: a flattened `src/sib_tests.rs` sibling (loaded via `#[path]`)
 /// is just as acceptable as the nested form. The rule only counts

--- a/tests/fixtures/excessive_inline_tests/any_test_cfg_production.rs
+++ b/tests/fixtures/excessive_inline_tests/any_test_cfg_production.rs
@@ -1,0 +1,67 @@
+pub fn keeps_file_production() -> i32 {
+    1
+}
+
+#[cfg(any(test, unix))]
+mod gated {
+    pub fn item_0() -> i32 { 0 }
+    pub fn item_1() -> i32 { 1 }
+    pub fn item_2() -> i32 { 2 }
+    pub fn item_3() -> i32 { 3 }
+    pub fn item_4() -> i32 { 4 }
+    pub fn item_5() -> i32 { 5 }
+    pub fn item_6() -> i32 { 6 }
+    pub fn item_7() -> i32 { 7 }
+    pub fn item_8() -> i32 { 8 }
+    pub fn item_9() -> i32 { 9 }
+    pub fn item_10() -> i32 { 10 }
+    pub fn item_11() -> i32 { 11 }
+    pub fn item_12() -> i32 { 12 }
+    pub fn item_13() -> i32 { 13 }
+    pub fn item_14() -> i32 { 14 }
+    pub fn item_15() -> i32 { 15 }
+    pub fn item_16() -> i32 { 16 }
+    pub fn item_17() -> i32 { 17 }
+    pub fn item_18() -> i32 { 18 }
+    pub fn item_19() -> i32 { 19 }
+    pub fn item_20() -> i32 { 20 }
+    pub fn item_21() -> i32 { 21 }
+    pub fn item_22() -> i32 { 22 }
+    pub fn item_23() -> i32 { 23 }
+    pub fn item_24() -> i32 { 24 }
+    pub fn item_25() -> i32 { 25 }
+    pub fn item_26() -> i32 { 26 }
+    pub fn item_27() -> i32 { 27 }
+    pub fn item_28() -> i32 { 28 }
+    pub fn item_29() -> i32 { 29 }
+    pub fn item_30() -> i32 { 30 }
+    pub fn item_31() -> i32 { 31 }
+    pub fn item_32() -> i32 { 32 }
+    pub fn item_33() -> i32 { 33 }
+    pub fn item_34() -> i32 { 34 }
+    pub fn item_35() -> i32 { 35 }
+    pub fn item_36() -> i32 { 36 }
+    pub fn item_37() -> i32 { 37 }
+    pub fn item_38() -> i32 { 38 }
+    pub fn item_39() -> i32 { 39 }
+    pub fn item_40() -> i32 { 40 }
+    pub fn item_41() -> i32 { 41 }
+    pub fn item_42() -> i32 { 42 }
+    pub fn item_43() -> i32 { 43 }
+    pub fn item_44() -> i32 { 44 }
+    pub fn item_45() -> i32 { 45 }
+    pub fn item_46() -> i32 { 46 }
+    pub fn item_47() -> i32 { 47 }
+    pub fn item_48() -> i32 { 48 }
+    pub fn item_49() -> i32 { 49 }
+    pub fn item_50() -> i32 { 50 }
+    pub fn item_51() -> i32 { 51 }
+    pub fn item_52() -> i32 { 52 }
+    pub fn item_53() -> i32 { 53 }
+    pub fn item_54() -> i32 { 54 }
+    pub fn item_55() -> i32 { 55 }
+    pub fn item_56() -> i32 { 56 }
+    pub fn item_57() -> i32 { 57 }
+    pub fn item_58() -> i32 { 58 }
+    pub fn item_59() -> i32 { 59 }
+}

--- a/tests/fixtures/excessive_inline_tests/nested_any_in_all_cfg_production.rs
+++ b/tests/fixtures/excessive_inline_tests/nested_any_in_all_cfg_production.rs
@@ -1,0 +1,67 @@
+pub fn keeps_file_production() -> i32 {
+    1
+}
+
+#[cfg(all(any(test, unix), unix))]
+mod gated {
+    pub fn item_0() -> i32 { 0 }
+    pub fn item_1() -> i32 { 1 }
+    pub fn item_2() -> i32 { 2 }
+    pub fn item_3() -> i32 { 3 }
+    pub fn item_4() -> i32 { 4 }
+    pub fn item_5() -> i32 { 5 }
+    pub fn item_6() -> i32 { 6 }
+    pub fn item_7() -> i32 { 7 }
+    pub fn item_8() -> i32 { 8 }
+    pub fn item_9() -> i32 { 9 }
+    pub fn item_10() -> i32 { 10 }
+    pub fn item_11() -> i32 { 11 }
+    pub fn item_12() -> i32 { 12 }
+    pub fn item_13() -> i32 { 13 }
+    pub fn item_14() -> i32 { 14 }
+    pub fn item_15() -> i32 { 15 }
+    pub fn item_16() -> i32 { 16 }
+    pub fn item_17() -> i32 { 17 }
+    pub fn item_18() -> i32 { 18 }
+    pub fn item_19() -> i32 { 19 }
+    pub fn item_20() -> i32 { 20 }
+    pub fn item_21() -> i32 { 21 }
+    pub fn item_22() -> i32 { 22 }
+    pub fn item_23() -> i32 { 23 }
+    pub fn item_24() -> i32 { 24 }
+    pub fn item_25() -> i32 { 25 }
+    pub fn item_26() -> i32 { 26 }
+    pub fn item_27() -> i32 { 27 }
+    pub fn item_28() -> i32 { 28 }
+    pub fn item_29() -> i32 { 29 }
+    pub fn item_30() -> i32 { 30 }
+    pub fn item_31() -> i32 { 31 }
+    pub fn item_32() -> i32 { 32 }
+    pub fn item_33() -> i32 { 33 }
+    pub fn item_34() -> i32 { 34 }
+    pub fn item_35() -> i32 { 35 }
+    pub fn item_36() -> i32 { 36 }
+    pub fn item_37() -> i32 { 37 }
+    pub fn item_38() -> i32 { 38 }
+    pub fn item_39() -> i32 { 39 }
+    pub fn item_40() -> i32 { 40 }
+    pub fn item_41() -> i32 { 41 }
+    pub fn item_42() -> i32 { 42 }
+    pub fn item_43() -> i32 { 43 }
+    pub fn item_44() -> i32 { 44 }
+    pub fn item_45() -> i32 { 45 }
+    pub fn item_46() -> i32 { 46 }
+    pub fn item_47() -> i32 { 47 }
+    pub fn item_48() -> i32 { 48 }
+    pub fn item_49() -> i32 { 49 }
+    pub fn item_50() -> i32 { 50 }
+    pub fn item_51() -> i32 { 51 }
+    pub fn item_52() -> i32 { 52 }
+    pub fn item_53() -> i32 { 53 }
+    pub fn item_54() -> i32 { 54 }
+    pub fn item_55() -> i32 { 55 }
+    pub fn item_56() -> i32 { 56 }
+    pub fn item_57() -> i32 { 57 }
+    pub fn item_58() -> i32 { 58 }
+    pub fn item_59() -> i32 { 59 }
+}


### PR DESCRIPTION
Resolves #211.

## Problem

In `perfectionist::excessive_inline_tests`, the compound-`cfg` recognizer (`cfg_test.rs`) treated `all(...)` and `any(...)` identically — `.any()` over the sub-entries. That over-matches `any`: an item is *test-only* only when its `cfg` is satisfiable solely with `test` set, and the implication composes differently per connective:

- `all(e1, …, en)` implies `test` ⟺ **some** `ei` implies `test`.
- `any(e1, …, en)` implies `test` ⟺ **every** `ei` implies `test`.

So `#[cfg(any(test, unix))]` was misclassified as test-only, charging a real production module against the inline-test budget and skipping descent into its body — a false-positive "inline test code spans N lines".

## Fix (`cfg_test.rs`, `scan.rs`)

- Split the `All`/`Any` match arms (`All` → `.any()`, `Any` → `.all()`); composes correctly through nesting, e.g. `all(any(test, foo), bar)` is *not* test-only because `any(test, foo)` is not.
- Renamed the helpers `*_mentions_test` → `*_implies_test` (`cfg_predicate_implies_test`, `entry_implies_test`), since `any(test, unix)` *mentions* `test` yet is correctly not test-only, and refreshed the docstrings to state the per-connective implication semantics.

## Regression tests (`tests/excessive_inline_tests.rs` + `tests/fixtures/excessive_inline_tests/`)

Two tests guard the fix, each **mutation-checked** to fail under the pre-fix logic and pass under it:

- `does_not_flag_production_module_gated_by_any_test_cfg` — the flat `#[cfg(any(test, unix))]` case.
- `does_not_flag_production_module_gated_by_nested_any_in_all_cfg` — the nested `#[cfg(all(any(test, unix), unix))]` case, exercising the recursive `all`/`any` split the flat cases never reach.

Each fixture (committed under `tests/fixtures/excessive_inline_tests/` and pulled in with `include_str!`) wraps a >50-line module in the non-test-only `cfg` **and** carries a separate top-level production item. The production item is load-bearing: `emit_inline_style` returns early unless a file has both test items and `production_count > 0`, so without it the gated module is charged as a test footprint yet the lint stays silent under the bug — the test would pass with or without the fix (vacuous). With the production item present, the pre-fix logic fires `inline test code spans 62 lines, over the limit of 50`, so the tests genuinely protect against the regression.

The secondary observation in the issue (shared-line double-counting in `record_test`) is left out of scope.

## Validation

`just all` is green, including `self-lint` (perfectionist's own lints on its source), `fmt`, `clippy`, `doc`/`check-rules-md`, and the full test suite.