### PR TITLE
docs: recommend `#[expect]` over `#[allow]` for self-suppression

### DIFF
--- a/planned-rules/dedented-multiline-string.md
+++ b/planned-rules/dedented-multiline-string.md
@@ -434,7 +434,7 @@ concentrates in the suggestions, all attached to one diagnostic:
 
 Active by default. The dedented shape is a broad, project-agnostic
 readability regression. Suppress per-site with
-`#[allow(perfectionist::dedented_multiline_string)]` or globally via
+`#[expect(perfectionist::dedented_multiline_string)]` or globally via
 `[perfectionist].disable`.
 
 ## Interaction with sibling rules

--- a/planned-rules/error-type-derives.md
+++ b/planned-rules/error-type-derives.md
@@ -70,7 +70,7 @@ defect, not a preference.
 > each sub-check is registered as its own flat tool lint
 > `perfectionist::<sub_check_name>` (e.g.
 > `perfectionist::copyable_error`). Suppression attributes use the
-> flat form: `#[allow(perfectionist::copyable_error)]`.
+> flat form: `#[expect(perfectionist::copyable_error)]`.
 
 ### `error_type_derives::unused_error`
 
@@ -106,7 +106,7 @@ despite being the *successful* return type of
 The check is a heuristic, not an absolute defect: small unit-style
 error enums (`enum ParseError { Empty, Negative }`) are legitimate
 `Copy` errors. Suppress per-type with
-`#[allow(perfectionist::copyable_error)]` when the heuristic misfires.
+`#[expect(perfectionist::copyable_error)]` when the heuristic misfires.
 
 ### `error_type_derives::unconventional_error_name`
 
@@ -143,7 +143,7 @@ matching covers the realistic configuration space without a regex
 dependency.
 
 Suppress per-type with
-`#[allow(perfectionist::unconventional_error_name)]` when the
+`#[expect(perfectionist::unconventional_error_name)]` when the
 mismatch is intentional (e.g. a public type whose existing name
 cannot be changed without a breaking release).
 

--- a/planned-rules/private-reexport-imports.md
+++ b/planned-rules/private-reexport-imports.md
@@ -169,7 +169,7 @@ None. The rule has one correct direction, so there is no knob to tune.
 The one legitimate exception — a module that *intentionally* keeps a
 shared private import for its descendants to reach through `super::` —
 is suppressed at the offending import with
-`#[allow(perfectionist::private_reexport_imports)]` (or `#[expect(…)]`).
+`#[expect(perfectionist::private_reexport_imports)]`.
 A per-site attribute is the right tool *because the violation is
 positional*: the realistic trigger is a relative `use super::Thing;`,
 whose written path is meaningful only inside its own module. There is
@@ -288,5 +288,5 @@ definition or a public re-export), matching
 legitimate counter-pattern — a module that *intentionally* holds a
 shared private import for its descendants to reach through `super::` —
 is suppressed per import with
-`#[allow(perfectionist::private_reexport_imports)]`, not a config knob
+`#[expect(perfectionist::private_reexport_imports)]`, not a config knob
 (see *Configuration*).

--- a/rules/thiserror_usage.md
+++ b/rules/thiserror_usage.md
@@ -49,7 +49,7 @@ makes the bare `#[derive(Error)]` short-hand resolve as
 thiserror everywhere. In practice that overlap is rare and
 the rule treats it as acceptable false-positive surface; a
 project that hits it can suppress individual sites with
-`#[allow(perfectionist::thiserror_usage)]`.
+`#[expect(perfectionist::thiserror_usage)]`.
 
 ## Why restrict this?
 

--- a/src/rules/thiserror_usage.rs
+++ b/src/rules/thiserror_usage.rs
@@ -53,7 +53,7 @@ declare_tool_lint! {
     /// thiserror everywhere. In practice that overlap is rare and
     /// the rule treats it as acceptable false-positive surface; a
     /// project that hits it can suppress individual sites with
-    /// `#[allow(perfectionist::thiserror_usage)]`.
+    /// `#[expect(perfectionist::thiserror_usage)]`.
     ///
     /// ### Why restrict this?
     ///


### PR DESCRIPTION
Several rule docs recommended `#[allow(perfectionist::…)]` to suppress *their own* lint. That contradicts the catalogue's stated preference — `perfectionist::prefer_expect_over_allow` rewrites `#[allow]` to `#[expect]` — so a reader copying the snippet is immediately flagged.

This switches the per-site suppression recommendations to `#[expect(perfectionist::…)]`, matching the precedent set for `avoidable_string_escapes` (formerly `prefer_raw_string`) in KSXGitHub/perfectionist#233.

## Changes

- **`src/rules/thiserror_usage.rs`** — the rule's rustdoc (the implemented rule the issue referred to as `prefer_derive_more_over_thiserror.rs`, since renamed).
- **`rules/thiserror_usage.md`** — the generated in-tree catalogue, kept in sync.
- **`planned-rules/error-type-derives.md`** — the `copyable_error` and `unconventional_error_name` suppression mentions.
- **`planned-rules/dedented-multiline-string.md`** and **`planned-rules/private-reexport-imports.md`** — additional self-suppression recommendations in planning files added/changed on `master` since the issue was filed.

Intentionally left as-is: the `#[allow]` mentions in `IMPLEMENTATION_CONVENTIONS.md` (and the `[perfectionist].disable` placeholder) explain the suppression *mechanism* generically; `unknown_perfectionist_lints`'s subject *is* `#[allow]`/`#[expect]` typos; and the `ui/` / `tests/` fixtures are real code, not recommendations.

## Validation

`just fmt`, `just build`, `just doc` (including `check-rules-md`), and `just lint` pass. `just test` and `just self-lint` could not run in the authoring environment: the dylint driver build needs to `git clone` `rust-clippy`, which the egress policy blocks (HTTP 403). The change is doc-comment/markdown text only, so neither blocked step is affected by it.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/236>.