### PR TITLE
chore(task/install-git-hooks): remove redundant `chmod`

### DIFF
--- a/justfile
+++ b/justfile
@@ -68,7 +68,6 @@ install-dev-tools:
 # locally for commit messages and tag pushes.
 install-git-hooks:
   git config core.hooksPath .githooks
-  chmod +x .githooks/commit-msg .githooks/pre-push .githooks/commit-msg-hooks/*
 
 # Undo `install-git-hooks`. Idempotent: silently succeeds when
 # `core.hooksPath` is already unset, so it is safe to run from


### PR DESCRIPTION
Removes the redundant `chmod +x` line from the `install-git-hooks` recipe in `justfile`.

The files it targeted — `.githooks/commit-msg`, `.githooks/pre-push`, and `.githooks/commit-msg-hooks/*` — are all tracked in git with mode `100755`, so git restores their executable bit on checkout. The `chmod` was a no-op. The recipe now just sets `core.hooksPath`.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/331>.