### PR TITLE
feat(git/hooks): show deploy-check compile progress on stderr

### DIFF
--- a/.githooks/commit-msg-hooks/release-contract
+++ b/.githooks/commit-msg-hooks/release-contract
@@ -26,6 +26,13 @@ cd "$root"
 # this hook must work even on a fresh checkout where
 # `just install-dev-tools` has not run yet — mirror that recipe's
 # linker override.
+#
+# No `--quiet`: a cold build of `_deploy_check` can take many seconds,
+# during which a silent hook looks hung. Cargo writes its build
+# progress to stderr (never stdout), and a git hook signals purely via
+# exit code — nothing parses this hook's output — so surfacing the
+# progress can't corrupt anything. deploy-check's own diagnostics go to
+# stderr too, so the two interleave harmlessly.
 exec cargo --config 'target."cfg(all())".linker="cc"' run \
-  --quiet --locked --package _deploy_check --bin deploy-check -- \
+  --locked --package _deploy_check --bin deploy-check -- \
   "$root" commit-msg "$msg_file"

--- a/.githooks/commit-msg-hooks/release-contract
+++ b/.githooks/commit-msg-hooks/release-contract
@@ -27,12 +27,9 @@ cd "$root"
 # `just install-dev-tools` has not run yet — mirror that recipe's
 # linker override.
 #
-# No `--quiet`: a cold build of `_deploy_check` can take many seconds,
-# during which a silent hook looks hung. Cargo writes its build
-# progress to stderr (never stdout), and a git hook signals purely via
-# exit code — nothing parses this hook's output — so surfacing the
-# progress can't corrupt anything. deploy-check's own diagnostics go to
-# stderr too, so the two interleave harmlessly.
+# No `--quiet`: a cold build takes seconds, and a silent hook looks
+# hung. Cargo's progress goes to stderr and hooks signal via exit
+# code, so surfacing it is harmless.
 exec cargo --config 'target."cfg(all())".linker="cc"' run \
   --locked --package _deploy_check --bin deploy-check -- \
   "$root" commit-msg "$msg_file"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -39,12 +39,9 @@ cd "$root"
 
 # See `.githooks/commit-msg` for why the linker override is here.
 #
-# No `--quiet`: a cold build of `_deploy_check` can take many seconds,
-# during which a silent hook looks hung. Cargo writes its build
-# progress to stderr (never stdout), and a git hook signals purely via
-# exit code — nothing parses this hook's output — so surfacing the
-# progress can't corrupt anything. deploy-check's own diagnostics go to
-# stderr too, so the two interleave harmlessly.
+# No `--quiet`: a cold build takes seconds, and a silent hook looks
+# hung. Cargo's progress goes to stderr and hooks signal via exit
+# code, so surfacing it is harmless.
 exec cargo --config 'target."cfg(all())".linker="cc"' run \
   --locked --package _deploy_check --bin deploy-check -- \
   "$root" pre-push <<< "$input"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -38,6 +38,13 @@ root=$(git rev-parse --show-toplevel)
 cd "$root"
 
 # See `.githooks/commit-msg` for why the linker override is here.
+#
+# No `--quiet`: a cold build of `_deploy_check` can take many seconds,
+# during which a silent hook looks hung. Cargo writes its build
+# progress to stderr (never stdout), and a git hook signals purely via
+# exit code — nothing parses this hook's output — so surfacing the
+# progress can't corrupt anything. deploy-check's own diagnostics go to
+# stderr too, so the two interleave harmlessly.
 exec cargo --config 'target."cfg(all())".linker="cc"' run \
-  --quiet --locked --package _deploy_check --bin deploy-check -- \
+  --locked --package _deploy_check --bin deploy-check -- \
   "$root" pre-push <<< "$input"


### PR DESCRIPTION
## What

Two git hooks compile the `_deploy_check` tool by spawning `cargo run --quiet`:

- `.githooks/pre-push` — runs the version-bump contract check when a release-shaped tag is pushed.
- `.githooks/commit-msg-hooks/release-contract` — runs it when a commit subject is a bare version literal.

This drops `--quiet` from both so cargo's build progress reaches the terminal.

## Why

`--quiet` had been there since the hooks were introduced, with no documented justification. A *cold* build of `_deploy_check` can take many seconds, during which a silenced hook produces no output at all — a version-bump commit or release-tag push just looks hung.

The silence was never necessary for correctness:

- **Git hooks signal via exit code.** Nothing parses a `commit-msg` or `pre-push` hook's stdout/stderr; the output is only shown to the user.
- **Cargo writes build progress to stderr, never stdout.** So dropping `--quiet` cannot pollute any stdout channel — verified empirically (stdout stayed empty, only stderr carried the `Compiling …` / `Finished …` lines).
- **`deploy-check` reports its own errors to stderr too** (`eprintln!` in `tools/deploy-check/src/main.rs`), so cargo's progress and the tool's diagnostics interleave harmlessly.

No test or doc depended on the suppressed output — the only `--quiet` occurrences in the tree were these two lines.

## Changes

- Remove `--quiet` from both hook invocations.
- Add a comment to each explaining why progress is intentionally surfaced, so the flag isn't "helpfully" re-added later.

## Verification

- `bash -n` passes on both scripts.
- Running the exact hook command with streams separated: stdout empty, stderr shows cargo progress, exit code preserved.

No Rust code changed, so the dylint self-lint / `just all` gate doesn't apply to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)