### PR TITLE
fix(bare-identifier-reference): downgrade autofix to `MaybeIncorrect`

### DIFF
--- a/rules/bare_identifier_reference.md
+++ b/rules/bare_identifier_reference.md
@@ -55,10 +55,10 @@ pub fn install(manifest: &PackageManifest, store: &Store) {}
 When a backticked word names a *foreign* symbol that merely
 shares its name with an in-scope item, rewriting `` `Foo` `` to
 `` [`Foo`] `` links to the *local* item — a wrong reference that
-still compiles. The suggestion is therefore only
-`MaybeIncorrect`. For an external target, write an explicit
-reference link instead: `` [`Foo`][foo-ext] `` plus a
-`` [foo-ext]: <url> `` definition.
+still compiles. The rule therefore only suggests the link
+rather than applying it automatically. For an external target,
+write an explicit reference link instead:
+`` [`Foo`][foo-ext] `` plus a `` [foo-ext]: <url> `` definition.
 
 ## Configuration
 

--- a/rules/bare_identifier_reference.md
+++ b/rules/bare_identifier_reference.md
@@ -52,24 +52,12 @@ pub fn install(manifest: &PackageManifest, store: &Store) {}
 
 ## Caveat: linking is not always correct
 
-A backticked word can name a *foreign* symbol the prose only
-mentions — an upstream type the local code mirrors — that
-happens to share its name with an in-scope item. Rewriting
-`` `Foo` `` to `` [`Foo`] `` then resolves to the *local* item,
-manufacturing a self-reference that compiles cleanly while the
-rendered link points the reader at the wrong place:
-
-```rust,ignore
-/// Mirrors the relevant subset of pnpm's [`DepsGraphNode`].
-pub struct DepsGraphNode<Key> { /* ... */ }
-```
-
-Because the rewrite can change meaning, the suggestion is only
-`MaybeIncorrect`, so `cargo fix`, `cargo clippy --fix`, and an
-editor's "apply suggestion" won't apply it blindly. When the
-name really denotes an external symbol, don't link it to the
-local item; write an explicit reference link to the real source
-instead — `` [`Foo`][foo-ext] `` paired with a
+When a backticked word names a *foreign* symbol that merely
+shares its name with an in-scope item, rewriting `` `Foo` `` to
+`` [`Foo`] `` links to the *local* item — a wrong reference that
+still compiles. The suggestion is therefore only
+`MaybeIncorrect`. For an external target, write an explicit
+reference link instead: `` [`Foo`][foo-ext] `` plus a
 `` [foo-ext]: <url> `` definition.
 
 ## Configuration

--- a/rules/bare_identifier_reference.md
+++ b/rules/bare_identifier_reference.md
@@ -50,6 +50,28 @@ pub fn install(manifest: &PackageManifest, store: &Store) {}
 pub fn install(manifest: &PackageManifest, store: &Store) {}
 ```
 
+## Caveat: linking is not always correct
+
+A backticked word can name a *foreign* symbol the prose only
+mentions — an upstream type the local code mirrors — that
+happens to share its name with an in-scope item. Rewriting
+`` `Foo` `` to `` [`Foo`] `` then resolves to the *local* item,
+manufacturing a self-reference that compiles cleanly while the
+rendered link points the reader at the wrong place:
+
+```rust,ignore
+/// Mirrors the relevant subset of pnpm's [`DepsGraphNode`].
+pub struct DepsGraphNode<Key> { /* ... */ }
+```
+
+Because the rewrite can change meaning, the suggestion is only
+`MaybeIncorrect`, so `cargo fix`, `cargo clippy --fix`, and an
+editor's "apply suggestion" won't apply it blindly. When the
+name really denotes an external symbol, don't link it to the
+local item; write an explicit reference link to the real source
+instead — `` [`Foo`][foo-ext] `` paired with a
+`` [foo-ext]: <url> `` definition.
+
 ## Configuration
 
 Configure via `dylint.toml` under `["perfectionist::bare_identifier_reference"]`. Every field is optional; the per-field prose below states the default.

--- a/src/rules/bare_identifier_reference.rs
+++ b/src/rules/bare_identifier_reference.rs
@@ -594,7 +594,9 @@ fn emit(
                     // editor's "apply suggestion" must not apply it blindly.
                     diag.span_suggestion(
                         span,
-                        "if it refers to this item, wrap it as an intra-doc link",
+                        "only once the surrounding context confirms it refers to this \
+                         item, not a foreign symbol of the same name, wrap it as an \
+                         intra-doc link",
                         format!("[{snippet}]"),
                         Applicability::MaybeIncorrect,
                     );
@@ -602,8 +604,10 @@ fn emit(
                 Resolution::Ambiguous(prefix) => {
                     let prefix = prefix.as_str();
                     diag.help(format!(
-                        "`{ident}` resolves in more than one namespace; write a \
-                         disambiguated intra-doc link such as `[`{ident}`]({prefix}{ident})`",
+                        "`{ident}` resolves in more than one namespace; only once the \
+                         surrounding context confirms it refers to this item, not a \
+                         foreign symbol of the same name, write a disambiguated \
+                         intra-doc link such as `[`{ident}`]({prefix}{ident})`",
                     ));
                 }
             }

--- a/src/rules/bare_identifier_reference.rs
+++ b/src/rules/bare_identifier_reference.rs
@@ -61,24 +61,12 @@ declare_tool_lint! {
     ///
     /// ### Caveat: linking is not always correct
     ///
-    /// A backticked word can name a *foreign* symbol the prose only
-    /// mentions — an upstream type the local code mirrors — that
-    /// happens to share its name with an in-scope item. Rewriting
-    /// `` `Foo` `` to `` [`Foo`] `` then resolves to the *local* item,
-    /// manufacturing a self-reference that compiles cleanly while the
-    /// rendered link points the reader at the wrong place:
-    ///
-    /// ```rust,ignore
-    /// /// Mirrors the relevant subset of pnpm's [`DepsGraphNode`].
-    /// pub struct DepsGraphNode<Key> { /* ... */ }
-    /// ```
-    ///
-    /// Because the rewrite can change meaning, the suggestion is only
-    /// `MaybeIncorrect`, so `cargo fix`, `cargo clippy --fix`, and an
-    /// editor's "apply suggestion" won't apply it blindly. When the
-    /// name really denotes an external symbol, don't link it to the
-    /// local item; write an explicit reference link to the real source
-    /// instead — `` [`Foo`][foo-ext] `` paired with a
+    /// When a backticked word names a *foreign* symbol that merely
+    /// shares its name with an in-scope item, rewriting `` `Foo` `` to
+    /// `` [`Foo`] `` links to the *local* item — a wrong reference that
+    /// still compiles. The suggestion is therefore only
+    /// `MaybeIncorrect`. For an external target, write an explicit
+    /// reference link instead: `` [`Foo`][foo-ext] `` plus a
     /// `` [foo-ext]: <url> `` definition.
     pub perfectionist::BARE_IDENTIFIER_REFERENCE,
     Warn,

--- a/src/rules/bare_identifier_reference.rs
+++ b/src/rules/bare_identifier_reference.rs
@@ -64,10 +64,10 @@ declare_tool_lint! {
     /// When a backticked word names a *foreign* symbol that merely
     /// shares its name with an in-scope item, rewriting `` `Foo` `` to
     /// `` [`Foo`] `` links to the *local* item — a wrong reference that
-    /// still compiles. The suggestion is therefore only
-    /// `MaybeIncorrect`. For an external target, write an explicit
-    /// reference link instead: `` [`Foo`][foo-ext] `` plus a
-    /// `` [foo-ext]: <url> `` definition.
+    /// still compiles. The rule therefore only suggests the link
+    /// rather than applying it automatically. For an external target,
+    /// write an explicit reference link instead:
+    /// `` [`Foo`][foo-ext] `` plus a `` [foo-ext]: <url> `` definition.
     pub perfectionist::BARE_IDENTIFIER_REFERENCE,
     Warn,
     "backticked identifier in a doc comment that resolves in scope should be an intra-doc link",

--- a/src/rules/bare_identifier_reference.rs
+++ b/src/rules/bare_identifier_reference.rs
@@ -58,6 +58,28 @@ declare_tool_lint! {
     /// /// Installs the package described by [`PackageManifest`] into [`Store`].
     /// pub fn install(manifest: &PackageManifest, store: &Store) {}
     /// ```
+    ///
+    /// ### Caveat: linking is not always correct
+    ///
+    /// A backticked word can name a *foreign* symbol the prose only
+    /// mentions — an upstream type the local code mirrors — that
+    /// happens to share its name with an in-scope item. Rewriting
+    /// `` `Foo` `` to `` [`Foo`] `` then resolves to the *local* item,
+    /// manufacturing a self-reference that compiles cleanly while the
+    /// rendered link points the reader at the wrong place:
+    ///
+    /// ```rust,ignore
+    /// /// Mirrors the relevant subset of pnpm's [`DepsGraphNode`].
+    /// pub struct DepsGraphNode<Key> { /* ... */ }
+    /// ```
+    ///
+    /// Because the rewrite can change meaning, the suggestion is only
+    /// `MaybeIncorrect`, so `cargo fix`, `cargo clippy --fix`, and an
+    /// editor's "apply suggestion" won't apply it blindly. When the
+    /// name really denotes an external symbol, don't link it to the
+    /// local item; write an explicit reference link to the real source
+    /// instead — `` [`Foo`][foo-ext] `` paired with a
+    /// `` [foo-ext]: <url> `` definition.
     pub perfectionist::BARE_IDENTIFIER_REFERENCE,
     Warn,
     "backticked identifier in a doc comment that resolves in scope should be an intra-doc link",
@@ -293,7 +315,9 @@ impl BareIdentifierReference {
 #[derive(Clone, Copy)]
 enum Resolution {
     /// Resolves in exactly one namespace — a plain `` [`Foo`] `` link
-    /// is unambiguous, so the autofix is machine-applicable.
+    /// is unambiguous, so the rule offers it as a structured
+    /// suggestion (only `MaybeIncorrect`: see [`emit`], as the name may
+    /// instead denote a foreign symbol that merely shares it).
     Unique,
     /// The name exists in more than one namespace (e.g. a type and a
     /// function). A bare `` [`Foo`] `` would be an ambiguous intra-doc
@@ -571,23 +595,41 @@ fn emit(
         BARE_IDENTIFIER_REFERENCE,
         hir_id,
         span,
-        format!("`{ident}` resolves in scope; write it as an intra-doc link"),
-        |diag| match resolution {
-            Resolution::Unique => {
-                diag.span_suggestion(
-                    span,
-                    "wrap as an intra-doc link",
-                    format!("[{snippet}]"),
-                    Applicability::MachineApplicable,
-                );
+        format!("`{ident}` resolves in scope; consider writing it as an intra-doc link"),
+        |diag| {
+            match resolution {
+                Resolution::Unique => {
+                    // `MaybeIncorrect`, not `MachineApplicable`: the rewrite
+                    // changes meaning when the prose names a foreign symbol
+                    // that merely shares this name (see the caveat help
+                    // below), so `cargo fix` / `cargo clippy --fix` and an
+                    // editor's "apply suggestion" must not apply it blindly.
+                    diag.span_suggestion(
+                        span,
+                        "if it refers to this item, wrap it as an intra-doc link",
+                        format!("[{snippet}]"),
+                        Applicability::MaybeIncorrect,
+                    );
+                }
+                Resolution::Ambiguous(prefix) => {
+                    let prefix = prefix.as_str();
+                    diag.help(format!(
+                        "`{ident}` resolves in more than one namespace; write a \
+                         disambiguated intra-doc link such as `[`{ident}`]({prefix}{ident})`",
+                    ));
+                }
             }
-            Resolution::Ambiguous(prefix) => {
-                let prefix = prefix.as_str();
-                diag.help(format!(
-                    "`{ident}` resolves in more than one namespace; write a \
-                     disambiguated intra-doc link such as `[`{ident}`]({prefix}{ident})`",
-                ));
-            }
+            // A backticked name can denote a foreign/upstream symbol the doc
+            // only mentions, coinciding with an in-scope item; an intra-doc
+            // link would then resolve to the wrong target while still
+            // compiling. Point authors at an explicit reference link to the
+            // real source for that case.
+            diag.help(format!(
+                "if `{ident}` instead names a foreign or upstream symbol that the doc \
+                 only mentions by name, do not link it to the local item; write an \
+                 explicit reference link to the real source, such as \
+                 `[`{ident}`][{ident}-ext]` with a `[{ident}-ext]: <url>` definition",
+            ));
         },
     );
 }

--- a/ui-toml/bare_identifier_reference/case_filters/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/case_filters/fixture.stderr
@@ -1,10 +1,16 @@
-warning: `Mixed_Thing` resolves in scope; write it as an intra-doc link
+warning: `Mixed_Thing` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:13:5
    |
 LL | /// `Mixed_Thing`, which is flagged regardless.
-   |     ^^^^^^^^^^^^^ help: wrap as an intra-doc link: `[`Mixed_Thing`]`
+   |     ^^^^^^^^^^^^^
    |
+   = help: if `Mixed_Thing` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Mixed_Thing`][Mixed_Thing-ext]` with a `[Mixed_Thing-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - /// `Mixed_Thing`, which is flagged regardless.
+LL + /// [`Mixed_Thing`], which is flagged regardless.
+   |
 
 warning: 1 warning emitted
 

--- a/ui-toml/bare_identifier_reference/case_filters/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/case_filters/fixture.stderr
@@ -6,7 +6,7 @@ LL | /// `Mixed_Thing`, which is flagged regardless.
    |
    = help: if `Mixed_Thing` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Mixed_Thing`][Mixed_Thing-ext]` with a `[Mixed_Thing-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - /// `Mixed_Thing`, which is flagged regardless.
 LL + /// [`Mixed_Thing`], which is flagged regardless.

--- a/ui-toml/bare_identifier_reference/dependency_crate/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/dependency_crate/fixture.stderr
@@ -1,10 +1,16 @@
-warning: `LocalThing` resolves in scope; write it as an intra-doc link
+warning: `LocalThing` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:10:14
    |
 LL | /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
-   |              ^^^^^^^^^^^^ help: wrap as an intra-doc link: `[`LocalThing`]`
+   |              ^^^^^^^^^^^^
    |
+   = help: if `LocalThing` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`LocalThing`][LocalThing-ext]` with a `[LocalThing-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
+LL + /// Mentions [`LocalThing`] (first-party) and `DepThing` (a third-party
+   |
 
 warning: 1 warning emitted
 

--- a/ui-toml/bare_identifier_reference/dependency_crate/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/dependency_crate/fixture.stderr
@@ -6,7 +6,7 @@ LL | /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
    |
    = help: if `LocalThing` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`LocalThing`][LocalThing-ext]` with a `[LocalThing-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
 LL + /// Mentions [`LocalThing`] (first-party) and `DepThing` (a third-party

--- a/ui-toml/bare_identifier_reference/dependency_third_party/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/dependency_third_party/fixture.stderr
@@ -6,7 +6,7 @@ LL | /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
    |
    = help: if `LocalThing` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`LocalThing`][LocalThing-ext]` with a `[LocalThing-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
 LL + /// Mentions [`LocalThing`] (first-party) and `DepThing` (a third-party
@@ -19,7 +19,7 @@ LL | /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
    |                                             ^^^^^^^^^^
    |
    = help: if `DepThing` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`DepThing`][DepThing-ext]` with a `[DepThing-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
 LL + /// Mentions `LocalThing` (first-party) and [`DepThing`] (a third-party

--- a/ui-toml/bare_identifier_reference/dependency_third_party/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/dependency_third_party/fixture.stderr
@@ -1,16 +1,29 @@
-warning: `LocalThing` resolves in scope; write it as an intra-doc link
+warning: `LocalThing` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:10:14
    |
 LL | /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
-   |              ^^^^^^^^^^^^ help: wrap as an intra-doc link: `[`LocalThing`]`
+   |              ^^^^^^^^^^^^
    |
+   = help: if `LocalThing` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`LocalThing`][LocalThing-ext]` with a `[LocalThing-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
+LL + /// Mentions [`LocalThing`] (first-party) and `DepThing` (a third-party
+   |
 
-warning: `DepThing` resolves in scope; write it as an intra-doc link
+warning: `DepThing` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:10:45
    |
 LL | /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
-   |                                             ^^^^^^^^^^ help: wrap as an intra-doc link: `[`DepThing`]`
+   |                                             ^^^^^^^^^^
+   |
+   = help: if `DepThing` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`DepThing`][DepThing-ext]` with a `[DepThing-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - /// Mentions `LocalThing` (first-party) and `DepThing` (a third-party
+LL + /// Mentions `LocalThing` (first-party) and [`DepThing`] (a third-party
+   |
 
 warning: 2 warnings emitted
 

--- a/ui-toml/bare_identifier_reference/imports_anywhere/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/imports_anywhere/fixture.stderr
@@ -1,28 +1,55 @@
-warning: `Defined` resolves in scope; write it as an intra-doc link
+warning: `Defined` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:16:18
    |
 LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
-   |                  ^^^^^^^^^ help: wrap as an intra-doc link: `[`Defined`]`
+   |                  ^^^^^^^^^
    |
+   = help: if `Defined` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Defined`][Defined-ext]` with a `[Defined-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
+LL +     /// Mentions [`Defined`] (local), `InternalItem` (this module's
+   |
 
-warning: `InternalItem` resolves in scope; write it as an intra-doc link
+warning: `InternalItem` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:16:37
    |
 LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
-   |                                     ^^^^^^^^^^^^^^ help: wrap as an intra-doc link: `[`InternalItem`]`
+   |                                     ^^^^^^^^^^^^^^
+   |
+   = help: if `InternalItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`InternalItem`][InternalItem-ext]` with a `[InternalItem-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
+LL +     /// Mentions `Defined` (local), [`InternalItem`] (this module's
+   |
 
-warning: `RootItem` resolves in scope; write it as an intra-doc link
+warning: `RootItem` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:17:19
    |
 LL |     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
-   |                   ^^^^^^^^^^ help: wrap as an intra-doc link: `[`RootItem`]`
+   |                   ^^^^^^^^^^
+   |
+   = help: if `RootItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`RootItem`][RootItem-ext]` with a `[RootItem-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
+LL +     /// subtree), [`RootItem`] (reached via `crate::`), and `HashMap`
+   |
 
-warning: `HashMap` resolves in scope; write it as an intra-doc link
+warning: `HashMap` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:17:59
    |
 LL |     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
-   |                                                           ^^^^^^^^^ help: wrap as an intra-doc link: `[`HashMap`]`
+   |                                                           ^^^^^^^^^
+   |
+   = help: if `HashMap` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`HashMap`][HashMap-ext]` with a `[HashMap-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
+LL +     /// subtree), `RootItem` (reached via `crate::`), and [`HashMap`]
+   |
 
 warning: 4 warnings emitted
 

--- a/ui-toml/bare_identifier_reference/imports_anywhere/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/imports_anywhere/fixture.stderr
@@ -6,7 +6,7 @@ LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
    |
    = help: if `Defined` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Defined`][Defined-ext]` with a `[Defined-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
 LL +     /// Mentions [`Defined`] (local), `InternalItem` (this module's
@@ -19,7 +19,7 @@ LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
    |                                     ^^^^^^^^^^^^^^
    |
    = help: if `InternalItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`InternalItem`][InternalItem-ext]` with a `[InternalItem-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
 LL +     /// Mentions `Defined` (local), [`InternalItem`] (this module's
@@ -32,7 +32,7 @@ LL |     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
    |                   ^^^^^^^^^^
    |
    = help: if `RootItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`RootItem`][RootItem-ext]` with a `[RootItem-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
 LL +     /// subtree), [`RootItem`] (reached via `crate::`), and `HashMap`
@@ -45,7 +45,7 @@ LL |     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
    |                                                           ^^^^^^^^^
    |
    = help: if `HashMap` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`HashMap`][HashMap-ext]` with a `[HashMap-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
 LL +     /// subtree), `RootItem` (reached via `crate::`), and [`HashMap`]

--- a/ui-toml/bare_identifier_reference/imports_crate/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/imports_crate/fixture.stderr
@@ -1,22 +1,42 @@
-warning: `Defined` resolves in scope; write it as an intra-doc link
+warning: `Defined` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:16:18
    |
 LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
-   |                  ^^^^^^^^^ help: wrap as an intra-doc link: `[`Defined`]`
+   |                  ^^^^^^^^^
    |
+   = help: if `Defined` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Defined`][Defined-ext]` with a `[Defined-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
+LL +     /// Mentions [`Defined`] (local), `InternalItem` (this module's
+   |
 
-warning: `InternalItem` resolves in scope; write it as an intra-doc link
+warning: `InternalItem` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:16:37
    |
 LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
-   |                                     ^^^^^^^^^^^^^^ help: wrap as an intra-doc link: `[`InternalItem`]`
+   |                                     ^^^^^^^^^^^^^^
+   |
+   = help: if `InternalItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`InternalItem`][InternalItem-ext]` with a `[InternalItem-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
+LL +     /// Mentions `Defined` (local), [`InternalItem`] (this module's
+   |
 
-warning: `RootItem` resolves in scope; write it as an intra-doc link
+warning: `RootItem` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:17:19
    |
 LL |     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
-   |                   ^^^^^^^^^^ help: wrap as an intra-doc link: `[`RootItem`]`
+   |                   ^^^^^^^^^^
+   |
+   = help: if `RootItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`RootItem`][RootItem-ext]` with a `[RootItem-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
+LL +     /// subtree), [`RootItem`] (reached via `crate::`), and `HashMap`
+   |
 
 warning: 3 warnings emitted
 

--- a/ui-toml/bare_identifier_reference/imports_crate/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/imports_crate/fixture.stderr
@@ -6,7 +6,7 @@ LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
    |
    = help: if `Defined` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Defined`][Defined-ext]` with a `[Defined-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
 LL +     /// Mentions [`Defined`] (local), `InternalItem` (this module's
@@ -19,7 +19,7 @@ LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
    |                                     ^^^^^^^^^^^^^^
    |
    = help: if `InternalItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`InternalItem`][InternalItem-ext]` with a `[InternalItem-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
 LL +     /// Mentions `Defined` (local), [`InternalItem`] (this module's
@@ -32,7 +32,7 @@ LL |     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
    |                   ^^^^^^^^^^
    |
    = help: if `RootItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`RootItem`][RootItem-ext]` with a `[RootItem-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
 LL +     /// subtree), [`RootItem`] (reached via `crate::`), and `HashMap`

--- a/ui-toml/bare_identifier_reference/imports_ignore/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/imports_ignore/fixture.stderr
@@ -6,7 +6,7 @@ LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
    |
    = help: if `Defined` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Defined`][Defined-ext]` with a `[Defined-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
 LL +     /// Mentions [`Defined`] (local), `InternalItem` (this module's

--- a/ui-toml/bare_identifier_reference/imports_ignore/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/imports_ignore/fixture.stderr
@@ -1,10 +1,16 @@
-warning: `Defined` resolves in scope; write it as an intra-doc link
+warning: `Defined` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:16:18
    |
 LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
-   |                  ^^^^^^^^^ help: wrap as an intra-doc link: `[`Defined`]`
+   |                  ^^^^^^^^^
    |
+   = help: if `Defined` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Defined`][Defined-ext]` with a `[Defined-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
+LL +     /// Mentions [`Defined`] (local), `InternalItem` (this module's
+   |
 
 warning: 1 warning emitted
 

--- a/ui-toml/bare_identifier_reference/imports_internal/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/imports_internal/fixture.stderr
@@ -6,7 +6,7 @@ LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
    |
    = help: if `Defined` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Defined`][Defined-ext]` with a `[Defined-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
 LL +     /// Mentions [`Defined`] (local), `InternalItem` (this module's
@@ -19,7 +19,7 @@ LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
    |                                     ^^^^^^^^^^^^^^
    |
    = help: if `InternalItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`InternalItem`][InternalItem-ext]` with a `[InternalItem-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
 LL +     /// Mentions `Defined` (local), [`InternalItem`] (this module's

--- a/ui-toml/bare_identifier_reference/imports_internal/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/imports_internal/fixture.stderr
@@ -1,16 +1,29 @@
-warning: `Defined` resolves in scope; write it as an intra-doc link
+warning: `Defined` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:16:18
    |
 LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
-   |                  ^^^^^^^^^ help: wrap as an intra-doc link: `[`Defined`]`
+   |                  ^^^^^^^^^
    |
+   = help: if `Defined` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Defined`][Defined-ext]` with a `[Defined-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
+LL +     /// Mentions [`Defined`] (local), `InternalItem` (this module's
+   |
 
-warning: `InternalItem` resolves in scope; write it as an intra-doc link
+warning: `InternalItem` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:16:37
    |
 LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
-   |                                     ^^^^^^^^^^^^^^ help: wrap as an intra-doc link: `[`InternalItem`]`
+   |                                     ^^^^^^^^^^^^^^
+   |
+   = help: if `InternalItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`InternalItem`][InternalItem-ext]` with a `[InternalItem-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
+LL +     /// Mentions `Defined` (local), [`InternalItem`] (this module's
+   |
 
 warning: 2 warnings emitted
 

--- a/ui-toml/bare_identifier_reference/imports_third_party/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/imports_third_party/fixture.stderr
@@ -1,22 +1,42 @@
-warning: `Defined` resolves in scope; write it as an intra-doc link
+warning: `Defined` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:16:18
    |
 LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
-   |                  ^^^^^^^^^ help: wrap as an intra-doc link: `[`Defined`]`
+   |                  ^^^^^^^^^
    |
+   = help: if `Defined` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Defined`][Defined-ext]` with a `[Defined-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
+LL +     /// Mentions [`Defined`] (local), `InternalItem` (this module's
+   |
 
-warning: `InternalItem` resolves in scope; write it as an intra-doc link
+warning: `InternalItem` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:16:37
    |
 LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
-   |                                     ^^^^^^^^^^^^^^ help: wrap as an intra-doc link: `[`InternalItem`]`
+   |                                     ^^^^^^^^^^^^^^
+   |
+   = help: if `InternalItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`InternalItem`][InternalItem-ext]` with a `[InternalItem-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
+LL +     /// Mentions `Defined` (local), [`InternalItem`] (this module's
+   |
 
-warning: `RootItem` resolves in scope; write it as an intra-doc link
+warning: `RootItem` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:17:19
    |
 LL |     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
-   |                   ^^^^^^^^^^ help: wrap as an intra-doc link: `[`RootItem`]`
+   |                   ^^^^^^^^^^
+   |
+   = help: if `RootItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`RootItem`][RootItem-ext]` with a `[RootItem-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
+LL +     /// subtree), [`RootItem`] (reached via `crate::`), and `HashMap`
+   |
 
 warning: 3 warnings emitted
 

--- a/ui-toml/bare_identifier_reference/imports_third_party/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/imports_third_party/fixture.stderr
@@ -6,7 +6,7 @@ LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
    |
    = help: if `Defined` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Defined`][Defined-ext]` with a `[Defined-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
 LL +     /// Mentions [`Defined`] (local), `InternalItem` (this module's
@@ -19,7 +19,7 @@ LL |     /// Mentions `Defined` (local), `InternalItem` (this module's
    |                                     ^^^^^^^^^^^^^^
    |
    = help: if `InternalItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`InternalItem`][InternalItem-ext]` with a `[InternalItem-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// Mentions `Defined` (local), `InternalItem` (this module's
 LL +     /// Mentions `Defined` (local), [`InternalItem`] (this module's
@@ -32,7 +32,7 @@ LL |     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
    |                   ^^^^^^^^^^
    |
    = help: if `RootItem` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`RootItem`][RootItem-ext]` with a `[RootItem-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// subtree), `RootItem` (reached via `crate::`), and `HashMap`
 LL +     /// subtree), [`RootItem`] (reached via `crate::`), and `HashMap`

--- a/ui-toml/bare_identifier_reference/macro_disambiguator/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/macro_disambiguator/fixture.stderr
@@ -4,7 +4,7 @@ warning: `dual` resolves in scope; consider writing it as an intra-doc link
 LL | /// A public macro and a private function both answer to `dual`; the
    |                                                          ^^^^^^
    |
-   = help: `dual` resolves in more than one namespace; write a disambiguated intra-doc link such as `[`dual`](macro@dual)`
+   = help: `dual` resolves in more than one namespace; only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, write a disambiguated intra-doc link such as `[`dual`](macro@dual)`
    = help: if `dual` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`dual`][dual-ext]` with a `[dual-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
 

--- a/ui-toml/bare_identifier_reference/macro_disambiguator/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/macro_disambiguator/fixture.stderr
@@ -1,10 +1,11 @@
-warning: `dual` resolves in scope; write it as an intra-doc link
+warning: `dual` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:10:58
    |
 LL | /// A public macro and a private function both answer to `dual`; the
    |                                                          ^^^^^^
    |
    = help: `dual` resolves in more than one namespace; write a disambiguated intra-doc link such as `[`dual`](macro@dual)`
+   = help: if `dual` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`dual`][dual-ext]` with a `[dual-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
 
 warning: 1 warning emitted

--- a/ui-toml/bare_identifier_reference/min_words/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/min_words/fixture.stderr
@@ -6,7 +6,7 @@ LL | /// At or above it and checked: `FooBarBaz` (3), `foo_bar_baz` (3).
    |
    = help: if `FooBarBaz` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`FooBarBaz`][FooBarBaz-ext]` with a `[FooBarBaz-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - /// At or above it and checked: `FooBarBaz` (3), `foo_bar_baz` (3).
 LL + /// At or above it and checked: [`FooBarBaz`] (3), `foo_bar_baz` (3).
@@ -19,7 +19,7 @@ LL | /// At or above it and checked: `FooBarBaz` (3), `foo_bar_baz` (3).
    |                                                  ^^^^^^^^^^^^^
    |
    = help: if `foo_bar_baz` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`foo_bar_baz`][foo_bar_baz-ext]` with a `[foo_bar_baz-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - /// At or above it and checked: `FooBarBaz` (3), `foo_bar_baz` (3).
 LL + /// At or above it and checked: `FooBarBaz` (3), [`foo_bar_baz`] (3).
@@ -32,7 +32,7 @@ LL | /// Non-conformist and checked regardless: `Mixed_Thing`.
    |                                            ^^^^^^^^^^^^^
    |
    = help: if `Mixed_Thing` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Mixed_Thing`][Mixed_Thing-ext]` with a `[Mixed_Thing-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - /// Non-conformist and checked regardless: `Mixed_Thing`.
 LL + /// Non-conformist and checked regardless: [`Mixed_Thing`].

--- a/ui-toml/bare_identifier_reference/min_words/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/min_words/fixture.stderr
@@ -1,22 +1,42 @@
-warning: `FooBarBaz` resolves in scope; write it as an intra-doc link
+warning: `FooBarBaz` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:14:33
    |
 LL | /// At or above it and checked: `FooBarBaz` (3), `foo_bar_baz` (3).
-   |                                 ^^^^^^^^^^^ help: wrap as an intra-doc link: `[`FooBarBaz`]`
+   |                                 ^^^^^^^^^^^
    |
+   = help: if `FooBarBaz` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`FooBarBaz`][FooBarBaz-ext]` with a `[FooBarBaz-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - /// At or above it and checked: `FooBarBaz` (3), `foo_bar_baz` (3).
+LL + /// At or above it and checked: [`FooBarBaz`] (3), `foo_bar_baz` (3).
+   |
 
-warning: `foo_bar_baz` resolves in scope; write it as an intra-doc link
+warning: `foo_bar_baz` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:14:50
    |
 LL | /// At or above it and checked: `FooBarBaz` (3), `foo_bar_baz` (3).
-   |                                                  ^^^^^^^^^^^^^ help: wrap as an intra-doc link: `[`foo_bar_baz`]`
+   |                                                  ^^^^^^^^^^^^^
+   |
+   = help: if `foo_bar_baz` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`foo_bar_baz`][foo_bar_baz-ext]` with a `[foo_bar_baz-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - /// At or above it and checked: `FooBarBaz` (3), `foo_bar_baz` (3).
+LL + /// At or above it and checked: `FooBarBaz` (3), [`foo_bar_baz`] (3).
+   |
 
-warning: `Mixed_Thing` resolves in scope; write it as an intra-doc link
+warning: `Mixed_Thing` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:15:44
    |
 LL | /// Non-conformist and checked regardless: `Mixed_Thing`.
-   |                                            ^^^^^^^^^^^^^ help: wrap as an intra-doc link: `[`Mixed_Thing`]`
+   |                                            ^^^^^^^^^^^^^
+   |
+   = help: if `Mixed_Thing` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Mixed_Thing`][Mixed_Thing-ext]` with a `[Mixed_Thing-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - /// Non-conformist and checked regardless: `Mixed_Thing`.
+LL + /// Non-conformist and checked regardless: [`Mixed_Thing`].
+   |
 
 warning: 3 warnings emitted
 

--- a/ui-toml/bare_identifier_reference/skip_idents/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/skip_idents/fixture.stderr
@@ -6,7 +6,7 @@ LL | /// Mentions `Flagged`, which still fires, and `Skipped`, which the
    |
    = help: if `Flagged` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Flagged`][Flagged-ext]` with a `[Flagged-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - /// Mentions `Flagged`, which still fires, and `Skipped`, which the
 LL + /// Mentions [`Flagged`], which still fires, and `Skipped`, which the

--- a/ui-toml/bare_identifier_reference/skip_idents/fixture.stderr
+++ b/ui-toml/bare_identifier_reference/skip_idents/fixture.stderr
@@ -1,10 +1,16 @@
-warning: `Flagged` resolves in scope; write it as an intra-doc link
+warning: `Flagged` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/fixture.rs:7:14
    |
 LL | /// Mentions `Flagged`, which still fires, and `Skipped`, which the
-   |              ^^^^^^^^^ help: wrap as an intra-doc link: `[`Flagged`]`
+   |              ^^^^^^^^^
    |
+   = help: if `Flagged` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Flagged`][Flagged-ext]` with a `[Flagged-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - /// Mentions `Flagged`, which still fires, and `Skipped`, which the
+LL + /// Mentions [`Flagged`], which still fires, and `Skipped`, which the
+   |
 
 warning: 1 warning emitted
 

--- a/ui/bare_identifier_reference.stderr
+++ b/ui/bare_identifier_reference.stderr
@@ -1,66 +1,104 @@
-warning: `Helper` resolves in scope; write it as an intra-doc link
+warning: `Helper` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/bare_identifier_reference.rs:3:32
    |
 LL | //! The crate-level mention of `Helper` resolves at the crate root, so
-   |                                ^^^^^^^^ help: wrap as an intra-doc link: `[`Helper`]`
+   |                                ^^^^^^^^
    |
+   = help: if `Helper` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Helper`][Helper-ext]` with a `[Helper-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - //! The crate-level mention of `Helper` resolves at the crate root, so
+LL + //! The crate-level mention of [`Helper`] resolves at the crate root, so
+   |
 
-warning: `Helper` resolves in scope; write it as an intra-doc link
+warning: `Helper` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/bare_identifier_reference.rs:11:20
    |
 LL | /// Installs using `Helper` and `Store`.
-   |                    ^^^^^^^^ help: wrap as an intra-doc link: `[`Helper`]`
+   |                    ^^^^^^^^
+   |
+   = help: if `Helper` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Helper`][Helper-ext]` with a `[Helper-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - /// Installs using `Helper` and `Store`.
+LL + /// Installs using [`Helper`] and `Store`.
+   |
 
-warning: `Store` resolves in scope; write it as an intra-doc link
+warning: `Store` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/bare_identifier_reference.rs:11:33
    |
 LL | /// Installs using `Helper` and `Store`.
-   |                                 ^^^^^^^ help: wrap as an intra-doc link: `[`Store`]`
+   |                                 ^^^^^^^
+   |
+   = help: if `Store` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Store`][Store-ext]` with a `[Store-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - /// Installs using `Helper` and `Store`.
+LL + /// Installs using `Helper` and [`Store`].
+   |
 
-warning: `Helper` resolves in scope; write it as an intra-doc link
+warning: `Helper` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/bare_identifier_reference.rs:34:17
    |
 LL |     /// Reaches `Helper` through the `use` import in this module.
-   |                 ^^^^^^^^ help: wrap as an intra-doc link: `[`Helper`]`
+   |                 ^^^^^^^^
+   |
+   = help: if `Helper` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Helper`][Helper-ext]` with a `[Helper-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL -     /// Reaches `Helper` through the `use` import in this module.
+LL +     /// Reaches [`Helper`] through the `use` import in this module.
+   |
 
-warning: `overlap` resolves in scope; write it as an intra-doc link
+warning: `overlap` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/bare_identifier_reference.rs:41:44
    |
 LL | /// A module and a function both answer to `overlap`, which therefore
    |                                            ^^^^^^^^^
    |
    = help: `overlap` resolves in more than one namespace; write a disambiguated intra-doc link such as `[`overlap`](type@overlap)`
+   = help: if `overlap` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`overlap`][overlap-ext]` with a `[overlap-ext]: <url>` definition
 
-warning: `PrivateHelper` resolves in scope; write it as an intra-doc link
+warning: `PrivateHelper` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/bare_identifier_reference.rs:57:5
    |
 LL | /// `PrivateHelper` — both sit below the public API — so this one fires.
-   |     ^^^^^^^^^^^^^^^ help: wrap as an intra-doc link: `[`PrivateHelper`]`
+   |     ^^^^^^^^^^^^^^^
+   |
+   = help: if `PrivateHelper` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`PrivateHelper`][PrivateHelper-ext]` with a `[PrivateHelper-ext]: <url>` definition
+help: if it refers to this item, wrap it as an intra-doc link
+   |
+LL - /// `PrivateHelper` — both sit below the public API — so this one fires.
+LL + /// [`PrivateHelper`] — both sit below the public API — so this one fires.
+   |
 
-warning: `mixed_vis` resolves in scope; write it as an intra-doc link
+warning: `mixed_vis` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/bare_identifier_reference.rs:60:61
    |
 LL | /// A public module and a *private* function both answer to `mixed_vis`.
    |                                                             ^^^^^^^^^^^
    |
    = help: `mixed_vis` resolves in more than one namespace; write a disambiguated intra-doc link such as `[`mixed_vis`](type@mixed_vis)`
+   = help: if `mixed_vis` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`mixed_vis`][mixed_vis-ext]` with a `[mixed_vis-ext]: <url>` definition
 
-warning: `mixed_vis` resolves in scope; write it as an intra-doc link
+warning: `mixed_vis` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/bare_identifier_reference.rs:71:20
    |
 LL | /// The inverse of `mixed_vis`: the type (`flipped_vis`) is private and
    |                    ^^^^^^^^^^^
    |
    = help: `mixed_vis` resolves in more than one namespace; write a disambiguated intra-doc link such as `[`mixed_vis`](type@mixed_vis)`
+   = help: if `mixed_vis` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`mixed_vis`][mixed_vis-ext]` with a `[mixed_vis-ext]: <url>` definition
 
-warning: `flipped_vis` resolves in scope; write it as an intra-doc link
+warning: `flipped_vis` resolves in scope; consider writing it as an intra-doc link
   --> $DIR/bare_identifier_reference.rs:71:43
    |
 LL | /// The inverse of `mixed_vis`: the type (`flipped_vis`) is private and
    |                                           ^^^^^^^^^^^^^
    |
    = help: `flipped_vis` resolves in more than one namespace; write a disambiguated intra-doc link such as `[`flipped_vis`](value@flipped_vis)`
+   = help: if `flipped_vis` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`flipped_vis`][flipped_vis-ext]` with a `[flipped_vis-ext]: <url>` definition
 
 warning: 9 warnings emitted
 

--- a/ui/bare_identifier_reference.stderr
+++ b/ui/bare_identifier_reference.stderr
@@ -6,7 +6,7 @@ LL | //! The crate-level mention of `Helper` resolves at the crate root, so
    |
    = help: if `Helper` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Helper`][Helper-ext]` with a `[Helper-ext]: <url>` definition
    = note: `#[warn(perfectionist::bare_identifier_reference)]` on by default
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - //! The crate-level mention of `Helper` resolves at the crate root, so
 LL + //! The crate-level mention of [`Helper`] resolves at the crate root, so
@@ -19,7 +19,7 @@ LL | /// Installs using `Helper` and `Store`.
    |                    ^^^^^^^^
    |
    = help: if `Helper` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Helper`][Helper-ext]` with a `[Helper-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - /// Installs using `Helper` and `Store`.
 LL + /// Installs using [`Helper`] and `Store`.
@@ -32,7 +32,7 @@ LL | /// Installs using `Helper` and `Store`.
    |                                 ^^^^^^^
    |
    = help: if `Store` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Store`][Store-ext]` with a `[Store-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - /// Installs using `Helper` and `Store`.
 LL + /// Installs using `Helper` and [`Store`].
@@ -45,7 +45,7 @@ LL |     /// Reaches `Helper` through the `use` import in this module.
    |                 ^^^^^^^^
    |
    = help: if `Helper` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`Helper`][Helper-ext]` with a `[Helper-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL -     /// Reaches `Helper` through the `use` import in this module.
 LL +     /// Reaches [`Helper`] through the `use` import in this module.
@@ -57,7 +57,7 @@ warning: `overlap` resolves in scope; consider writing it as an intra-doc link
 LL | /// A module and a function both answer to `overlap`, which therefore
    |                                            ^^^^^^^^^
    |
-   = help: `overlap` resolves in more than one namespace; write a disambiguated intra-doc link such as `[`overlap`](type@overlap)`
+   = help: `overlap` resolves in more than one namespace; only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, write a disambiguated intra-doc link such as `[`overlap`](type@overlap)`
    = help: if `overlap` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`overlap`][overlap-ext]` with a `[overlap-ext]: <url>` definition
 
 warning: `PrivateHelper` resolves in scope; consider writing it as an intra-doc link
@@ -67,7 +67,7 @@ LL | /// `PrivateHelper` — both sit below the public API — so this one fires
    |     ^^^^^^^^^^^^^^^
    |
    = help: if `PrivateHelper` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`PrivateHelper`][PrivateHelper-ext]` with a `[PrivateHelper-ext]: <url>` definition
-help: if it refers to this item, wrap it as an intra-doc link
+help: only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, wrap it as an intra-doc link
    |
 LL - /// `PrivateHelper` — both sit below the public API — so this one fires.
 LL + /// [`PrivateHelper`] — both sit below the public API — so this one fires.
@@ -79,7 +79,7 @@ warning: `mixed_vis` resolves in scope; consider writing it as an intra-doc link
 LL | /// A public module and a *private* function both answer to `mixed_vis`.
    |                                                             ^^^^^^^^^^^
    |
-   = help: `mixed_vis` resolves in more than one namespace; write a disambiguated intra-doc link such as `[`mixed_vis`](type@mixed_vis)`
+   = help: `mixed_vis` resolves in more than one namespace; only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, write a disambiguated intra-doc link such as `[`mixed_vis`](type@mixed_vis)`
    = help: if `mixed_vis` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`mixed_vis`][mixed_vis-ext]` with a `[mixed_vis-ext]: <url>` definition
 
 warning: `mixed_vis` resolves in scope; consider writing it as an intra-doc link
@@ -88,7 +88,7 @@ warning: `mixed_vis` resolves in scope; consider writing it as an intra-doc link
 LL | /// The inverse of `mixed_vis`: the type (`flipped_vis`) is private and
    |                    ^^^^^^^^^^^
    |
-   = help: `mixed_vis` resolves in more than one namespace; write a disambiguated intra-doc link such as `[`mixed_vis`](type@mixed_vis)`
+   = help: `mixed_vis` resolves in more than one namespace; only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, write a disambiguated intra-doc link such as `[`mixed_vis`](type@mixed_vis)`
    = help: if `mixed_vis` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`mixed_vis`][mixed_vis-ext]` with a `[mixed_vis-ext]: <url>` definition
 
 warning: `flipped_vis` resolves in scope; consider writing it as an intra-doc link
@@ -97,7 +97,7 @@ warning: `flipped_vis` resolves in scope; consider writing it as an intra-doc li
 LL | /// The inverse of `mixed_vis`: the type (`flipped_vis`) is private and
    |                                           ^^^^^^^^^^^^^
    |
-   = help: `flipped_vis` resolves in more than one namespace; write a disambiguated intra-doc link such as `[`flipped_vis`](value@flipped_vis)`
+   = help: `flipped_vis` resolves in more than one namespace; only once the surrounding context confirms it refers to this item, not a foreign symbol of the same name, write a disambiguated intra-doc link such as `[`flipped_vis`](value@flipped_vis)`
    = help: if `flipped_vis` instead names a foreign or upstream symbol that the doc only mentions by name, do not link it to the local item; write an explicit reference link to the real source, such as `[`flipped_vis`][flipped_vis-ext]` with a `[flipped_vis-ext]: <url>` definition
 
 warning: 9 warnings emitted


### PR DESCRIPTION
## Summary

Softens `perfectionist::bare_identifier_reference`'s autofix, which was reported as a "false promise" from a downstream port in [pnpm/pnpm#12719](https://github.com/pnpm/pnpm/pull/12719#issuecomment-4832077247).

The rule rewrote every flagged code span (`` `Foo` `` → `` [`Foo`] ``) as a **`MachineApplicable`** suggestion, without checking the target is a *local* item. When the prose names a foreign/upstream symbol that merely shares a name with an in-scope item, the link silently resolves to the local item — a wrong reference that still compiles, so nothing downstream catches it.

## Changes

- **Downgrade applicability `MachineApplicable` → `MaybeIncorrect`** on the unique-resolution suggestion, so `cargo fix`, `cargo clippy --fix`, and editor "apply suggestion" affordances no longer apply it blindly.
- **Reword the docs, diagnostic message, and hints** to make explicit that converting a code span to an intra-doc link is not always correct, and to point at an explicit reference link (`` [`Foo`][foo-ext] `` + `` [foo-ext]: <url> ``) when the target is external. Both "convert it" hints now tell the reader to do so only once the surrounding context confirms the name refers to this item and not a foreign symbol of the same name.
- Regenerate `rules/bare_identifier_reference.md` and re-bless the UI fixtures.

## Verification

`just all` passes locally — fmt, build, doc (including `cargo doc -D warnings` and the `rules/` catalogue sync check), clippy, test, and self-lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
