### PR TITLE
feat(allow-attributes): offer removal beside the `#[expect]` fix

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -8,7 +8,7 @@ Lint-control attributes use the `perfectionist::` namespace.
 
 - [`allow_attributes`](./allow_attributes.md) (default: `active`).
 
-  `#[allow]` for a deterministically-firing lint should be `#[expect]`
+  `#[allow]` for a deterministically-firing lint should be removed or be `#[expect]`
 
 - [`allow_attributes_without_reason`](./allow_attributes_without_reason.md) (default: `active`).
 

--- a/rules/allow_attributes.md
+++ b/rules/allow_attributes.md
@@ -12,8 +12,8 @@
 Flags `#[allow(<lints>)]` when every named lint fires
 deterministically — a built-in rustc lint (not on the exempt
 list), a `clippy::*` / `rustdoc::*` lint, or a tool-namespaced
-lint such as `perfectionist::*`. It suggests two ways to resolve
-the attribute:
+lint such as `perfectionist::*`. Such a suppression can be
+resolved two ways:
 
 1. **Remove** it — when the lint can no longer fire at the site
    (a dead suppression, e.g. `clippy::too_many_arguments` left on

--- a/rules/allow_attributes.md
+++ b/rules/allow_attributes.md
@@ -5,22 +5,41 @@
 **Default state:** `active`  
 **Source:** [`src/rules/allow_attributes.rs`](../src/rules/allow_attributes.rs)
 
-> `#[allow]` for a deterministically-firing lint should be `#[expect]`
+> `#[allow]` for a deterministically-firing lint should be removed or be `#[expect]`
 
 ## What it does
 
-Rewrites `#[allow(<lints>)]` to `#[expect(<lints>)]` when every
-named lint fires deterministically — a built-in rustc lint (not
-on the exempt list), a `clippy::*` / `rustdoc::*` lint, or a
-tool-namespaced lint such as `perfectionist::*`. The
-`cfg_attr`-wrapped form (`#[cfg_attr(<cfg>, allow(...))]`) is
-rewritten in place, swapping only the inner `allow` identifier.
+Flags `#[allow(<lints>)]` whenever every named lint fires
+deterministically — a built-in rustc lint (not on the exempt
+list), a `clippy::*` / `rustdoc::*` lint, or a tool-namespaced
+lint such as `perfectionist::*`. A deterministic `#[allow]` has
+two better forms, and the rule can't tell which one fits because
+it can't see whether the lint still fires at the site, so it
+offers **both** as review-me suggestions:
+
+1. **Remove** the suppression — the right fix when the lint can no
+   longer fire (a *dead* `#[allow]`, e.g. `clippy::too_many_arguments`
+   left on a function that has since shed its arguments).
+2. **Replace** `#[allow]` with `#[expect]` — the right fix when the
+   lint still fires and you want the suppression to self-clean.
+
+Both are emitted at `Applicability::MaybeIncorrect`: they are
+hints for a human to choose between, not an autofix. Picking the
+wrong one is itself caught by routine compilation — `#[expect]` on
+a dead lint trips `unfulfilled_lint_expectations`, and removing a
+live `#[allow]` reinstates the original warning.
+
+The `cfg_attr`-wrapped form (`#[cfg_attr(<cfg>, allow(...))]`) is
+handled in place: the `#[expect]` suggestion swaps the inner
+`allow` identifier, and removal is offered only where it can be
+expressed without dropping the `cfg` wrapper.
 
 When an attribute mixes a rewriteable lint with a
 non-rewriteable one (an exempt-list entry or an unknown lint),
-it is split: the non-rewriteable names stay under `#[allow]` and
-the rewriteable ones move to a new `#[expect]`, copying the
-`reason` field to each.
+the suggestions act on the rewriteable names only: drop them from
+the `#[allow]`, or split them into a new `#[expect]` — the
+non-rewriteable names stay under `#[allow]` either way, with the
+`reason` field copied to each.
 
 Crate- and module-level scopes (`#![allow(...)]`, and outer
 `#[allow(...)]` on a `mod` item) are left alone by default,
@@ -46,14 +65,15 @@ issue is observed rather than hidden.
 
 `clippy::allow_attributes` (`restriction`, off by default)
 also pushes `#[allow]` towards `#[expect]`, but rewrites
-*every* `#[allow]` indiscriminately. This rule converts only
-the lints that fire **deterministically**, leaving lint groups
-and conditionally-firing lints under `#[allow]` (splitting a
-mixed attribute in two), so the `#[expect]` it produces is
-always fulfilled rather than a fresh
-`unfulfilled_lint_expectations` warning. Reach for this rule
-for that precision, or `clippy::allow_attributes` for a blunt
-crate-wide sweep.
+*every* `#[allow]` indiscriminately, and only towards `#[expect]`.
+This rule flags only the lints that fire **deterministically**,
+leaving lint groups and conditionally-firing lints under
+`#[allow]`. Crucially, it does not assume `#[expect]` is always
+the answer: a deterministic `#[allow]` may already be dead, in
+which case `#[expect]` would be unfulfilled and removal is the
+right fix, so the rule offers both. Reach for this rule for that
+precision, or `clippy::allow_attributes` for a blunt crate-wide
+sweep.
 
 ## Example
 

--- a/rules/allow_attributes.md
+++ b/rules/allow_attributes.md
@@ -9,37 +9,21 @@
 
 ## What it does
 
-Flags `#[allow(<lints>)]` whenever every named lint fires
+Flags `#[allow(<lints>)]` when every named lint fires
 deterministically — a built-in rustc lint (not on the exempt
 list), a `clippy::*` / `rustdoc::*` lint, or a tool-namespaced
-lint such as `perfectionist::*`. A deterministic `#[allow]` has
-two better forms, and the rule can't tell which one fits because
-it can't see whether the lint still fires at the site, so it
-offers **both** as review-me suggestions:
+lint such as `perfectionist::*`. It suggests two ways to resolve
+the attribute:
 
-1. **Remove** the suppression — the right fix when the lint can no
-   longer fire (a *dead* `#[allow]`, e.g. `clippy::too_many_arguments`
-   left on a function that has since shed its arguments).
-2. **Replace** `#[allow]` with `#[expect]` — the right fix when the
-   lint still fires and you want the suppression to self-clean.
+1. **Remove** it — when the lint can no longer fire at the site
+   (a dead suppression, e.g. `clippy::too_many_arguments` left on
+   a function that has since shed its arguments).
+2. **Replace** it with `#[expect]` — when the lint still fires and
+   you want the suppression to report itself the moment it stops.
 
-Both are emitted at `Applicability::MaybeIncorrect`: they are
-hints for a human to choose between, not an autofix. Picking the
-wrong one is itself caught by routine compilation — `#[expect]` on
-a dead lint trips `unfulfilled_lint_expectations`, and removing a
-live `#[allow]` reinstates the original warning.
-
-The `cfg_attr`-wrapped form (`#[cfg_attr(<cfg>, allow(...))]`) is
-handled in place: the `#[expect]` suggestion swaps the inner
-`allow` identifier, and removal is offered only where it can be
-expressed without dropping the `cfg` wrapper.
-
-When an attribute mixes a rewriteable lint with a
-non-rewriteable one (an exempt-list entry or an unknown lint),
-the suggestions act on the rewriteable names only: drop them from
-the `#[allow]`, or split them into a new `#[expect]` — the
-non-rewriteable names stay under `#[allow]` either way, with the
-`reason` field copied to each.
+If the attribute also names a lint the rule leaves alone (an
+exempt or unknown lint), only the deterministic names are
+resolved; the rest stay under `#[allow]`.
 
 Crate- and module-level scopes (`#![allow(...)]`, and outer
 `#[allow(...)]` on a `mod` item) are left alone by default,

--- a/src/rules/allow_attributes.rs
+++ b/src/rules/allow_attributes.rs
@@ -15,37 +15,21 @@ mod tests;
 declare_tool_lint! {
     /// ### What it does
     ///
-    /// Flags `#[allow(<lints>)]` whenever every named lint fires
+    /// Flags `#[allow(<lints>)]` when every named lint fires
     /// deterministically — a built-in rustc lint (not on the exempt
     /// list), a `clippy::*` / `rustdoc::*` lint, or a tool-namespaced
-    /// lint such as `perfectionist::*`. A deterministic `#[allow]` has
-    /// two better forms, and the rule can't tell which one fits because
-    /// it can't see whether the lint still fires at the site, so it
-    /// offers **both** as review-me suggestions:
+    /// lint such as `perfectionist::*`. It suggests two ways to resolve
+    /// the attribute:
     ///
-    /// 1. **Remove** the suppression — the right fix when the lint can no
-    ///    longer fire (a *dead* `#[allow]`, e.g. `clippy::too_many_arguments`
-    ///    left on a function that has since shed its arguments).
-    /// 2. **Replace** `#[allow]` with `#[expect]` — the right fix when the
-    ///    lint still fires and you want the suppression to self-clean.
+    /// 1. **Remove** it — when the lint can no longer fire at the site
+    ///    (a dead suppression, e.g. `clippy::too_many_arguments` left on
+    ///    a function that has since shed its arguments).
+    /// 2. **Replace** it with `#[expect]` — when the lint still fires and
+    ///    you want the suppression to report itself the moment it stops.
     ///
-    /// Both are emitted at `Applicability::MaybeIncorrect`: they are
-    /// hints for a human to choose between, not an autofix. Picking the
-    /// wrong one is itself caught by routine compilation — `#[expect]` on
-    /// a dead lint trips `unfulfilled_lint_expectations`, and removing a
-    /// live `#[allow]` reinstates the original warning.
-    ///
-    /// The `cfg_attr`-wrapped form (`#[cfg_attr(<cfg>, allow(...))]`) is
-    /// handled in place: the `#[expect]` suggestion swaps the inner
-    /// `allow` identifier, and removal is offered only where it can be
-    /// expressed without dropping the `cfg` wrapper.
-    ///
-    /// When an attribute mixes a rewriteable lint with a
-    /// non-rewriteable one (an exempt-list entry or an unknown lint),
-    /// the suggestions act on the rewriteable names only: drop them from
-    /// the `#[allow]`, or split them into a new `#[expect]` — the
-    /// non-rewriteable names stay under `#[allow]` either way, with the
-    /// `reason` field copied to each.
+    /// If the attribute also names a lint the rule leaves alone (an
+    /// exempt or unknown lint), only the deterministic names are
+    /// resolved; the rest stay under `#[allow]`.
     ///
     /// Crate- and module-level scopes (`#![allow(...)]`, and outer
     /// `#[allow(...)]` on a `mod` item) are left alone by default,

--- a/src/rules/allow_attributes.rs
+++ b/src/rules/allow_attributes.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, render_meta_path, resolve_string_set, resolved_state};
-use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_sugg};
+use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
 use clippy_utils::is_from_proc_macro;
 use clippy_utils::source::{indent_of, snippet_opt};
 use rustc_ast::{AttrStyle, Attribute, Item, ItemKind, MetaItem, MetaItemInner, MetaItemKind};
@@ -15,18 +15,37 @@ mod tests;
 declare_tool_lint! {
     /// ### What it does
     ///
-    /// Rewrites `#[allow(<lints>)]` to `#[expect(<lints>)]` when every
-    /// named lint fires deterministically — a built-in rustc lint (not
-    /// on the exempt list), a `clippy::*` / `rustdoc::*` lint, or a
-    /// tool-namespaced lint such as `perfectionist::*`. The
-    /// `cfg_attr`-wrapped form (`#[cfg_attr(<cfg>, allow(...))]`) is
-    /// rewritten in place, swapping only the inner `allow` identifier.
+    /// Flags `#[allow(<lints>)]` whenever every named lint fires
+    /// deterministically — a built-in rustc lint (not on the exempt
+    /// list), a `clippy::*` / `rustdoc::*` lint, or a tool-namespaced
+    /// lint such as `perfectionist::*`. A deterministic `#[allow]` has
+    /// two better forms, and the rule can't tell which one fits because
+    /// it can't see whether the lint still fires at the site, so it
+    /// offers **both** as review-me suggestions:
+    ///
+    /// 1. **Remove** the suppression — the right fix when the lint can no
+    ///    longer fire (a *dead* `#[allow]`, e.g. `clippy::too_many_arguments`
+    ///    left on a function that has since shed its arguments).
+    /// 2. **Replace** `#[allow]` with `#[expect]` — the right fix when the
+    ///    lint still fires and you want the suppression to self-clean.
+    ///
+    /// Both are emitted at `Applicability::MaybeIncorrect`: they are
+    /// hints for a human to choose between, not an autofix. Picking the
+    /// wrong one is itself caught by routine compilation — `#[expect]` on
+    /// a dead lint trips `unfulfilled_lint_expectations`, and removing a
+    /// live `#[allow]` reinstates the original warning.
+    ///
+    /// The `cfg_attr`-wrapped form (`#[cfg_attr(<cfg>, allow(...))]`) is
+    /// handled in place: the `#[expect]` suggestion swaps the inner
+    /// `allow` identifier, and removal is offered only where it can be
+    /// expressed without dropping the `cfg` wrapper.
     ///
     /// When an attribute mixes a rewriteable lint with a
     /// non-rewriteable one (an exempt-list entry or an unknown lint),
-    /// it is split: the non-rewriteable names stay under `#[allow]` and
-    /// the rewriteable ones move to a new `#[expect]`, copying the
-    /// `reason` field to each.
+    /// the suggestions act on the rewriteable names only: drop them from
+    /// the `#[allow]`, or split them into a new `#[expect]` — the
+    /// non-rewriteable names stay under `#[allow]` either way, with the
+    /// `reason` field copied to each.
     ///
     /// Crate- and module-level scopes (`#![allow(...)]`, and outer
     /// `#[allow(...)]` on a `mod` item) are left alone by default,
@@ -52,14 +71,15 @@ declare_tool_lint! {
     ///
     /// `clippy::allow_attributes` (`restriction`, off by default)
     /// also pushes `#[allow]` towards `#[expect]`, but rewrites
-    /// *every* `#[allow]` indiscriminately. This rule converts only
-    /// the lints that fire **deterministically**, leaving lint groups
-    /// and conditionally-firing lints under `#[allow]` (splitting a
-    /// mixed attribute in two), so the `#[expect]` it produces is
-    /// always fulfilled rather than a fresh
-    /// `unfulfilled_lint_expectations` warning. Reach for this rule
-    /// for that precision, or `clippy::allow_attributes` for a blunt
-    /// crate-wide sweep.
+    /// *every* `#[allow]` indiscriminately, and only towards `#[expect]`.
+    /// This rule flags only the lints that fire **deterministically**,
+    /// leaving lint groups and conditionally-firing lints under
+    /// `#[allow]`. Crucially, it does not assume `#[expect]` is always
+    /// the answer: a deterministic `#[allow]` may already be dead, in
+    /// which case `#[expect]` would be unfulfilled and removal is the
+    /// right fix, so the rule offers both. Reach for this rule for that
+    /// precision, or `clippy::allow_attributes` for a blunt crate-wide
+    /// sweep.
     ///
     /// ### Example
     ///
@@ -78,7 +98,7 @@ declare_tool_lint! {
     /// ```
     pub perfectionist::ALLOW_ATTRIBUTES,
     Warn,
-    "`#[allow]` for a deterministically-firing lint should be `#[expect]`",
+    "`#[allow]` for a deterministically-firing lint should be removed or be `#[expect]`",
     report_in_external_macro: false
 }
 
@@ -348,40 +368,35 @@ impl AllowAttributes {
             }
         }
 
-        // Nothing deterministic to move — leave the attribute as-is.
+        // Nothing deterministic to act on — leave the attribute as-is.
         if rewriteable.is_empty() {
             return;
         }
 
         let reason_snippet = reason.and_then(|meta| snippet_opt(lint_context, meta.span));
+        let container = container_of(lint_context, attr_span, attr_style);
 
         if kept.is_empty() {
-            // Every named lint is rewriteable: a one-word swap.
-            span_lint_and_sugg(
-                lint_context,
-                ALLOW_ATTRIBUTES,
-                ident_span,
-                "this `#[allow]` can be `#[expect]` so the suppression self-cleans",
-                "replace `allow` with `expect`",
-                "expect".to_owned(),
-                Applicability::MaybeIncorrect,
-            );
+            // Every named lint is rewriteable: offer removal of the whole
+            // suppression or a one-word `allow` -> `expect` swap.
+            self.emit_simple(lint_context, ident_span, container.as_ref());
             return;
         }
 
-        // Mixed: split the rewriteable lints into a separate `#[expect]`.
-        // The textual rewrite needs the source snippet to place the new
-        // attribute (bare vs inside a `cfg_attr` arg list) and to copy
-        // the `reason` verbatim. If either is unavailable — only
-        // reachable for spans `is_from_proc_macro` somehow let through —
-        // flag the site without an autofix rather than risk emitting a
-        // rewrite that drops the reason or injects `#[..]` inside a
-        // `cfg_attr`.
+        // Mixed: act on the rewriteable lints only — drop them, or split
+        // them into a separate `#[expect]`. The textual rewrite needs the
+        // source snippet to place the new attribute (bare vs inside a
+        // `cfg_attr` arg list) and to copy the `reason` verbatim. If
+        // either is unavailable — only reachable for spans
+        // `is_from_proc_macro` somehow let through — flag the site without
+        // a structured suggestion rather than risk a rewrite that drops
+        // the reason or injects `#[..]` inside a `cfg_attr`.
         let reason_recoverable = reason.is_none() || reason_snippet.is_some();
-        match container_of(lint_context, attr_span, attr_style) {
+        match container {
             Some(container) if reason_recoverable => self.emit_split(
                 lint_context,
-                container,
+                ident_span,
+                &container,
                 &kept,
                 &rewriteable,
                 reason_snippet.as_deref(),
@@ -418,39 +433,100 @@ impl AllowAttributes {
         }
     }
 
+    /// Emit the lint for a simple `#[allow]` whose every named lint is
+    /// rewriteable, offering the two resolutions a deterministic
+    /// suppression has. The lint might still fire here (so `#[expect]`
+    /// keeps the suppression and makes it self-clean) or might be long
+    /// dead (so the suppression should go) — the rule can't tell which,
+    /// so both are `MaybeIncorrect` hints for the author to choose.
+    fn emit_simple(
+        &self,
+        lint_context: &EarlyContext<'_>,
+        ident_span: Span,
+        container: Option<&Container>,
+    ) {
+        span_lint_and_then(
+            lint_context,
+            ALLOW_ATTRIBUTES,
+            ident_span,
+            "this `#[allow]` stays silent even after its lint stops firing",
+            |diag| {
+                // Resolution 1: remove the suppression — correct when the
+                // lint can no longer fire here. Only a bare attribute can
+                // be deleted outright; the inner `allow` of a `cfg_attr`
+                // can't go without dropping its `cfg` wrapper, so removal
+                // is left to the author in that case.
+                if let Some(Container::Bare { span, .. }) = container {
+                    diag.span_suggestion(
+                        *span,
+                        "remove the suppression if its lint can no longer fire here",
+                        String::new(),
+                        Applicability::MaybeIncorrect,
+                    );
+                }
+                // Resolution 2: keep the suppression but make it report
+                // once the lint stops firing.
+                diag.span_suggestion(
+                    ident_span,
+                    "otherwise replace `allow` with `expect`, which warns once the lint stops firing",
+                    "expect".to_owned(),
+                    Applicability::MaybeIncorrect,
+                );
+            },
+        );
+    }
+
+    /// Emit the lint for a mixed `#[allow]`, acting on the rewriteable
+    /// lints only: drop them, or split them into a separate `#[expect]`.
+    /// The kept (non-rewriteable) names stay under `#[allow]` either way.
+    /// Like [`Self::emit_simple`], both are `MaybeIncorrect` hints.
     fn emit_split(
         &self,
         lint_context: &EarlyContext<'_>,
-        container: Container,
+        ident_span: Span,
+        container: &Container,
         kept: &[String],
         rewriteable: &[String],
         reason: Option<&str>,
     ) {
-        let allow_body = render_invocation("allow", kept, reason);
-        let expect_body = render_invocation("expect", rewriteable, reason);
-        let (span, replacement) = match container {
-            Container::CfgAttrInner { span } => (span, format!("{allow_body}, {expect_body}")),
-            Container::Bare { span, style } => {
-                let hash = match style {
-                    AttrStyle::Inner => "#!",
-                    AttrStyle::Outer => "#",
-                };
-                let pad = " ".repeat(indent_of(lint_context, span).unwrap_or(0));
-                (
-                    span,
-                    format!("{hash}[{allow_body}]\n{pad}{hash}[{expect_body}]"),
-                )
-            }
-        };
-        span_lint_and_sugg(
+        let span = container.span();
+        let drop_rewriteable = render_attrs(lint_context, container, &[("allow", kept)], reason);
+        let split = render_attrs(
+            lint_context,
+            container,
+            &[("allow", kept), ("expect", rewriteable)],
+            reason,
+        );
+        span_lint_and_then(
             lint_context,
             ALLOW_ATTRIBUTES,
-            span,
-            "the deterministically-firing lints here can move to `#[expect]`",
-            "split the deterministic lints into a separate `#[expect]`",
-            replacement,
-            Applicability::MaybeIncorrect,
+            ident_span,
+            "some lints in this `#[allow]` stay silent even after they stop firing",
+            |diag| {
+                diag.span_suggestion(
+                    span,
+                    "drop them from the `#[allow]` if they can no longer fire here",
+                    drop_rewriteable,
+                    Applicability::MaybeIncorrect,
+                );
+                diag.span_suggestion(
+                    span,
+                    "otherwise split them into a separate `#[expect]` that self-cleans",
+                    split,
+                    Applicability::MaybeIncorrect,
+                );
+            },
         );
+    }
+}
+
+impl Container {
+    /// The span the suggestions replace — the whole bare attribute, or
+    /// the inner `allow(...)` item of a `cfg_attr`.
+    fn span(&self) -> Span {
+        match *self {
+            Container::Bare { span, .. } | Container::CfgAttrInner { span } => span,
+        }
     }
 }
 
@@ -474,18 +550,52 @@ fn container_of(
     })
 }
 
-/// Flag a mixed `#[allow]` without a machine-applicable suggestion,
-/// used when the source text needed to render a correct split rewrite
-/// is unavailable.
+/// Flag a mixed `#[allow]` without structured suggestions, used when the
+/// source text needed to render them is unavailable. Describes both
+/// resolutions in prose instead.
 fn emit_split_without_fix(lint_context: &EarlyContext<'_>, ident_span: Span) {
     span_lint_and_help(
         lint_context,
         ALLOW_ATTRIBUTES,
         ident_span,
-        "the deterministically-firing lints here can move to `#[expect]`",
+        "some lints in this `#[allow]` stay silent even after they stop firing",
         None,
-        "split the deterministic lints out into a separate `#[expect]`",
+        "drop them from the `#[allow]` if they can no longer fire here, or split them \
+         out into a separate `#[expect]` that self-cleans",
     );
+}
+
+/// Render the replacement text for a list of lint-control invocations
+/// (`("allow", names)`, `("expect", names)`) in the form `container`
+/// expects: standalone `#[..]` attributes for a bare `#[allow]`, or a
+/// comma-joined `allow(..), expect(..)` for the inner item of a
+/// `cfg_attr`. Groups with no names are skipped, so passing only a
+/// non-empty `("allow", kept)` renders the attribute with the
+/// rewriteable lints dropped.
+fn render_attrs(
+    lint_context: &EarlyContext<'_>,
+    container: &Container,
+    groups: &[(&str, &[String])],
+    reason: Option<&str>,
+) -> String {
+    let bodies = groups
+        .iter()
+        .filter(|(_, names)| !names.is_empty())
+        .map(|(keyword, names)| render_invocation(keyword, names, reason));
+    match container {
+        Container::CfgAttrInner { .. } => bodies.collect::<Vec<_>>().join(", "),
+        Container::Bare { span, style } => {
+            let hash = match style {
+                AttrStyle::Inner => "#!",
+                AttrStyle::Outer => "#",
+            };
+            let pad = " ".repeat(indent_of(lint_context, *span).unwrap_or(0));
+            bodies
+                .map(|body| format!("{hash}[{body}]"))
+                .collect::<Vec<_>>()
+                .join(&format!("\n{pad}"))
+        }
+    }
 }
 
 /// Render an `allow(...)` / `expect(...)` invocation from a list of

--- a/src/rules/allow_attributes.rs
+++ b/src/rules/allow_attributes.rs
@@ -18,8 +18,8 @@ declare_tool_lint! {
     /// Flags `#[allow(<lints>)]` when every named lint fires
     /// deterministically — a built-in rustc lint (not on the exempt
     /// list), a `clippy::*` / `rustdoc::*` lint, or a tool-namespaced
-    /// lint such as `perfectionist::*`. It suggests two ways to resolve
-    /// the attribute:
+    /// lint such as `perfectionist::*`. Such a suppression can be
+    /// resolved two ways:
     ///
     /// 1. **Remove** it — when the lint can no longer fire at the site
     ///    (a dead suppression, e.g. `clippy::too_many_arguments` left on
@@ -315,10 +315,11 @@ impl AllowAttributes {
 
     /// Apply the rule to a single `allow(...)` invocation.
     ///
-    /// `ident_span` covers the `allow` keyword (the anchor for the
-    /// simple swap). `attr_span` / `attr_style` locate the whole
-    /// attribute (used to render the split rewrite). `args` is the
-    /// attribute's argument list.
+    /// `ident_span` covers the `allow` keyword; it anchors the
+    /// diagnostic and is the target of the `expect` swap. `attr_span` /
+    /// `attr_style` locate the whole attribute, used to classify its
+    /// container and render the removal / split suggestions. `args` is
+    /// the attribute's argument list.
     fn check_allow(
         &self,
         lint_context: &EarlyContext<'_>,
@@ -429,6 +430,17 @@ impl AllowAttributes {
         ident_span: Span,
         container: Option<&Container>,
     ) {
+        // Removal is only offered for a bare attribute; the inner `allow`
+        // of a `cfg_attr` can't be deleted without dropping its `cfg`
+        // wrapper. When it isn't offered, the `#[expect]` suggestion drops
+        // its "otherwise" lead-in, which would otherwise dangle with no
+        // alternative to contrast against.
+        let removable = matches!(container, Some(Container::Bare { .. }));
+        let replace_help = if removable {
+            "otherwise replace `allow` with `expect`, which warns once the lint stops firing"
+        } else {
+            "replace `allow` with `expect`, which warns once the lint stops firing"
+        };
         span_lint_and_then(
             lint_context,
             ALLOW_ATTRIBUTES,
@@ -452,7 +464,7 @@ impl AllowAttributes {
                 // once the lint stops firing.
                 diag.span_suggestion(
                     ident_span,
-                    "otherwise replace `allow` with `expect`, which warns once the lint stops firing",
+                    replace_help,
                     "expect".to_owned(),
                     Applicability::MaybeIncorrect,
                 );

--- a/ui-toml/allow_attributes/apply_to_outer_scopes/fixture.stderr
+++ b/ui-toml/allow_attributes/apply_to_outer_scopes/fixture.stderr
@@ -1,16 +1,35 @@
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/fixture.rs:8:3
    |
 LL | #[allow(non_snake_case, reason = "module-wide")]
-   |   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |   ^^^^^
    |
    = note: `#[warn(perfectionist::allow_attributes)]` on by default
+help: remove the suppression if its lint can no longer fire here
+   |
+LL - #[allow(non_snake_case, reason = "module-wide")]
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[allow(non_snake_case, reason = "module-wide")]
+LL + #[expect(non_snake_case, reason = "module-wide")]
+   |
 
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/fixture.rs:15:8
    |
 LL |     #![allow(clippy::needless_return, reason = "inner attr")]
-   |        ^^^^^ help: replace `allow` with `expect`: `expect`
+   |        ^^^^^
+   |
+help: remove the suppression if its lint can no longer fire here
+   |
+LL -     #![allow(clippy::needless_return, reason = "inner attr")]
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL -     #![allow(clippy::needless_return, reason = "inner attr")]
+LL +     #![expect(clippy::needless_return, reason = "inner attr")]
+   |
 
 warning: 2 warnings emitted
 

--- a/ui-toml/allow_attributes/apply_to_tool_namespaces_false/fixture.stderr
+++ b/ui-toml/allow_attributes/apply_to_tool_namespaces_false/fixture.stderr
@@ -1,22 +1,51 @@
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/fixture.rs:10:3
    |
 LL | #[allow(clippy::too_many_arguments, reason = "matches upstream signature")]
-   |   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |   ^^^^^
    |
    = note: `#[warn(perfectionist::allow_attributes)]` on by default
+help: remove the suppression if its lint can no longer fire here
+   |
+LL - #[allow(clippy::too_many_arguments, reason = "matches upstream signature")]
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[allow(clippy::too_many_arguments, reason = "matches upstream signature")]
+LL + #[expect(clippy::too_many_arguments, reason = "matches upstream signature")]
+   |
 
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/fixture.rs:14:3
    |
 LL | #[allow(rustdoc::broken_intra_doc_links, reason = "links resolve downstream")]
-   |   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |   ^^^^^
+   |
+help: remove the suppression if its lint can no longer fire here
+   |
+LL - #[allow(rustdoc::broken_intra_doc_links, reason = "links resolve downstream")]
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[allow(rustdoc::broken_intra_doc_links, reason = "links resolve downstream")]
+LL + #[expect(rustdoc::broken_intra_doc_links, reason = "links resolve downstream")]
+   |
 
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/fixture.rs:18:3
    |
 LL | #[allow(non_snake_case, reason = "external API uses camelCase")]
-   |   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |   ^^^^^
+   |
+help: remove the suppression if its lint can no longer fire here
+   |
+LL - #[allow(non_snake_case, reason = "external API uses camelCase")]
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[allow(non_snake_case, reason = "external API uses camelCase")]
+LL + #[expect(non_snake_case, reason = "external API uses camelCase")]
+   |
 
 warning: 3 warnings emitted
 

--- a/ui-toml/allow_attributes/exempt_lints/fixture.stderr
+++ b/ui-toml/allow_attributes/exempt_lints/fixture.stderr
@@ -1,10 +1,19 @@
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/fixture.rs:15:3
    |
 LL | #[allow(dead_code, reason = "kept around for symmetry")]
-   |   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |   ^^^^^
    |
    = note: `#[warn(perfectionist::allow_attributes)]` on by default
+help: remove the suppression if its lint can no longer fire here
+   |
+LL - #[allow(dead_code, reason = "kept around for symmetry")]
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[allow(dead_code, reason = "kept around for symmetry")]
+LL + #[expect(dead_code, reason = "kept around for symmetry")]
+   |
 
 warning: 1 warning emitted
 

--- a/ui/allow_attributes.rs
+++ b/ui/allow_attributes.rs
@@ -6,7 +6,7 @@
     reason = "the leading comments document each case; they are not rationales to lift",
 )]
 
-// Bad: a built-in lint that is not exempt — simple `allow` -> `expect` swap.
+// Bad: a built-in lint that is not exempt — offers removal or `#[expect]`.
 #[allow(non_snake_case, reason = "external API uses camelCase")]
 fn simple_builtin() {}
 
@@ -24,14 +24,14 @@ fn simple_perfectionist(x: i32) -> i32 {
     x
 }
 
-// Bad: multi-line single-lint attribute, still a simple swap.
+// Bad: multi-line single-lint attribute — removal or `#[expect]`.
 #[allow(
     clippy::type_complexity,
     reason = "the type mirrors the upstream alias",
 )]
 fn multiline_simple() {}
 
-// Bad: `cfg_attr`-wrapped — swap only the inner `allow` identifier.
+// Bad: `cfg_attr`-wrapped — only the inner `allow` -> `expect` swap (no removal).
 #[cfg_attr(all(), allow(clippy::too_many_arguments, reason = "cfg-gated"))]
 fn cfg_attr_simple() {}
 
@@ -39,11 +39,11 @@ fn cfg_attr_simple() {}
 #[cfg_attr(all(), cfg_attr(all(), allow(clippy::type_complexity, reason = "nested")))]
 fn cfg_attr_nested() {}
 
-// Bad: mixed exempt + rewriteable — split into `allow` + `expect`.
+// Bad: mixed exempt + rewriteable — drop the rewriteable lints or split them.
 #[allow(dead_code, clippy::too_many_arguments, reason = "scaffolding")]
 fn split_mixed() {}
 
-// Bad: `cfg_attr`-wrapped split — the inner meta item splits in place.
+// Bad: `cfg_attr`-wrapped mixed — drop or split the inner meta item in place.
 #[cfg_attr(all(), allow(dead_code, clippy::type_complexity, reason = "split under cfg"))]
 fn split_cfg_attr() {}
 

--- a/ui/allow_attributes.stderr
+++ b/ui/allow_attributes.stderr
@@ -1,64 +1,143 @@
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/allow_attributes.rs:10:3
    |
 LL | #[allow(non_snake_case, reason = "external API uses camelCase")]
-   |   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |   ^^^^^
    |
    = note: `#[warn(perfectionist::allow_attributes)]` on by default
+help: remove the suppression if its lint can no longer fire here
+   |
+LL - #[allow(non_snake_case, reason = "external API uses camelCase")]
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[allow(non_snake_case, reason = "external API uses camelCase")]
+LL + #[expect(non_snake_case, reason = "external API uses camelCase")]
+   |
 
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/allow_attributes.rs:14:3
    |
 LL | #[allow(clippy::too_many_arguments, reason = "matches upstream signature")]
-   |   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |   ^^^^^
+   |
+help: remove the suppression if its lint can no longer fire here
+   |
+LL - #[allow(clippy::too_many_arguments, reason = "matches upstream signature")]
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[allow(clippy::too_many_arguments, reason = "matches upstream signature")]
+LL + #[expect(clippy::too_many_arguments, reason = "matches upstream signature")]
+   |
 
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/allow_attributes.rs:18:3
    |
 LL | #[allow(rustdoc::broken_intra_doc_links, reason = "links resolve downstream")]
-   |   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |   ^^^^^
+   |
+help: remove the suppression if its lint can no longer fire here
+   |
+LL - #[allow(rustdoc::broken_intra_doc_links, reason = "links resolve downstream")]
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[allow(rustdoc::broken_intra_doc_links, reason = "links resolve downstream")]
+LL + #[expect(rustdoc::broken_intra_doc_links, reason = "links resolve downstream")]
+   |
 
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/allow_attributes.rs:22:3
    |
 LL | #[allow(perfectionist::single_letter_function_param, reason = "math convention")]
-   |   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |   ^^^^^
+   |
+help: remove the suppression if its lint can no longer fire here
+   |
+LL - #[allow(perfectionist::single_letter_function_param, reason = "math convention")]
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[allow(perfectionist::single_letter_function_param, reason = "math convention")]
+LL + #[expect(perfectionist::single_letter_function_param, reason = "math convention")]
+   |
 
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/allow_attributes.rs:28:3
    |
 LL | #[allow(
-   |   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |   ^^^^^
+   |
+help: remove the suppression if its lint can no longer fire here
+   |
+LL - #[allow(
+LL -     clippy::type_complexity,
+LL -     reason = "the type mirrors the upstream alias",
+LL - )]
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[allow(
+LL + #[expect(
+   |
 
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/allow_attributes.rs:35:19
    |
 LL | #[cfg_attr(all(), allow(clippy::too_many_arguments, reason = "cfg-gated"))]
-   |                   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |                   ^^^^^
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[cfg_attr(all(), allow(clippy::too_many_arguments, reason = "cfg-gated"))]
+LL + #[cfg_attr(all(), expect(clippy::too_many_arguments, reason = "cfg-gated"))]
+   |
 
-warning: this `#[allow]` can be `#[expect]` so the suppression self-cleans
+warning: this `#[allow]` stays silent even after its lint stops firing
   --> $DIR/allow_attributes.rs:39:35
    |
 LL | #[cfg_attr(all(), cfg_attr(all(), allow(clippy::type_complexity, reason = "nested")))]
-   |                                   ^^^^^ help: replace `allow` with `expect`: `expect`
+   |                                   ^^^^^
+   |
+help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+   |
+LL - #[cfg_attr(all(), cfg_attr(all(), allow(clippy::type_complexity, reason = "nested")))]
+LL + #[cfg_attr(all(), cfg_attr(all(), expect(clippy::type_complexity, reason = "nested")))]
+   |
 
-warning: the deterministically-firing lints here can move to `#[expect]`
-  --> $DIR/allow_attributes.rs:43:1
+warning: some lints in this `#[allow]` stay silent even after they stop firing
+  --> $DIR/allow_attributes.rs:43:3
    |
 LL | #[allow(dead_code, clippy::too_many_arguments, reason = "scaffolding")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |   ^^^^^
    |
-help: split the deterministic lints into a separate `#[expect]`
+help: drop them from the `#[allow]` if they can no longer fire here
+   |
+LL - #[allow(dead_code, clippy::too_many_arguments, reason = "scaffolding")]
+LL + #[allow(dead_code, reason = "scaffolding")]
+   |
+help: otherwise split them into a separate `#[expect]` that self-cleans
    |
 LL ~ #[allow(dead_code, reason = "scaffolding")]
 LL ~ #[expect(clippy::too_many_arguments, reason = "scaffolding")]
    |
 
-warning: the deterministically-firing lints here can move to `#[expect]`
+warning: some lints in this `#[allow]` stay silent even after they stop firing
   --> $DIR/allow_attributes.rs:47:19
    |
 LL | #[cfg_attr(all(), allow(dead_code, clippy::type_complexity, reason = "split under cfg"))]
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: split the deterministic lints into a separate `#[expect]`: `allow(dead_code, reason = "split under cfg"), expect(clippy::type_complexity, reason = "split under cfg")`
+   |                   ^^^^^
+   |
+help: drop them from the `#[allow]` if they can no longer fire here
+   |
+LL - #[cfg_attr(all(), allow(dead_code, clippy::type_complexity, reason = "split under cfg"))]
+LL + #[cfg_attr(all(), allow(dead_code, reason = "split under cfg"))]
+   |
+help: otherwise split them into a separate `#[expect]` that self-cleans
+   |
+LL | #[cfg_attr(all(), allow(dead_code, reason = "split under cfg"), expect(clippy::type_complexity, reason = "split under cfg"))]
+   |                                    ++++++++++++++++++++++++++++++++++++
 
 warning: 9 warnings emitted
 

--- a/ui/allow_attributes.stderr
+++ b/ui/allow_attributes.stderr
@@ -88,7 +88,7 @@ warning: this `#[allow]` stays silent even after its lint stops firing
 LL | #[cfg_attr(all(), allow(clippy::too_many_arguments, reason = "cfg-gated"))]
    |                   ^^^^^
    |
-help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+help: replace `allow` with `expect`, which warns once the lint stops firing
    |
 LL - #[cfg_attr(all(), allow(clippy::too_many_arguments, reason = "cfg-gated"))]
 LL + #[cfg_attr(all(), expect(clippy::too_many_arguments, reason = "cfg-gated"))]
@@ -100,7 +100,7 @@ warning: this `#[allow]` stays silent even after its lint stops firing
 LL | #[cfg_attr(all(), cfg_attr(all(), allow(clippy::type_complexity, reason = "nested")))]
    |                                   ^^^^^
    |
-help: otherwise replace `allow` with `expect`, which warns once the lint stops firing
+help: replace `allow` with `expect`, which warns once the lint stops firing
    |
 LL - #[cfg_attr(all(), cfg_attr(all(), allow(clippy::type_complexity, reason = "nested")))]
 LL + #[cfg_attr(all(), cfg_attr(all(), expect(clippy::type_complexity, reason = "nested")))]


### PR DESCRIPTION
This keeps `perfectionist::allow_attributes` flagging exactly the same `#[allow]`s, but replaces its single hint — "replace `allow` with `expect`" — with two `MaybeIncorrect` suggestions: remove the suppression, or replace it with `#[expect]`. A flagged `#[allow]` no longer implies that `#[expect]` is the only answer.

**Why.** A deterministic `#[allow]` has two valid resolutions, and the rule can't tell which one fits because it can't see whether the lint still fires at the site. When the suppression is dead — the lint can no longer fire there — the old single hint was actively wrong: the `#[expect]` it produced is unfulfilled, trips `unfulfilled_lint_expectations`, and breaks a `-D warnings` build. That is worse for a lint the active driver never loads (a nursery lint under `cargo dylint`, say): the `#[expect]` looks fine under dylint and only fails later under `cargo clippy`. So the rule now presents both resolutions and lets the author choose — remove it when the lint is dead, or upgrade to `#[expect]` when it still fires and you want the suppression to self-clean. Either choice is self-checking: a stray `#[expect]` trips `unfulfilled_lint_expectations`, and removing a live `#[allow]` reinstates the original warning.

**Scope.** The trigger is unchanged; this only changes the diagnostic. A mixed `#[allow]` (some lints exempt or unknown) offers the two suggestions on the rewriteable lints only — drop them from the `#[allow]`, or split them into a separate `#[expect]` — with the kept names left under `#[allow]` either way. For the `cfg_attr`-wrapped form the `#[expect]` swap is offered as before, and removal is offered only where it can be expressed without dropping the `cfg` wrapper. The change also corrects the rule's docstring, which previously claimed the `#[expect]` it produces is "always fulfilled" — the exact assumption that fails for a dead suppression.

**Validation.** `just all` passes locally: `fmt`, `build`, `doc` (including `cargo doc`), `clippy`, the full test suite, and `self-lint`. The four affected UI `.stderr` fixtures and the rule's generated catalogue entry are regenerated from the updated docstring.

Surfaced while upgrading pnpm to rc.21; see the discussion in pnpm/pnpm#12719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3GPPg9JVUYYTt2r5swCDw