### PR TITLE
docs(dev/guide): when GitHub-specific markdown may be used

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -580,11 +580,6 @@ things, and only the second may become an alert:
   a `text` fence would render the `**error:**` markers literally
   and lose what the block is showing.
 
-For live examples run `grep -rn '^> ' planned-rules/`. This guide
-deliberately names no planning file: they are deleted as their
-rules land, and the cleanup procedure above greps only
-`planned-rules/`, so a reference from here would rot unnoticed.
-
 ## Symlinks
 
 This file is the authoritative implementation guide. It is also

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -554,42 +554,38 @@ works against its purpose.
 
 ### Choosing the alert type
 
-In files that may use alerts, the type carries meaning. Pick it
-for the reader, not for emphasis:
-
-- `[!IMPORTANT]` — a correctness precondition the reader must not
-  miss.
-- `[!NOTE]` — context that is genuinely optional to skim.
-- `[!TIP]` — optional advice.
-- `[!WARNING]` / `[!CAUTION]` — an actual hazard: data loss,
-  breakage, a security issue. A spec caveat is not a hazard.
-  Reserving these two is what keeps them worth reading.
+GitHub defines five, and their plain meanings apply: `[!NOTE]`,
+`[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`. The one
+editorial rule worth stating is that `[!WARNING]` and
+`[!CAUTION]` mark an actual hazard — data loss, breakage, a
+security issue — never emphasis. A spec caveat is not a hazard,
+and reserving those two is what keeps them worth reading.
 
 ### A blockquote is not always an alert
 
 `>` is also plain markdown for a quotation, and the catalogue
-relies on that: every `## Statement` section in `planned-rules/`
-quotes the rule's upstream style-guide source verbatim — see
-[`em-dash-prose.md`](planned-rules/em-dash-prose.md),
-[`error-type-derives.md`](planned-rules/error-type-derives.md), and
-[`excessive-inline-bounds.md`](planned-rules/excessive-inline-bounds.md).
+relies on that. A `>` block in `planned-rules/` is one of three
+things, and only the second may become an alert:
 
-Those are quotations, not asides. Leave them alone, and do not
-run a sweep that mechanically upgrades every `>` block to an
-alert. Convert a blockquote only when it is already an aside — a
-remark in the author's own voice, addressed to the reader.
-`error-type-derives.md`'s "Lint name shape" block is the worked
-example: it exists to stop a misreading that has a correctness
-consequence for anyone writing the suppression attribute, so it
-is `[!IMPORTANT]`.
+- **A quotation.** Every `## Statement` section quotes the rule's
+  upstream style-guide source verbatim. Leave these alone, and do
+  not run a sweep that mechanically upgrades every `>` block to
+  an alert.
+- **An aside** — a remark in the author's own voice, addressed to
+  the reader. This is the one an alert improves. An aside written
+  to head off a misreading that has a correctness consequence
+  (say, one that would produce a suppression attribute
+  suppressing nothing) is `[!IMPORTANT]`.
+- **A sketch of emitted diagnostic text**, typically introduced
+  by a line ending "should emit text along these lines:". Leave
+  it as a blockquote: the markup inside is part of the sketch, so
+  a `text` fence would render the `**error:**` markers literally
+  and lose what the block is showing.
 
-A blockquote holding a sketch of emitted diagnostic text is a
-third thing again, neither quotation nor aside. Leave it as a
-blockquote. The one under "The implementation should emit text
-along these lines:" in `planned-rules/em-dash-prose.md` is the
-example: the markup inside it is part of the sketch, so a `text`
-fence would render the `**error:**` markers literally and lose
-what the block is showing.
+For live examples run `grep -rn '^> ' planned-rules/`. This guide
+deliberately names no planning file: they are deleted as their
+rules land, and the cleanup procedure above greps only
+`planned-rules/`, so a reference from here would rot unnoticed.
 
 ## Symlinks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,12 +533,12 @@ extensions, and `tools/gen-docs/` parses with `pulldown-cmark`
 under `ENABLE_TABLES | ENABLE_STRIKETHROUGH | ENABLE_FOOTNOTES`
 (`tools/gen-docs/src/render/markdown.rs`). What survives each:
 
-| Feature | rustdoc | `gen-docs` | GitHub |
-| --- | --- | --- | --- |
-| Alerts (`> [!NOTE]`) | literal text | literal text | callout |
-| Task lists (`- [ ]`) | checkbox | literal text | checkbox |
-| Mermaid fences | code block | code block | diagram |
-| Tables, `~~del~~`, `[^1]` | renders | renders | renders |
+| Feature                   | rustdoc      | `gen-docs`   | GitHub   |
+|---------------------------|--------------|--------------|----------|
+| Alerts (`> [!NOTE]`)      | literal text | literal text | callout  |
+| Task lists (`- [ ]`)      | checkbox     | literal text | checkbox |
+| Mermaid fences            | code block   | code block   | diagram  |
+| Tables, `~~del~~`, `[^1]` | renders      | renders      | renders  |
 
 So the three to keep out of rustdoc-bound docs are **alerts, task
 lists, and mermaid fences**. The alert is the trap worth naming:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -507,6 +507,90 @@ resolve correctly (GitHub, local editors, agent tooling). Prefer
 relative links in those files; they survive repository renames
 and don't bake in a hosting URL.
 
+## GitHub-specific markdown
+
+Some markdown renders as intended only on GitHub. Whether a file
+may use it depends on who renders that file.
+
+**Documentation that double-serves as rustdoc must not use it.**
+Two things are rustdoc-bound:
+
+- the rustdoc on a `declare_tool_lint!` block, and
+- the generated `rules/*.md`, which `tools/gen-docs/` renders
+  from that rustdoc, together with the docs site built from the
+  same source.
+
+`planned-rules/*.md`, `CLAUDE.md`, and the other in-repo guides
+are only ever rendered by GitHub, local editors, and agent
+tooling, so they may use these features where one genuinely
+helps. `README.md` is the exception among them: `Cargo.toml` sets
+`readme = "README.md"`, so it also ships to crates.io and lib.rs.
+Keep it conservative for the same reason its links are absolute.
+
+The constraint is not "GitHub invented it" but "the other two
+renderers drop it". Rustdoc parses CommonMark plus a few
+extensions, and `tools/gen-docs/` parses with `pulldown-cmark`
+under `ENABLE_TABLES | ENABLE_STRIKETHROUGH | ENABLE_FOOTNOTES`
+(`tools/gen-docs/src/render/markdown.rs`). What survives each:
+
+| Feature | rustdoc | `gen-docs` | GitHub |
+| --- | --- | --- | --- |
+| Alerts (`> [!NOTE]`) | literal text | literal text | callout |
+| Task lists (`- [ ]`) | checkbox | literal text | checkbox |
+| Mermaid fences | code block | code block | diagram |
+| Tables, `~~del~~`, `[^1]` | renders | renders | renders |
+
+So the three to keep out of rustdoc-bound docs are **alerts, task
+lists, and mermaid fences**. The alert is the trap worth naming:
+it degrades to a bare `[!IMPORTANT]` string in both the in-tree
+catalogue and the docs site, where it reads as a typo.
+
+`<details>` / `<summary>` renders in all three, but still does
+not belong in rustdoc-bound docs. `rules/*.md` exists so the
+catalogue can be read in an editor without a browser, and
+`tools/gen-docs/src/render_md.rs` drops the HTML renderer's
+`<details>` panels for that reason; raw HTML in the markdown copy
+works against its purpose.
+
+### Choosing the alert type
+
+In files that may use alerts, the type carries meaning. Pick it
+for the reader, not for emphasis:
+
+- `[!IMPORTANT]` — a correctness precondition the reader must not
+  miss.
+- `[!NOTE]` — context that is genuinely optional to skim.
+- `[!TIP]` — optional advice.
+- `[!WARNING]` / `[!CAUTION]` — an actual hazard: data loss,
+  breakage, a security issue. A spec caveat is not a hazard.
+  Reserving these two is what keeps them worth reading.
+
+### A blockquote is not always an alert
+
+`>` is also plain markdown for a quotation, and the catalogue
+relies on that: every `## Statement` section in `planned-rules/`
+quotes the rule's upstream style-guide source verbatim — see
+[`em-dash-prose.md`](planned-rules/em-dash-prose.md),
+[`error-type-derives.md`](planned-rules/error-type-derives.md), and
+[`excessive-inline-bounds.md`](planned-rules/excessive-inline-bounds.md).
+
+Those are quotations, not asides. Leave them alone, and do not
+run a sweep that mechanically upgrades every `>` block to an
+alert. Convert a blockquote only when it is already an aside — a
+remark in the author's own voice, addressed to the reader.
+`error-type-derives.md`'s "Lint name shape" block is the worked
+example: it exists to stop a misreading that has a correctness
+consequence for anyone writing the suppression attribute, so it
+is `[!IMPORTANT]`.
+
+A blockquote holding a sketch of emitted diagnostic text is a
+third thing again, neither quotation nor aside. Leave it as a
+blockquote. The one under "The implementation should emit text
+along these lines:" in `planned-rules/em-dash-prose.md` is the
+example: the markup inside it is part of the sketch, so a `text`
+fence would render the `**error:**` markers literally and lose
+what the block is showing.
+
 ## Symlinks
 
 This file is the authoritative implementation guide. It is also

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -572,10 +572,8 @@ things, and only the second may become an alert:
   not run a sweep that mechanically upgrades every `>` block to
   an alert.
 - **An aside** — a remark in the author's own voice, addressed to
-  the reader. This is the one an alert improves. An aside written
-  to head off a misreading that has a correctness consequence
-  (say, one that would produce a suppression attribute
-  suppressing nothing) is `[!IMPORTANT]`.
+  the reader. This is the one an alert improves; pick its type by
+  the rules above.
 - **A sketch of emitted diagnostic text**, typically introduced
   by a line ending "should emit text along these lines:". Leave
   it as a blockquote: the markup inside is part of the sketch, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,8 +542,8 @@ under `ENABLE_TABLES | ENABLE_STRIKETHROUGH | ENABLE_FOOTNOTES`
 
 So the three to keep out of rustdoc-bound docs are **alerts, task
 lists, and mermaid fences**. The alert is the trap worth naming:
-it degrades to a bare `[!IMPORTANT]` string in both the in-tree
-catalogue and the docs site, where it reads as a typo.
+its marker is left as literal text in both the in-tree catalogue
+and the docs site, where it reads as a typo.
 
 `<details>` / `<summary>` renders in all three, but still does
 not belong in rustdoc-bound docs. `rules/*.md` exists so the

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -916,3 +916,22 @@ observes directly (`unfulfilled_lint_expectations` notes,
 `unknown_lints`): that is behaviour the consumer sees, not this
 plugin's pass internals.
 
+## GitHub-specific markdown in rule docs
+
+A rule's `declare_tool_lint!` rustdoc is rendered by rustdoc and by
+`tools/gen-docs/` as well as by GitHub, so it must stay within the
+markdown all three understand. GitHub alerts (`> [!NOTE]`,
+`> [!IMPORTANT]`, …), task lists, and mermaid fences are out: the
+first two render as literal `[!NOTE]` / `[ ]` text somewhere in the
+chain, and a mermaid fence is just a code block outside GitHub.
+Tables, strikethrough, and footnotes are fine.
+
+The planning files in this directory carry no such constraint — only
+GitHub, local editors, and agent tooling ever render them — so they
+may use alerts where one genuinely helps. Note that a `>` block is
+not automatically an alert: the `## Statement` section of a planning
+file quotes its upstream style-guide source verbatim, and those
+quotations must stay plain blockquotes. See the "GitHub-specific
+markdown" section of [`CLAUDE.md`](../CLAUDE.md) for the full rule,
+the per-renderer table, and how to choose the alert type.
+

--- a/planned-rules/error-type-derives.md
+++ b/planned-rules/error-type-derives.md
@@ -63,6 +63,7 @@ defect, not a preference.
 
 ## What to lint
 
+> [!IMPORTANT]
 > **Lint name shape.** The `error_type_derives::` prefix used in the
 > sub-check headings below is a documentation label grouping related
 > checks under one banner. Per the


### PR DESCRIPTION
Documents when GitHub-specific markdown may be used, and applies the rule to the one `planned-rules/` blockquote that warranted it.

Documentation that double-serves as rustdoc — the `declare_tool_lint!` block and the generated `rules/*.md` — must stay within the markdown that rustdoc, `tools/gen-docs/`, and GitHub all understand. The planning files carry no such constraint; `README.md` does, since `Cargo.toml` sets `readme = "README.md"` and it therefore ships to crates.io.

The per-renderer table is verified against the three renderers rather than assumed, and it does not match what the issue predicted: rustdoc renders task lists and footnotes fine, so the constraint is the intersection of the three renderers rather than "GitHub-specific" as such. Alerts fail under rustdoc and `tools/gen-docs/` alike; task lists survive rustdoc but not `tools/gen-docs/`; a mermaid fence is a plain code block anywhere but GitHub. `<details>` renders in all three and is excluded for a different reason — raw HTML works against `rules/*.md` being readable in an editor.

The guide also covers choosing an alert type, and telling a quotation from an aside so a sweep does not convert the verbatim `## Statement` quotations. It names no planning file, since those are deleted as their rules land and the documented cleanup greps only `planned-rules/`. `planned-rules/IMPLEMENTATION_CONVENTIONS.md` gains a cross-reference for rule authors. The single markup change is `error-type-derives.md`'s `**Lint name shape.**` block, now `[!IMPORTANT]`; the three `## Statement` quotations and the diagnostic sketch in `em-dash-prose.md` stay plain blockquotes.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/358>.
Resolves <https://github.com/KSXGitHub/perfectionist/issues/359>.
