### PR TITLE
docs(plan): settle namespacing of config tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,15 +40,17 @@ Read three things first, in this order:
      more than the trigger checks.
    - **Lint name namespacing.** Every lint registers under the
      `perfectionist` tool namespace via
-     `rustc_session::declare_tool_lint!`. The planning files name
-     the lint unqualified (`path_qualification_mismatch`) *in prose
-     only*; the registered name is
-     `perfectionist::path_qualification_mismatch`, and every code
-     context — `declare_tool_lint!`, `dylint.toml` tables (including
-     a planning file's own `## Configuration` fence),
-     `#[allow(...)]` / `#[deny(...)]`, diagnostic output — is
-     namespaced. See the conventions file for the exact per-context
-     spelling.
+     `rustc_session::declare_tool_lint!`. A per-rule `dylint.toml`
+     table is *addressed* by its config key, so its header has to be
+     the namespaced name, quoted —
+     `["perfectionist::path_qualification_mismatch"]` — in a planning
+     file's `## Configuration` fence exactly as in a consumer's
+     `dylint.toml`; `#[allow(...)]` / `#[deny(...)]` likewise take the
+     `perfectionist::`-qualified path rustc resolves. Where the rule
+     is merely *named*, the unqualified
+     `path_qualification_mismatch` is correct — in prose, and in a
+     `[perfectionist]` `enable` / `disable` entry. See the
+     conventions file for the per-context spelling.
 
 If the rule is one of several that share a helper (markdown
 exclusion, format-string parsing, URL discovery, unicode-width

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,15 @@ Read three things first, in this order:
      more than the trigger checks.
    - **Lint name namespacing.** Every lint registers under the
      `perfectionist` tool namespace via
-     `rustc_session::declare_tool_lint!`. The planning files use
-     the unqualified form (`path_qualification_mismatch`) for readability;
-     the registered name is `perfectionist::path_qualification_mismatch`.
+     `rustc_session::declare_tool_lint!`. The planning files name
+     the lint unqualified (`path_qualification_mismatch`) *in prose
+     only*; the registered name is
+     `perfectionist::path_qualification_mismatch`, and every code
+     context — `declare_tool_lint!`, `dylint.toml` tables (including
+     a planning file's own `## Configuration` fence),
+     `#[allow(...)]` / `#[deny(...)]`, diagnostic output — is
+     namespaced. See the conventions file for the exact per-context
+     spelling.
 
 If the rule is one of several that share a helper (markdown
 exclusion, format-string parsing, URL discovery, unicode-width

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -422,12 +422,23 @@ that the rule covers `warn` / `deny` / `forbid`, not just the
 
 Every lint registered by this plugin lives in the `perfectionist`
 *tool namespace*. The planning files in this directory use the
-unqualified form for readability — `path_qualification_mismatch` reads better
-than `perfectionist::path_qualification_mismatch` in a sentence — but the lint
+unqualified form when their **prose** names the lint, for
+readability: `path_qualification_mismatch` reads better than
+`perfectionist::path_qualification_mismatch` in a sentence. The lint
 as it appears in `declare_tool_lint!`, in the `dylint.toml`
 configuration table, in `#[allow(...)]` / `#[deny(...)]`
 attributes, and in compiler diagnostic output is always
 namespaced.
+
+The split is **prose versus code**, not planning file versus
+implementation. Every planning file sits on both sides of it: the
+same file that calls the rule `path_qualification_mismatch` in a
+sentence writes `["perfectionist::path_qualification_mismatch"]` in
+its `## Configuration` fence, because that fence is a `dylint.toml`
+excerpt, and a `dylint.toml` table header is one of the contexts
+listed above as always namespaced. The one unquoted `dylint.toml`
+header is the crate-wide `[perfectionist]` table: that is its
+literal name, and it has no `::` to quote.
 
 ### Why namespace at all
 
@@ -507,7 +518,7 @@ the `declare_tool_lint!` invocation reads:
 
 ```rust
 rustc_session::declare_tool_lint! {
-    pub perfectionist::QUALIFIED_PATHS,
+    pub perfectionist::PATH_QUALIFICATION_MISMATCH,
     Warn,
     "decide whether items from outside the current scope are named \
      by their full path or imported via `use`",
@@ -522,20 +533,22 @@ from the planning H1, uppercase it for the macro identifier, slot
 it under `perfectionist::`. The diagnostic text inside the lint is
 the rule's own one-line summary.
 
-Configuration tables follow the same shape. The planning file
-shows:
-
-```toml
-[path_qualification_mismatch]
-style = "unqualified"
-```
-
-The actual `dylint.toml` reads:
+Configuration tables need no translation at all — they are written
+in their final form, because a planning file's `## Configuration`
+fence *is* a `dylint.toml` excerpt. The planning file and the
+consumer's `dylint.toml` read identically:
 
 ```toml
 ["perfectionist::path_qualification_mismatch"]
 style = "unqualified"
 ```
+
+The header is quoted because `perfectionist::path_qualification_mismatch`
+is not a TOML bare key: bare keys admit only `A-Za-z0-9_-`, so the
+`::` has to sit inside a quoted key. Writing
+`[perfectionist::path_qualification_mismatch]` unquoted is a parse
+error, and writing `[path_qualification_mismatch]` parses but names a
+table the plugin never reads.
 
 A user-side suppression reads:
 

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -430,15 +430,17 @@ configuration table, in `#[allow(...)]` / `#[deny(...)]`
 attributes, and in compiler diagnostic output is always
 namespaced.
 
-The split is **prose versus code**, not planning file versus
-implementation. Every planning file sits on both sides of it: the
-same file that calls the rule `path_qualification_mismatch` in a
-sentence writes `["perfectionist::path_qualification_mismatch"]` in
-its `## Configuration` fence, because that fence is a `dylint.toml`
-excerpt, and a `dylint.toml` table header is one of the contexts
-listed above as always namespaced. The one unquoted `dylint.toml`
-header is the crate-wide `[perfectionist]` table: that is its
-literal name, and it has no `::` to quote.
+Which form applies follows from what the string *is*, not from which
+file it sits in. A per-rule `dylint.toml` table header is the key the
+plugin looks up, so it has to carry the full namespaced name, quoted;
+that is why a planning file's `## Configuration` fence heads its table
+`["perfectionist::path_qualification_mismatch"]` even where the same
+file calls the rule `path_qualification_mismatch` a paragraph earlier.
+A name that nothing resolves against is under no such constraint: the
+crate-wide `[perfectionist]` table's `enable` / `disable` entries take
+*unqualified* rule names (see
+[`CONFIGURATION.md`](../CONFIGURATION.md)), so `dylint.toml` is not
+uniformly namespaced either.
 
 ### Why namespace at all
 

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -535,22 +535,12 @@ from the planning H1, uppercase it for the macro identifier, slot
 it under `perfectionist::`. The diagnostic text inside the lint is
 the rule's own one-line summary.
 
-Configuration tables need no translation at all — they are written
-in their final form, because a planning file's `## Configuration`
-fence *is* a `dylint.toml` excerpt. The planning file and the
-consumer's `dylint.toml` read identically:
+A configuration table reads:
 
 ```toml
 ["perfectionist::path_qualification_mismatch"]
 style = "unqualified"
 ```
-
-The header is quoted because `perfectionist::path_qualification_mismatch`
-is not a TOML bare key: bare keys admit only `A-Za-z0-9_-`, so the
-`::` has to sit inside a quoted key. Writing
-`[perfectionist::path_qualification_mismatch]` unquoted is a parse
-error, and writing `[path_qualification_mismatch]` parses but names a
-table the plugin never reads.
 
 A user-side suppression reads:
 

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -520,7 +520,7 @@ the `declare_tool_lint!` invocation reads:
 
 ```rust
 rustc_session::declare_tool_lint! {
-    pub perfectionist::PATH_QUALIFICATION_MISMATCH,
+    pub perfectionist::QUALIFIED_PATHS,
     Warn,
     "decide whether items from outside the current scope are named \
      by their full path or imported via `use`",

--- a/planned-rules/clap-help-too-long.md
+++ b/planned-rules/clap-help-too-long.md
@@ -127,7 +127,7 @@ struct Cli {
 ## Configuration
 
 ```toml
-[clap_help_too_long]
+["perfectionist::clap_help_too_long"]
 about_max_lines = 1
 about_max_chars = 120
 long_about_max_lines = 8

--- a/planned-rules/commit-id-length-mismatch.md
+++ b/planned-rules/commit-id-length-mismatch.md
@@ -37,7 +37,7 @@ codebase.
 ## Configuration
 
 ```toml
-[commit_id_length_mismatch]
+["perfectionist::commit_id_length_mismatch"]
 # Where the lint scans. Each defaults to `true`.
 scan_doc_comments = true       # `///`, `//!`, `/** */`, `/*! */`
 scan_regular_comments = true   # `//`, `/* */`

--- a/planned-rules/core-instead-of-std.md
+++ b/planned-rules/core-instead-of-std.md
@@ -27,7 +27,7 @@ is the `std`-preferring counterpart they have no equivalent for.
 #
 # Inactive by default. Enable in `[perfectionist].enable`. The rule has
 # a single direction (prefer `std::`), so there is no `style` knob.
-[core_instead_of_std]
+["perfectionist::core_instead_of_std"]
 # Defaults to `true`. When `false`, the lint ignores `alloc`-vs-`std`
 # differences and only governs `core`-vs-`std`. Useful for projects that
 # depend on `std` permanently but want to track `core` cleanliness for

--- a/planned-rules/em-dash-prose.md
+++ b/planned-rules/em-dash-prose.md
@@ -141,10 +141,12 @@ action.
 
 ## Configuration
 
-- `em_dash_prose.targets` — array of `"doc"`, `"comment"`, `"macro"`.
-- `em_dash_prose.flag_en_dash` — defaults to `true`.
-- `em_dash_prose.allow_in_tests` — defaults to `true`.
-- `em_dash_prose.message` — optional override for the help text.
+Keys of the `["perfectionist::em_dash_prose"]` table:
+
+- `targets` — array of `"doc"`, `"comment"`, `"macro"`.
+- `flag_en_dash` — defaults to `true`.
+- `allow_in_tests` — defaults to `true`.
+- `message` — optional override for the help text.
   Useful for projects that want to localise the diagnostic or expand
   it with a link to an internal style guide. The default message
   above is used when this is unset.

--- a/planned-rules/error-type-derives.md
+++ b/planned-rules/error-type-derives.md
@@ -116,15 +116,14 @@ name does not match the project's error-naming convention. The default
 pattern is the `Error` suffix, matching `std::io::Error`,
 `serde_json::Error`, the thiserror documentation's examples, and the
 parallel-disk-usage convention that motivated the rule. Configure
-under the `[unconventional_error_name]` table (registered as
-`["perfectionist::unconventional_error_name"]` in the consumer's
-`dylint.toml` per the
-[lint-name namespacing convention](./IMPLEMENTATION_CONVENTIONS.md#lint-name-namespacing));
+under the `["perfectionist::unconventional_error_name"]` table of the
+consumer's `dylint.toml`, spelt per the
+[lint-name namespacing convention](./IMPLEMENTATION_CONVENTIONS.md#lint-name-namespacing);
 the `error_name_pattern` key accepts one of five forms — pick
 exactly one (uncomment one line, leave the others commented):
 
 ```toml
-[unconventional_error_name]
+["perfectionist::unconventional_error_name"]
 # Default; equivalent to omitting the key.
 error_name_pattern = { suffix = "Error" }
 # Bare-string shorthand for `{ suffix = ... }`.

--- a/planned-rules/escaped-multiline-string.md
+++ b/planned-rules/escaped-multiline-string.md
@@ -219,7 +219,7 @@ let _ = text_block! { "foo" "bar" "baz" };  // already inside text_block!
 ## Configuration
 
 ```toml
-[escaped_multiline_string]
+["perfectionist::escaped_multiline_string"]
 style = "text_block_macros"  # or "line_continuation"
 
 # Minimum number of `\n` characters in the decoded value before

--- a/planned-rules/excessive-inline-bounds.md
+++ b/planned-rules/excessive-inline-bounds.md
@@ -16,13 +16,14 @@ inline bound, suggest moving every inline bound into a `where` clause.
 
 ## Threshold
 
-Two heuristics, both configurable:
+Two heuristics, both configurable under the
+`["perfectionist::excessive_inline_bounds"]` table:
 
-- `excessive_inline_bounds.max_inline_bounds_per_param` (default `1`): an
-  individual generic parameter may carry up to this many inline bounds.
-- `excessive_inline_bounds.max_total_inline_bounds` (default `2`): across all
-  generic parameters of one item, the sum of inline bounds may not exceed
-  this number before a `where` clause is required.
+- `max_inline_bounds_per_param` (default `1`): an individual generic
+  parameter may carry up to this many inline bounds.
+- `max_total_inline_bounds` (default `2`): across all generic parameters
+  of one item, the sum of inline bounds may not exceed this number
+  before a `where` clause is required.
 
 Defaults match the examples in both source documents (one inline bound on
 a single param is fine; multiple bounds or multiple params should switch

--- a/planned-rules/impure-macro-arguments.md
+++ b/planned-rules/impure-macro-arguments.md
@@ -666,7 +666,7 @@ let payload = serde_json::json!({ "id": next_id(), "ts": now() });
 ## Configuration
 
 ```toml
-[impure_macro_arguments]
+["perfectionist::impure_macro_arguments"]
 # Eligibility mode. Defaults to "allow_and_deny".
 mode = "allow_and_deny"
 

--- a/planned-rules/lint-downgrade-without-reason.md
+++ b/planned-rules/lint-downgrade-without-reason.md
@@ -168,7 +168,7 @@ The too-short case has no autofix; the diagnostic points at the
 ## Configuration
 
 ```toml
-[lint_downgrade_without_reason]
+["perfectionist::lint_downgrade_without_reason"]
 # Lints excluded from the requirement.
 exempt_lints = [
     # "clippy::module_name_repetitions",

--- a/planned-rules/macro-trailing-comma.md
+++ b/planned-rules/macro-trailing-comma.md
@@ -466,7 +466,7 @@ my_proc::custom!(
 ## Configuration
 
 ```toml
-[macro_trailing_comma]
+["perfectionist::macro_trailing_comma"]
 # Additional macros to treat as name-based matches, beyond the
 # built-in core/std and well-known third-party set. Each entry
 # is a fully-qualified macro path (no trailing `!`) or a bare

--- a/planned-rules/manual-derive-more-impl.md
+++ b/planned-rules/manual-derive-more-impl.md
@@ -133,7 +133,7 @@ exercised on real codebases.
 ## Configuration
 
 ```toml
-[manual_derive_more_impl]
+["perfectionist::manual_derive_more_impl"]
 # Easy sub-lints — on by default. Each registers as its own flat tool
 # lint `perfectionist::manual_<trait>_impl`.
 manual_from_impl       = true

--- a/planned-rules/manual-json-string.md
+++ b/planned-rules/manual-json-string.md
@@ -297,7 +297,7 @@ fn not_json() {
 ## Configuration
 
 ```toml
-[manual_json_string]
+["perfectionist::manual_json_string"]
 # Whether to gate the rule on detecting `serde_json` as a
 # dependency anywhere in the workspace (see "Workspace gate"). When
 # `true` (default), the rule is silent in workspaces that don't

--- a/planned-rules/named-prelude-imports.md
+++ b/planned-rules/named-prelude-imports.md
@@ -128,7 +128,7 @@ As built (see `src/rules/named_prelude_imports.rs`):
 
 ```toml
 # dylint.toml
-[named_prelude_imports]
+["perfectionist::named_prelude_imports"]
 # Names recognised as prelude segments. Match `wildcard_imports`'s knob
 # of the same name so a project can flip both rules with one value.
 prelude_segment_names = ["prelude"]

--- a/planned-rules/needless-borrowed-parameters.md
+++ b/planned-rules/needless-borrowed-parameters.md
@@ -179,7 +179,7 @@ fn log_and_store(name: &str, registry: &mut HashMap<String, u32>) {
 ## Configuration
 
 ```toml
-[needless_borrowed_parameters]
+["perfectionist::needless_borrowed_parameters"]
 # Pairs of (borrowed_type, owned_type) the lint recognises. The
 # defaults cover the standard library's common cases; extend this
 # for project-specific newtypes.

--- a/planned-rules/overly-long-derive-more-template.md
+++ b/planned-rules/overly-long-derive-more-template.md
@@ -121,7 +121,7 @@ struct Custom;
 ## Configuration
 
 ```toml
-[overly_long_derive_more_template]
+["perfectionist::overly_long_derive_more_template"]
 # Source-line width that triggers the rule. Default 100 matches
 # rustfmt's column default. Width is unicode display width of the
 # line containing the attribute, not its byte length.

--- a/planned-rules/overly-long-format-macro.md
+++ b/planned-rules/overly-long-format-macro.md
@@ -140,7 +140,7 @@ write!(f, "a\nb {x}")?;  // not in target_macros (write! is splittable)
 ## Configuration
 
 ```toml
-[overly_long_format_macro]
+["perfectionist::overly_long_format_macro"]
 # Source-line width that triggers the rule. Default 100 matches
 # rustfmt's column default. Width is unicode display width of the
 # line containing the macro invocation, not its byte length.

--- a/planned-rules/overly-long-print-macro.md
+++ b/planned-rules/overly-long-print-macro.md
@@ -175,7 +175,7 @@ println!("a\nb");  // short source line
 ## Configuration
 
 ```toml
-[overly_long_print_macro]
+["perfectionist::overly_long_print_macro"]
 # NOT YET IMPLEMENTED — the `style` knob is absent from the current
 # config (only `line_continuation` ships). Setting it today is rejected
 # by `deny_unknown_fields` and aborts the lint driver; leave it out

--- a/planned-rules/path-qualification-mismatch.md
+++ b/planned-rules/path-qualification-mismatch.md
@@ -56,7 +56,7 @@ external module.
 ## Configuration
 
 ```toml
-[path_qualification_mismatch]
+["perfectionist::path_qualification_mismatch"]
 # Inactive by default. Enable in `[perfectionist].enable`, then set
 # `style` — it is mandatory and has no default. The value below is an
 # example, not a default.

--- a/planned-rules/pipe-style.md
+++ b/planned-rules/pipe-style.md
@@ -147,7 +147,7 @@ non-chain expression.
 ## Configuration
 
 ```toml
-[pipe_style]
+["perfectionist::pipe_style"]
 # Each sub-check can be turned off independently. Defaults are both
 # enforce.
 pipe_at_chain_boundary = "forbid"   # or "allow" to permit pipe at chain start

--- a/planned-rules/serde-wrapper-form-mismatch.md
+++ b/planned-rules/serde-wrapper-form-mismatch.md
@@ -45,7 +45,7 @@ two forms would produce identical behaviour.
 ## Configuration
 
 ```toml
-[serde_wrapper_form_mismatch]
+["perfectionist::serde_wrapper_form_mismatch"]
 # Inactive by default. Enable in `[perfectionist].enable`, then set
 # `style` — it is mandatory and has no default. The value below is an
 # example, not a default.

--- a/planned-rules/uninlined-derive-more-args.md
+++ b/planned-rules/uninlined-derive-more-args.md
@@ -137,7 +137,7 @@ suggestion preserves the spec: `{:>5}` paired with `name` becomes
 ## Configuration
 
 ```toml
-[uninlined_derive_more_args]
+["perfectionist::uninlined_derive_more_args"]
 # Attribute paths to scan. Defaults cover derive_more 1.x.
 attribute_paths = ["display", "debug"]
 


### PR DESCRIPTION
Resolves <https://github.com/KSXGitHub/perfectionist/issues/364>.

`planned-rules/IMPLEMENTATION_CONVENTIONS.md` stated the lint-name namespacing rule twice and the two statements disagreed about a planning file's `## Configuration` fence: §"Lint name namespacing" listed the `dylint.toml` configuration table among the always-namespaced contexts, while the worked example in §"How to apply the namespace" presented the bare `[path_qualification_mismatch]` as what a planning file shows and the namespaced quoted header as what "the actual `dylint.toml` reads". This settles it the way the primary statement already implied: a planning file's configuration fence *is* a `dylint.toml` excerpt, so its header is namespaced and quoted.

The rule is framed by what the string is rather than by which file it sits in. A per-rule table header is the key the plugin looks up, so it has to be the namespaced name, quoted; `#[allow(...)]` / `#[deny(...)]` have to be the tool path rustc resolves. A name that nothing resolves against carries no such requirement, which is why prose and `[perfectionist]`'s `enable` / `disable` entries are unqualified — this repository's own `dylint.toml` has `enable = ["import_grouping_mismatch"]`. The `CLAUDE.md` summary, which had dropped the qualifiers that decide the case, now carries the same framing, and the worked example just shows the table alongside the section's other forms instead of arguing against spellings the document no longer contains.

Nineteen planning files move from a bare `[<rule_name>]` header to `["perfectionist::<rule_name>"]`. All were valid TOML, so nothing failed to parse; the headers simply named tables the plugin never reads. `named-prelude-imports.md` shows they were wrong rather than merely inconsistent — that rule ships, and `src/rules/named_prelude_imports.rs` reads `perfectionist::named_prelude_imports`.

Two sites beyond the issue's list named a config table in prose rather than in a fence and are normalised the same way, by stating the table once and listing bare key names under it: the dotted `em_dash_prose.<key>` and `excessive_inline_bounds.<key>` bullets. Genuinely unqualified prose mentions and the crate-wide `[perfectionist]` table are untouched.

`master` is merged in. #370 rewrote `pipe-style.md` while this branch was open, adding two sub-check knobs under the header form the convention endorsed at the time; the merge keeps those knobs and applies this branch's header, so the file lands with the rest of the sweep. The unrelated stale-identifier fix that once rode along here was extracted to #367 and is now on `master`, leaving this pull request to config-table naming alone.
