### PR TITLE
refactor: move the rule list into a static index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,29 +310,26 @@ explicitly retracted.
 ## Registering a new rule in the index
 
 `src/rule_index.rs` indexes every rule the plugin ships. Its
-`rule_index!` invocation names each rule once and expands to three
-things: a marker type per rule, the `LINT_NAMES` set, and the
-`register_all` function that `src/lib.rs::register_lints` calls.
-Each rule module implements the index's `RuleRegistration` trait
-for its own marker — `register_lint` adds the lint declaration,
-`register_pass` installs the early/late pass.
+`rule_index!` invocation names each rule once and expands to a
+marker type per rule, the `LINT_NAMES` set, and the `register_all`
+function that `src/lib.rs::register_lints` calls. Each rule module
+implements the index's `RuleRegistration` trait for its own marker:
+`register_lint` adds the lint declaration, `register_pass` installs
+the early/late pass.
 
-Nothing in the list depends on its neighbours' positions, so it is
-plain alphabetical throughout. The rule that needs the whole set of
-lint names, `perfectionist::unknown_perfectionist_lints`, reads
-`LINT_NAMES` rather than the `LintStore` it is registering into —
-which is what dropped the exception that once pinned it to the end
-of the list.
+The list is alphabetical with no exceptions — no entry depends on
+another's position, for the reason the module's own docstring
+gives.
 
 When you add a new rule:
 
 1. Add the `pub mod` line to `src/rules.rs`.
 2. Add an entry to the `rule_index!` invocation in
-   `src/rule_index.rs`, in alphabetical order — a `const`
-   assertion rejects an out-of-order one, since `LINT_NAMES` is
-   binary-searched. The entry pairs the rule's snake_case name
-   (its file name, and the name its `declare_tool_lint!` block
-   declares) with the marker type to generate for it.
+   `src/rule_index.rs`, in alphabetical order — `LINT_NAMES` is
+   binary-searched, so the index's tests reject an out-of-order
+   entry. The entry pairs the rule's snake_case name (its file
+   name, and the name its `declare_tool_lint!` block declares)
+   with the marker type to generate for it.
 3. Implement `RuleRegistration` for that marker in the rule's own
    file.
 4. Do not introduce a second list of rule names. The `rule_index!`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,8 @@ has these consequences for the implementer:
    forbids the `mod.rs` form (via `clippy::mod_module_files`,
    enabled in `Cargo.toml`), so the layout is `src/rules/<rule>.rs` next to
    `src/rules/<rule>/<concern>.rs`. The flat `.rs` entry keeps the
-   `declare_tool_lint!` block, the `register_lint` / `register_pass`
-   functions, the `EarlyLintPass` / `LateLintPass` driver, and any
+   `declare_tool_lint!` block, the `RuleRegistration` impl, the
+   `EarlyLintPass` / `LateLintPass` driver, and any
    process-wide state (`static PENDING_VIOLATIONS`, etc.). Common
    submodule names that have emerged:
    - `config` — `Config` struct, default lists, in-memory rule state.
@@ -161,7 +161,7 @@ The shapes to avoid:
 - **Do not describe a lint as existing until it is registered.**
   Shipped docs — `declare_tool_lint!` rustdoc and the `rules/*.md`
   catalogue generated from it — must not name a lint that
-  `src/lib.rs::register_lints` does not, or a reader who writes
+  `src/rule_index.rs` does not, or a reader who writes
   `#[expect(perfectionist::<that name>)]` for it is flagged by
   `perfectionist::unknown_perfectionist_lints`. Planning files are
   exempt; naming unimplemented siblings is what they are for.
@@ -177,11 +177,11 @@ useless.
 Some of these are mechanically checkable and worth a grep before
 committing:
 backticked in-repo paths should resolve, and a `perfectionist::`
-name should be one `register_lints` registers. Both have standing
-exceptions — prose about a *linted* crate, planning files and this
-guide, the deliberate typos around `unknown_perfectionist_lints`, and
-`gen-docs`' unit tests, which invent lint names — so read the hits,
-not the count.
+name should be one the `rule_index!` invocation names. Both have
+standing exceptions — prose about a *linted* crate, planning files
+and this guide, the deliberate typos around
+`unknown_perfectionist_lints`, and `gen-docs`' unit tests, which
+invent lint names — so read the hits, not the count.
 
 ## Shipped docs address the consumer, not the contributor
 
@@ -307,33 +307,38 @@ knobs, or autofix branches, the planning file stays:
 The rule file lives until everything in it is implemented or
 explicitly retracted.
 
-## Registering a new rule in `lib.rs`
+## Registering a new rule in the index
 
-Every rule module exposes a `register_lint(lint_store)`, which
-registers the lint declaration only, and a
-`register_pass(lint_store)`, which installs the rule's early/late
-pass.
+`src/rule_index.rs` indexes every rule the plugin ships. Its
+`rule_index!` invocation names each rule once and expands to three
+things: a marker type per rule, the `LINT_NAMES` set, and the
+`register_all` function that `src/lib.rs::register_lints` calls.
+Each rule module implements the index's `RuleRegistration` trait
+for its own marker — `register_lint` adds the lint declaration,
+`register_pass` installs the early/late pass.
 
-`src/lib.rs::register_lints` calls them in two phases: every
-`register_lint` first, then every `register_pass`. The phasing
-exists because `unknown_perfectionist_lints::register_pass`
-snapshots the registered `perfectionist::*` lint names out of the
-`LintStore` at construction time, so every rule's lint
-declaration must already be in the store before any pass is
-installed. The `register!` macro in `register_lints` emits both
-phases from one list of rule names, so a rule is named there
-exactly once.
+Nothing in the list depends on its neighbours' positions, so it is
+plain alphabetical throughout. The rule that needs the whole set of
+lint names, `perfectionist::unknown_perfectionist_lints`, reads
+`LINT_NAMES` rather than the `LintStore` it is registering into —
+which is what dropped the exception that once pinned it to the end
+of the list.
 
 When you add a new rule:
 
-1. Add the `pub mod` line to `src/rules.rs`, and expose both
-   `register_lint` and `register_pass` from the rule module.
-2. Add the rule's name to the `register!` invocation in
-   `src/lib.rs::register_lints`, in alphabetical order —
-   except that `unknown_perfectionist_lints` stays last, for the
-   snapshotting reason above.
-3. Do not introduce a parallel `REGISTERED_LINT_NAMES`-style
-   array. The `LintStore` is the single source of truth.
+1. Add the `pub mod` line to `src/rules.rs`.
+2. Add an entry to the `rule_index!` invocation in
+   `src/rule_index.rs`, in alphabetical order — a `const`
+   assertion rejects an out-of-order one, since `LINT_NAMES` is
+   binary-searched. The entry pairs the rule's snake_case name
+   (its file name, and the name its `declare_tool_lint!` block
+   declares) with the marker type to generate for it.
+3. Implement `RuleRegistration` for that marker in the rule's own
+   file.
+4. Do not introduce a second list of rule names. The `rule_index!`
+   invocation is the single source of truth, and
+   `src/rule_index/tests.rs` holds it to the `declare_tool_lint!`
+   blocks under `src/rules/`.
 
 ## Validating Rust changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,9 +311,10 @@ explicitly retracted.
 
 `src/rule_index.rs` indexes every rule the plugin ships. Its
 `rule_index!` invocation names each rule once and expands to a
-marker type per rule, the `LINT_NAMES` set, and the `register_all`
-function that `src/lib.rs::register_lints` calls. Each rule module
-implements the index's `Register` trait for its own marker:
+type per rule (in the index's `rule` module), the `LINT_NAMES` set,
+and the `register_all` function that `src/lib.rs::register_lints`
+calls. Each rule module implements the index's `Register` trait for
+its own type:
 `register_lint` adds the lint declaration, `register_pass` installs
 the early/late pass.
 
@@ -329,8 +330,9 @@ When you add a new rule:
    binary-searched, so the index's tests reject an out-of-order
    entry. The entry pairs the rule's snake_case name (its file
    name, and the name its `declare_tool_lint!` block declares)
-   with the marker type to generate for it.
-3. Implement `Register` for that marker in the rule's own file.
+   with the type to generate for it.
+3. Implement `Register` for `rule::<ThatType>` in the rule's own
+   file.
 4. Do not introduce a second list of rule names. The `rule_index!`
    invocation is the single source of truth, and
    `src/rule_index/tests.rs` holds it to the `declare_tool_lint!`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,9 @@ has these consequences for the implementer:
    forbids the `mod.rs` form (via `clippy::mod_module_files`,
    enabled in `Cargo.toml`), so the layout is `src/rules/<rule>.rs` next to
    `src/rules/<rule>/<concern>.rs`. The flat `.rs` entry keeps the
-   `declare_tool_lint!` block, the `RuleRegistration` impl, the
-   `EarlyLintPass` / `LateLintPass` driver, and any
-   process-wide state (`static PENDING_VIOLATIONS`, etc.). Common
+   `declare_tool_lint!` block, the `Register` impl, the
+   `EarlyLintPass` / `LateLintPass` driver, and any process-wide
+   state (`static PENDING_VIOLATIONS`, etc.). Common
    submodule names that have emerged:
    - `config` — `Config` struct, default lists, in-memory rule state.
    - `early` / `late` — the corresponding pass implementation when
@@ -313,7 +313,7 @@ explicitly retracted.
 `rule_index!` invocation names each rule once and expands to a
 marker type per rule, the `LINT_NAMES` set, and the `register_all`
 function that `src/lib.rs::register_lints` calls. Each rule module
-implements the index's `RuleRegistration` trait for its own marker:
+implements the index's `Register` trait for its own marker:
 `register_lint` adds the lint declaration, `register_pass` installs
 the early/late pass.
 
@@ -330,8 +330,7 @@ When you add a new rule:
    entry. The entry pairs the rule's snake_case name (its file
    name, and the name its `declare_tool_lint!` block declares)
    with the marker type to generate for it.
-3. Implement `RuleRegistration` for that marker in the rule's own
-   file.
+3. Implement `Register` for that marker in the rule's own file.
 4. Do not introduce a second list of rule names. The `rule_index!`
    invocation is the single source of truth, and
    `src/rule_index/tests.rs` holds it to the `declare_tool_lint!`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,34 +309,21 @@ explicitly retracted.
 
 ## Registering a new rule in the index
 
-`src/rule_index.rs` indexes every rule the plugin ships. Its
-`rule_index!` invocation names each rule once and expands to a
-type per rule (in the index's `rule` module), the `LINT_NAMES` set,
-and the `register_all` function that `src/lib.rs::register_lints`
-calls. Each rule module implements the index's `Register` trait for
-its own type:
-`register_lint` adds the lint declaration, `register_pass` installs
-the early/late pass.
+`src/rule_index.rs` indexes every rule the plugin ships: its
+`rule_index!` invocation names each rule once, and the module's
+docstring says what that expands to.
 
-The list is alphabetical with no exceptions — no entry depends on
-another's position, for the reason the module's own docstring
-gives.
+The list is alphabetical.
 
 When you add a new rule:
 
 1. Add the `pub mod` line to `src/rules.rs`.
 2. Add an entry to the `rule_index!` invocation in
-   `src/rule_index.rs`, in alphabetical order — `LINT_NAMES` is
-   binary-searched, so the index's tests reject an out-of-order
-   entry. The entry pairs the rule's snake_case name (its file
-   name, and the name its `declare_tool_lint!` block declares)
-   with the type to generate for it.
-3. Implement `Register` for `rule::<ThatType>` in the rule's own
-   file.
-4. Do not introduce a second list of rule names. The `rule_index!`
-   invocation is the single source of truth, and
-   `src/rule_index/tests.rs` holds it to the `declare_tool_lint!`
-   blocks under `src/rules/`.
+   `src/rule_index.rs`.
+3. Implement `Register` for the type that entry generates, in the
+   rule's own file.
+4. Do not introduce a second list of rule names; the `rule_index!`
+   invocation is the single source of truth.
 
 ## Validating Rust changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,8 +310,7 @@ explicitly retracted.
 ## Registering a new rule in the index
 
 `src/rule_index.rs` indexes every rule the plugin ships: its
-`rule_index!` invocation names each rule once, and the module's
-docstring says what that expands to.
+`rule_index!` invocation names each rule once.
 
 The list is alphabetical.
 

--- a/planned-rules/IMPLEMENTATION_CONVENTIONS.md
+++ b/planned-rules/IMPLEMENTATION_CONVENTIONS.md
@@ -879,14 +879,17 @@ past regression skipped.
 ## Rule activation model
 
 Every rule registered by this plugin is declared at the `Warn`
-lint level. Each rule documents its **default state**: whether
+lint level. Each rule documents its **default state** — whether
 the rule's pass installs at all when the consumer runs
-`cargo dylint` without overrides.
+`cargo dylint` without overrides — as the `DEFAULT_STATE`
+constant of its `Register` impl, where the rule index reads it to
+decide whether to call `register_pass` at all:
 
 ```rust
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
-// or
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
+impl Register for rule::SomeExampleRule {
+    /// Why this rule ships on (or off) out of the box.
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+    // or DefaultState::Inactive
 ```
 
 The two states map to the consumer-visible behaviour as follows:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod macro_path;
 mod macro_template;
 mod markdown;
 mod module_reparse;
+mod rule_index;
 mod rules;
 mod test_code;
 mod url_scan;
@@ -43,56 +44,5 @@ mod url_scan;
 pub fn register_lints(session: &Session, lint_store: &mut LintStore) {
     dylint_linting::init_config(session);
     common::init_global_config();
-
-    macro_rules! register {
-        ($( $rule_name:ident )+) => {
-            $( rules::$rule_name::register_lint(lint_store); )+
-            $( rules::$rule_name::register_pass(lint_store); )+
-        };
-    }
-
-    register! {
-        allow_attributes
-        allow_attributes_without_reason
-        avoidable_string_escapes
-        bare_email
-        bare_identifier_reference
-        bare_issue_reference
-        bare_url
-        clap_help_markdown
-        excessive_inline_tests
-        exhaustive_error_enums
-        import_granularity_mismatch
-        import_grouping_mismatch
-        impure_macro_arguments
-        lint_attribute_trailing_comment
-        macro_trailing_comma
-        named_prelude_imports
-        needless_borrowed_parameters
-        overly_long_print_macro
-        redundant_derive_more_forward_template
-        single_letter_closure_param
-        single_letter_const_generic
-        single_letter_const_item
-        single_letter_function_param
-        single_letter_generic
-        single_letter_let_binding
-        single_letter_static_item
-        thiserror_usage
-        uncombined_self_import
-        unicode_ellipsis_in_comments
-        unicode_ellipsis_in_docs
-        unicode_ellipsis_in_panic_messages
-        unordered_derives
-        unpinned_repo_ref
-        wildcard_imports
-
-        // `unknown_perfectionist_lints::register_pass` snapshots the registered
-        // `perfectionist::*` lint names out of the `LintStore`, so its pass must
-        // be installed after every other rule's `register_lint` call. Keep this
-        // rule's registrations last, regardless of alphabetical order — a future
-        // rule whose name starts with `v`..=`z` would otherwise silently break
-        // the snapshot if these calls were left to alphabetical sorting.
-        unknown_perfectionist_lints
-    }
+    rule_index::register_all(lint_store);
 }

--- a/src/rule_index.rs
+++ b/src/rule_index.rs
@@ -88,16 +88,18 @@ macro_rules! rule_index {
         /// registered on its own — no entry depends on another
         /// having registered first.
         pub(crate) fn register_all(lint_store: &mut LintStore) {
-            $({
+            $(
                 <rule::$marker as Register>::register_lint(lint_store);
-                let state = resolved_state(
+                match resolved_state(
                     stringify!($rule_name),
                     <rule::$marker as Register>::DEFAULT_STATE,
-                );
-                if let DefaultState::Active = state {
-                    <rule::$marker as Register>::register_pass(lint_store);
+                ) {
+                    DefaultState::Active => {
+                        <rule::$marker as Register>::register_pass(lint_store);
+                    }
+                    DefaultState::Inactive => {}
                 }
-            })+
+            )+
         }
     };
 }

--- a/src/rule_index.rs
+++ b/src/rule_index.rs
@@ -41,8 +41,8 @@ pub(crate) trait RuleRegistration {
 /// generate for it. Both are spelled out because `macro_rules!`
 /// cannot case-convert an identifier.
 ///
-/// Entries are in ascending order, which a `const` assertion below
-/// enforces: [`is_registered_lint`] binary-searches [`LINT_NAMES`].
+/// Entries are in ascending order, since [`is_registered_lint`]
+/// binary-searches [`LINT_NAMES`]; the tests below hold them to it.
 macro_rules! rule_index {
     ($( $rule_name:ident => $marker:ident ),+ $(,)?) => {
         $(
@@ -117,41 +117,9 @@ rule_index! {
     wildcard_imports => WildcardImportsRule,
 }
 
-const _: () = assert!(
-    is_ascending(LINT_NAMES),
-    "rule_index! entries must be in ascending order",
-);
-
 /// Whether `name` is one of [`LINT_NAMES`].
 pub(crate) fn is_registered_lint(name: &str) -> bool {
     LINT_NAMES.binary_search(&name).is_ok()
-}
-
-/// Whether `names` is strictly ascending, and so a valid subject for
-/// [`slice::binary_search`].
-const fn is_ascending(names: &[&str]) -> bool {
-    let mut index = 1;
-    while index < names.len() {
-        if !precedes(names[index - 1].as_bytes(), names[index].as_bytes()) {
-            return false;
-        }
-        index += 1;
-    }
-    true
-}
-
-/// Whether `left` sorts before `right`, comparing bytes — the order
-/// [`str`]'s own comparison operators define, spelled out here
-/// because they are not `const`.
-const fn precedes(left: &[u8], right: &[u8]) -> bool {
-    let mut index = 0;
-    while index < left.len() && index < right.len() {
-        if left[index] != right[index] {
-            return left[index] < right[index];
-        }
-        index += 1;
-    }
-    left.len() < right.len()
 }
 
 #[cfg(test)]

--- a/src/rule_index.rs
+++ b/src/rule_index.rs
@@ -1,10 +1,10 @@
 //! The index of every rule this plugin ships.
 //!
 //! `rule_index!` turns one list of rule names into what the rest of
-//! the crate needs from it: a marker type per rule, the
+//! the crate needs from it: a type per rule, the
 //! [`LINT_NAMES`] set, and [`register_all`], which
 //! [`crate::register_lints`] calls. Each rule's own module
-//! implements [`Register`] for its marker type.
+//! implements [`Register`] for its type.
 //!
 //! The name set is what keeps the list free of ordering exceptions.
 //! `unknown_perfectionist_lints` reports a `perfectionist::*` name
@@ -18,7 +18,7 @@
 use rustc_lint::LintStore;
 
 /// What the index needs from a rule, implemented by each rule module
-/// for the marker type `rule_index!` generates for it.
+/// for the type `rule_index!` generates for it.
 pub(crate) trait Register {
     /// Add the rule's lint declaration to the store. Called for
     /// every rule, whatever `dylint.toml` says about it — only
@@ -35,22 +35,28 @@ pub(crate) trait Register {
 ///
 /// Each entry pairs the rule's name — the snake_case one it wears in
 /// `dylint.toml` and in `#[allow(perfectionist::...)]`, and the name
-/// of its `src/rules/<name>.rs` file — with the marker type to
-/// generate for it. Both are spelled out because `macro_rules!`
+/// of its `src/rules/<name>.rs` file — with the type to generate
+/// for it. Both are spelled out because `macro_rules!`
 /// cannot case-convert an identifier.
 ///
 /// Entries are in ascending order, since [`is_registered_lint`]
 /// binary-searches [`LINT_NAMES`]; the tests below hold them to it.
 macro_rules! rule_index {
     ($( $rule_name:ident => $marker:ident ),+ $(,)?) => {
-        $(
-            #[doc = concat!(
-                "Rule marker for `", stringify!($rule_name),
-                "`; `src/rules/", stringify!($rule_name),
-                ".rs` implements [`Register`] for it.",
-            )]
-            pub(crate) struct $marker;
-        )+
+        /// One type per rule, standing in for it wherever the
+        /// index needs something to implement [`Register`] on. They
+        /// are a module of their own because a rule's type and the
+        /// rule's lint pass want the same name.
+        pub(crate) mod rule {
+            $(
+                #[doc = concat!(
+                    "The `", stringify!($rule_name),
+                    "` rule; `src/rules/", stringify!($rule_name),
+                    ".rs` implements [`Register`](super::Register) for it.",
+                )]
+                pub(crate) struct $marker;
+            )+
+        }
 
         /// Every lint this plugin registers, unqualified — the name
         /// as it appears after the `perfectionist::` prefix — in
@@ -72,49 +78,49 @@ macro_rules! rule_index {
         /// registered first.
         pub(crate) fn register_all(lint_store: &mut LintStore) {
             $(
-                <$marker as Register>::register_lint(lint_store);
-                <$marker as Register>::register_pass(lint_store);
+                <rule::$marker as Register>::register_lint(lint_store);
+                <rule::$marker as Register>::register_pass(lint_store);
             )+
         }
     };
 }
 
 rule_index! {
-    allow_attributes => AllowAttributesRule,
-    allow_attributes_without_reason => AllowAttributesWithoutReasonRule,
-    avoidable_string_escapes => AvoidableStringEscapesRule,
-    bare_email => BareEmailRule,
-    bare_identifier_reference => BareIdentifierReferenceRule,
-    bare_issue_reference => BareIssueReferenceRule,
-    bare_url => BareUrlRule,
-    clap_help_markdown => ClapHelpMarkdownRule,
-    excessive_inline_tests => ExcessiveInlineTestsRule,
-    exhaustive_error_enums => ExhaustiveErrorEnumsRule,
-    import_granularity_mismatch => ImportGranularityMismatchRule,
-    import_grouping_mismatch => ImportGroupingMismatchRule,
-    impure_macro_arguments => ImpureMacroArgumentsRule,
-    lint_attribute_trailing_comment => LintAttributeTrailingCommentRule,
-    macro_trailing_comma => MacroTrailingCommaRule,
-    named_prelude_imports => NamedPreludeImportsRule,
-    needless_borrowed_parameters => NeedlessBorrowedParametersRule,
-    overly_long_print_macro => OverlyLongPrintMacroRule,
-    redundant_derive_more_forward_template => RedundantDeriveMoreForwardTemplateRule,
-    single_letter_closure_param => SingleLetterClosureParamRule,
-    single_letter_const_generic => SingleLetterConstGenericRule,
-    single_letter_const_item => SingleLetterConstItemRule,
-    single_letter_function_param => SingleLetterFunctionParamRule,
-    single_letter_generic => SingleLetterGenericRule,
-    single_letter_let_binding => SingleLetterLetBindingRule,
-    single_letter_static_item => SingleLetterStaticItemRule,
-    thiserror_usage => ThiserrorUsageRule,
-    uncombined_self_import => UncombinedSelfImportRule,
-    unicode_ellipsis_in_comments => UnicodeEllipsisInCommentsRule,
-    unicode_ellipsis_in_docs => UnicodeEllipsisInDocsRule,
-    unicode_ellipsis_in_panic_messages => UnicodeEllipsisInPanicMessagesRule,
-    unknown_perfectionist_lints => UnknownPerfectionistLintsRule,
-    unordered_derives => UnorderedDerivesRule,
-    unpinned_repo_ref => UnpinnedRepoRefRule,
-    wildcard_imports => WildcardImportsRule,
+    allow_attributes => AllowAttributes,
+    allow_attributes_without_reason => AllowAttributesWithoutReason,
+    avoidable_string_escapes => AvoidableStringEscapes,
+    bare_email => BareEmail,
+    bare_identifier_reference => BareIdentifierReference,
+    bare_issue_reference => BareIssueReference,
+    bare_url => BareUrl,
+    clap_help_markdown => ClapHelpMarkdown,
+    excessive_inline_tests => ExcessiveInlineTests,
+    exhaustive_error_enums => ExhaustiveErrorEnums,
+    import_granularity_mismatch => ImportGranularityMismatch,
+    import_grouping_mismatch => ImportGroupingMismatch,
+    impure_macro_arguments => ImpureMacroArguments,
+    lint_attribute_trailing_comment => LintAttributeTrailingComment,
+    macro_trailing_comma => MacroTrailingComma,
+    named_prelude_imports => NamedPreludeImports,
+    needless_borrowed_parameters => NeedlessBorrowedParameters,
+    overly_long_print_macro => OverlyLongPrintMacro,
+    redundant_derive_more_forward_template => RedundantDeriveMoreForwardTemplate,
+    single_letter_closure_param => SingleLetterClosureParam,
+    single_letter_const_generic => SingleLetterConstGeneric,
+    single_letter_const_item => SingleLetterConstItem,
+    single_letter_function_param => SingleLetterFunctionParam,
+    single_letter_generic => SingleLetterGeneric,
+    single_letter_let_binding => SingleLetterLetBinding,
+    single_letter_static_item => SingleLetterStaticItem,
+    thiserror_usage => ThiserrorUsage,
+    uncombined_self_import => UncombinedSelfImport,
+    unicode_ellipsis_in_comments => UnicodeEllipsisInComments,
+    unicode_ellipsis_in_docs => UnicodeEllipsisInDocs,
+    unicode_ellipsis_in_panic_messages => UnicodeEllipsisInPanicMessages,
+    unknown_perfectionist_lints => UnknownPerfectionistLints,
+    unordered_derives => UnorderedDerives,
+    unpinned_repo_ref => UnpinnedRepoRef,
+    wildcard_imports => WildcardImports,
 }
 
 /// Whether `name` — with the `perfectionist::` prefix already

--- a/src/rule_index.rs
+++ b/src/rule_index.rs
@@ -51,6 +51,18 @@ pub(crate) trait Register {
 ///
 /// Entries are in ascending order, since [`is_registered_lint`]
 /// binary-searches [`LINT_NAMES`]; the tests below hold them to it.
+/// Register one rule: its lint declaration always, its pass where
+/// `dylint.toml` and [`Register::DEFAULT_STATE`] leave it active.
+/// Module scope rather than the macro body, so each entry expands to
+/// a call rather than to another copy of this.
+fn register_rule<Rule: Register>(lint_store: &mut LintStore, name: &str) {
+    Rule::register_lint(lint_store);
+    match resolved_state(name, Rule::DEFAULT_STATE) {
+        DefaultState::Active => Rule::register_pass(lint_store),
+        DefaultState::Inactive => {}
+    }
+}
+
 macro_rules! rule_index {
     ($( $rule_name:ident => $marker:ident ),+ $(,)?) => {
         /// One type per rule, standing in for it wherever the
@@ -89,16 +101,7 @@ macro_rules! rule_index {
         /// having registered first.
         pub(crate) fn register_all(lint_store: &mut LintStore) {
             $(
-                <rule::$marker as Register>::register_lint(lint_store);
-                match resolved_state(
-                    stringify!($rule_name),
-                    <rule::$marker as Register>::DEFAULT_STATE,
-                ) {
-                    DefaultState::Active => {
-                        <rule::$marker as Register>::register_pass(lint_store);
-                    }
-                    DefaultState::Inactive => {}
-                }
+                register_rule::<rule::$marker>(lint_store, stringify!($rule_name));
             )+
         }
     };

--- a/src/rule_index.rs
+++ b/src/rule_index.rs
@@ -1,0 +1,158 @@
+//! The index of every rule this plugin ships.
+//!
+//! `rule_index!` turns one list of rule names into the three
+//! things the rest of the crate needs from it: a marker type per
+//! rule, the [`LINT_NAMES`] set, and [`register_all`] — which
+//! [`crate::register_lints`] calls, and which is the only place the
+//! rule modules are reached from. Each rule's own module implements
+//! [`RuleRegistration`] for its marker type.
+//!
+//! The name set is what keeps the list free of ordering exceptions.
+//! `unknown_perfectionist_lints` reports a `perfectionist::*` name
+//! that this plugin does not ship, so it needs the whole set; read
+//! back out of the `LintStore` that set is only complete once every
+//! other rule has registered, which forced that one rule to the end
+//! of the list. Read from [`LINT_NAMES`] it is complete before
+//! registration starts, and the rule sits in the list alphabetically
+//! like any other.
+
+use rustc_lint::LintStore;
+
+/// What the index needs from a rule, implemented by each rule module
+/// for the marker type `rule_index!` generates for it.
+pub(crate) trait RuleRegistration {
+    /// Add the rule's lint declaration to the store. Called for
+    /// every rule, including one the user turned off: the lint stays
+    /// registered either way so that
+    /// `#[allow(perfectionist::<rule>)]` keeps resolving.
+    fn register_lint(lint_store: &mut LintStore);
+
+    /// Install the rule's pass, unless
+    /// [`crate::common::resolved_state`] resolves the rule to
+    /// [`crate::common::DefaultState::Inactive`].
+    fn register_pass(lint_store: &mut LintStore);
+}
+
+/// Expand the rule list into the index.
+///
+/// Each entry pairs the rule's name — the snake_case one it wears in
+/// `dylint.toml` and in `#[allow(perfectionist::...)]`, and the name
+/// of its `src/rules/<name>.rs` file — with the marker type to
+/// generate for it. Both are spelled out because `macro_rules!`
+/// cannot case-convert an identifier.
+///
+/// Entries are in ascending order, which a `const` assertion below
+/// enforces: [`is_registered_lint`] binary-searches [`LINT_NAMES`].
+macro_rules! rule_index {
+    ($( $rule_name:ident => $marker:ident ),+ $(,)?) => {
+        $(
+            #[doc = concat!(
+                "Index marker for the `",
+                stringify!($rule_name),
+                "` rule.",
+            )]
+            pub(crate) struct $marker;
+        )+
+
+        /// Every lint this plugin registers, unqualified — the name
+        /// as it appears after the `perfectionist::` prefix — in
+        /// ascending order.
+        ///
+        /// A sorted slice rather than a `LazyLock<HashSet>` or a
+        /// `LazyLock<BTreeSet>`: at this size (a few dozen short
+        /// names, laid out contiguously) a binary search over cached
+        /// bytes beats hashing, and beats a tree's pointer chase.
+        /// The set is also swept end to end whenever an unknown name
+        /// is reported, to find the closest registered name to
+        /// suggest — an order a slice already has and a `HashSet`
+        /// does not. Being static, it costs no lazy initialisation
+        /// and no allocation in the runs that never consult it.
+        pub(crate) static LINT_NAMES: &[&str] = &[$( stringify!($rule_name) ),+];
+
+        /// Register every rule's lint and install its pass.
+        pub(crate) fn register_all(lint_store: &mut LintStore) {
+            $(
+                <$marker as RuleRegistration>::register_lint(lint_store);
+                <$marker as RuleRegistration>::register_pass(lint_store);
+            )+
+        }
+    };
+}
+
+rule_index! {
+    allow_attributes => AllowAttributesRule,
+    allow_attributes_without_reason => AllowAttributesWithoutReasonRule,
+    avoidable_string_escapes => AvoidableStringEscapesRule,
+    bare_email => BareEmailRule,
+    bare_identifier_reference => BareIdentifierReferenceRule,
+    bare_issue_reference => BareIssueReferenceRule,
+    bare_url => BareUrlRule,
+    clap_help_markdown => ClapHelpMarkdownRule,
+    excessive_inline_tests => ExcessiveInlineTestsRule,
+    exhaustive_error_enums => ExhaustiveErrorEnumsRule,
+    import_granularity_mismatch => ImportGranularityMismatchRule,
+    import_grouping_mismatch => ImportGroupingMismatchRule,
+    impure_macro_arguments => ImpureMacroArgumentsRule,
+    lint_attribute_trailing_comment => LintAttributeTrailingCommentRule,
+    macro_trailing_comma => MacroTrailingCommaRule,
+    named_prelude_imports => NamedPreludeImportsRule,
+    needless_borrowed_parameters => NeedlessBorrowedParametersRule,
+    overly_long_print_macro => OverlyLongPrintMacroRule,
+    redundant_derive_more_forward_template => RedundantDeriveMoreForwardTemplateRule,
+    single_letter_closure_param => SingleLetterClosureParamRule,
+    single_letter_const_generic => SingleLetterConstGenericRule,
+    single_letter_const_item => SingleLetterConstItemRule,
+    single_letter_function_param => SingleLetterFunctionParamRule,
+    single_letter_generic => SingleLetterGenericRule,
+    single_letter_let_binding => SingleLetterLetBindingRule,
+    single_letter_static_item => SingleLetterStaticItemRule,
+    thiserror_usage => ThiserrorUsageRule,
+    uncombined_self_import => UncombinedSelfImportRule,
+    unicode_ellipsis_in_comments => UnicodeEllipsisInCommentsRule,
+    unicode_ellipsis_in_docs => UnicodeEllipsisInDocsRule,
+    unicode_ellipsis_in_panic_messages => UnicodeEllipsisInPanicMessagesRule,
+    unknown_perfectionist_lints => UnknownPerfectionistLintsRule,
+    unordered_derives => UnorderedDerivesRule,
+    unpinned_repo_ref => UnpinnedRepoRefRule,
+    wildcard_imports => WildcardImportsRule,
+}
+
+const _: () = assert!(
+    is_ascending(LINT_NAMES),
+    "rule_index! entries must be in ascending order",
+);
+
+/// Whether `name` is one of [`LINT_NAMES`].
+pub(crate) fn is_registered_lint(name: &str) -> bool {
+    LINT_NAMES.binary_search(&name).is_ok()
+}
+
+/// Whether `names` is strictly ascending, and so a valid subject for
+/// [`slice::binary_search`].
+const fn is_ascending(names: &[&str]) -> bool {
+    let mut index = 1;
+    while index < names.len() {
+        if !precedes(names[index - 1].as_bytes(), names[index].as_bytes()) {
+            return false;
+        }
+        index += 1;
+    }
+    true
+}
+
+/// Whether `left` sorts before `right`, comparing bytes — the order
+/// [`str`]'s own comparison operators define, spelled out here
+/// because they are not `const`.
+const fn precedes(left: &[u8], right: &[u8]) -> bool {
+    let mut index = 0;
+    while index < left.len() && index < right.len() {
+        if left[index] != right[index] {
+            return left[index] < right[index];
+        }
+        index += 1;
+    }
+    left.len() < right.len()
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/rule_index.rs
+++ b/src/rule_index.rs
@@ -4,7 +4,7 @@
 //! the crate needs from it: a marker type per rule, the
 //! [`LINT_NAMES`] set, and [`register_all`], which
 //! [`crate::register_lints`] calls. Each rule's own module
-//! implements [`RuleRegistration`] for its marker type.
+//! implements [`Register`] for its marker type.
 //!
 //! The name set is what keeps the list free of ordering exceptions.
 //! `unknown_perfectionist_lints` reports a `perfectionist::*` name
@@ -19,7 +19,7 @@ use rustc_lint::LintStore;
 
 /// What the index needs from a rule, implemented by each rule module
 /// for the marker type `rule_index!` generates for it.
-pub(crate) trait RuleRegistration {
+pub(crate) trait Register {
     /// Add the rule's lint declaration to the store. Called for
     /// every rule, whatever `dylint.toml` says about it — only
     /// [`Self::register_pass`] consults the rule's resolved state.
@@ -47,7 +47,7 @@ macro_rules! rule_index {
             #[doc = concat!(
                 "Rule marker for `", stringify!($rule_name),
                 "`; `src/rules/", stringify!($rule_name),
-                ".rs` implements [`RuleRegistration`] for it.",
+                ".rs` implements [`Register`] for it.",
             )]
             pub(crate) struct $marker;
         )+
@@ -72,8 +72,8 @@ macro_rules! rule_index {
         /// registered first.
         pub(crate) fn register_all(lint_store: &mut LintStore) {
             $(
-                <$marker as RuleRegistration>::register_lint(lint_store);
-                <$marker as RuleRegistration>::register_pass(lint_store);
+                <$marker as Register>::register_lint(lint_store);
+                <$marker as Register>::register_pass(lint_store);
             )+
         }
     };

--- a/src/rule_index.rs
+++ b/src/rule_index.rs
@@ -1,11 +1,10 @@
 //! The index of every rule this plugin ships.
 //!
-//! `rule_index!` turns one list of rule names into the three
-//! things the rest of the crate needs from it: a marker type per
-//! rule, the [`LINT_NAMES`] set, and [`register_all`] — which
-//! [`crate::register_lints`] calls, and which is the only place the
-//! rule modules are reached from. Each rule's own module implements
-//! [`RuleRegistration`] for its marker type.
+//! `rule_index!` turns one list of rule names into what the rest of
+//! the crate needs from it: a marker type per rule, the
+//! [`LINT_NAMES`] set, and [`register_all`], which
+//! [`crate::register_lints`] calls. Each rule's own module
+//! implements [`RuleRegistration`] for its marker type.
 //!
 //! The name set is what keeps the list free of ordering exceptions.
 //! `unknown_perfectionist_lints` reports a `perfectionist::*` name
@@ -22,9 +21,8 @@ use rustc_lint::LintStore;
 /// for the marker type `rule_index!` generates for it.
 pub(crate) trait RuleRegistration {
     /// Add the rule's lint declaration to the store. Called for
-    /// every rule, including one the user turned off: the lint stays
-    /// registered either way so that
-    /// `#[allow(perfectionist::<rule>)]` keeps resolving.
+    /// every rule, whatever `dylint.toml` says about it — only
+    /// [`Self::register_pass`] consults the rule's resolved state.
     fn register_lint(lint_store: &mut LintStore);
 
     /// Install the rule's pass, unless
@@ -47,9 +45,9 @@ macro_rules! rule_index {
     ($( $rule_name:ident => $marker:ident ),+ $(,)?) => {
         $(
             #[doc = concat!(
-                "Index marker for the `",
-                stringify!($rule_name),
-                "` rule.",
+                "Rule marker for `", stringify!($rule_name),
+                "`; `src/rules/", stringify!($rule_name),
+                ".rs` implements [`RuleRegistration`] for it.",
             )]
             pub(crate) struct $marker;
         )+
@@ -69,7 +67,9 @@ macro_rules! rule_index {
         /// and no allocation in the runs that never consult it.
         pub(crate) static LINT_NAMES: &[&str] = &[$( stringify!($rule_name) ),+];
 
-        /// Register every rule's lint and install its pass.
+        /// Register every rule. Each rule's two calls are made
+        /// back to back — no entry depends on another having
+        /// registered first.
         pub(crate) fn register_all(lint_store: &mut LintStore) {
             $(
                 <$marker as RuleRegistration>::register_lint(lint_store);
@@ -117,7 +117,8 @@ rule_index! {
     wildcard_imports => WildcardImportsRule,
 }
 
-/// Whether `name` is one of [`LINT_NAMES`].
+/// Whether `name` — with the `perfectionist::` prefix already
+/// stripped — is a lint this plugin registers.
 pub(crate) fn is_registered_lint(name: &str) -> bool {
     LINT_NAMES.binary_search(&name).is_ok()
 }

--- a/src/rule_index.rs
+++ b/src/rule_index.rs
@@ -51,18 +51,6 @@ pub(crate) trait Register {
 ///
 /// Entries are in ascending order, since [`is_registered_lint`]
 /// binary-searches [`LINT_NAMES`]; the tests below hold them to it.
-/// Register one rule: its lint declaration always, its pass where
-/// `dylint.toml` and [`Register::DEFAULT_STATE`] leave it active.
-/// Module scope rather than the macro body, so each entry expands to
-/// a call rather than to another copy of this.
-fn register_rule<Rule: Register>(lint_store: &mut LintStore, name: &str) {
-    Rule::register_lint(lint_store);
-    match resolved_state(name, Rule::DEFAULT_STATE) {
-        DefaultState::Active => Rule::register_pass(lint_store),
-        DefaultState::Inactive => {}
-    }
-}
-
 macro_rules! rule_index {
     ($( $rule_name:ident => $marker:ident ),+ $(,)?) => {
         /// One type per rule, standing in for it wherever the
@@ -143,6 +131,18 @@ rule_index! {
     unordered_derives => UnorderedDerives,
     unpinned_repo_ref => UnpinnedRepoRef,
     wildcard_imports => WildcardImports,
+}
+
+/// Register one rule: its lint declaration always, its pass where
+/// `dylint.toml` and [`Register::DEFAULT_STATE`] leave it active.
+/// Module scope rather than the macro body, so each entry expands to
+/// a call rather than to another copy of this.
+fn register_rule<Rule: Register>(lint_store: &mut LintStore, name: &str) {
+    Rule::register_lint(lint_store);
+    match resolved_state(name, Rule::DEFAULT_STATE) {
+        DefaultState::Active => Rule::register_pass(lint_store),
+        DefaultState::Inactive => {}
+    }
 }
 
 /// Whether `name` — with the `perfectionist::` prefix already

--- a/src/rule_index.rs
+++ b/src/rule_index.rs
@@ -15,19 +15,29 @@
 //! registration starts, and the rule sits in the list alphabetically
 //! like any other.
 
+use crate::common::{DefaultState, resolved_state};
 use rustc_lint::LintStore;
 
 /// What the index needs from a rule, implemented by each rule module
 /// for the type `rule_index!` generates for it.
 pub(crate) trait Register {
+    /// Whether the rule's pass installs when `dylint.toml` says
+    /// nothing about the rule either way. Each rule's own impl
+    /// documents why it chose what it chose; the choice itself is
+    /// governed by the rule activation model in
+    /// `planned-rules/IMPLEMENTATION_CONVENTIONS.md`. `gen-docs`
+    /// reads the initializer with syn to render the rule's
+    /// catalogue entry, so it has to be a plain [`DefaultState`]
+    /// variant rather than anything computed.
+    const DEFAULT_STATE: DefaultState;
+
     /// Add the rule's lint declaration to the store. Called for
-    /// every rule, whatever `dylint.toml` says about it — only
-    /// [`Self::register_pass`] consults the rule's resolved state.
+    /// every rule, whatever `dylint.toml` says about it — the lint
+    /// stays registered even where the pass does not install.
     fn register_lint(lint_store: &mut LintStore);
 
-    /// Install the rule's pass, unless
-    /// [`crate::common::resolved_state`] resolves the rule to
-    /// [`crate::common::DefaultState::Inactive`].
+    /// Install the rule's pass. Called only for a rule that
+    /// [`register_all`] resolved to [`DefaultState::Active`].
     fn register_pass(lint_store: &mut LintStore);
 }
 
@@ -73,14 +83,21 @@ macro_rules! rule_index {
         /// and no allocation in the runs that never consult it.
         pub(crate) static LINT_NAMES: &[&str] = &[$( stringify!($rule_name) ),+];
 
-        /// Register every rule. Each rule's two calls are made
-        /// back to back — no entry depends on another having
-        /// registered first.
+        /// Register every rule: its lint declaration always, its
+        /// pass where the rule resolves to active. Each rule is
+        /// registered on its own — no entry depends on another
+        /// having registered first.
         pub(crate) fn register_all(lint_store: &mut LintStore) {
-            $(
+            $({
                 <rule::$marker as Register>::register_lint(lint_store);
-                <rule::$marker as Register>::register_pass(lint_store);
-            )+
+                let state = resolved_state(
+                    stringify!($rule_name),
+                    <rule::$marker as Register>::DEFAULT_STATE,
+                );
+                if let DefaultState::Active = state {
+                    <rule::$marker as Register>::register_pass(lint_store);
+                }
+            })+
         }
     };
 }

--- a/src/rule_index/tests.rs
+++ b/src/rule_index/tests.rs
@@ -1,6 +1,7 @@
-//! Unit tests that keep the index and `src/rules/` in step: every
-//! entry names a rule module that declares the matching lint, and
-//! every rule module is named by an entry.
+//! Unit tests that keep the index and `src/rules/` in step: its
+//! entries are in the order [`super::is_registered_lint`] searches
+//! them in, every entry names a rule module that declares the
+//! matching lint, and every rule module is named by an entry.
 //!
 //! The `LintStore` used to answer the first question by construction
 //! — the names came out of it — and the compiler answers the second
@@ -30,6 +31,12 @@ fn declared_lint_name(source: &str) -> Option<String> {
 
 fn read_rule_source(path: &Path) -> String {
     fs::read_to_string(path).unwrap_or_else(|error| panic!("{}: {error}", path.display()))
+}
+
+#[test]
+fn entries_are_in_ascending_order() {
+    let disorder = LINT_NAMES.windows(2).find(|pair| pair[0] >= pair[1]);
+    assert_eq!(disorder, None, "`rule_index!` entries are out of order");
 }
 
 #[test]

--- a/src/rule_index/tests.rs
+++ b/src/rule_index/tests.rs
@@ -1,15 +1,14 @@
-//! Unit tests that keep the index and `src/rules/` in step: its
-//! entries are in the order [`super::is_registered_lint`] searches
-//! them in, every entry names a rule module that declares the
-//! matching lint, and every rule module is named by an entry.
+//! Unit tests for the index's invariants: its entries are in the
+//! order [`super::is_registered_lint`] searches them in, every entry
+//! names a rule module that declares the matching lint, and every
+//! rule module is named by an entry.
 //!
-//! The `LintStore` used to answer the first question by construction
-//! — the names came out of it — and the compiler answers the second
-//! one, since a rule module implements [`super::RuleRegistration`]
-//! for a marker type only the index defines. What neither catches is
-//! an entry whose spelling has drifted from the name its
-//! `declare_tool_lint!` block declares, which would leave
-//! `unknown_perfectionist_lints` reporting a shipped lint as unknown.
+//! Reading the names out of the `LintStore` made the last two hold
+//! by construction. A written-out index can drift instead: an entry
+//! whose spelling parts ways with the name its `declare_tool_lint!`
+//! block declares leaves `unknown_perfectionist_lints` reporting a
+//! shipped lint as unknown, and a rule module the index never names
+//! registers nothing at all.
 
 use super::LINT_NAMES;
 use std::collections::BTreeSet;

--- a/src/rule_index/tests.rs
+++ b/src/rule_index/tests.rs
@@ -1,0 +1,67 @@
+//! Unit tests that keep the index and `src/rules/` in step: every
+//! entry names a rule module that declares the matching lint, and
+//! every rule module is named by an entry.
+//!
+//! The `LintStore` used to answer the first question by construction
+//! — the names came out of it — and the compiler answers the second
+//! one, since a rule module implements [`super::RuleRegistration`]
+//! for a marker type only the index defines. What neither catches is
+//! an entry whose spelling has drifted from the name its
+//! `declare_tool_lint!` block declares, which would leave
+//! `unknown_perfectionist_lints` reporting a shipped lint as unknown.
+
+use super::LINT_NAMES;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn rules_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src/rules")
+}
+
+/// The lint `source`'s `declare_tool_lint!` block declares, in the
+/// snake_case form the macro derives from the constant's identifier,
+/// or `None` for a source file that declares no lint at all.
+fn declared_lint_name(source: &str) -> Option<String> {
+    let (_, after_prefix) = source.split_once("pub perfectionist::")?;
+    let (identifier, _) = after_prefix.split_once(',')?;
+    Some(identifier.trim().to_lowercase())
+}
+
+fn read_rule_source(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|error| panic!("{}: {error}", path.display()))
+}
+
+#[test]
+fn every_entry_names_a_module_that_declares_it() {
+    for name in LINT_NAMES {
+        let path = rules_dir().join(format!("{name}.rs"));
+        let declared = declared_lint_name(&read_rule_source(&path));
+        assert_eq!(
+            declared.as_deref(),
+            Some(*name),
+            "`{name}` is indexed, but {} declares {declared:?}",
+            path.display(),
+        );
+    }
+}
+
+#[test]
+fn every_declared_lint_is_indexed() {
+    let indexed: BTreeSet<&str> = LINT_NAMES.iter().copied().collect();
+    let entries = fs::read_dir(rules_dir()).expect("failed to read src/rules/");
+    for entry in entries {
+        let path = entry.expect("failed to read directory entry").path();
+        if path.extension().is_none_or(|extension| extension != "rs") {
+            continue;
+        }
+        let Some(declared) = declared_lint_name(&read_rule_source(&path)) else {
+            continue;
+        };
+        assert!(
+            indexed.contains(declared.as_str()),
+            "{} declares `{declared}`, which no `rule_index!` entry names",
+            path.display(),
+        );
+    }
+}

--- a/src/rules/allow_attributes.rs
+++ b/src/rules/allow_attributes.rs
@@ -1,4 +1,5 @@
 use crate::common::{DefaultState, render_meta_path, resolve_string_set, resolved_state};
+use crate::rule_index::{AllowAttributesRule, RuleRegistration};
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
 use clippy_utils::is_from_proc_macro;
 use clippy_utils::source::{indent_of, snippet_opt};
@@ -88,8 +89,9 @@ declare_tool_lint! {
 
 /// Active by default. The rewrite is conservative — it only fires when
 /// every named lint is known to fire deterministically — so a baseline
-/// policy is not presumptuous. Read by [`register_pass`]; gen-docs picks
-/// the constant up to render the rule's default state.
+/// policy is not presumptuous. Read by
+/// [`RuleRegistration::register_pass`]; gen-docs picks the constant up
+/// to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::allow_attributes";
@@ -213,16 +215,19 @@ impl AllowAttributes {
 
 impl_lint_pass!(AllowAttributes => [ALLOW_ATTRIBUTES]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[ALLOW_ATTRIBUTES]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("allow_attributes", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for AllowAttributesRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[ALLOW_ATTRIBUTES]);
     }
-    let builtin_lints = collect_builtin_lint_names(lint_store);
-    lint_store.register_early_pass(move || Box::new(AllowAttributes::new(builtin_lints.clone())));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("allow_attributes", DEFAULT_STATE) {
+            return;
+        }
+        let builtin_lints = collect_builtin_lint_names(lint_store);
+        lint_store
+            .register_early_pass(move || Box::new(AllowAttributes::new(builtin_lints.clone())));
+    }
 }
 
 /// Collect every registered lint whose printed name carries no tool

--- a/src/rules/allow_attributes.rs
+++ b/src/rules/allow_attributes.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, render_meta_path, resolve_string_set, resolved_state};
-use crate::rule_index::{AllowAttributesRule, RuleRegistration};
+use crate::rule_index::{AllowAttributesRule, Register};
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
 use clippy_utils::is_from_proc_macro;
 use clippy_utils::source::{indent_of, snippet_opt};
@@ -89,9 +89,8 @@ declare_tool_lint! {
 
 /// Active by default. The rewrite is conservative — it only fires when
 /// every named lint is known to fire deterministically — so a baseline
-/// policy is not presumptuous. Read by
-/// [`RuleRegistration::register_pass`]; gen-docs picks the constant up
-/// to render the rule's default state.
+/// policy is not presumptuous. Read by [`Register::register_pass`];
+/// gen-docs picks the constant up to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::allow_attributes";
@@ -215,7 +214,7 @@ impl AllowAttributes {
 
 impl_lint_pass!(AllowAttributes => [ALLOW_ATTRIBUTES]);
 
-impl RuleRegistration for AllowAttributesRule {
+impl Register for AllowAttributesRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[ALLOW_ATTRIBUTES]);
     }

--- a/src/rules/allow_attributes.rs
+++ b/src/rules/allow_attributes.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, render_meta_path, resolve_string_set, resolved_state};
-use crate::rule_index::{AllowAttributesRule, Register};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
 use clippy_utils::is_from_proc_macro;
 use clippy_utils::source::{indent_of, snippet_opt};
@@ -214,7 +214,7 @@ impl AllowAttributes {
 
 impl_lint_pass!(AllowAttributes => [ALLOW_ATTRIBUTES]);
 
-impl Register for AllowAttributesRule {
+impl Register for rule::AllowAttributes {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[ALLOW_ATTRIBUTES]);
     }

--- a/src/rules/allow_attributes.rs
+++ b/src/rules/allow_attributes.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, render_meta_path, resolve_string_set, resolved_state};
+use crate::common::{DefaultState, render_meta_path, resolve_string_set};
 use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::{span_lint_and_help, span_lint_and_then};
 use clippy_utils::is_from_proc_macro;
@@ -86,12 +86,6 @@ declare_tool_lint! {
     "`#[allow]` for a deterministically-firing lint should be removed or be `#[expect]`",
     report_in_external_macro: false
 }
-
-/// Active by default. The rewrite is conservative — it only fires when
-/// every named lint is known to fire deterministically — so a baseline
-/// policy is not presumptuous. Read by [`Register::register_pass`];
-/// gen-docs picks the constant up to render the rule's default state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::allow_attributes";
 
@@ -215,14 +209,16 @@ impl AllowAttributes {
 impl_lint_pass!(AllowAttributes => [ALLOW_ATTRIBUTES]);
 
 impl Register for rule::AllowAttributes {
+    /// Active by default. The rewrite is conservative — it only fires
+    /// when every named lint is known to fire deterministically — so a
+    /// baseline policy is not presumptuous.
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[ALLOW_ATTRIBUTES]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("allow_attributes", DEFAULT_STATE) {
-            return;
-        }
         let builtin_lints = collect_builtin_lint_names(lint_store);
         lint_store
             .register_early_pass(move || Box::new(AllowAttributes::new(builtin_lints.clone())));

--- a/src/rules/allow_attributes_without_reason.rs
+++ b/src/rules/allow_attributes_without_reason.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, attr_has_reason, render_meta_path, resolved_state};
-use crate::rule_index::{AllowAttributesWithoutReasonRule, Register};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::is_from_proc_macro;
 use core::num::NonZeroUsize;
@@ -122,7 +122,7 @@ impl AllowAttributesWithoutReason {
 
 impl_lint_pass!(AllowAttributesWithoutReason => [ALLOW_ATTRIBUTES_WITHOUT_REASON]);
 
-impl Register for AllowAttributesWithoutReasonRule {
+impl Register for rule::AllowAttributesWithoutReason {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[ALLOW_ATTRIBUTES_WITHOUT_REASON]);
     }

--- a/src/rules/allow_attributes_without_reason.rs
+++ b/src/rules/allow_attributes_without_reason.rs
@@ -1,4 +1,5 @@
 use crate::common::{DefaultState, attr_has_reason, render_meta_path, resolved_state};
+use crate::rule_index::{AllowAttributesWithoutReasonRule, RuleRegistration};
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::is_from_proc_macro;
 use core::num::NonZeroUsize;
@@ -121,17 +122,19 @@ impl AllowAttributesWithoutReason {
 
 impl_lint_pass!(AllowAttributesWithoutReason => [ALLOW_ATTRIBUTES_WITHOUT_REASON]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[ALLOW_ATTRIBUTES_WITHOUT_REASON]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("allow_attributes_without_reason", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for AllowAttributesWithoutReasonRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[ALLOW_ATTRIBUTES_WITHOUT_REASON]);
     }
-    lint_store.register_early_pass(|| Box::new(AllowAttributesWithoutReason::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("allow_attributes_without_reason", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_early_pass(|| Box::new(AllowAttributesWithoutReason::new()));
+    }
 }
 
 impl EarlyLintPass for AllowAttributesWithoutReason {

--- a/src/rules/allow_attributes_without_reason.rs
+++ b/src/rules/allow_attributes_without_reason.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, attr_has_reason, render_meta_path, resolved_state};
-use crate::rule_index::{AllowAttributesWithoutReasonRule, RuleRegistration};
+use crate::rule_index::{AllowAttributesWithoutReasonRule, Register};
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::is_from_proc_macro;
 use core::num::NonZeroUsize;
@@ -122,7 +122,7 @@ impl AllowAttributesWithoutReason {
 
 impl_lint_pass!(AllowAttributesWithoutReason => [ALLOW_ATTRIBUTES_WITHOUT_REASON]);
 
-impl RuleRegistration for AllowAttributesWithoutReasonRule {
+impl Register for AllowAttributesWithoutReasonRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[ALLOW_ATTRIBUTES_WITHOUT_REASON]);
     }

--- a/src/rules/allow_attributes_without_reason.rs
+++ b/src/rules/allow_attributes_without_reason.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, attr_has_reason, render_meta_path, resolved_state};
+use crate::common::{DefaultState, attr_has_reason, render_meta_path};
 use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::{span_lint_and_sugg, span_lint_and_then};
 use clippy_utils::is_from_proc_macro;
@@ -123,16 +123,13 @@ impl AllowAttributesWithoutReason {
 impl_lint_pass!(AllowAttributesWithoutReason => [ALLOW_ATTRIBUTES_WITHOUT_REASON]);
 
 impl Register for rule::AllowAttributesWithoutReason {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[ALLOW_ATTRIBUTES_WITHOUT_REASON]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("allow_attributes_without_reason", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_early_pass(|| Box::new(AllowAttributesWithoutReason::new()));
     }
 }

--- a/src/rules/avoidable_string_escapes.rs
+++ b/src/rules/avoidable_string_escapes.rs
@@ -1,4 +1,4 @@
-use crate::rule_index::{AvoidableStringEscapesRule, Register};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use core::num::NonZeroUsize;
 use rustc_ast::{LitKind, StrStyle};
@@ -228,7 +228,7 @@ fn queue(violation: PendingViolation) {
 impl_lint_pass!(AvoidableStringEscapes => [AVOIDABLE_STRING_ESCAPES]);
 impl_lint_pass!(AvoidableStringEscapesEarly => [AVOIDABLE_STRING_ESCAPES]);
 
-impl Register for AvoidableStringEscapesRule {
+impl Register for rule::AvoidableStringEscapes {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[AVOIDABLE_STRING_ESCAPES]);
     }

--- a/src/rules/avoidable_string_escapes.rs
+++ b/src/rules/avoidable_string_escapes.rs
@@ -14,7 +14,7 @@ mod emit;
 mod parser;
 mod queue;
 
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::find_enclosing_hir_ids;
 use early::AvoidableStringEscapesEarly;
 use parser::{
@@ -229,16 +229,13 @@ impl_lint_pass!(AvoidableStringEscapes => [AVOIDABLE_STRING_ESCAPES]);
 impl_lint_pass!(AvoidableStringEscapesEarly => [AVOIDABLE_STRING_ESCAPES]);
 
 impl Register for rule::AvoidableStringEscapes {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[AVOIDABLE_STRING_ESCAPES]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("avoidable_string_escapes", DefaultState::Active)
-        {
-            return;
-        }
         // The pre-expansion pass sees every macro's string literals while
         // the source tokens are intact — including the ones lowering would
         // consume before the HIR exists — and parks each rewrite for the late

--- a/src/rules/avoidable_string_escapes.rs
+++ b/src/rules/avoidable_string_escapes.rs
@@ -1,3 +1,4 @@
+use crate::rule_index::{AvoidableStringEscapesRule, RuleRegistration};
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use core::num::NonZeroUsize;
 use rustc_ast::{LitKind, StrStyle};
@@ -227,21 +228,24 @@ fn queue(violation: PendingViolation) {
 impl_lint_pass!(AvoidableStringEscapes => [AVOIDABLE_STRING_ESCAPES]);
 impl_lint_pass!(AvoidableStringEscapesEarly => [AVOIDABLE_STRING_ESCAPES]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[AVOIDABLE_STRING_ESCAPES]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("avoidable_string_escapes", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for AvoidableStringEscapesRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[AVOIDABLE_STRING_ESCAPES]);
     }
-    // The pre-expansion pass sees every macro's string literals while
-    // the source tokens are intact — including the ones lowering would
-    // consume before the HIR exists — and parks each rewrite for the late
-    // pass to dedup, anchor, and emit. See [`mod@early`].
-    lint_store.register_pre_expansion_pass(|| Box::new(AvoidableStringEscapesEarly::new()));
-    lint_store.register_late_pass(|_| Box::new(AvoidableStringEscapes::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("avoidable_string_escapes", DefaultState::Active)
+        {
+            return;
+        }
+        // The pre-expansion pass sees every macro's string literals while
+        // the source tokens are intact — including the ones lowering would
+        // consume before the HIR exists — and parks each rewrite for the late
+        // pass to dedup, anchor, and emit. See [`mod@early`].
+        lint_store.register_pre_expansion_pass(|| Box::new(AvoidableStringEscapesEarly::new()));
+        lint_store.register_late_pass(|_| Box::new(AvoidableStringEscapes::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for AvoidableStringEscapes {

--- a/src/rules/avoidable_string_escapes.rs
+++ b/src/rules/avoidable_string_escapes.rs
@@ -1,4 +1,4 @@
-use crate::rule_index::{AvoidableStringEscapesRule, RuleRegistration};
+use crate::rule_index::{AvoidableStringEscapesRule, Register};
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use core::num::NonZeroUsize;
 use rustc_ast::{LitKind, StrStyle};
@@ -228,7 +228,7 @@ fn queue(violation: PendingViolation) {
 impl_lint_pass!(AvoidableStringEscapes => [AVOIDABLE_STRING_ESCAPES]);
 impl_lint_pass!(AvoidableStringEscapesEarly => [AVOIDABLE_STRING_ESCAPES]);
 
-impl RuleRegistration for AvoidableStringEscapesRule {
+impl Register for AvoidableStringEscapesRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[AVOIDABLE_STRING_ESCAPES]);
     }

--- a/src/rules/bare_email.rs
+++ b/src/rules/bare_email.rs
@@ -1,5 +1,5 @@
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
 use crate::rule_index::{Register, rule};
@@ -134,14 +134,13 @@ impl BareEmail {
 impl_lint_pass!(BareEmail => [BARE_EMAIL]);
 
 impl Register for rule::BareEmail {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_EMAIL]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("bare_email", DefaultState::Active) {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(BareEmail::new()));
     }
 }

--- a/src/rules/bare_email.rs
+++ b/src/rules/bare_email.rs
@@ -2,6 +2,7 @@ use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
+use crate::rule_index::{BareEmailRule, RuleRegistration};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir::HirId;
@@ -132,15 +133,17 @@ impl BareEmail {
 
 impl_lint_pass!(BareEmail => [BARE_EMAIL]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[BARE_EMAIL]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("bare_email", DefaultState::Active) {
-        return;
+impl RuleRegistration for BareEmailRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[BARE_EMAIL]);
     }
-    lint_store.register_late_pass(|_| Box::new(BareEmail::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("bare_email", DefaultState::Active) {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(BareEmail::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for BareEmail {

--- a/src/rules/bare_email.rs
+++ b/src/rules/bare_email.rs
@@ -2,7 +2,7 @@ use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
-use crate::rule_index::{BareEmailRule, Register};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir::HirId;
@@ -133,7 +133,7 @@ impl BareEmail {
 
 impl_lint_pass!(BareEmail => [BARE_EMAIL]);
 
-impl Register for BareEmailRule {
+impl Register for rule::BareEmail {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_EMAIL]);
     }

--- a/src/rules/bare_email.rs
+++ b/src/rules/bare_email.rs
@@ -2,7 +2,7 @@ use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
-use crate::rule_index::{BareEmailRule, RuleRegistration};
+use crate::rule_index::{BareEmailRule, Register};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir::HirId;
@@ -133,7 +133,7 @@ impl BareEmail {
 
 impl_lint_pass!(BareEmail => [BARE_EMAIL]);
 
-impl RuleRegistration for BareEmailRule {
+impl Register for BareEmailRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_EMAIL]);
     }

--- a/src/rules/bare_identifier_reference.rs
+++ b/src/rules/bare_identifier_reference.rs
@@ -1,7 +1,7 @@
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolve_symbol_set, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
-use crate::rule_index::{BareIdentifierReferenceRule, Register};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use core::num::NonZeroUsize;
 use rustc_errors::Applicability;
@@ -220,7 +220,7 @@ impl BareIdentifierReference {
 
 impl_lint_pass!(BareIdentifierReference => [BARE_IDENTIFIER_REFERENCE]);
 
-impl Register for BareIdentifierReferenceRule {
+impl Register for rule::BareIdentifierReference {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_IDENTIFIER_REFERENCE]);
     }

--- a/src/rules/bare_identifier_reference.rs
+++ b/src/rules/bare_identifier_reference.rs
@@ -1,7 +1,7 @@
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolve_symbol_set, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
-use crate::rule_index::{BareIdentifierReferenceRule, RuleRegistration};
+use crate::rule_index::{BareIdentifierReferenceRule, Register};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use core::num::NonZeroUsize;
 use rustc_errors::Applicability;
@@ -220,7 +220,7 @@ impl BareIdentifierReference {
 
 impl_lint_pass!(BareIdentifierReference => [BARE_IDENTIFIER_REFERENCE]);
 
-impl RuleRegistration for BareIdentifierReferenceRule {
+impl Register for BareIdentifierReferenceRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_IDENTIFIER_REFERENCE]);
     }

--- a/src/rules/bare_identifier_reference.rs
+++ b/src/rules/bare_identifier_reference.rs
@@ -1,5 +1,5 @@
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
-use crate::common::{DefaultState, resolve_symbol_set, resolved_state};
+use crate::common::{DefaultState, resolve_symbol_set};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
@@ -221,16 +221,13 @@ impl BareIdentifierReference {
 impl_lint_pass!(BareIdentifierReference => [BARE_IDENTIFIER_REFERENCE]);
 
 impl Register for rule::BareIdentifierReference {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_IDENTIFIER_REFERENCE]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("bare_identifier_reference", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(BareIdentifierReference::new()));
     }
 }

--- a/src/rules/bare_identifier_reference.rs
+++ b/src/rules/bare_identifier_reference.rs
@@ -1,6 +1,7 @@
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolve_symbol_set, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
+use crate::rule_index::{BareIdentifierReferenceRule, RuleRegistration};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use core::num::NonZeroUsize;
 use rustc_errors::Applicability;
@@ -219,17 +220,19 @@ impl BareIdentifierReference {
 
 impl_lint_pass!(BareIdentifierReference => [BARE_IDENTIFIER_REFERENCE]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[BARE_IDENTIFIER_REFERENCE]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("bare_identifier_reference", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for BareIdentifierReferenceRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[BARE_IDENTIFIER_REFERENCE]);
     }
-    lint_store.register_late_pass(|_| Box::new(BareIdentifierReference::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("bare_identifier_reference", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(BareIdentifierReference::new()));
+    }
 }
 
 /// One parked finding: the identifier text plus the source snippet of

--- a/src/rules/bare_issue_reference.rs
+++ b/src/rules/bare_issue_reference.rs
@@ -2,7 +2,7 @@ use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
-use crate::rule_index::{BareIssueReferenceRule, Register};
+use crate::rule_index::{Register, rule};
 use crate::url_scan::back_scan_url_fragment;
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
@@ -344,7 +344,7 @@ fn host_of(url: &str) -> Option<&str> {
 
 impl_lint_pass!(BareIssueReference => [BARE_ISSUE_REFERENCE]);
 
-impl Register for BareIssueReferenceRule {
+impl Register for rule::BareIssueReference {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_ISSUE_REFERENCE]);
     }

--- a/src/rules/bare_issue_reference.rs
+++ b/src/rules/bare_issue_reference.rs
@@ -1,5 +1,5 @@
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
 use crate::rule_index::{Register, rule};
@@ -345,15 +345,13 @@ fn host_of(url: &str) -> Option<&str> {
 impl_lint_pass!(BareIssueReference => [BARE_ISSUE_REFERENCE]);
 
 impl Register for rule::BareIssueReference {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_ISSUE_REFERENCE]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("bare_issue_reference", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(BareIssueReference::new()));
     }
 }

--- a/src/rules/bare_issue_reference.rs
+++ b/src/rules/bare_issue_reference.rs
@@ -2,7 +2,7 @@ use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
-use crate::rule_index::{BareIssueReferenceRule, RuleRegistration};
+use crate::rule_index::{BareIssueReferenceRule, Register};
 use crate::url_scan::back_scan_url_fragment;
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
@@ -344,7 +344,7 @@ fn host_of(url: &str) -> Option<&str> {
 
 impl_lint_pass!(BareIssueReference => [BARE_ISSUE_REFERENCE]);
 
-impl RuleRegistration for BareIssueReferenceRule {
+impl Register for BareIssueReferenceRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_ISSUE_REFERENCE]);
     }

--- a/src/rules/bare_issue_reference.rs
+++ b/src/rules/bare_issue_reference.rs
@@ -2,6 +2,7 @@ use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
+use crate::rule_index::{BareIssueReferenceRule, RuleRegistration};
 use crate::url_scan::back_scan_url_fragment;
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
@@ -343,15 +344,18 @@ fn host_of(url: &str) -> Option<&str> {
 
 impl_lint_pass!(BareIssueReference => [BARE_ISSUE_REFERENCE]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[BARE_ISSUE_REFERENCE]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("bare_issue_reference", DefaultState::Active) {
-        return;
+impl RuleRegistration for BareIssueReferenceRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[BARE_ISSUE_REFERENCE]);
     }
-    lint_store.register_late_pass(|_| Box::new(BareIssueReference::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("bare_issue_reference", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(BareIssueReference::new()));
+    }
 }
 
 /// One bare `#NNN` finding, parked during the comment walk and emitted

--- a/src/rules/bare_url.rs
+++ b/src/rules/bare_url.rs
@@ -2,7 +2,7 @@ use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
-use crate::rule_index::{BareUrlRule, RuleRegistration};
+use crate::rule_index::{BareUrlRule, Register};
 use crate::url_scan::{DEFAULT_FORWARD_SCHEMES, TrailingClass, classify_trailing, take_url};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
@@ -123,7 +123,7 @@ impl BareUrl {
 
 impl_lint_pass!(BareUrl => [BARE_URL]);
 
-impl RuleRegistration for BareUrlRule {
+impl Register for BareUrlRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_URL]);
     }

--- a/src/rules/bare_url.rs
+++ b/src/rules/bare_url.rs
@@ -2,6 +2,7 @@ use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
+use crate::rule_index::{BareUrlRule, RuleRegistration};
 use crate::url_scan::{DEFAULT_FORWARD_SCHEMES, TrailingClass, classify_trailing, take_url};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
@@ -122,15 +123,17 @@ impl BareUrl {
 
 impl_lint_pass!(BareUrl => [BARE_URL]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[BARE_URL]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("bare_url", DefaultState::Active) {
-        return;
+impl RuleRegistration for BareUrlRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[BARE_URL]);
     }
-    lint_store.register_late_pass(|_| Box::new(BareUrl::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("bare_url", DefaultState::Active) {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(BareUrl::new()));
+    }
 }
 
 /// One bare-URL finding, parked during the comment walk and emitted

--- a/src/rules/bare_url.rs
+++ b/src/rules/bare_url.rs
@@ -1,5 +1,5 @@
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
 use crate::rule_index::{Register, rule};
@@ -124,14 +124,13 @@ impl BareUrl {
 impl_lint_pass!(BareUrl => [BARE_URL]);
 
 impl Register for rule::BareUrl {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_URL]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("bare_url", DefaultState::Active) {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(BareUrl::new()));
     }
 }

--- a/src/rules/bare_url.rs
+++ b/src/rules/bare_url.rs
@@ -2,7 +2,7 @@ use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{position_in_skip, scan_skip_regions, utf8_char_len};
-use crate::rule_index::{BareUrlRule, Register};
+use crate::rule_index::{Register, rule};
 use crate::url_scan::{DEFAULT_FORWARD_SCHEMES, TrailingClass, classify_trailing, take_url};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
@@ -123,7 +123,7 @@ impl BareUrl {
 
 impl_lint_pass!(BareUrl => [BARE_URL]);
 
-impl Register for BareUrlRule {
+impl Register for rule::BareUrl {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[BARE_URL]);
     }

--- a/src/rules/clap_help_markdown.rs
+++ b/src/rules/clap_help_markdown.rs
@@ -1,5 +1,5 @@
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{ClassifyOptions, classify_constructs};
 use crate::module_reparse::parse_crate_module_files;
@@ -101,11 +101,6 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`Register::register_pass`] below;
-/// gen-docs picks the constant up via syn to render the rule's default
-/// state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
-
 const CONFIG_KEY: &str = "perfectionist::clap_help_markdown";
 
 pub struct ClapHelpMarkdown {
@@ -124,14 +119,13 @@ impl ClapHelpMarkdown {
 impl_lint_pass!(ClapHelpMarkdown => [CLAP_HELP_MARKDOWN]);
 
 impl Register for rule::ClapHelpMarkdown {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[CLAP_HELP_MARKDOWN]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("clap_help_markdown", DEFAULT_STATE) {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(ClapHelpMarkdown::new()));
     }
 }

--- a/src/rules/clap_help_markdown.rs
+++ b/src/rules/clap_help_markdown.rs
@@ -3,7 +3,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{ClassifyOptions, classify_constructs};
 use crate::module_reparse::parse_crate_module_files;
-use crate::rule_index::{ClapHelpMarkdownRule, Register};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -123,7 +123,7 @@ impl ClapHelpMarkdown {
 
 impl_lint_pass!(ClapHelpMarkdown => [CLAP_HELP_MARKDOWN]);
 
-impl Register for ClapHelpMarkdownRule {
+impl Register for rule::ClapHelpMarkdown {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[CLAP_HELP_MARKDOWN]);
     }

--- a/src/rules/clap_help_markdown.rs
+++ b/src/rules/clap_help_markdown.rs
@@ -3,6 +3,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{ClassifyOptions, classify_constructs};
 use crate::module_reparse::parse_crate_module_files;
+use crate::rule_index::{ClapHelpMarkdownRule, RuleRegistration};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -100,8 +101,9 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`register_pass`] below; gen-docs picks
-/// the constant up via syn to render the rule's default state.
+/// Active by default. Read by [`RuleRegistration::register_pass`]
+/// below; gen-docs picks the constant up via syn to render the rule's
+/// default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::clap_help_markdown";
@@ -121,15 +123,17 @@ impl ClapHelpMarkdown {
 
 impl_lint_pass!(ClapHelpMarkdown => [CLAP_HELP_MARKDOWN]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[CLAP_HELP_MARKDOWN]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("clap_help_markdown", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for ClapHelpMarkdownRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[CLAP_HELP_MARKDOWN]);
     }
-    lint_store.register_late_pass(|_| Box::new(ClapHelpMarkdown::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("clap_help_markdown", DEFAULT_STATE) {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(ClapHelpMarkdown::new()));
+    }
 }
 
 /// One parked finding, resolved to its enclosing HIR node and emitted in

--- a/src/rules/clap_help_markdown.rs
+++ b/src/rules/clap_help_markdown.rs
@@ -3,7 +3,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::markdown::{ClassifyOptions, classify_constructs};
 use crate::module_reparse::parse_crate_module_files;
-use crate::rule_index::{ClapHelpMarkdownRule, RuleRegistration};
+use crate::rule_index::{ClapHelpMarkdownRule, Register};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -101,9 +101,9 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`RuleRegistration::register_pass`]
-/// below; gen-docs picks the constant up via syn to render the rule's
-/// default state.
+/// Active by default. Read by [`Register::register_pass`] below;
+/// gen-docs picks the constant up via syn to render the rule's default
+/// state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::clap_help_markdown";
@@ -123,7 +123,7 @@ impl ClapHelpMarkdown {
 
 impl_lint_pass!(ClapHelpMarkdown => [CLAP_HELP_MARKDOWN]);
 
-impl RuleRegistration for ClapHelpMarkdownRule {
+impl Register for ClapHelpMarkdownRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[CLAP_HELP_MARKDOWN]);
     }

--- a/src/rules/excessive_inline_tests.rs
+++ b/src/rules/excessive_inline_tests.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
-use crate::rule_index::{ExcessiveInlineTestsRule, RuleRegistration};
+use crate::rule_index::{ExcessiveInlineTestsRule, Register};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 
@@ -80,7 +80,7 @@ const CONFIG_KEY: &str = "perfectionist::excessive_inline_tests";
 
 impl_lint_pass!(ExcessiveInlineTests => [EXCESSIVE_INLINE_TESTS]);
 
-impl RuleRegistration for ExcessiveInlineTestsRule {
+impl Register for ExcessiveInlineTestsRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[EXCESSIVE_INLINE_TESTS]);
     }

--- a/src/rules/excessive_inline_tests.rs
+++ b/src/rules/excessive_inline_tests.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::rule_index::{Register, rule};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -81,6 +81,8 @@ const CONFIG_KEY: &str = "perfectionist::excessive_inline_tests";
 impl_lint_pass!(ExcessiveInlineTests => [EXCESSIVE_INLINE_TESTS]);
 
 impl Register for rule::ExcessiveInlineTests {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[EXCESSIVE_INLINE_TESTS]);
     }
@@ -97,11 +99,6 @@ impl Register for rule::ExcessiveInlineTests {
     /// build where `cfg(test)` is active, i.e. the unit-test target that
     /// `cargo dylint -- --all-targets` checks.
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("excessive_inline_tests", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(ExcessiveInlineTests::new()));
     }
 }

--- a/src/rules/excessive_inline_tests.rs
+++ b/src/rules/excessive_inline_tests.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
-use crate::rule_index::{ExcessiveInlineTestsRule, Register};
+use crate::rule_index::{Register, rule};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 
@@ -80,7 +80,7 @@ const CONFIG_KEY: &str = "perfectionist::excessive_inline_tests";
 
 impl_lint_pass!(ExcessiveInlineTests => [EXCESSIVE_INLINE_TESTS]);
 
-impl Register for ExcessiveInlineTestsRule {
+impl Register for rule::ExcessiveInlineTests {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[EXCESSIVE_INLINE_TESTS]);
     }

--- a/src/rules/excessive_inline_tests.rs
+++ b/src/rules/excessive_inline_tests.rs
@@ -1,4 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
+use crate::rule_index::{ExcessiveInlineTestsRule, RuleRegistration};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 
@@ -79,28 +80,30 @@ const CONFIG_KEY: &str = "perfectionist::excessive_inline_tests";
 
 impl_lint_pass!(ExcessiveInlineTests => [EXCESSIVE_INLINE_TESTS]);
 
-/// Register this rule's lint declaration. Paired with [`register_pass`];
-/// see the module-level convention documented in `register_lints`.
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[EXCESSIVE_INLINE_TESTS]);
-}
-
-/// Install this rule's late pass.
-///
-/// A late pass is required because the only reliable way to tell that
-/// an item carries `#[cfg(test)]` is the `CfgTrace` attribute rustc
-/// leaves behind after configuration, which
-/// `crate::test_code::cfg_predicate_implies_test` reads — information
-/// that needs `TyCtxt` and is unavailable to the pre-/post-expansion
-/// AST passes (the raw `#[cfg(test)]` attribute is consumed during
-/// configuration). Consequently the rule only sees test code in a
-/// build where `cfg(test)` is active, i.e. the unit-test target that
-/// `cargo dylint -- --all-targets` checks.
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("excessive_inline_tests", DefaultState::Active) {
-        return;
+impl RuleRegistration for ExcessiveInlineTestsRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[EXCESSIVE_INLINE_TESTS]);
     }
-    lint_store.register_late_pass(|_| Box::new(ExcessiveInlineTests::new()));
+
+    /// Install this rule's late pass.
+    ///
+    /// A late pass is required because the only reliable way to tell that
+    /// an item carries `#[cfg(test)]` is the `CfgTrace` attribute rustc
+    /// leaves behind after configuration, which
+    /// `crate::test_code::cfg_predicate_implies_test` reads — information
+    /// that needs `TyCtxt` and is unavailable to the pre-/post-expansion
+    /// AST passes (the raw `#[cfg(test)]` attribute is consumed during
+    /// configuration). Consequently the rule only sees test code in a
+    /// build where `cfg(test)` is active, i.e. the unit-test target that
+    /// `cargo dylint -- --all-targets` checks.
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("excessive_inline_tests", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(ExcessiveInlineTests::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for ExcessiveInlineTests {

--- a/src/rules/exhaustive_error_enums.rs
+++ b/src/rules/exhaustive_error_enums.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolve_string_set, resolved_state};
-use crate::rule_index::{ExhaustiveErrorEnumsRule, RuleRegistration};
+use crate::rule_index::{ExhaustiveErrorEnumsRule, Register};
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::indent_of;
 use clippy_utils::sym;
@@ -89,8 +89,8 @@ declare_tool_lint! {
 /// Off by default — enable it in `dylint.toml` via the crate-wide
 /// `[perfectionist] enable = ["exhaustive_error_enums"]` (or the
 /// `[[perfectionist.enable]]` array-of-tables form). Read by
-/// [`RuleRegistration::register_pass`] below; gen-docs picks the
-/// constant up via syn to render the rule's default state.
+/// [`Register::register_pass`] below; gen-docs picks the constant up
+/// via syn to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
 
 const CONFIG_KEY: &str = "perfectionist::exhaustive_error_enums";
@@ -188,7 +188,7 @@ impl ExhaustiveErrorEnums {
 
 impl_lint_pass!(ExhaustiveErrorEnums => [EXHAUSTIVE_ERROR_ENUMS]);
 
-impl RuleRegistration for ExhaustiveErrorEnumsRule {
+impl Register for ExhaustiveErrorEnumsRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[EXHAUSTIVE_ERROR_ENUMS]);
     }

--- a/src/rules/exhaustive_error_enums.rs
+++ b/src/rules/exhaustive_error_enums.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolve_string_set, resolved_state};
-use crate::rule_index::{ExhaustiveErrorEnumsRule, Register};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::indent_of;
 use clippy_utils::sym;
@@ -188,7 +188,7 @@ impl ExhaustiveErrorEnums {
 
 impl_lint_pass!(ExhaustiveErrorEnums => [EXHAUSTIVE_ERROR_ENUMS]);
 
-impl Register for ExhaustiveErrorEnumsRule {
+impl Register for rule::ExhaustiveErrorEnums {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[EXHAUSTIVE_ERROR_ENUMS]);
     }

--- a/src/rules/exhaustive_error_enums.rs
+++ b/src/rules/exhaustive_error_enums.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, resolve_string_set, resolved_state};
+use crate::common::{DefaultState, resolve_string_set};
 use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::indent_of;
@@ -85,13 +85,6 @@ declare_tool_lint! {
     "error-shaped type is missing `#[non_exhaustive]`",
     report_in_external_macro: false
 }
-
-/// Off by default — enable it in `dylint.toml` via the crate-wide
-/// `[perfectionist] enable = ["exhaustive_error_enums"]` (or the
-/// `[[perfectionist.enable]]` array-of-tables form). Read by
-/// [`Register::register_pass`] below; gen-docs picks the constant up
-/// via syn to render the rule's default state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
 
 const CONFIG_KEY: &str = "perfectionist::exhaustive_error_enums";
 
@@ -189,14 +182,16 @@ impl ExhaustiveErrorEnums {
 impl_lint_pass!(ExhaustiveErrorEnums => [EXHAUSTIVE_ERROR_ENUMS]);
 
 impl Register for rule::ExhaustiveErrorEnums {
+    /// Off by default — enable it in `dylint.toml` via the crate-wide
+    /// `[perfectionist] enable = ["exhaustive_error_enums"]` (or the
+    /// `[[perfectionist.enable]]` array-of-tables form).
+    const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[EXHAUSTIVE_ERROR_ENUMS]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("exhaustive_error_enums", DEFAULT_STATE) {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(ExhaustiveErrorEnums::new()));
     }
 }

--- a/src/rules/exhaustive_error_enums.rs
+++ b/src/rules/exhaustive_error_enums.rs
@@ -1,4 +1,5 @@
 use crate::common::{DefaultState, resolve_string_set, resolved_state};
+use crate::rule_index::{ExhaustiveErrorEnumsRule, RuleRegistration};
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::indent_of;
 use clippy_utils::sym;
@@ -88,8 +89,8 @@ declare_tool_lint! {
 /// Off by default — enable it in `dylint.toml` via the crate-wide
 /// `[perfectionist] enable = ["exhaustive_error_enums"]` (or the
 /// `[[perfectionist.enable]]` array-of-tables form). Read by
-/// [`register_pass`] below; gen-docs picks the constant up via syn
-/// to render the rule's default state.
+/// [`RuleRegistration::register_pass`] below; gen-docs picks the
+/// constant up via syn to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
 
 const CONFIG_KEY: &str = "perfectionist::exhaustive_error_enums";
@@ -187,18 +188,17 @@ impl ExhaustiveErrorEnums {
 
 impl_lint_pass!(ExhaustiveErrorEnums => [EXHAUSTIVE_ERROR_ENUMS]);
 
-/// Register this rule's lint declaration. Paired with [`register_pass`];
-/// see the module-level convention documented in `register_lints`.
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[EXHAUSTIVE_ERROR_ENUMS]);
-}
-
-/// Install this rule's late pass.
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("exhaustive_error_enums", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for ExhaustiveErrorEnumsRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[EXHAUSTIVE_ERROR_ENUMS]);
     }
-    lint_store.register_late_pass(|_| Box::new(ExhaustiveErrorEnums::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("exhaustive_error_enums", DEFAULT_STATE) {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(ExhaustiveErrorEnums::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for ExhaustiveErrorEnums {

--- a/src/rules/import_granularity_mismatch.rs
+++ b/src/rules/import_granularity_mismatch.rs
@@ -1,3 +1,4 @@
+use crate::rule_index::{ImportGranularityMismatchRule, RuleRegistration};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::source::indent_of;
 use rustc_ast::{
@@ -116,8 +117,8 @@ declare_tool_lint! {
 
 /// Active by default. `module` is the shipped baseline; a project that
 /// prefers `crate` or `item` sets `style` in `dylint.toml`. Read by
-/// [`register_pass`]; gen-docs picks the constant up to render the rule's
-/// default state.
+/// [`RuleRegistration::register_pass`]; gen-docs picks the constant up
+/// to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::import_granularity_mismatch";
@@ -145,23 +146,23 @@ impl ImportGranularityMismatch {
 
 impl_lint_pass!(ImportGranularityMismatch => [IMPORT_GRANULARITY_MISMATCH]);
 
-/// Register this rule's lint declaration. Paired with [`register_pass`];
-/// see the module-level convention documented in `register_lints`.
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[IMPORT_GRANULARITY_MISMATCH]);
-}
-
-/// Install this rule's pass.
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("import_granularity_mismatch", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for ImportGranularityMismatchRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[IMPORT_GRANULARITY_MISMATCH]);
     }
-    // Late pass: out-of-line `mod foo;` modules are `ModKind::Unloaded`
-    // until macro expansion, so a pre-expansion pass never sees them.
-    // `check_crate` re-parses each source file instead, which reaches
-    // every submodule while keeping `#[cfg(...)]` gates intact (parsing
-    // does not strip cfg, unlike the post-expansion AST).
-    lint_store.register_late_pass(|_| Box::new(ImportGranularityMismatch::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("import_granularity_mismatch", DEFAULT_STATE)
+        {
+            return;
+        }
+        // Late pass: out-of-line `mod foo;` modules are `ModKind::Unloaded`
+        // until macro expansion, so a pre-expansion pass never sees them.
+        // `check_crate` re-parses each source file instead, which reaches
+        // every submodule while keeping `#[cfg(...)]` gates intact (parsing
+        // does not strip cfg, unlike the post-expansion AST).
+        lint_store.register_late_pass(|_| Box::new(ImportGranularityMismatch::new()));
+    }
 }
 
 /// A detected violation parked until the enclosing HIR node is known.

--- a/src/rules/import_granularity_mismatch.rs
+++ b/src/rules/import_granularity_mismatch.rs
@@ -1,4 +1,4 @@
-use crate::rule_index::{ImportGranularityMismatchRule, RuleRegistration};
+use crate::rule_index::{ImportGranularityMismatchRule, Register};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::source::indent_of;
 use rustc_ast::{
@@ -117,8 +117,8 @@ declare_tool_lint! {
 
 /// Active by default. `module` is the shipped baseline; a project that
 /// prefers `crate` or `item` sets `style` in `dylint.toml`. Read by
-/// [`RuleRegistration::register_pass`]; gen-docs picks the constant up
-/// to render the rule's default state.
+/// [`Register::register_pass`]; gen-docs picks the constant up to
+/// render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::import_granularity_mismatch";
@@ -146,7 +146,7 @@ impl ImportGranularityMismatch {
 
 impl_lint_pass!(ImportGranularityMismatch => [IMPORT_GRANULARITY_MISMATCH]);
 
-impl RuleRegistration for ImportGranularityMismatchRule {
+impl Register for ImportGranularityMismatchRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[IMPORT_GRANULARITY_MISMATCH]);
     }

--- a/src/rules/import_granularity_mismatch.rs
+++ b/src/rules/import_granularity_mismatch.rs
@@ -14,7 +14,7 @@ mod config;
 mod model;
 mod render;
 
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::find_enclosing_hir_ids;
 use crate::module_reparse::for_each_module_file;
 use check::is_compliant;
@@ -115,12 +115,6 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. `module` is the shipped baseline; a project that
-/// prefers `crate` or `item` sets `style` in `dylint.toml`. Read by
-/// [`Register::register_pass`]; gen-docs picks the constant up to
-/// render the rule's default state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
-
 const CONFIG_KEY: &str = "perfectionist::import_granularity_mismatch";
 
 pub struct ImportGranularityMismatch {
@@ -147,15 +141,15 @@ impl ImportGranularityMismatch {
 impl_lint_pass!(ImportGranularityMismatch => [IMPORT_GRANULARITY_MISMATCH]);
 
 impl Register for rule::ImportGranularityMismatch {
+    /// Active by default. `module` is the shipped baseline; a project
+    /// that prefers `crate` or `item` sets `style` in `dylint.toml`.
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[IMPORT_GRANULARITY_MISMATCH]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("import_granularity_mismatch", DEFAULT_STATE)
-        {
-            return;
-        }
         // Late pass: out-of-line `mod foo;` modules are `ModKind::Unloaded`
         // until macro expansion, so a pre-expansion pass never sees them.
         // `check_crate` re-parses each source file instead, which reaches

--- a/src/rules/import_granularity_mismatch.rs
+++ b/src/rules/import_granularity_mismatch.rs
@@ -1,4 +1,4 @@
-use crate::rule_index::{ImportGranularityMismatchRule, Register};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::source::indent_of;
 use rustc_ast::{
@@ -146,7 +146,7 @@ impl ImportGranularityMismatch {
 
 impl_lint_pass!(ImportGranularityMismatch => [IMPORT_GRANULARITY_MISMATCH]);
 
-impl Register for ImportGranularityMismatchRule {
+impl Register for rule::ImportGranularityMismatch {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[IMPORT_GRANULARITY_MISMATCH]);
     }

--- a/src/rules/import_grouping_mismatch.rs
+++ b/src/rules/import_grouping_mismatch.rs
@@ -13,7 +13,7 @@ mod classify;
 mod config;
 mod render;
 
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::find_enclosing_hir_ids;
 use crate::module_reparse::{SpanRange, parse_crate_module_files};
 use config::{Config, ReexportGrouping, Style};
@@ -181,13 +181,6 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Inactive by default. The rule is direction-less: a project that
-/// adopts it picks `multi_block` (ordered, blank-line-separated blocks)
-/// or `single_block` (one contiguous block), so `style` is mandatory
-/// whenever the rule is enabled. Read by [`Register::register_pass`];
-/// gen-docs picks the constant up to render the rule's default state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
-
 const CONFIG_KEY: &str = "perfectionist::import_grouping_mismatch";
 
 pub struct ImportGroupingMismatch {
@@ -197,14 +190,17 @@ pub struct ImportGroupingMismatch {
 impl_lint_pass!(ImportGroupingMismatch => [IMPORT_GROUPING_MISMATCH]);
 
 impl Register for rule::ImportGroupingMismatch {
+    /// Inactive by default. The rule is direction-less: a project that
+    /// adopts it picks `multi_block` (ordered, blank-line-separated
+    /// blocks) or `single_block` (one contiguous block), so `style` is
+    /// mandatory whenever the rule is enabled.
+    const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[IMPORT_GROUPING_MISMATCH]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("import_grouping_mismatch", DEFAULT_STATE) {
-            return;
-        }
         // The rule is enabled, so `style` and `reexports` are mandatory and
         // have no default. Read with `config` rather than `config_or_default`:
         // the latter needs `Config: Default`, which would force defaults for

--- a/src/rules/import_grouping_mismatch.rs
+++ b/src/rules/import_grouping_mismatch.rs
@@ -1,3 +1,4 @@
+use crate::rule_index::{ImportGroupingMismatchRule, RuleRegistration};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::source::indent_of;
 use rustc_ast::{Item, ItemKind, ModKind, VisibilityKind};
@@ -181,10 +182,11 @@ declare_tool_lint! {
 }
 
 /// Inactive by default. The rule is direction-less: a project that
-/// adopts it picks `multi_block` (ordered, blank-line-separated blocks) or
-/// `single_block` (one contiguous block), so `style` is mandatory
-/// whenever the rule is enabled. Read by [`register_pass`]; gen-docs picks
-/// the constant up to render the rule's default state.
+/// adopts it picks `multi_block` (ordered, blank-line-separated blocks)
+/// or `single_block` (one contiguous block), so `style` is mandatory
+/// whenever the rule is enabled. Read by
+/// [`RuleRegistration::register_pass`]; gen-docs picks the constant up
+/// to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
 
 const CONFIG_KEY: &str = "perfectionist::import_grouping_mismatch";
@@ -195,49 +197,48 @@ pub struct ImportGroupingMismatch {
 
 impl_lint_pass!(ImportGroupingMismatch => [IMPORT_GROUPING_MISMATCH]);
 
-/// Register this rule's lint declaration. Paired with [`register_pass`];
-/// see the module-level convention documented in `register_lints`.
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[IMPORT_GROUPING_MISMATCH]);
-}
-
-/// Install this rule's pass.
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("import_grouping_mismatch", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for ImportGroupingMismatchRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[IMPORT_GROUPING_MISMATCH]);
     }
-    // The rule is enabled, so `style` and `reexports` are mandatory and
-    // have no default. Read with `config` rather than `config_or_default`:
-    // the latter needs `Config: Default`, which would force defaults for
-    // both. `config` instead returns `Ok(None)` when the table is absent
-    // and `Err` when it is present but a mandatory field is missing or
-    // invalid — both are configuration errors we fail loudly on.
-    let config = dylint_linting::config::<Config>(CONFIG_KEY)
-        .unwrap_or_else(|error| {
-            panic!(
-                "perfectionist::import_grouping_mismatch: invalid \
-                 `[\"perfectionist::import_grouping_mismatch\"]` configuration: {error}",
-            )
-        })
-        .unwrap_or_else(|| {
-            panic!(
-                "perfectionist::import_grouping_mismatch is enabled but not configured; \
-                 set `style` (`multi_block` / `single_block`) and `reexports` \
-                 (`grouped` / `split` / `by_path`) under \
-                 `[\"perfectionist::import_grouping_mismatch\"]` in dylint.toml",
-            )
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("import_grouping_mismatch", DEFAULT_STATE) {
+            return;
+        }
+        // The rule is enabled, so `style` and `reexports` are mandatory and
+        // have no default. Read with `config` rather than `config_or_default`:
+        // the latter needs `Config: Default`, which would force defaults for
+        // both. `config` instead returns `Ok(None)` when the table is absent
+        // and `Err` when it is present but a mandatory field is missing or
+        // invalid — both are configuration errors we fail loudly on.
+        let config = dylint_linting::config::<Config>(CONFIG_KEY)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "perfectionist::import_grouping_mismatch: invalid \
+                     `[\"perfectionist::import_grouping_mismatch\"]` configuration: {error}",
+                )
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "perfectionist::import_grouping_mismatch is enabled but not configured; \
+                     set `style` (`multi_block` / `single_block`) and `reexports` \
+                     (`grouped` / `split` / `by_path`) under \
+                     `[\"perfectionist::import_grouping_mismatch\"]` in dylint.toml",
+                )
+            });
+        // Late pass: out-of-line `mod foo;` modules are `ModKind::Unloaded`
+        // until macro expansion, so a pre-expansion pass never sees them.
+        // `check_crate` re-parses each module file instead (see
+        // [`crate::module_reparse`]), reaching every submodule while keeping
+        // `#[cfg(...)]` gates intact — parsing does not strip cfg, the reason
+        // a pre-expansion pass would otherwise be needed.
+        lint_store.register_late_pass(move |_| {
+            Box::new(ImportGroupingMismatch {
+                config: config.clone(),
+            })
         });
-    // Late pass: out-of-line `mod foo;` modules are `ModKind::Unloaded`
-    // until macro expansion, so a pre-expansion pass never sees them.
-    // `check_crate` re-parses each module file instead (see
-    // [`crate::module_reparse`]), reaching every submodule while keeping
-    // `#[cfg(...)]` gates intact — parsing does not strip cfg, the reason
-    // a pre-expansion pass would otherwise be needed.
-    lint_store.register_late_pass(move |_| {
-        Box::new(ImportGroupingMismatch {
-            config: config.clone(),
-        })
-    });
+    }
 }
 
 /// One `use` statement admitted into a run. The submodules

--- a/src/rules/import_grouping_mismatch.rs
+++ b/src/rules/import_grouping_mismatch.rs
@@ -1,4 +1,4 @@
-use crate::rule_index::{ImportGroupingMismatchRule, Register};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::source::indent_of;
 use rustc_ast::{Item, ItemKind, ModKind, VisibilityKind};
@@ -196,7 +196,7 @@ pub struct ImportGroupingMismatch {
 
 impl_lint_pass!(ImportGroupingMismatch => [IMPORT_GROUPING_MISMATCH]);
 
-impl Register for ImportGroupingMismatchRule {
+impl Register for rule::ImportGroupingMismatch {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[IMPORT_GROUPING_MISMATCH]);
     }

--- a/src/rules/import_grouping_mismatch.rs
+++ b/src/rules/import_grouping_mismatch.rs
@@ -1,4 +1,4 @@
-use crate::rule_index::{ImportGroupingMismatchRule, RuleRegistration};
+use crate::rule_index::{ImportGroupingMismatchRule, Register};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use clippy_utils::source::indent_of;
 use rustc_ast::{Item, ItemKind, ModKind, VisibilityKind};
@@ -184,9 +184,8 @@ declare_tool_lint! {
 /// Inactive by default. The rule is direction-less: a project that
 /// adopts it picks `multi_block` (ordered, blank-line-separated blocks)
 /// or `single_block` (one contiguous block), so `style` is mandatory
-/// whenever the rule is enabled. Read by
-/// [`RuleRegistration::register_pass`]; gen-docs picks the constant up
-/// to render the rule's default state.
+/// whenever the rule is enabled. Read by [`Register::register_pass`];
+/// gen-docs picks the constant up to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
 
 const CONFIG_KEY: &str = "perfectionist::import_grouping_mismatch";
@@ -197,7 +196,7 @@ pub struct ImportGroupingMismatch {
 
 impl_lint_pass!(ImportGroupingMismatch => [IMPORT_GROUPING_MISMATCH]);
 
-impl RuleRegistration for ImportGroupingMismatchRule {
+impl Register for ImportGroupingMismatchRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[IMPORT_GROUPING_MISMATCH]);
     }

--- a/src/rules/impure_macro_arguments.rs
+++ b/src/rules/impure_macro_arguments.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
-use crate::rule_index::{ImpureMacroArgumentsRule, Register};
+use crate::rule_index::{Register, rule};
 use rustc_ast::MacCall;
 use rustc_ast::token::Delimiter;
 use rustc_ast::tokenstream::TokenTree;
@@ -118,7 +118,7 @@ declare_tool_lint! {
 impl_lint_pass!(ImpureMacroArguments => [IMPURE_MACRO_ARGUMENTS]);
 impl_lint_pass!(ImpureMacroArgumentsLate => [IMPURE_MACRO_ARGUMENTS]);
 
-impl Register for ImpureMacroArgumentsRule {
+impl Register for rule::ImpureMacroArguments {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[IMPURE_MACRO_ARGUMENTS]);
     }

--- a/src/rules/impure_macro_arguments.rs
+++ b/src/rules/impure_macro_arguments.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
-use crate::rule_index::{ImpureMacroArgumentsRule, RuleRegistration};
+use crate::rule_index::{ImpureMacroArgumentsRule, Register};
 use rustc_ast::MacCall;
 use rustc_ast::token::Delimiter;
 use rustc_ast::tokenstream::TokenTree;
@@ -118,7 +118,7 @@ declare_tool_lint! {
 impl_lint_pass!(ImpureMacroArguments => [IMPURE_MACRO_ARGUMENTS]);
 impl_lint_pass!(ImpureMacroArgumentsLate => [IMPURE_MACRO_ARGUMENTS]);
 
-impl RuleRegistration for ImpureMacroArgumentsRule {
+impl Register for ImpureMacroArgumentsRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[IMPURE_MACRO_ARGUMENTS]);
     }

--- a/src/rules/impure_macro_arguments.rs
+++ b/src/rules/impure_macro_arguments.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::rule_index::{Register, rule};
 use rustc_ast::MacCall;
 use rustc_ast::token::Delimiter;
@@ -119,16 +119,13 @@ impl_lint_pass!(ImpureMacroArguments => [IMPURE_MACRO_ARGUMENTS]);
 impl_lint_pass!(ImpureMacroArgumentsLate => [IMPURE_MACRO_ARGUMENTS]);
 
 impl Register for rule::ImpureMacroArguments {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[IMPURE_MACRO_ARGUMENTS]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("impure_macro_arguments", DefaultState::Active)
-        {
-            return;
-        }
         // Same split as `macro_trailing_comma`: a pre-expansion pass parks
         // violation spans, a late pass walks the HIR and emits each at the
         // deepest enclosing node so `cfg_attr`-wrapped `#[expect]` and

--- a/src/rules/impure_macro_arguments.rs
+++ b/src/rules/impure_macro_arguments.rs
@@ -1,4 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
+use crate::rule_index::{ImpureMacroArgumentsRule, RuleRegistration};
 use rustc_ast::MacCall;
 use rustc_ast::token::Delimiter;
 use rustc_ast::tokenstream::TokenTree;
@@ -117,20 +118,24 @@ declare_tool_lint! {
 impl_lint_pass!(ImpureMacroArguments => [IMPURE_MACRO_ARGUMENTS]);
 impl_lint_pass!(ImpureMacroArgumentsLate => [IMPURE_MACRO_ARGUMENTS]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[IMPURE_MACRO_ARGUMENTS]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("impure_macro_arguments", DefaultState::Active) {
-        return;
+impl RuleRegistration for ImpureMacroArgumentsRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[IMPURE_MACRO_ARGUMENTS]);
     }
-    // Same split as `macro_trailing_comma`: a pre-expansion pass parks
-    // violation spans, a late pass walks the HIR and emits each at the
-    // deepest enclosing node so `cfg_attr`-wrapped `#[expect]` and
-    // `#[allow]` attributes resolve correctly.
-    lint_store.register_pre_expansion_pass(|| Box::new(ImpureMacroArguments::new()));
-    lint_store.register_late_pass(|_| Box::new(ImpureMacroArgumentsLate));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("impure_macro_arguments", DefaultState::Active)
+        {
+            return;
+        }
+        // Same split as `macro_trailing_comma`: a pre-expansion pass parks
+        // violation spans, a late pass walks the HIR and emits each at the
+        // deepest enclosing node so `cfg_attr`-wrapped `#[expect]` and
+        // `#[allow]` attributes resolve correctly.
+        lint_store.register_pre_expansion_pass(|| Box::new(ImpureMacroArguments::new()));
+        lint_store.register_late_pass(|_| Box::new(ImpureMacroArgumentsLate));
+    }
 }
 
 /// Violation spans the pre-expansion pass has parked, waiting for the

--- a/src/rules/lint_attribute_trailing_comment.rs
+++ b/src/rules/lint_attribute_trailing_comment.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
-use crate::rule_index::{LintAttributeTrailingCommentRule, RuleRegistration};
+use crate::rule_index::{LintAttributeTrailingCommentRule, Register};
 use rustc_ast::Attribute;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -90,7 +90,7 @@ impl LintAttributeTrailingComment {
 
 impl_lint_pass!(LintAttributeTrailingComment => [LINT_ATTRIBUTE_TRAILING_COMMENT]);
 
-impl RuleRegistration for LintAttributeTrailingCommentRule {
+impl Register for LintAttributeTrailingCommentRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[LINT_ATTRIBUTE_TRAILING_COMMENT]);
     }

--- a/src/rules/lint_attribute_trailing_comment.rs
+++ b/src/rules/lint_attribute_trailing_comment.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
-use crate::rule_index::{LintAttributeTrailingCommentRule, Register};
+use crate::rule_index::{Register, rule};
 use rustc_ast::Attribute;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -90,7 +90,7 @@ impl LintAttributeTrailingComment {
 
 impl_lint_pass!(LintAttributeTrailingComment => [LINT_ATTRIBUTE_TRAILING_COMMENT]);
 
-impl Register for LintAttributeTrailingCommentRule {
+impl Register for rule::LintAttributeTrailingComment {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[LINT_ATTRIBUTE_TRAILING_COMMENT]);
     }

--- a/src/rules/lint_attribute_trailing_comment.rs
+++ b/src/rules/lint_attribute_trailing_comment.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::rule_index::{Register, rule};
 use rustc_ast::Attribute;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
@@ -91,16 +91,13 @@ impl LintAttributeTrailingComment {
 impl_lint_pass!(LintAttributeTrailingComment => [LINT_ATTRIBUTE_TRAILING_COMMENT]);
 
 impl Register for rule::LintAttributeTrailingComment {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[LINT_ATTRIBUTE_TRAILING_COMMENT]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("lint_attribute_trailing_comment", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_early_pass(|| Box::new(LintAttributeTrailingComment::new()));
     }
 }

--- a/src/rules/lint_attribute_trailing_comment.rs
+++ b/src/rules/lint_attribute_trailing_comment.rs
@@ -1,4 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
+use crate::rule_index::{LintAttributeTrailingCommentRule, RuleRegistration};
 use rustc_ast::Attribute;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -89,17 +90,19 @@ impl LintAttributeTrailingComment {
 
 impl_lint_pass!(LintAttributeTrailingComment => [LINT_ATTRIBUTE_TRAILING_COMMENT]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[LINT_ATTRIBUTE_TRAILING_COMMENT]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("lint_attribute_trailing_comment", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for LintAttributeTrailingCommentRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[LINT_ATTRIBUTE_TRAILING_COMMENT]);
     }
-    lint_store.register_early_pass(|| Box::new(LintAttributeTrailingComment::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("lint_attribute_trailing_comment", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_early_pass(|| Box::new(LintAttributeTrailingComment::new()));
+    }
 }
 
 const LINT_LEVEL_NAMES: [Symbol; 5] = [sym::allow, sym::expect, sym::warn, sym::deny, sym::forbid];

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
-use crate::rule_index::{MacroTrailingCommaRule, Register};
+use crate::rule_index::{Register, rule};
 use rustc_ast::MacCall;
 use rustc_ast::token::TokenKind;
 use rustc_ast::tokenstream::TokenTree;
@@ -83,7 +83,7 @@ declare_tool_lint! {
 impl_lint_pass!(MacroTrailingComma => [MACRO_TRAILING_COMMA]);
 impl_lint_pass!(MacroTrailingCommaLate => [MACRO_TRAILING_COMMA]);
 
-impl Register for MacroTrailingCommaRule {
+impl Register for rule::MacroTrailingComma {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[MACRO_TRAILING_COMMA]);
     }

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::rule_index::{Register, rule};
 use rustc_ast::MacCall;
 use rustc_ast::token::TokenKind;
@@ -84,15 +84,13 @@ impl_lint_pass!(MacroTrailingComma => [MACRO_TRAILING_COMMA]);
 impl_lint_pass!(MacroTrailingCommaLate => [MACRO_TRAILING_COMMA]);
 
 impl Register for rule::MacroTrailingComma {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[MACRO_TRAILING_COMMA]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("macro_trailing_comma", DefaultState::Active)
-        {
-            return;
-        }
         // Split across two passes per
         // <https://github.com/KSXGitHub/parallel-disk-usage/issues/409>:
         // pre-expansion sees the `MacCall` tokens but runs before

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -1,4 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
+use crate::rule_index::{MacroTrailingCommaRule, RuleRegistration};
 use rustc_ast::MacCall;
 use rustc_ast::token::TokenKind;
 use rustc_ast::tokenstream::TokenTree;
@@ -82,24 +83,27 @@ declare_tool_lint! {
 impl_lint_pass!(MacroTrailingComma => [MACRO_TRAILING_COMMA]);
 impl_lint_pass!(MacroTrailingCommaLate => [MACRO_TRAILING_COMMA]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[MACRO_TRAILING_COMMA]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("macro_trailing_comma", DefaultState::Active) {
-        return;
+impl RuleRegistration for MacroTrailingCommaRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[MACRO_TRAILING_COMMA]);
     }
-    // Split across two passes per
-    // <https://github.com/KSXGitHub/parallel-disk-usage/issues/409>:
-    // pre-expansion sees the `MacCall` tokens but runs before
-    // `cfg_attr` is evaluated, so a `cfg_attr`-wrapped `#[expect]`
-    // is invisible at emission time. The pre-expansion pass parks
-    // violation spans in `PENDING_VIOLATIONS`; the late pass walks
-    // the HIR and emits each at its deepest enclosing node, by which
-    // point `cfg_attr` has resolved and lint-level attributes apply.
-    lint_store.register_pre_expansion_pass(|| Box::new(MacroTrailingComma::new()));
-    lint_store.register_late_pass(|_| Box::new(MacroTrailingCommaLate));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("macro_trailing_comma", DefaultState::Active)
+        {
+            return;
+        }
+        // Split across two passes per
+        // <https://github.com/KSXGitHub/parallel-disk-usage/issues/409>:
+        // pre-expansion sees the `MacCall` tokens but runs before
+        // `cfg_attr` is evaluated, so a `cfg_attr`-wrapped `#[expect]`
+        // is invisible at emission time. The pre-expansion pass parks
+        // violation spans in `PENDING_VIOLATIONS`; the late pass walks
+        // the HIR and emits each at its deepest enclosing node, by which
+        // point `cfg_attr` has resolved and lint-level attributes apply.
+        lint_store.register_pre_expansion_pass(|| Box::new(MacroTrailingComma::new()));
+        lint_store.register_late_pass(|_| Box::new(MacroTrailingCommaLate));
+    }
 }
 
 /// Violations the pre-expansion pass has found, waiting to be emitted

--- a/src/rules/macro_trailing_comma.rs
+++ b/src/rules/macro_trailing_comma.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
-use crate::rule_index::{MacroTrailingCommaRule, RuleRegistration};
+use crate::rule_index::{MacroTrailingCommaRule, Register};
 use rustc_ast::MacCall;
 use rustc_ast::token::TokenKind;
 use rustc_ast::tokenstream::TokenTree;
@@ -83,7 +83,7 @@ declare_tool_lint! {
 impl_lint_pass!(MacroTrailingComma => [MACRO_TRAILING_COMMA]);
 impl_lint_pass!(MacroTrailingCommaLate => [MACRO_TRAILING_COMMA]);
 
-impl RuleRegistration for MacroTrailingCommaRule {
+impl Register for MacroTrailingCommaRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[MACRO_TRAILING_COMMA]);
     }

--- a/src/rules/named_prelude_imports.rs
+++ b/src/rules/named_prelude_imports.rs
@@ -30,7 +30,7 @@ use rustc_span::kw;
 
 mod config;
 
-use crate::common::{DefaultState, hir_in_external_macro, resolved_state};
+use crate::common::{DefaultState, hir_in_external_macro};
 use config::{Config, Resolved};
 
 declare_tool_lint! {
@@ -90,12 +90,6 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. The prelude convention is the shipped baseline;
-/// `prelude_segment_names` / `allowed_paths` tune it. Read by
-/// [`Register::register_pass`]; gen-docs picks the constant up to
-/// render the rule's default state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
-
 const CONFIG_KEY: &str = "perfectionist::named_prelude_imports";
 
 pub struct NamedPreludeImports {
@@ -105,14 +99,15 @@ pub struct NamedPreludeImports {
 impl_lint_pass!(NamedPreludeImports => [NAMED_PRELUDE_IMPORTS]);
 
 impl Register for rule::NamedPreludeImports {
+    /// Active by default. The prelude convention is the shipped
+    /// baseline; `prelude_segment_names` / `allowed_paths` tune it.
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[NAMED_PRELUDE_IMPORTS]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("named_prelude_imports", DEFAULT_STATE) {
-            return;
-        }
         let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
         // Every `allowed_paths` entry has to end with a prelude segment (it
         // matches the path up to and including the prelude), so reject a

--- a/src/rules/named_prelude_imports.rs
+++ b/src/rules/named_prelude_imports.rs
@@ -17,7 +17,7 @@
 //!   [`UseKind::Single`] item per leaf, so each cherry-picked name is
 //!   flagged individually with no flattening of our own.)
 
-use crate::rule_index::{NamedPreludeImportsRule, Register};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
@@ -104,7 +104,7 @@ pub struct NamedPreludeImports {
 
 impl_lint_pass!(NamedPreludeImports => [NAMED_PRELUDE_IMPORTS]);
 
-impl Register for NamedPreludeImportsRule {
+impl Register for rule::NamedPreludeImports {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[NAMED_PRELUDE_IMPORTS]);
     }

--- a/src/rules/named_prelude_imports.rs
+++ b/src/rules/named_prelude_imports.rs
@@ -17,7 +17,7 @@
 //!   [`UseKind::Single`] item per leaf, so each cherry-picked name is
 //!   flagged individually with no flattening of our own.)
 
-use crate::rule_index::{NamedPreludeImportsRule, RuleRegistration};
+use crate::rule_index::{NamedPreludeImportsRule, Register};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
@@ -92,8 +92,8 @@ declare_tool_lint! {
 
 /// Active by default. The prelude convention is the shipped baseline;
 /// `prelude_segment_names` / `allowed_paths` tune it. Read by
-/// [`RuleRegistration::register_pass`]; gen-docs picks the constant up
-/// to render the rule's default state.
+/// [`Register::register_pass`]; gen-docs picks the constant up to
+/// render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::named_prelude_imports";
@@ -104,7 +104,7 @@ pub struct NamedPreludeImports {
 
 impl_lint_pass!(NamedPreludeImports => [NAMED_PRELUDE_IMPORTS]);
 
-impl RuleRegistration for NamedPreludeImportsRule {
+impl Register for NamedPreludeImportsRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[NAMED_PRELUDE_IMPORTS]);
     }

--- a/src/rules/named_prelude_imports.rs
+++ b/src/rules/named_prelude_imports.rs
@@ -17,6 +17,7 @@
 //!   [`UseKind::Single`] item per leaf, so each cherry-picked name is
 //!   flagged individually with no flattening of our own.)
 
+use crate::rule_index::{NamedPreludeImportsRule, RuleRegistration};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir::def::Res;
@@ -91,8 +92,8 @@ declare_tool_lint! {
 
 /// Active by default. The prelude convention is the shipped baseline;
 /// `prelude_segment_names` / `allowed_paths` tune it. Read by
-/// [`register_pass`]; gen-docs picks the constant up to render the rule's
-/// default state.
+/// [`RuleRegistration::register_pass`]; gen-docs picks the constant up
+/// to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::named_prelude_imports";
@@ -103,30 +104,29 @@ pub struct NamedPreludeImports {
 
 impl_lint_pass!(NamedPreludeImports => [NAMED_PRELUDE_IMPORTS]);
 
-/// Register this rule's lint declaration. Paired with [`register_pass`];
-/// see the module-level convention documented in `register_lints`.
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[NAMED_PRELUDE_IMPORTS]);
-}
-
-/// Install this rule's pass.
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("named_prelude_imports", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for NamedPreludeImportsRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[NAMED_PRELUDE_IMPORTS]);
     }
-    let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-    // Every `allowed_paths` entry has to end with a prelude segment (it
-    // matches the path up to and including the prelude), so reject a
-    // misconfigured one loudly rather than letting it silently match
-    // nothing.
-    config::validate(&config).unwrap_or_else(|message| {
-        panic!("perfectionist::named_prelude_imports: {message}");
-    });
-    lint_store.register_late_pass(move |_| {
-        Box::new(NamedPreludeImports {
-            config: Resolved::from_config(config.clone()),
-        })
-    });
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("named_prelude_imports", DEFAULT_STATE) {
+            return;
+        }
+        let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
+        // Every `allowed_paths` entry has to end with a prelude segment (it
+        // matches the path up to and including the prelude), so reject a
+        // misconfigured one loudly rather than letting it silently match
+        // nothing.
+        config::validate(&config).unwrap_or_else(|message| {
+            panic!("perfectionist::named_prelude_imports: {message}");
+        });
+        lint_store.register_late_pass(move |_| {
+            Box::new(NamedPreludeImports {
+                config: Resolved::from_config(config.clone()),
+            })
+        });
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for NamedPreludeImports {

--- a/src/rules/needless_borrowed_parameters.rs
+++ b/src/rules/needless_borrowed_parameters.rs
@@ -2,7 +2,7 @@ use crate::cargo_target::{CargoTarget, crate_target};
 use crate::common::{
     DefaultState, binding_hir_id, binding_ident, hir_in_external_macro, resolved_state,
 };
-use crate::rule_index::{NeedlessBorrowedParametersRule, RuleRegistration};
+use crate::rule_index::{NeedlessBorrowedParametersRule, Register};
 use crate::test_code::in_test_code;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::{snippet, snippet_opt};
@@ -91,9 +91,9 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`RuleRegistration::register_pass`]
-/// below; gen-docs picks the constant up via syn to render the rule's
-/// default state.
+/// Active by default. Read by [`Register::register_pass`] below;
+/// gen-docs picks the constant up via syn to render the rule's default
+/// state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::needless_borrowed_parameters";
@@ -118,7 +118,7 @@ impl NeedlessBorrowedParameters {
 
 impl_lint_pass!(NeedlessBorrowedParameters => [NEEDLESS_BORROWED_PARAMETERS]);
 
-impl RuleRegistration for NeedlessBorrowedParametersRule {
+impl Register for NeedlessBorrowedParametersRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[NEEDLESS_BORROWED_PARAMETERS]);
     }

--- a/src/rules/needless_borrowed_parameters.rs
+++ b/src/rules/needless_borrowed_parameters.rs
@@ -1,7 +1,5 @@
 use crate::cargo_target::{CargoTarget, crate_target};
-use crate::common::{
-    DefaultState, binding_hir_id, binding_ident, hir_in_external_macro, resolved_state,
-};
+use crate::common::{DefaultState, binding_hir_id, binding_ident, hir_in_external_macro};
 use crate::rule_index::{Register, rule};
 use crate::test_code::in_test_code;
 use clippy_utils::diagnostics::span_lint_and_then;
@@ -91,11 +89,6 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`Register::register_pass`] below;
-/// gen-docs picks the constant up via syn to render the rule's default
-/// state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
-
 const CONFIG_KEY: &str = "perfectionist::needless_borrowed_parameters";
 
 pub struct NeedlessBorrowedParameters {
@@ -119,16 +112,13 @@ impl NeedlessBorrowedParameters {
 impl_lint_pass!(NeedlessBorrowedParameters => [NEEDLESS_BORROWED_PARAMETERS]);
 
 impl Register for rule::NeedlessBorrowedParameters {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[NEEDLESS_BORROWED_PARAMETERS]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("needless_borrowed_parameters", DEFAULT_STATE)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(NeedlessBorrowedParameters::new()));
     }
 }

--- a/src/rules/needless_borrowed_parameters.rs
+++ b/src/rules/needless_borrowed_parameters.rs
@@ -2,6 +2,7 @@ use crate::cargo_target::{CargoTarget, crate_target};
 use crate::common::{
     DefaultState, binding_hir_id, binding_ident, hir_in_external_macro, resolved_state,
 };
+use crate::rule_index::{NeedlessBorrowedParametersRule, RuleRegistration};
 use crate::test_code::in_test_code;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::{snippet, snippet_opt};
@@ -90,8 +91,9 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`register_pass`] below; gen-docs picks
-/// the constant up via syn to render the rule's default state.
+/// Active by default. Read by [`RuleRegistration::register_pass`]
+/// below; gen-docs picks the constant up via syn to render the rule's
+/// default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::needless_borrowed_parameters";
@@ -116,18 +118,19 @@ impl NeedlessBorrowedParameters {
 
 impl_lint_pass!(NeedlessBorrowedParameters => [NEEDLESS_BORROWED_PARAMETERS]);
 
-/// Register this rule's lint declaration. Paired with [`register_pass`];
-/// see the module-level convention documented in `register_lints`.
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[NEEDLESS_BORROWED_PARAMETERS]);
-}
-
-/// Install this rule's late pass.
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("needless_borrowed_parameters", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for NeedlessBorrowedParametersRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[NEEDLESS_BORROWED_PARAMETERS]);
     }
-    lint_store.register_late_pass(|_| Box::new(NeedlessBorrowedParameters::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("needless_borrowed_parameters", DEFAULT_STATE)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(NeedlessBorrowedParameters::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for NeedlessBorrowedParameters {

--- a/src/rules/needless_borrowed_parameters.rs
+++ b/src/rules/needless_borrowed_parameters.rs
@@ -2,7 +2,7 @@ use crate::cargo_target::{CargoTarget, crate_target};
 use crate::common::{
     DefaultState, binding_hir_id, binding_ident, hir_in_external_macro, resolved_state,
 };
-use crate::rule_index::{NeedlessBorrowedParametersRule, Register};
+use crate::rule_index::{Register, rule};
 use crate::test_code::in_test_code;
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::source::{snippet, snippet_opt};
@@ -118,7 +118,7 @@ impl NeedlessBorrowedParameters {
 
 impl_lint_pass!(NeedlessBorrowedParameters => [NEEDLESS_BORROWED_PARAMETERS]);
 
-impl Register for NeedlessBorrowedParametersRule {
+impl Register for rule::NeedlessBorrowedParameters {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[NEEDLESS_BORROWED_PARAMETERS]);
     }

--- a/src/rules/overly_long_print_macro.rs
+++ b/src/rules/overly_long_print_macro.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::macro_template::find_template_literal;
 use crate::rule_index::{Register, rule};
 use rustc_ast::MacCall;
@@ -83,16 +83,13 @@ impl_lint_pass!(OverlyLongPrintMacro => [OVERLY_LONG_PRINT_MACRO]);
 impl_lint_pass!(OverlyLongPrintMacroLate => [OVERLY_LONG_PRINT_MACRO]);
 
 impl Register for rule::OverlyLongPrintMacro {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[OVERLY_LONG_PRINT_MACRO]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("overly_long_print_macro", DefaultState::Active)
-        {
-            return;
-        }
         // Same pre-expansion → late split as `macro_trailing_comma` and
         // `impure_macro_arguments`: the pre-expansion pass sees the
         // `MacCall` tokens and builds the rewrite from source, then parks

--- a/src/rules/overly_long_print_macro.rs
+++ b/src/rules/overly_long_print_macro.rs
@@ -1,5 +1,6 @@
 use crate::common::{DefaultState, resolved_state};
 use crate::macro_template::find_template_literal;
+use crate::rule_index::{OverlyLongPrintMacroRule, RuleRegistration};
 use rustc_ast::MacCall;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -81,23 +82,26 @@ declare_tool_lint! {
 impl_lint_pass!(OverlyLongPrintMacro => [OVERLY_LONG_PRINT_MACRO]);
 impl_lint_pass!(OverlyLongPrintMacroLate => [OVERLY_LONG_PRINT_MACRO]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[OVERLY_LONG_PRINT_MACRO]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("overly_long_print_macro", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for OverlyLongPrintMacroRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[OVERLY_LONG_PRINT_MACRO]);
     }
-    // Same pre-expansion → late split as `macro_trailing_comma` and
-    // `impure_macro_arguments`: the pre-expansion pass sees the
-    // `MacCall` tokens and builds the rewrite from source, then parks
-    // it; the late pass walks the HIR and emits each at its deepest
-    // enclosing node, by which point `cfg_attr` has resolved and
-    // lint-level attributes apply.
-    lint_store.register_pre_expansion_pass(|| Box::new(OverlyLongPrintMacro::new()));
-    lint_store.register_late_pass(|_| Box::new(OverlyLongPrintMacroLate));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("overly_long_print_macro", DefaultState::Active)
+        {
+            return;
+        }
+        // Same pre-expansion → late split as `macro_trailing_comma` and
+        // `impure_macro_arguments`: the pre-expansion pass sees the
+        // `MacCall` tokens and builds the rewrite from source, then parks
+        // it; the late pass walks the HIR and emits each at its deepest
+        // enclosing node, by which point `cfg_attr` has resolved and
+        // lint-level attributes apply.
+        lint_store.register_pre_expansion_pass(|| Box::new(OverlyLongPrintMacro::new()));
+        lint_store.register_late_pass(|_| Box::new(OverlyLongPrintMacroLate));
+    }
 }
 
 /// Rewrites the pre-expansion pass has built, waiting for the late pass

--- a/src/rules/overly_long_print_macro.rs
+++ b/src/rules/overly_long_print_macro.rs
@@ -1,6 +1,6 @@
 use crate::common::{DefaultState, resolved_state};
 use crate::macro_template::find_template_literal;
-use crate::rule_index::{OverlyLongPrintMacroRule, RuleRegistration};
+use crate::rule_index::{OverlyLongPrintMacroRule, Register};
 use rustc_ast::MacCall;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -82,7 +82,7 @@ declare_tool_lint! {
 impl_lint_pass!(OverlyLongPrintMacro => [OVERLY_LONG_PRINT_MACRO]);
 impl_lint_pass!(OverlyLongPrintMacroLate => [OVERLY_LONG_PRINT_MACRO]);
 
-impl RuleRegistration for OverlyLongPrintMacroRule {
+impl Register for OverlyLongPrintMacroRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[OVERLY_LONG_PRINT_MACRO]);
     }

--- a/src/rules/overly_long_print_macro.rs
+++ b/src/rules/overly_long_print_macro.rs
@@ -1,6 +1,6 @@
 use crate::common::{DefaultState, resolved_state};
 use crate::macro_template::find_template_literal;
-use crate::rule_index::{OverlyLongPrintMacroRule, Register};
+use crate::rule_index::{Register, rule};
 use rustc_ast::MacCall;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -82,7 +82,7 @@ declare_tool_lint! {
 impl_lint_pass!(OverlyLongPrintMacro => [OVERLY_LONG_PRINT_MACRO]);
 impl_lint_pass!(OverlyLongPrintMacroLate => [OVERLY_LONG_PRINT_MACRO]);
 
-impl Register for OverlyLongPrintMacroRule {
+impl Register for rule::OverlyLongPrintMacro {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[OVERLY_LONG_PRINT_MACRO]);
     }

--- a/src/rules/redundant_derive_more_forward_template.rs
+++ b/src/rules/redundant_derive_more_forward_template.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::module_reparse::parse_crate_module_files;
 use crate::rule_index::{Register, rule};
@@ -99,11 +99,6 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`Register::register_pass`] below;
-/// gen-docs picks the constant up via syn to render the rule's default
-/// state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
-
 const CONFIG_KEY: &str = "perfectionist::redundant_derive_more_forward_template";
 
 /// The rule has no configuration knobs. Not dead code: the read
@@ -125,16 +120,13 @@ impl RedundantDeriveMoreForwardTemplate {
 impl_lint_pass!(RedundantDeriveMoreForwardTemplate => [REDUNDANT_DERIVE_MORE_FORWARD_TEMPLATE]);
 
 impl Register for rule::RedundantDeriveMoreForwardTemplate {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[REDUNDANT_DERIVE_MORE_FORWARD_TEMPLATE]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("redundant_derive_more_forward_template", DEFAULT_STATE)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(RedundantDeriveMoreForwardTemplate::new()));
     }
 }

--- a/src/rules/redundant_derive_more_forward_template.rs
+++ b/src/rules/redundant_derive_more_forward_template.rs
@@ -1,7 +1,7 @@
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::module_reparse::parse_crate_module_files;
-use crate::rule_index::{RedundantDeriveMoreForwardTemplateRule, RuleRegistration};
+use crate::rule_index::{RedundantDeriveMoreForwardTemplateRule, Register};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -99,9 +99,9 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`RuleRegistration::register_pass`]
-/// below; gen-docs picks the constant up via syn to render the rule's
-/// default state.
+/// Active by default. Read by [`Register::register_pass`] below;
+/// gen-docs picks the constant up via syn to render the rule's default
+/// state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::redundant_derive_more_forward_template";
@@ -124,7 +124,7 @@ impl RedundantDeriveMoreForwardTemplate {
 
 impl_lint_pass!(RedundantDeriveMoreForwardTemplate => [REDUNDANT_DERIVE_MORE_FORWARD_TEMPLATE]);
 
-impl RuleRegistration for RedundantDeriveMoreForwardTemplateRule {
+impl Register for RedundantDeriveMoreForwardTemplateRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[REDUNDANT_DERIVE_MORE_FORWARD_TEMPLATE]);
     }

--- a/src/rules/redundant_derive_more_forward_template.rs
+++ b/src/rules/redundant_derive_more_forward_template.rs
@@ -1,7 +1,7 @@
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::module_reparse::parse_crate_module_files;
-use crate::rule_index::{RedundantDeriveMoreForwardTemplateRule, Register};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -124,7 +124,7 @@ impl RedundantDeriveMoreForwardTemplate {
 
 impl_lint_pass!(RedundantDeriveMoreForwardTemplate => [REDUNDANT_DERIVE_MORE_FORWARD_TEMPLATE]);
 
-impl Register for RedundantDeriveMoreForwardTemplateRule {
+impl Register for rule::RedundantDeriveMoreForwardTemplate {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[REDUNDANT_DERIVE_MORE_FORWARD_TEMPLATE]);
     }

--- a/src/rules/redundant_derive_more_forward_template.rs
+++ b/src/rules/redundant_derive_more_forward_template.rs
@@ -1,6 +1,7 @@
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::module_reparse::parse_crate_module_files;
+use crate::rule_index::{RedundantDeriveMoreForwardTemplateRule, RuleRegistration};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
@@ -98,8 +99,9 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`register_pass`] below; gen-docs picks
-/// the constant up via syn to render the rule's default state.
+/// Active by default. Read by [`RuleRegistration::register_pass`]
+/// below; gen-docs picks the constant up via syn to render the rule's
+/// default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::redundant_derive_more_forward_template";
@@ -122,17 +124,19 @@ impl RedundantDeriveMoreForwardTemplate {
 
 impl_lint_pass!(RedundantDeriveMoreForwardTemplate => [REDUNDANT_DERIVE_MORE_FORWARD_TEMPLATE]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[REDUNDANT_DERIVE_MORE_FORWARD_TEMPLATE]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("redundant_derive_more_forward_template", DEFAULT_STATE)
-    {
-        return;
+impl RuleRegistration for RedundantDeriveMoreForwardTemplateRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[REDUNDANT_DERIVE_MORE_FORWARD_TEMPLATE]);
     }
-    lint_store.register_late_pass(|_| Box::new(RedundantDeriveMoreForwardTemplate::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("redundant_derive_more_forward_template", DEFAULT_STATE)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(RedundantDeriveMoreForwardTemplate::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for RedundantDeriveMoreForwardTemplate {

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -1,7 +1,7 @@
 use crate::ascii_letter::AsciiLetter;
 use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set,
-    resolve_symbol_set_from_chars, resolved_state,
+    resolve_symbol_set_from_chars,
 };
 use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
@@ -243,16 +243,13 @@ impl SingleLetterClosureParam {
 impl_lint_pass!(SingleLetterClosureParam => [SINGLE_LETTER_CLOSURE_PARAM]);
 
 impl Register for rule::SingleLetterClosureParam {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_CLOSURE_PARAM]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("single_letter_closure_param", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(SingleLetterClosureParam::new()));
     }
 }

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set,
     resolve_symbol_set_from_chars, resolved_state,
 };
-use crate::rule_index::{RuleRegistration, SingleLetterClosureParamRule};
+use crate::rule_index::{Register, SingleLetterClosureParamRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -242,7 +242,7 @@ impl SingleLetterClosureParam {
 
 impl_lint_pass!(SingleLetterClosureParam => [SINGLE_LETTER_CLOSURE_PARAM]);
 
-impl RuleRegistration for SingleLetterClosureParamRule {
+impl Register for SingleLetterClosureParamRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_CLOSURE_PARAM]);
     }

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set,
     resolve_symbol_set_from_chars, resolved_state,
 };
-use crate::rule_index::{Register, SingleLetterClosureParamRule};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -242,7 +242,7 @@ impl SingleLetterClosureParam {
 
 impl_lint_pass!(SingleLetterClosureParam => [SINGLE_LETTER_CLOSURE_PARAM]);
 
-impl Register for SingleLetterClosureParamRule {
+impl Register for rule::SingleLetterClosureParam {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_CLOSURE_PARAM]);
     }

--- a/src/rules/single_letter_closure_param.rs
+++ b/src/rules/single_letter_closure_param.rs
@@ -3,6 +3,7 @@ use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set,
     resolve_symbol_set_from_chars, resolved_state,
 };
+use crate::rule_index::{RuleRegistration, SingleLetterClosureParamRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -241,17 +242,19 @@ impl SingleLetterClosureParam {
 
 impl_lint_pass!(SingleLetterClosureParam => [SINGLE_LETTER_CLOSURE_PARAM]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[SINGLE_LETTER_CLOSURE_PARAM]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("single_letter_closure_param", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for SingleLetterClosureParamRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[SINGLE_LETTER_CLOSURE_PARAM]);
     }
-    lint_store.register_late_pass(|_| Box::new(SingleLetterClosureParam::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("single_letter_closure_param", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(SingleLetterClosureParam::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for SingleLetterClosureParam {

--- a/src/rules/single_letter_const_generic.rs
+++ b/src/rules/single_letter_const_generic.rs
@@ -1,7 +1,6 @@
 use crate::ascii_letter::AsciiLetter;
 use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
-    resolved_state,
 };
 use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
@@ -87,16 +86,13 @@ impl SingleLetterConstGeneric {
 impl_lint_pass!(SingleLetterConstGeneric => [SINGLE_LETTER_CONST_GENERIC]);
 
 impl Register for rule::SingleLetterConstGeneric {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_CONST_GENERIC]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("single_letter_const_generic", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(SingleLetterConstGeneric::new()));
     }
 }

--- a/src/rules/single_letter_const_generic.rs
+++ b/src/rules/single_letter_const_generic.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
     resolved_state,
 };
-use crate::rule_index::{RuleRegistration, SingleLetterConstGenericRule};
+use crate::rule_index::{Register, SingleLetterConstGenericRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -86,7 +86,7 @@ impl SingleLetterConstGeneric {
 
 impl_lint_pass!(SingleLetterConstGeneric => [SINGLE_LETTER_CONST_GENERIC]);
 
-impl RuleRegistration for SingleLetterConstGenericRule {
+impl Register for SingleLetterConstGenericRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_CONST_GENERIC]);
     }

--- a/src/rules/single_letter_const_generic.rs
+++ b/src/rules/single_letter_const_generic.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
     resolved_state,
 };
-use crate::rule_index::{Register, SingleLetterConstGenericRule};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -86,7 +86,7 @@ impl SingleLetterConstGeneric {
 
 impl_lint_pass!(SingleLetterConstGeneric => [SINGLE_LETTER_CONST_GENERIC]);
 
-impl Register for SingleLetterConstGenericRule {
+impl Register for rule::SingleLetterConstGeneric {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_CONST_GENERIC]);
     }

--- a/src/rules/single_letter_const_generic.rs
+++ b/src/rules/single_letter_const_generic.rs
@@ -3,6 +3,7 @@ use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
     resolved_state,
 };
+use crate::rule_index::{RuleRegistration, SingleLetterConstGenericRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -85,17 +86,19 @@ impl SingleLetterConstGeneric {
 
 impl_lint_pass!(SingleLetterConstGeneric => [SINGLE_LETTER_CONST_GENERIC]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[SINGLE_LETTER_CONST_GENERIC]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("single_letter_const_generic", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for SingleLetterConstGenericRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[SINGLE_LETTER_CONST_GENERIC]);
     }
-    lint_store.register_late_pass(|_| Box::new(SingleLetterConstGeneric::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("single_letter_const_generic", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(SingleLetterConstGeneric::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for SingleLetterConstGeneric {

--- a/src/rules/single_letter_const_item.rs
+++ b/src/rules/single_letter_const_item.rs
@@ -3,6 +3,7 @@ use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
     resolved_state,
 };
+use crate::rule_index::{RuleRegistration, SingleLetterConstItemRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -103,16 +104,19 @@ impl SingleLetterConstItem {
 
 impl_lint_pass!(SingleLetterConstItem => [SINGLE_LETTER_CONST_ITEM]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[SINGLE_LETTER_CONST_ITEM]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("single_letter_const_item", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for SingleLetterConstItemRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[SINGLE_LETTER_CONST_ITEM]);
     }
-    lint_store.register_late_pass(|_| Box::new(SingleLetterConstItem::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("single_letter_const_item", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(SingleLetterConstItem::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for SingleLetterConstItem {

--- a/src/rules/single_letter_const_item.rs
+++ b/src/rules/single_letter_const_item.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
     resolved_state,
 };
-use crate::rule_index::{Register, SingleLetterConstItemRule};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -104,7 +104,7 @@ impl SingleLetterConstItem {
 
 impl_lint_pass!(SingleLetterConstItem => [SINGLE_LETTER_CONST_ITEM]);
 
-impl Register for SingleLetterConstItemRule {
+impl Register for rule::SingleLetterConstItem {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_CONST_ITEM]);
     }

--- a/src/rules/single_letter_const_item.rs
+++ b/src/rules/single_letter_const_item.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
     resolved_state,
 };
-use crate::rule_index::{RuleRegistration, SingleLetterConstItemRule};
+use crate::rule_index::{Register, SingleLetterConstItemRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -104,7 +104,7 @@ impl SingleLetterConstItem {
 
 impl_lint_pass!(SingleLetterConstItem => [SINGLE_LETTER_CONST_ITEM]);
 
-impl RuleRegistration for SingleLetterConstItemRule {
+impl Register for SingleLetterConstItemRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_CONST_ITEM]);
     }

--- a/src/rules/single_letter_const_item.rs
+++ b/src/rules/single_letter_const_item.rs
@@ -1,7 +1,6 @@
 use crate::ascii_letter::AsciiLetter;
 use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
-    resolved_state,
 };
 use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
@@ -105,16 +104,13 @@ impl SingleLetterConstItem {
 impl_lint_pass!(SingleLetterConstItem => [SINGLE_LETTER_CONST_ITEM]);
 
 impl Register for rule::SingleLetterConstItem {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_CONST_ITEM]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("single_letter_const_item", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(SingleLetterConstItem::new()));
     }
 }

--- a/src/rules/single_letter_function_param.rs
+++ b/src/rules/single_letter_function_param.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter,
     resolve_symbol_set_from_chars, resolved_state,
 };
-use crate::rule_index::{RuleRegistration, SingleLetterFunctionParamRule};
+use crate::rule_index::{Register, SingleLetterFunctionParamRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_hir::intravisit::FnKind;
@@ -106,7 +106,7 @@ impl SingleLetterFunctionParam {
 
 impl_lint_pass!(SingleLetterFunctionParam => [SINGLE_LETTER_FUNCTION_PARAM]);
 
-impl RuleRegistration for SingleLetterFunctionParamRule {
+impl Register for SingleLetterFunctionParamRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_FUNCTION_PARAM]);
     }

--- a/src/rules/single_letter_function_param.rs
+++ b/src/rules/single_letter_function_param.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter,
     resolve_symbol_set_from_chars, resolved_state,
 };
-use crate::rule_index::{Register, SingleLetterFunctionParamRule};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_hir::intravisit::FnKind;
@@ -106,7 +106,7 @@ impl SingleLetterFunctionParam {
 
 impl_lint_pass!(SingleLetterFunctionParam => [SINGLE_LETTER_FUNCTION_PARAM]);
 
-impl Register for SingleLetterFunctionParamRule {
+impl Register for rule::SingleLetterFunctionParam {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_FUNCTION_PARAM]);
     }

--- a/src/rules/single_letter_function_param.rs
+++ b/src/rules/single_letter_function_param.rs
@@ -1,7 +1,7 @@
 use crate::ascii_letter::AsciiLetter;
 use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter,
-    resolve_symbol_set_from_chars, resolved_state,
+    resolve_symbol_set_from_chars,
 };
 use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
@@ -107,16 +107,13 @@ impl SingleLetterFunctionParam {
 impl_lint_pass!(SingleLetterFunctionParam => [SINGLE_LETTER_FUNCTION_PARAM]);
 
 impl Register for rule::SingleLetterFunctionParam {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_FUNCTION_PARAM]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("single_letter_function_param", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(SingleLetterFunctionParam::new()));
     }
 }

--- a/src/rules/single_letter_function_param.rs
+++ b/src/rules/single_letter_function_param.rs
@@ -3,6 +3,7 @@ use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter,
     resolve_symbol_set_from_chars, resolved_state,
 };
+use crate::rule_index::{RuleRegistration, SingleLetterFunctionParamRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_hir::intravisit::FnKind;
@@ -105,17 +106,19 @@ impl SingleLetterFunctionParam {
 
 impl_lint_pass!(SingleLetterFunctionParam => [SINGLE_LETTER_FUNCTION_PARAM]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[SINGLE_LETTER_FUNCTION_PARAM]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("single_letter_function_param", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for SingleLetterFunctionParamRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[SINGLE_LETTER_FUNCTION_PARAM]);
     }
-    lint_store.register_late_pass(|_| Box::new(SingleLetterFunctionParam::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("single_letter_function_param", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(SingleLetterFunctionParam::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for SingleLetterFunctionParam {

--- a/src/rules/single_letter_generic.rs
+++ b/src/rules/single_letter_generic.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, hir_in_external_macro, is_single_ascii_letter, resolved_state};
-use crate::rule_index::{Register, SingleLetterGenericRule};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -78,7 +78,7 @@ impl SingleLetterGeneric {
 
 impl_lint_pass!(SingleLetterGeneric => [SINGLE_LETTER_GENERIC]);
 
-impl Register for SingleLetterGenericRule {
+impl Register for rule::SingleLetterGeneric {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_GENERIC]);
     }

--- a/src/rules/single_letter_generic.rs
+++ b/src/rules/single_letter_generic.rs
@@ -1,4 +1,5 @@
 use crate::common::{DefaultState, hir_in_external_macro, is_single_ascii_letter, resolved_state};
+use crate::rule_index::{RuleRegistration, SingleLetterGenericRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -77,15 +78,19 @@ impl SingleLetterGeneric {
 
 impl_lint_pass!(SingleLetterGeneric => [SINGLE_LETTER_GENERIC]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[SINGLE_LETTER_GENERIC]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("single_letter_generic", DefaultState::Active) {
-        return;
+impl RuleRegistration for SingleLetterGenericRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[SINGLE_LETTER_GENERIC]);
     }
-    lint_store.register_late_pass(|_| Box::new(SingleLetterGeneric::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("single_letter_generic", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(SingleLetterGeneric::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for SingleLetterGeneric {

--- a/src/rules/single_letter_generic.rs
+++ b/src/rules/single_letter_generic.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, hir_in_external_macro, is_single_ascii_letter, resolved_state};
+use crate::common::{DefaultState, hir_in_external_macro, is_single_ascii_letter};
 use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
@@ -79,16 +79,13 @@ impl SingleLetterGeneric {
 impl_lint_pass!(SingleLetterGeneric => [SINGLE_LETTER_GENERIC]);
 
 impl Register for rule::SingleLetterGeneric {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_GENERIC]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("single_letter_generic", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(SingleLetterGeneric::new()));
     }
 }

--- a/src/rules/single_letter_generic.rs
+++ b/src/rules/single_letter_generic.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, hir_in_external_macro, is_single_ascii_letter, resolved_state};
-use crate::rule_index::{RuleRegistration, SingleLetterGenericRule};
+use crate::rule_index::{Register, SingleLetterGenericRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -78,7 +78,7 @@ impl SingleLetterGeneric {
 
 impl_lint_pass!(SingleLetterGeneric => [SINGLE_LETTER_GENERIC]);
 
-impl RuleRegistration for SingleLetterGenericRule {
+impl Register for SingleLetterGenericRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_GENERIC]);
     }

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -3,6 +3,7 @@ use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter,
     resolve_symbol_set_from_chars, resolved_state,
 };
+use crate::rule_index::{RuleRegistration, SingleLetterLetBindingRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -99,17 +100,19 @@ impl SingleLetterLetBinding {
 
 impl_lint_pass!(SingleLetterLetBinding => [SINGLE_LETTER_LET_BINDING]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[SINGLE_LETTER_LET_BINDING]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("single_letter_let_binding", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for SingleLetterLetBindingRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[SINGLE_LETTER_LET_BINDING]);
     }
-    lint_store.register_late_pass(|_| Box::new(SingleLetterLetBinding::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("single_letter_let_binding", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(SingleLetterLetBinding::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for SingleLetterLetBinding {

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter,
     resolve_symbol_set_from_chars, resolved_state,
 };
-use crate::rule_index::{Register, SingleLetterLetBindingRule};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -100,7 +100,7 @@ impl SingleLetterLetBinding {
 
 impl_lint_pass!(SingleLetterLetBinding => [SINGLE_LETTER_LET_BINDING]);
 
-impl Register for SingleLetterLetBindingRule {
+impl Register for rule::SingleLetterLetBinding {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_LET_BINDING]);
     }

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter,
     resolve_symbol_set_from_chars, resolved_state,
 };
-use crate::rule_index::{RuleRegistration, SingleLetterLetBindingRule};
+use crate::rule_index::{Register, SingleLetterLetBindingRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -100,7 +100,7 @@ impl SingleLetterLetBinding {
 
 impl_lint_pass!(SingleLetterLetBinding => [SINGLE_LETTER_LET_BINDING]);
 
-impl RuleRegistration for SingleLetterLetBindingRule {
+impl Register for SingleLetterLetBindingRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_LET_BINDING]);
     }

--- a/src/rules/single_letter_let_binding.rs
+++ b/src/rules/single_letter_let_binding.rs
@@ -1,7 +1,7 @@
 use crate::ascii_letter::AsciiLetter;
 use crate::common::{
     DefaultState, binding_ident, hir_in_external_macro, is_single_ascii_letter,
-    resolve_symbol_set_from_chars, resolved_state,
+    resolve_symbol_set_from_chars,
 };
 use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
@@ -101,16 +101,13 @@ impl SingleLetterLetBinding {
 impl_lint_pass!(SingleLetterLetBinding => [SINGLE_LETTER_LET_BINDING]);
 
 impl Register for rule::SingleLetterLetBinding {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_LET_BINDING]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("single_letter_let_binding", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(SingleLetterLetBinding::new()));
     }
 }

--- a/src/rules/single_letter_static_item.rs
+++ b/src/rules/single_letter_static_item.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
     resolved_state,
 };
-use crate::rule_index::{RuleRegistration, SingleLetterStaticItemRule};
+use crate::rule_index::{Register, SingleLetterStaticItemRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -83,7 +83,7 @@ impl SingleLetterStaticItem {
 
 impl_lint_pass!(SingleLetterStaticItem => [SINGLE_LETTER_STATIC_ITEM]);
 
-impl RuleRegistration for SingleLetterStaticItemRule {
+impl Register for SingleLetterStaticItemRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_STATIC_ITEM]);
     }

--- a/src/rules/single_letter_static_item.rs
+++ b/src/rules/single_letter_static_item.rs
@@ -1,7 +1,6 @@
 use crate::ascii_letter::AsciiLetter;
 use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
-    resolved_state,
 };
 use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
@@ -84,16 +83,13 @@ impl SingleLetterStaticItem {
 impl_lint_pass!(SingleLetterStaticItem => [SINGLE_LETTER_STATIC_ITEM]);
 
 impl Register for rule::SingleLetterStaticItem {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_STATIC_ITEM]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("single_letter_static_item", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(SingleLetterStaticItem::new()));
     }
 }

--- a/src/rules/single_letter_static_item.rs
+++ b/src/rules/single_letter_static_item.rs
@@ -3,6 +3,7 @@ use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
     resolved_state,
 };
+use crate::rule_index::{RuleRegistration, SingleLetterStaticItemRule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -82,17 +83,19 @@ impl SingleLetterStaticItem {
 
 impl_lint_pass!(SingleLetterStaticItem => [SINGLE_LETTER_STATIC_ITEM]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[SINGLE_LETTER_STATIC_ITEM]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("single_letter_static_item", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for SingleLetterStaticItemRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[SINGLE_LETTER_STATIC_ITEM]);
     }
-    lint_store.register_late_pass(|_| Box::new(SingleLetterStaticItem::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("single_letter_static_item", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(SingleLetterStaticItem::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for SingleLetterStaticItem {

--- a/src/rules/single_letter_static_item.rs
+++ b/src/rules/single_letter_static_item.rs
@@ -3,7 +3,7 @@ use crate::common::{
     DefaultState, hir_in_external_macro, is_single_ascii_letter, resolve_symbol_set_from_chars,
     resolved_state,
 };
-use crate::rule_index::{Register, SingleLetterStaticItemRule};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -83,7 +83,7 @@ impl SingleLetterStaticItem {
 
 impl_lint_pass!(SingleLetterStaticItem => [SINGLE_LETTER_STATIC_ITEM]);
 
-impl Register for SingleLetterStaticItemRule {
+impl Register for rule::SingleLetterStaticItem {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[SINGLE_LETTER_STATIC_ITEM]);
     }

--- a/src/rules/thiserror_usage.rs
+++ b/src/rules/thiserror_usage.rs
@@ -1,3 +1,4 @@
+use crate::rule_index::{RuleRegistration, ThiserrorUsageRule};
 use rustc_ast::{Crate, Item, ItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -95,26 +96,29 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`register_pass`] below; gen-docs picks
-/// the constant up via syn to render the rule's default state.
+/// Active by default. Read by [`RuleRegistration::register_pass`]
+/// below; gen-docs picks the constant up via syn to render the rule's
+/// default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 impl_lint_pass!(ThiserrorUsage => [THISERROR_USAGE]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[THISERROR_USAGE]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("thiserror_usage", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for ThiserrorUsageRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[THISERROR_USAGE]);
     }
-    // Pre-expansion: derives are consumed during macro expansion, so a
-    // regular (post-expansion) pass no longer sees the
-    // `#[derive(...)]` attribute by the time the rule looks for it.
-    // The sibling `perfectionist::unordered_derives` rule uses the same
-    // hook for the same reason.
-    lint_store.register_pre_expansion_pass(|| Box::new(ThiserrorUsage::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("thiserror_usage", DEFAULT_STATE) {
+            return;
+        }
+        // Pre-expansion: derives are consumed during macro expansion, so a
+        // regular (post-expansion) pass no longer sees the
+        // `#[derive(...)]` attribute by the time the rule looks for it.
+        // The sibling `perfectionist::unordered_derives` rule uses the same
+        // hook for the same reason.
+        lint_store.register_pre_expansion_pass(|| Box::new(ThiserrorUsage::new()));
+    }
 }
 
 impl EarlyLintPass for ThiserrorUsage {

--- a/src/rules/thiserror_usage.rs
+++ b/src/rules/thiserror_usage.rs
@@ -8,7 +8,7 @@ mod detect;
 mod emit;
 mod scan;
 
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use config::ThiserrorUsage;
 
 declare_tool_lint! {
@@ -96,22 +96,16 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`Register::register_pass`] below;
-/// gen-docs picks the constant up via syn to render the rule's default
-/// state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
-
 impl_lint_pass!(ThiserrorUsage => [THISERROR_USAGE]);
 
 impl Register for rule::ThiserrorUsage {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[THISERROR_USAGE]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("thiserror_usage", DEFAULT_STATE) {
-            return;
-        }
         // Pre-expansion: derives are consumed during macro expansion, so a
         // regular (post-expansion) pass no longer sees the
         // `#[derive(...)]` attribute by the time the rule looks for it.

--- a/src/rules/thiserror_usage.rs
+++ b/src/rules/thiserror_usage.rs
@@ -1,4 +1,4 @@
-use crate::rule_index::{RuleRegistration, ThiserrorUsageRule};
+use crate::rule_index::{Register, ThiserrorUsageRule};
 use rustc_ast::{Crate, Item, ItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -96,14 +96,14 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default. Read by [`RuleRegistration::register_pass`]
-/// below; gen-docs picks the constant up via syn to render the rule's
-/// default state.
+/// Active by default. Read by [`Register::register_pass`] below;
+/// gen-docs picks the constant up via syn to render the rule's default
+/// state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 impl_lint_pass!(ThiserrorUsage => [THISERROR_USAGE]);
 
-impl RuleRegistration for ThiserrorUsageRule {
+impl Register for ThiserrorUsageRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[THISERROR_USAGE]);
     }

--- a/src/rules/thiserror_usage.rs
+++ b/src/rules/thiserror_usage.rs
@@ -1,4 +1,4 @@
-use crate::rule_index::{Register, ThiserrorUsageRule};
+use crate::rule_index::{Register, rule};
 use rustc_ast::{Crate, Item, ItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -103,7 +103,7 @@ pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 impl_lint_pass!(ThiserrorUsage => [THISERROR_USAGE]);
 
-impl Register for ThiserrorUsageRule {
+impl Register for rule::ThiserrorUsage {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[THISERROR_USAGE]);
     }

--- a/src/rules/uncombined_self_import.rs
+++ b/src/rules/uncombined_self_import.rs
@@ -22,7 +22,7 @@
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::find_enclosing_hir_ids;
 use crate::module_reparse::for_each_module_file;
-use crate::rule_index::{Register, UncombinedSelfImportRule};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_ast::visit::{self, Visitor};
 use rustc_ast::{Block, Item, ItemKind, ModKind, Stmt, StmtKind};
@@ -108,7 +108,7 @@ pub struct UncombinedSelfImport;
 
 impl_lint_pass!(UncombinedSelfImport => [UNCOMBINED_SELF_IMPORT]);
 
-impl Register for UncombinedSelfImportRule {
+impl Register for rule::UncombinedSelfImport {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNCOMBINED_SELF_IMPORT]);
     }

--- a/src/rules/uncombined_self_import.rs
+++ b/src/rules/uncombined_self_import.rs
@@ -19,7 +19,7 @@
 //! gates intact (parsing does not strip cfg, unlike the post-expansion
 //! AST). The sibling `import_granularity_mismatch` rule shares the same machinery.
 
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::find_enclosing_hir_ids;
 use crate::module_reparse::for_each_module_file;
 use crate::rule_index::{Register, rule};
@@ -95,8 +95,6 @@ declare_tool_lint! {
 
 const CONFIG_KEY: &str = "perfectionist::uncombined_self_import";
 
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
-
 /// The rule has no configuration knobs. Not dead code: the read
 /// below rejects a mistyped key in the rule's `dylint.toml` table,
 /// and gen-docs needs the struct for `Configuration: none.`
@@ -109,14 +107,13 @@ pub struct UncombinedSelfImport;
 impl_lint_pass!(UncombinedSelfImport => [UNCOMBINED_SELF_IMPORT]);
 
 impl Register for rule::UncombinedSelfImport {
+    const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNCOMBINED_SELF_IMPORT]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("uncombined_self_import", DEFAULT_STATE) {
-            return;
-        }
         let _config: Config = dylint_linting::config_or_default(CONFIG_KEY);
         // Late pass: out-of-line `mod foo;` modules are `ModKind::Unloaded`
         // until macro expansion, so a pre-expansion pass never sees them.

--- a/src/rules/uncombined_self_import.rs
+++ b/src/rules/uncombined_self_import.rs
@@ -22,7 +22,7 @@
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::find_enclosing_hir_ids;
 use crate::module_reparse::for_each_module_file;
-use crate::rule_index::{RuleRegistration, UncombinedSelfImportRule};
+use crate::rule_index::{Register, UncombinedSelfImportRule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_ast::visit::{self, Visitor};
 use rustc_ast::{Block, Item, ItemKind, ModKind, Stmt, StmtKind};
@@ -108,7 +108,7 @@ pub struct UncombinedSelfImport;
 
 impl_lint_pass!(UncombinedSelfImport => [UNCOMBINED_SELF_IMPORT]);
 
-impl RuleRegistration for UncombinedSelfImportRule {
+impl Register for UncombinedSelfImportRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNCOMBINED_SELF_IMPORT]);
     }

--- a/src/rules/uncombined_self_import.rs
+++ b/src/rules/uncombined_self_import.rs
@@ -22,6 +22,7 @@
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::find_enclosing_hir_ids;
 use crate::module_reparse::for_each_module_file;
+use crate::rule_index::{RuleRegistration, UncombinedSelfImportRule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_ast::visit::{self, Visitor};
 use rustc_ast::{Block, Item, ItemKind, ModKind, Stmt, StmtKind};
@@ -107,21 +108,23 @@ pub struct UncombinedSelfImport;
 
 impl_lint_pass!(UncombinedSelfImport => [UNCOMBINED_SELF_IMPORT]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[UNCOMBINED_SELF_IMPORT]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("uncombined_self_import", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for UncombinedSelfImportRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[UNCOMBINED_SELF_IMPORT]);
     }
-    let _config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-    // Late pass: out-of-line `mod foo;` modules are `ModKind::Unloaded`
-    // until macro expansion, so a pre-expansion pass never sees them.
-    // `check_crate` re-parses each source file instead (see the module
-    // docs), reaching every module-scoped submodule while keeping
-    // `#[cfg(...)]` gates intact.
-    lint_store.register_late_pass(|_| Box::new(UncombinedSelfImport));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("uncombined_self_import", DEFAULT_STATE) {
+            return;
+        }
+        let _config: Config = dylint_linting::config_or_default(CONFIG_KEY);
+        // Late pass: out-of-line `mod foo;` modules are `ModKind::Unloaded`
+        // until macro expansion, so a pre-expansion pass never sees them.
+        // `check_crate` re-parses each source file instead (see the module
+        // docs), reaching every module-scoped submodule while keeping
+        // `#[cfg(...)]` gates intact.
+        lint_store.register_late_pass(|_| Box::new(UncombinedSelfImport));
+    }
 }
 
 /// A detected violation parked until its enclosing HIR node is known.

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -2,7 +2,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::emit_flagged_char_hir;
 use crate::module_reparse::crate_module_files;
-use crate::rule_index::{Register, UnicodeEllipsisInCommentsRule};
+use crate::rule_index::{Register, rule};
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
 use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -101,7 +101,7 @@ impl UnicodeEllipsisInComments {
 
 impl_lint_pass!(UnicodeEllipsisInComments => [UNICODE_ELLIPSIS_IN_COMMENTS]);
 
-impl Register for UnicodeEllipsisInCommentsRule {
+impl Register for rule::UnicodeEllipsisInComments {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_COMMENTS]);
     }

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -2,6 +2,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::emit_flagged_char_hir;
 use crate::module_reparse::crate_module_files;
+use crate::rule_index::{RuleRegistration, UnicodeEllipsisInCommentsRule};
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
 use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -100,17 +101,19 @@ impl UnicodeEllipsisInComments {
 
 impl_lint_pass!(UnicodeEllipsisInComments => [UNICODE_ELLIPSIS_IN_COMMENTS]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_COMMENTS]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("unicode_ellipsis_in_comments", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for UnicodeEllipsisInCommentsRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_COMMENTS]);
     }
-    lint_store.register_late_pass(|_| Box::new(UnicodeEllipsisInComments::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("unicode_ellipsis_in_comments", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(UnicodeEllipsisInComments::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for UnicodeEllipsisInComments {

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -2,7 +2,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::emit_flagged_char_hir;
 use crate::module_reparse::crate_module_files;
-use crate::rule_index::{RuleRegistration, UnicodeEllipsisInCommentsRule};
+use crate::rule_index::{Register, UnicodeEllipsisInCommentsRule};
 use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
 use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -101,7 +101,7 @@ impl UnicodeEllipsisInComments {
 
 impl_lint_pass!(UnicodeEllipsisInComments => [UNICODE_ELLIPSIS_IN_COMMENTS]);
 
-impl RuleRegistration for UnicodeEllipsisInCommentsRule {
+impl Register for UnicodeEllipsisInCommentsRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_COMMENTS]);
     }

--- a/src/rules/unicode_ellipsis_in_comments.rs
+++ b/src/rules/unicode_ellipsis_in_comments.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::emit_flagged_char_hir;
 use crate::module_reparse::crate_module_files;
@@ -102,16 +102,13 @@ impl UnicodeEllipsisInComments {
 impl_lint_pass!(UnicodeEllipsisInComments => [UNICODE_ELLIPSIS_IN_COMMENTS]);
 
 impl Register for rule::UnicodeEllipsisInComments {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_COMMENTS]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("unicode_ellipsis_in_comments", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(UnicodeEllipsisInComments::new()));
     }
 }

--- a/src/rules/unicode_ellipsis_in_docs.rs
+++ b/src/rules/unicode_ellipsis_in_docs.rs
@@ -3,7 +3,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::emit_flagged_char_hir;
 use crate::markdown::{position_in_skip, scan_code_regions};
-use crate::rule_index::{Register, UnicodeEllipsisInDocsRule};
+use crate::rule_index::{Register, rule};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
@@ -97,7 +97,7 @@ impl UnicodeEllipsisInDocs {
 
 impl_lint_pass!(UnicodeEllipsisInDocs => [UNICODE_ELLIPSIS_IN_DOCS]);
 
-impl Register for UnicodeEllipsisInDocsRule {
+impl Register for rule::UnicodeEllipsisInDocs {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_DOCS]);
     }

--- a/src/rules/unicode_ellipsis_in_docs.rs
+++ b/src/rules/unicode_ellipsis_in_docs.rs
@@ -3,7 +3,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::emit_flagged_char_hir;
 use crate::markdown::{position_in_skip, scan_code_regions};
-use crate::rule_index::{RuleRegistration, UnicodeEllipsisInDocsRule};
+use crate::rule_index::{Register, UnicodeEllipsisInDocsRule};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
@@ -97,7 +97,7 @@ impl UnicodeEllipsisInDocs {
 
 impl_lint_pass!(UnicodeEllipsisInDocs => [UNICODE_ELLIPSIS_IN_DOCS]);
 
-impl RuleRegistration for UnicodeEllipsisInDocsRule {
+impl Register for UnicodeEllipsisInDocsRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_DOCS]);
     }

--- a/src/rules/unicode_ellipsis_in_docs.rs
+++ b/src/rules/unicode_ellipsis_in_docs.rs
@@ -1,5 +1,5 @@
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::emit_flagged_char_hir;
 use crate::markdown::{position_in_skip, scan_code_regions};
@@ -98,16 +98,13 @@ impl UnicodeEllipsisInDocs {
 impl_lint_pass!(UnicodeEllipsisInDocs => [UNICODE_ELLIPSIS_IN_DOCS]);
 
 impl Register for rule::UnicodeEllipsisInDocs {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_DOCS]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("unicode_ellipsis_in_docs", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(UnicodeEllipsisInDocs::new()));
     }
 }

--- a/src/rules/unicode_ellipsis_in_docs.rs
+++ b/src/rules/unicode_ellipsis_in_docs.rs
@@ -3,6 +3,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::emit_flagged_char_hir;
 use crate::markdown::{position_in_skip, scan_code_regions};
+use crate::rule_index::{RuleRegistration, UnicodeEllipsisInDocsRule};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
@@ -96,16 +97,19 @@ impl UnicodeEllipsisInDocs {
 
 impl_lint_pass!(UnicodeEllipsisInDocs => [UNICODE_ELLIPSIS_IN_DOCS]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_DOCS]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("unicode_ellipsis_in_docs", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for UnicodeEllipsisInDocsRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_DOCS]);
     }
-    lint_store.register_late_pass(|_| Box::new(UnicodeEllipsisInDocs::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("unicode_ellipsis_in_docs", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(UnicodeEllipsisInDocs::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for UnicodeEllipsisInDocs {

--- a/src/rules/unicode_ellipsis_in_panic_messages.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
-use crate::rule_index::{RuleRegistration, UnicodeEllipsisInPanicMessagesRule};
+use crate::rule_index::{Register, UnicodeEllipsisInPanicMessagesRule};
 use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::res::MaybeDef;
 use rustc_ast::LitKind;
@@ -91,7 +91,7 @@ declare_tool_lint! {
 
 impl_lint_pass!(UnicodeEllipsisInPanicMessages => [UNICODE_ELLIPSIS_IN_PANIC_MESSAGES]);
 
-impl RuleRegistration for UnicodeEllipsisInPanicMessagesRule {
+impl Register for UnicodeEllipsisInPanicMessagesRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_PANIC_MESSAGES]);
     }

--- a/src/rules/unicode_ellipsis_in_panic_messages.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::rule_index::{Register, rule};
 use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::res::MaybeDef;
@@ -92,16 +92,13 @@ declare_tool_lint! {
 impl_lint_pass!(UnicodeEllipsisInPanicMessages => [UNICODE_ELLIPSIS_IN_PANIC_MESSAGES]);
 
 impl Register for rule::UnicodeEllipsisInPanicMessages {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_PANIC_MESSAGES]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("unicode_ellipsis_in_panic_messages", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(UnicodeEllipsisInPanicMessages::new()));
     }
 }

--- a/src/rules/unicode_ellipsis_in_panic_messages.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages.rs
@@ -1,4 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
+use crate::rule_index::{RuleRegistration, UnicodeEllipsisInPanicMessagesRule};
 use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::res::MaybeDef;
 use rustc_ast::LitKind;
@@ -90,17 +91,19 @@ declare_tool_lint! {
 
 impl_lint_pass!(UnicodeEllipsisInPanicMessages => [UNICODE_ELLIPSIS_IN_PANIC_MESSAGES]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_PANIC_MESSAGES]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("unicode_ellipsis_in_panic_messages", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for UnicodeEllipsisInPanicMessagesRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_PANIC_MESSAGES]);
     }
-    lint_store.register_late_pass(|_| Box::new(UnicodeEllipsisInPanicMessages::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("unicode_ellipsis_in_panic_messages", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(UnicodeEllipsisInPanicMessages::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for UnicodeEllipsisInPanicMessages {

--- a/src/rules/unicode_ellipsis_in_panic_messages.rs
+++ b/src/rules/unicode_ellipsis_in_panic_messages.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, resolved_state};
-use crate::rule_index::{Register, UnicodeEllipsisInPanicMessagesRule};
+use crate::rule_index::{Register, rule};
 use clippy_utils::macros::root_macro_call_first_node;
 use clippy_utils::res::MaybeDef;
 use rustc_ast::LitKind;
@@ -91,7 +91,7 @@ declare_tool_lint! {
 
 impl_lint_pass!(UnicodeEllipsisInPanicMessages => [UNICODE_ELLIPSIS_IN_PANIC_MESSAGES]);
 
-impl Register for UnicodeEllipsisInPanicMessagesRule {
+impl Register for rule::UnicodeEllipsisInPanicMessages {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNICODE_ELLIPSIS_IN_PANIC_MESSAGES]);
     }

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -1,4 +1,7 @@
 use crate::common::{DefaultState, render_meta_path, resolved_state};
+use crate::rule_index::{
+    LINT_NAMES, RuleRegistration, UnknownPerfectionistLintsRule, is_registered_lint,
+};
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Attribute, MetaItem, MetaItemInner, MetaItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
@@ -57,61 +60,37 @@ struct Config {}
 /// offered as a "did you mean" hint.
 const SUGGESTION_DISTANCE: usize = 3;
 
-pub struct UnknownPerfectionistLints {
-    registered_lints: Vec<String>,
-}
+pub struct UnknownPerfectionistLints;
 
 impl UnknownPerfectionistLints {
-    fn new(registered_lints: Vec<String>) -> Self {
+    fn new() -> Self {
         let _config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-        Self { registered_lints }
+        UnknownPerfectionistLints
     }
 }
 
 impl_lint_pass!(UnknownPerfectionistLints => [UNKNOWN_PERFECTIONIST_LINTS]);
 
-/// Register this rule's lint declaration. Paired with [`register_pass`];
-/// see the module-level convention documented in `register_lints`.
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[UNKNOWN_PERFECTIONIST_LINTS]);
-}
-
-/// Install this rule's early pass. Must be called *after* every rule module
-/// has registered its lints, since the pass snapshots the registered
-/// `perfectionist::*` names from `lint_store` at construction time.
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive =
-        resolved_state("unknown_perfectionist_lints", DefaultState::Active)
-    {
-        return;
+impl RuleRegistration for UnknownPerfectionistLintsRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[UNKNOWN_PERFECTIONIST_LINTS]);
     }
-    let registered_lints: Vec<String> = collect_registered_lint_names(lint_store);
-    lint_store.register_early_pass(move || {
-        Box::new(UnknownPerfectionistLints::new(registered_lints.clone()))
-    });
-}
 
-fn collect_registered_lint_names(lint_store: &LintStore) -> Vec<String> {
-    let tool_prefix = format!("{TOOL_NAME}::");
-    lint_store
-        .get_lints()
-        .iter()
-        .filter_map(|lint| {
-            // `Lint::name` is the upper-case macro identifier
-            // (`perfectionist::UNICODE_ELLIPSIS_IN_COMMENTS`); `name_lower()`
-            // returns the snake-case form rustc surfaces in diagnostics and
-            // attribute references (`perfectionist::unicode_ellipsis_in_comments`).
-            let lower_name = lint.name_lower();
-            lower_name.strip_prefix(&tool_prefix).map(str::to_owned)
-        })
-        .collect()
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive =
+            resolved_state("unknown_perfectionist_lints", DefaultState::Active)
+        {
+            return;
+        }
+        lint_store.register_early_pass(|| Box::new(UnknownPerfectionistLints::new()));
+    }
 }
 
 impl EarlyLintPass for UnknownPerfectionistLints {
     fn check_attribute(&mut self, lint_context: &EarlyContext<'_>, attribute: &Attribute) {
         if is_lint_level_attribute(attribute) {
             if let Some(lint_names) = attribute.meta_item_list() {
-                self.check_lint_name_list(lint_context, &lint_names);
+                check_lint_name_list(lint_context, &lint_names);
             }
         } else if attribute.has_name(sym::cfg_attr) {
             let Some(cfg_attr_args) = attribute.meta_item_list() else {
@@ -127,7 +106,7 @@ impl EarlyLintPass for UnknownPerfectionistLints {
                 let MetaItemKind::List(lint_names) = &wrapped_meta_item.kind else {
                     continue;
                 };
-                self.check_lint_name_list(lint_context, lint_names);
+                check_lint_name_list(lint_context, lint_names);
             }
         }
     }
@@ -148,113 +127,105 @@ fn is_lint_level_meta_item(meta_item: &MetaItem) -> bool {
         .any(|name| meta_item.has_name(*name))
 }
 
-impl UnknownPerfectionistLints {
-    fn check_lint_name_list(&self, lint_context: &EarlyContext<'_>, lint_names: &[MetaItemInner]) {
-        for lint_name in lint_names {
-            let Some(meta_item) = lint_name.meta_item() else {
-                continue;
-            };
-            self.check_lint_name(lint_context, meta_item);
-        }
-    }
-
-    fn check_lint_name(&self, lint_context: &EarlyContext<'_>, meta_item: &MetaItem) {
-        let segments = &meta_item.path.segments;
-        let Some(first_segment) = segments.first() else {
-            return;
+fn check_lint_name_list(lint_context: &EarlyContext<'_>, lint_names: &[MetaItemInner]) {
+    for lint_name in lint_names {
+        let Some(meta_item) = lint_name.meta_item() else {
+            continue;
         };
-        if first_segment.ident.name.as_str() != TOOL_NAME {
-            return;
+        check_lint_name(lint_context, meta_item);
+    }
+}
+
+fn check_lint_name(lint_context: &EarlyContext<'_>, meta_item: &MetaItem) {
+    let segments = &meta_item.path.segments;
+    let Some(first_segment) = segments.first() else {
+        return;
+    };
+    if first_segment.ident.name.as_str() != TOOL_NAME {
+        return;
+    }
+    let segments_after_tool: Vec<&str> = segments[1..]
+        .iter()
+        .map(|segment| segment.ident.name.as_str())
+        .collect();
+    match segments_after_tool.as_slice() {
+        [name] if is_registered_lint(name) => {}
+        [name] => report(lint_context, meta_item, name),
+        [] => report_no_name(lint_context, meta_item),
+        _ => {
+            let candidate = segments_after_tool.join("_");
+            report(lint_context, meta_item, &candidate);
         }
-        let segments_after_tool: Vec<&str> = segments[1..]
-            .iter()
-            .map(|segment| segment.ident.name.as_str())
-            .collect();
-        match segments_after_tool.as_slice() {
-            [name] if self.is_registered(name) => {}
-            [name] => self.report(lint_context, meta_item, name),
-            [] => self.report_no_name(lint_context, meta_item),
-            _ => {
-                let candidate = segments_after_tool.join("_");
-                self.report(lint_context, meta_item, &candidate);
+    }
+}
+
+/// The help line to attach to an unknown name, if there is anything
+/// useful to say about it.
+fn help_for(candidate: &str) -> Option<String> {
+    // No registered lint name holds a non-ASCII character, so a
+    // candidate that does is not a near-miss of one and there is
+    // nothing to guess at. The character itself is the answer: a
+    // homoglyph is invisible in the source, and the codepoint is
+    // what identifies it. rustc words its own reports of such a
+    // character the same way, down to `'о' (U+043E)`.
+    if let Some(non_ascii) = candidate.chars().find(|character| !character.is_ascii()) {
+        let codepoint = u32::from(non_ascii);
+        // A combining mark would otherwise land on the quote and a
+        // zero-width character would render as nothing at all —
+        // both defeating the point of naming the character. rustc
+        // escapes it the same way: its `uncommon_codepoints` reads
+        // `identifier contains an uncommon character: '\u{951}'`.
+        let escaped = non_ascii.escape_debug();
+        return Some(format!(
+            "contains a non-ASCII character: '{escaped}' (U+{codepoint:04X})",
+        ));
+    }
+    let suggested_name = find_closest_match(candidate)?;
+    Some(format!("did you mean `{TOOL_NAME}::{suggested_name}`?"))
+}
+
+/// The registered lint closest to `candidate`, within
+/// [`SUGGESTION_DISTANCE`] edits of it. `candidate` must be ASCII;
+/// [`help_for`] rules out everything else beforehand.
+fn find_closest_match(candidate: &str) -> Option<&'static str> {
+    let mut closest: Option<(&'static str, usize)> = None;
+    for registered in LINT_NAMES {
+        let distance = levenshtein(candidate.as_bytes(), registered.as_bytes());
+        if distance <= SUGGESTION_DISTANCE
+            && closest.is_none_or(|(_, closest_distance)| distance < closest_distance)
+        {
+            closest = Some((*registered, distance));
+        }
+    }
+    closest.map(|(name, _)| name)
+}
+
+fn report(lint_context: &EarlyContext<'_>, meta_item: &MetaItem, candidate: &str) {
+    let path_text = render_meta_path(meta_item);
+    span_lint_and_then(
+        lint_context,
+        UNKNOWN_PERFECTIONIST_LINTS,
+        meta_item.span,
+        format!("unknown lint: `{path_text}`"),
+        // Called only when the lint fires, so a site that carries
+        // `#[allow(perfectionist::unknown_perfectionist_lints)]`
+        // pays for neither the distance sweep nor the `String`.
+        |diagnostic| {
+            if let Some(help) = help_for(candidate) {
+                diagnostic.help(help);
             }
-        }
-    }
+        },
+    );
+}
 
-    fn is_registered(&self, name: &str) -> bool {
-        self.registered_lints
-            .iter()
-            .any(|registered| registered == name)
-    }
-
-    /// The help line to attach to an unknown name, if there is anything
-    /// useful to say about it.
-    fn help_for(&self, candidate: &str) -> Option<String> {
-        // No registered lint name holds a non-ASCII character, so a
-        // candidate that does is not a near-miss of one and there is
-        // nothing to guess at. The character itself is the answer: a
-        // homoglyph is invisible in the source, and the codepoint is
-        // what identifies it. rustc words its own reports of such a
-        // character the same way, down to `'о' (U+043E)`.
-        if let Some(non_ascii) = candidate.chars().find(|character| !character.is_ascii()) {
-            let codepoint = u32::from(non_ascii);
-            // A combining mark would otherwise land on the quote and a
-            // zero-width character would render as nothing at all —
-            // both defeating the point of naming the character. rustc
-            // escapes it the same way: its `uncommon_codepoints` reads
-            // `identifier contains an uncommon character: '\u{951}'`.
-            let escaped = non_ascii.escape_debug();
-            return Some(format!(
-                "contains a non-ASCII character: '{escaped}' (U+{codepoint:04X})",
-            ));
-        }
-        let suggested_name = self.find_closest_match(candidate)?;
-        Some(format!("did you mean `{TOOL_NAME}::{suggested_name}`?"))
-    }
-
-    /// The registered lint closest to `candidate`, within
-    /// [`SUGGESTION_DISTANCE`] edits of it. `candidate` must be ASCII;
-    /// [`Self::help_for`] rules out everything else beforehand.
-    fn find_closest_match(&self, candidate: &str) -> Option<&str> {
-        let mut closest: Option<(&str, usize)> = None;
-        for registered in &self.registered_lints {
-            let distance = levenshtein(candidate.as_bytes(), registered.as_bytes());
-            if distance <= SUGGESTION_DISTANCE
-                && closest.is_none_or(|(_, closest_distance)| distance < closest_distance)
-            {
-                closest = Some((registered.as_str(), distance));
-            }
-        }
-        closest.map(|(name, _)| name)
-    }
-
-    fn report(&self, lint_context: &EarlyContext<'_>, meta_item: &MetaItem, candidate: &str) {
-        let path_text = render_meta_path(meta_item);
-        span_lint_and_then(
-            lint_context,
-            UNKNOWN_PERFECTIONIST_LINTS,
-            meta_item.span,
-            format!("unknown lint: `{path_text}`"),
-            // Called only when the lint fires, so a site that carries
-            // `#[allow(perfectionist::unknown_perfectionist_lints)]`
-            // pays for neither the distance sweep nor the `String`.
-            |diagnostic| {
-                if let Some(help) = self.help_for(candidate) {
-                    diagnostic.help(help);
-                }
-            },
-        );
-    }
-
-    fn report_no_name(&self, lint_context: &EarlyContext<'_>, meta_item: &MetaItem) {
-        span_lint_and_then(
-            lint_context,
-            UNKNOWN_PERFECTIONIST_LINTS,
-            meta_item.span,
-            format!("unknown lint: `{TOOL_NAME}` is a tool prefix, not a lint name"),
-            |_| {},
-        );
-    }
+fn report_no_name(lint_context: &EarlyContext<'_>, meta_item: &MetaItem) {
+    span_lint_and_then(
+        lint_context,
+        UNKNOWN_PERFECTIONIST_LINTS,
+        meta_item.span,
+        format!("unknown lint: `{TOOL_NAME}` is a tool prefix, not a lint name"),
+        |_| {},
+    );
 }
 
 fn levenshtein(left: &[u8], right: &[u8]) -> usize {

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -1,5 +1,5 @@
 use crate::common::{DefaultState, render_meta_path, resolved_state};
-use crate::rule_index::{LINT_NAMES, Register, UnknownPerfectionistLintsRule, is_registered_lint};
+use crate::rule_index::{LINT_NAMES, Register, is_registered_lint, rule};
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Attribute, MetaItem, MetaItemInner, MetaItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
@@ -69,7 +69,7 @@ impl UnknownPerfectionistLints {
 
 impl_lint_pass!(UnknownPerfectionistLints => [UNKNOWN_PERFECTIONIST_LINTS]);
 
-impl Register for UnknownPerfectionistLintsRule {
+impl Register for rule::UnknownPerfectionistLints {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNKNOWN_PERFECTIONIST_LINTS]);
     }

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -1,4 +1,4 @@
-use crate::common::{DefaultState, render_meta_path, resolved_state};
+use crate::common::{DefaultState, render_meta_path};
 use crate::rule_index::{LINT_NAMES, Register, is_registered_lint, rule};
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Attribute, MetaItem, MetaItemInner, MetaItemKind};
@@ -70,16 +70,13 @@ impl UnknownPerfectionistLints {
 impl_lint_pass!(UnknownPerfectionistLints => [UNKNOWN_PERFECTIONIST_LINTS]);
 
 impl Register for rule::UnknownPerfectionistLints {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNKNOWN_PERFECTIONIST_LINTS]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive =
-            resolved_state("unknown_perfectionist_lints", DefaultState::Active)
-        {
-            return;
-        }
         lint_store.register_early_pass(|| Box::new(UnknownPerfectionistLints::new()));
     }
 }

--- a/src/rules/unknown_perfectionist_lints.rs
+++ b/src/rules/unknown_perfectionist_lints.rs
@@ -1,7 +1,5 @@
 use crate::common::{DefaultState, render_meta_path, resolved_state};
-use crate::rule_index::{
-    LINT_NAMES, RuleRegistration, UnknownPerfectionistLintsRule, is_registered_lint,
-};
+use crate::rule_index::{LINT_NAMES, Register, UnknownPerfectionistLintsRule, is_registered_lint};
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Attribute, MetaItem, MetaItemInner, MetaItemKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, LintStore};
@@ -71,7 +69,7 @@ impl UnknownPerfectionistLints {
 
 impl_lint_pass!(UnknownPerfectionistLints => [UNKNOWN_PERFECTIONIST_LINTS]);
 
-impl RuleRegistration for UnknownPerfectionistLintsRule {
+impl Register for UnknownPerfectionistLintsRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNKNOWN_PERFECTIONIST_LINTS]);
     }

--- a/src/rules/unordered_derives.rs
+++ b/src/rules/unordered_derives.rs
@@ -1,4 +1,4 @@
-use crate::rule_index::{Register, UnorderedDerivesRule};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Attribute, MetaItemInner, MetaItemKind};
 use rustc_errors::Applicability;
@@ -163,7 +163,7 @@ impl UnorderedDerives {
 
 impl_lint_pass!(UnorderedDerives => [UNORDERED_DERIVES]);
 
-impl Register for UnorderedDerivesRule {
+impl Register for rule::UnorderedDerives {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNORDERED_DERIVES]);
     }

--- a/src/rules/unordered_derives.rs
+++ b/src/rules/unordered_derives.rs
@@ -8,7 +8,7 @@ use rustc_span::sym;
 
 mod ordering;
 
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use ordering::{DeriveEntry, Style, desired_order, is_identity};
 
 declare_tool_lint! {
@@ -92,13 +92,6 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Off by default — enable it in `dylint.toml` via the crate-wide
-/// `[perfectionist] enable = ["unordered_derives"]` (or the
-/// `[[perfectionist.enable]]` array-of-tables form). Read by
-/// [`Register::register_pass`] below; gen-docs picks the constant up
-/// via syn to render the rule's default state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
-
 const CONFIG_KEY: &str = "perfectionist::unordered_derives";
 
 /// Default `prefix` list for the `prefix_then_alphabetical` style.
@@ -164,14 +157,16 @@ impl UnorderedDerives {
 impl_lint_pass!(UnorderedDerives => [UNORDERED_DERIVES]);
 
 impl Register for rule::UnorderedDerives {
+    /// Off by default — enable it in `dylint.toml` via the crate-wide
+    /// `[perfectionist] enable = ["unordered_derives"]` (or the
+    /// `[[perfectionist.enable]]` array-of-tables form).
+    const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNORDERED_DERIVES]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("unordered_derives", DEFAULT_STATE) {
-            return;
-        }
         // Pre-expansion: derives are consumed during macro expansion, so
         // a regular (post-expansion) `EarlyLintPass` no longer sees the
         // `#[derive(...)]` attribute by the time `check_attribute` would

--- a/src/rules/unordered_derives.rs
+++ b/src/rules/unordered_derives.rs
@@ -1,4 +1,4 @@
-use crate::rule_index::{RuleRegistration, UnorderedDerivesRule};
+use crate::rule_index::{Register, UnorderedDerivesRule};
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Attribute, MetaItemInner, MetaItemKind};
 use rustc_errors::Applicability;
@@ -95,8 +95,8 @@ declare_tool_lint! {
 /// Off by default — enable it in `dylint.toml` via the crate-wide
 /// `[perfectionist] enable = ["unordered_derives"]` (or the
 /// `[[perfectionist.enable]]` array-of-tables form). Read by
-/// [`RuleRegistration::register_pass`] below; gen-docs picks the
-/// constant up via syn to render the rule's default state.
+/// [`Register::register_pass`] below; gen-docs picks the constant up
+/// via syn to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
 
 const CONFIG_KEY: &str = "perfectionist::unordered_derives";
@@ -163,7 +163,7 @@ impl UnorderedDerives {
 
 impl_lint_pass!(UnorderedDerives => [UNORDERED_DERIVES]);
 
-impl RuleRegistration for UnorderedDerivesRule {
+impl Register for UnorderedDerivesRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNORDERED_DERIVES]);
     }

--- a/src/rules/unordered_derives.rs
+++ b/src/rules/unordered_derives.rs
@@ -1,3 +1,4 @@
+use crate::rule_index::{RuleRegistration, UnorderedDerivesRule};
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_ast::{Attribute, MetaItemInner, MetaItemKind};
 use rustc_errors::Applicability;
@@ -94,8 +95,8 @@ declare_tool_lint! {
 /// Off by default — enable it in `dylint.toml` via the crate-wide
 /// `[perfectionist] enable = ["unordered_derives"]` (or the
 /// `[[perfectionist.enable]]` array-of-tables form). Read by
-/// [`register_pass`] below; gen-docs picks the constant up via syn
-/// to render the rule's default state.
+/// [`RuleRegistration::register_pass`] below; gen-docs picks the
+/// constant up via syn to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
 
 const CONFIG_KEY: &str = "perfectionist::unordered_derives";
@@ -162,20 +163,22 @@ impl UnorderedDerives {
 
 impl_lint_pass!(UnorderedDerives => [UNORDERED_DERIVES]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[UNORDERED_DERIVES]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("unordered_derives", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for UnorderedDerivesRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[UNORDERED_DERIVES]);
     }
-    // Pre-expansion: derives are consumed during macro expansion, so
-    // a regular (post-expansion) `EarlyLintPass` no longer sees the
-    // `#[derive(...)]` attribute by the time `check_attribute` would
-    // be invoked. Running before expansion keeps the attribute
-    // tokens intact.
-    lint_store.register_pre_expansion_pass(|| Box::new(UnorderedDerives::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("unordered_derives", DEFAULT_STATE) {
+            return;
+        }
+        // Pre-expansion: derives are consumed during macro expansion, so
+        // a regular (post-expansion) `EarlyLintPass` no longer sees the
+        // `#[derive(...)]` attribute by the time `check_attribute` would
+        // be invoked. Running before expansion keeps the attribute
+        // tokens intact.
+        lint_store.register_pre_expansion_pass(|| Box::new(UnorderedDerives::new()));
+    }
 }
 
 impl EarlyLintPass for UnorderedDerives {

--- a/src/rules/unpinned_repo_ref.rs
+++ b/src/rules/unpinned_repo_ref.rs
@@ -3,7 +3,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::string_literal_quote_lengths;
 use crate::markdown::{SkipRange, scan_code_regions};
-use crate::rule_index::{Register, UnpinnedRepoRefRule};
+use crate::rule_index::{Register, rule};
 use config::{Config, ForgeKind, glob_match};
 use emit::{Violation, emit_diagnostic};
 use rustc_ast::LitKind;
@@ -167,7 +167,7 @@ impl UnpinnedRepoRef {
 
 impl_lint_pass!(UnpinnedRepoRef => [UNPINNED_REPO_REF]);
 
-impl Register for UnpinnedRepoRefRule {
+impl Register for rule::UnpinnedRepoRef {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNPINNED_REPO_REF]);
     }

--- a/src/rules/unpinned_repo_ref.rs
+++ b/src/rules/unpinned_repo_ref.rs
@@ -3,7 +3,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::string_literal_quote_lengths;
 use crate::markdown::{SkipRange, scan_code_regions};
-use crate::rule_index::{RuleRegistration, UnpinnedRepoRefRule};
+use crate::rule_index::{Register, UnpinnedRepoRefRule};
 use config::{Config, ForgeKind, glob_match};
 use emit::{Violation, emit_diagnostic};
 use rustc_ast::LitKind;
@@ -167,7 +167,7 @@ impl UnpinnedRepoRef {
 
 impl_lint_pass!(UnpinnedRepoRef => [UNPINNED_REPO_REF]);
 
-impl RuleRegistration for UnpinnedRepoRefRule {
+impl Register for UnpinnedRepoRefRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNPINNED_REPO_REF]);
     }

--- a/src/rules/unpinned_repo_ref.rs
+++ b/src/rules/unpinned_repo_ref.rs
@@ -1,5 +1,5 @@
 use crate::comment_walk::{CommentChunk, CommentSurface, walk_local_comments};
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::string_literal_quote_lengths;
 use crate::markdown::{SkipRange, scan_code_regions};
@@ -65,8 +65,6 @@ declare_tool_lint! {
 }
 
 use config::CONFIG_KEY;
-
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 pub struct UnpinnedRepoRef {
     scan_doc_comments: bool,
@@ -168,14 +166,13 @@ impl UnpinnedRepoRef {
 impl_lint_pass!(UnpinnedRepoRef => [UNPINNED_REPO_REF]);
 
 impl Register for rule::UnpinnedRepoRef {
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[UNPINNED_REPO_REF]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("unpinned_repo_ref", DEFAULT_STATE) {
-            return;
-        }
         lint_store.register_late_pass(|_| Box::new(UnpinnedRepoRef::new()));
     }
 }

--- a/src/rules/unpinned_repo_ref.rs
+++ b/src/rules/unpinned_repo_ref.rs
@@ -3,6 +3,7 @@ use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::emit_at_enclosing_hir;
 use crate::literal_scan::string_literal_quote_lengths;
 use crate::markdown::{SkipRange, scan_code_regions};
+use crate::rule_index::{RuleRegistration, UnpinnedRepoRefRule};
 use config::{Config, ForgeKind, glob_match};
 use emit::{Violation, emit_diagnostic};
 use rustc_ast::LitKind;
@@ -166,15 +167,17 @@ impl UnpinnedRepoRef {
 
 impl_lint_pass!(UnpinnedRepoRef => [UNPINNED_REPO_REF]);
 
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[UNPINNED_REPO_REF]);
-}
-
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("unpinned_repo_ref", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for UnpinnedRepoRefRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[UNPINNED_REPO_REF]);
     }
-    lint_store.register_late_pass(|_| Box::new(UnpinnedRepoRef::new()));
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("unpinned_repo_ref", DEFAULT_STATE) {
+            return;
+        }
+        lint_store.register_late_pass(|_| Box::new(UnpinnedRepoRef::new()));
+    }
 }
 
 impl<'tcx> LateLintPass<'tcx> for UnpinnedRepoRef {

--- a/src/rules/wildcard_imports.rs
+++ b/src/rules/wildcard_imports.rs
@@ -23,7 +23,7 @@ use std::collections::HashSet;
 
 mod config;
 
-use crate::common::{DefaultState, resolved_state};
+use crate::common::DefaultState;
 use crate::enclosing_hir::find_enclosing_hir_ids;
 use crate::module_reparse::{SpanRange, parse_crate_module_files};
 use config::{Config, Resolved};
@@ -117,12 +117,6 @@ declare_tool_lint! {
     report_in_external_macro: false
 }
 
-/// Active by default: both exceptions ship enabled, so the only globs
-/// flagged out of the box are non-prelude, non-re-export ones such as
-/// `use super::*;`. Read by [`Register::register_pass`]; gen-docs picks
-/// the constant up to render the rule's default state.
-pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
-
 const CONFIG_KEY: &str = "perfectionist::wildcard_imports";
 
 pub struct WildcardImports {
@@ -132,14 +126,16 @@ pub struct WildcardImports {
 impl_lint_pass!(WildcardImports => [WILDCARD_IMPORTS]);
 
 impl Register for rule::WildcardImports {
+    /// Active by default: both exceptions ship enabled, so the only
+    /// globs flagged out of the box are non-prelude, non-re-export ones
+    /// such as `use super::*;`.
+    const DEFAULT_STATE: DefaultState = DefaultState::Active;
+
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[WILDCARD_IMPORTS]);
     }
 
     fn register_pass(lint_store: &mut LintStore) {
-        if let DefaultState::Inactive = resolved_state("wildcard_imports", DEFAULT_STATE) {
-            return;
-        }
         let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
         // Reject a misconfigured `allowed_paths` entry loudly: each must be an
         // absolute path (`crate::...` or `::<extern crate>::...`), otherwise it

--- a/src/rules/wildcard_imports.rs
+++ b/src/rules/wildcard_imports.rs
@@ -13,7 +13,7 @@
 //! `live_module_spans` guard that keeps the walk from descending into a
 //! cfg-disabled inline module that is not part of the compiled crate.
 
-use crate::rule_index::{Register, WildcardImportsRule};
+use crate::rule_index::{Register, rule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_ast::{Item, ItemKind, ModKind, UseTree, UseTreeKind, VisibilityKind};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -131,7 +131,7 @@ pub struct WildcardImports {
 
 impl_lint_pass!(WildcardImports => [WILDCARD_IMPORTS]);
 
-impl Register for WildcardImportsRule {
+impl Register for rule::WildcardImports {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[WILDCARD_IMPORTS]);
     }

--- a/src/rules/wildcard_imports.rs
+++ b/src/rules/wildcard_imports.rs
@@ -13,6 +13,7 @@
 //! `live_module_spans` guard that keeps the walk from descending into a
 //! cfg-disabled inline module that is not part of the compiled crate.
 
+use crate::rule_index::{RuleRegistration, WildcardImportsRule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_ast::{Item, ItemKind, ModKind, UseTree, UseTreeKind, VisibilityKind};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -118,8 +119,8 @@ declare_tool_lint! {
 
 /// Active by default: both exceptions ship enabled, so the only globs
 /// flagged out of the box are non-prelude, non-re-export ones such as
-/// `use super::*;`. Read by [`register_pass`]; gen-docs picks the
-/// constant up to render the rule's default state.
+/// `use super::*;`. Read by [`RuleRegistration::register_pass`];
+/// gen-docs picks the constant up to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::wildcard_imports";
@@ -130,35 +131,34 @@ pub struct WildcardImports {
 
 impl_lint_pass!(WildcardImports => [WILDCARD_IMPORTS]);
 
-/// Register this rule's lint declaration. Paired with [`register_pass`];
-/// see the module-level convention documented in `register_lints`.
-pub fn register_lint(lint_store: &mut LintStore) {
-    lint_store.register_lints(&[WILDCARD_IMPORTS]);
-}
-
-/// Install this rule's pass.
-pub fn register_pass(lint_store: &mut LintStore) {
-    if let DefaultState::Inactive = resolved_state("wildcard_imports", DEFAULT_STATE) {
-        return;
+impl RuleRegistration for WildcardImportsRule {
+    fn register_lint(lint_store: &mut LintStore) {
+        lint_store.register_lints(&[WILDCARD_IMPORTS]);
     }
-    let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
-    // Reject a misconfigured `allowed_paths` entry loudly: each must be an
-    // absolute path (`crate::...` or `::<extern crate>::...`), otherwise it
-    // could never match the absolute key the rule builds from a glob `use`.
-    for entry in &config.allowed_paths {
-        crate::abs_path::validate_absolute(entry).unwrap_or_else(|message| {
-            panic!("perfectionist::wildcard_imports: {message}");
+
+    fn register_pass(lint_store: &mut LintStore) {
+        if let DefaultState::Inactive = resolved_state("wildcard_imports", DEFAULT_STATE) {
+            return;
+        }
+        let config: Config = dylint_linting::config_or_default(CONFIG_KEY);
+        // Reject a misconfigured `allowed_paths` entry loudly: each must be an
+        // absolute path (`crate::...` or `::<extern crate>::...`), otherwise it
+        // could never match the absolute key the rule builds from a glob `use`.
+        for entry in &config.allowed_paths {
+            crate::abs_path::validate_absolute(entry).unwrap_or_else(|message| {
+                panic!("perfectionist::wildcard_imports: {message}");
+            });
+        }
+        // Late pass: the cfg-gated `#[cfg(test)] mod tests { use super::*; }`
+        // case (and any out-of-line `mod foo;` submodule) is only reachable
+        // by re-parsing each module file in a late pass — see the module
+        // docs and [`crate::module_reparse`].
+        lint_store.register_late_pass(move |_| {
+            Box::new(WildcardImports {
+                config: Resolved::from_config(config.clone()),
+            })
         });
     }
-    // Late pass: the cfg-gated `#[cfg(test)] mod tests { use super::*; }`
-    // case (and any out-of-line `mod foo;` submodule) is only reachable
-    // by re-parsing each module file in a late pass — see the module
-    // docs and [`crate::module_reparse`].
-    lint_store.register_late_pass(move |_| {
-        Box::new(WildcardImports {
-            config: Resolved::from_config(config.clone()),
-        })
-    });
 }
 
 /// A detected violation parked until the enclosing HIR node is known.

--- a/src/rules/wildcard_imports.rs
+++ b/src/rules/wildcard_imports.rs
@@ -13,7 +13,7 @@
 //! `live_module_spans` guard that keeps the walk from descending into a
 //! cfg-disabled inline module that is not part of the compiled crate.
 
-use crate::rule_index::{RuleRegistration, WildcardImportsRule};
+use crate::rule_index::{Register, WildcardImportsRule};
 use clippy_utils::diagnostics::span_lint_hir_and_then;
 use rustc_ast::{Item, ItemKind, ModKind, UseTree, UseTreeKind, VisibilityKind};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
@@ -119,8 +119,8 @@ declare_tool_lint! {
 
 /// Active by default: both exceptions ship enabled, so the only globs
 /// flagged out of the box are non-prelude, non-re-export ones such as
-/// `use super::*;`. Read by [`RuleRegistration::register_pass`];
-/// gen-docs picks the constant up to render the rule's default state.
+/// `use super::*;`. Read by [`Register::register_pass`]; gen-docs picks
+/// the constant up to render the rule's default state.
 pub(crate) const DEFAULT_STATE: DefaultState = DefaultState::Active;
 
 const CONFIG_KEY: &str = "perfectionist::wildcard_imports";
@@ -131,7 +131,7 @@ pub struct WildcardImports {
 
 impl_lint_pass!(WildcardImports => [WILDCARD_IMPORTS]);
 
-impl RuleRegistration for WildcardImportsRule {
+impl Register for WildcardImportsRule {
     fn register_lint(lint_store: &mut LintStore) {
         lint_store.register_lints(&[WILDCARD_IMPORTS]);
     }

--- a/tests/global_config.rs
+++ b/tests/global_config.rs
@@ -68,6 +68,25 @@ fn disable_accepts_array_of_tables_form() {
     );
 }
 
+/// Disabling a rule skips its `register_pass` call only: the lint
+/// declaration registers whatever the rule's resolved state, so a
+/// call site that suppresses the rule keeps resolving. Guarding
+/// `register_lint` the same way would turn every such
+/// `#[allow(perfectionist::<rule>)]` into an `unknown_lints` warning
+/// from rustc — the fixture carries one, and expects no output.
+/// `allow_attributes` is turned off alongside it so that the
+/// fixture's own suppression is not itself a finding.
+#[test]
+fn disable_keeps_the_lint_name_resolvable() {
+    run(
+        "ui-toml/impure_macro_arguments/disabled_with_allow",
+        text_block_fnl! {
+            "[perfectionist]"
+            r#"disable = ["impure_macro_arguments", "allow_attributes"]"#
+        },
+    );
+}
+
 /// `enable = ["<rule>"]` flips a default-off rule to on, so the
 /// fixture's `pub enum FooError {}` produces the snapshot's
 /// diagnostic. Reuses the `exhaustive_error_enums/baseline` fixture

--- a/tools/gen-docs/src/extract.rs
+++ b/tools/gen-docs/src/extract.rs
@@ -143,10 +143,9 @@ fn extract_rules(source_path: &Path, shared: &SharedTypes) -> Vec<Rule> {
             // Catalogue policy (see `README.md` and the
             // `Rule::default_state` doc comment): every rule's
             // `declare_tool_lint!` declares level `Warn`. The
-            // default-disabled axis lives in
-            // `pub(crate) const DEFAULT_STATE: DefaultState =
-            // DefaultState::Inactive;` alongside the macro, not in
-            // the level. A non-`Warn` here means the source has
+            // default-disabled axis lives in the rule's `Register`
+            // impl, as `const DEFAULT_STATE: DefaultState =
+            // DefaultState::Inactive;`, not in the level. A non-`Warn` here means the source has
             // drifted from the policy; we panic so a doc
             // regeneration catches it rather than silently
             // rendering the old "Default level" surface we removed.
@@ -154,10 +153,9 @@ fn extract_rules(source_path: &Path, shared: &SharedTypes) -> Vec<Rule> {
                 panic!(
                     "{} declares level `{level_ident}`; catalogue policy is that \
                      every `declare_tool_lint!` uses level `Warn`. Move the \
-                     off-by-default signal into \
-                     `pub(crate) const DEFAULT_STATE: DefaultState = \
-                     DefaultState::Inactive;` next to the macro and change \
-                     the level to `Warn`.",
+                     off-by-default signal into the rule's `Register` impl, \
+                     as `const DEFAULT_STATE: DefaultState = \
+                     DefaultState::Inactive;`, and change the level to `Warn`.",
                     source_path.display(),
                 );
             }
@@ -173,68 +171,83 @@ fn extract_rules(source_path: &Path, shared: &SharedTypes) -> Vec<Rule> {
         .collect()
 }
 
-/// Find a `pub(crate) const DEFAULT_STATE: DefaultState = <variant>;`
-/// item in `merged_file` and translate its enum-variant initializer
-/// into the corresponding [`DefaultState`]. The merged file already
-/// includes submodule items, so the constant can live in either the
-/// flat rule file or a sibling `<rule>/<concern>.rs` (in practice
-/// every rule keeps it next to `declare_tool_lint!`). Absence of the
-/// constant means the rule is on out of the box — the common case
-/// across the catalogue — so the function returns
-/// [`DefaultState::Active`].
+/// Find the `const DEFAULT_STATE: DefaultState = <variant>;` item in
+/// the rule's `Register` impl (see the rule activation model in
+/// `planned-rules/IMPLEMENTATION_CONVENTIONS.md`) and translate its
+/// enum-variant initializer into the corresponding [`DefaultState`].
+/// The merged file already includes submodule items, so the impl can
+/// live in either the flat rule file or a sibling `<rule>/<concern>.rs`
+/// (in practice every rule keeps it next to `declare_tool_lint!`).
+///
+/// The trait requires the constant, so a rule that reaches the
+/// registry has one. A source file that states none — a stand-in in a
+/// test, a rule-shaped file that never registered — is reported as on
+/// out of the box, the catalogue default.
 ///
 /// No `bool` intermediate: the runtime constant uses the same enum
 /// shape gen-docs renders, and we read its initializer's *path* end
 /// segment directly. `DefaultState::Inactive` and a `use ... Inactive`
 /// alias both work because we only inspect the last segment.
 fn extract_default_state(source_path: &Path, merged_file: &syn::File) -> DefaultState {
-    use syn::{Expr, ExprPath, Type, TypePath};
-
     for item in &merged_file.items {
-        let Item::Const(item_const) = item else {
+        let Item::Impl(item_impl) = item else {
             continue;
         };
-        if item_const.ident != "DEFAULT_STATE" {
-            continue;
+        for impl_item in &item_impl.items {
+            let syn::ImplItem::Const(impl_const) = impl_item else {
+                continue;
+            };
+            if impl_const.ident != "DEFAULT_STATE" {
+                continue;
+            }
+            return read_default_state(source_path, &impl_const.ty, &impl_const.expr);
         }
-        let is_default_state_type = matches!(
-            &*item_const.ty,
-            Type::Path(TypePath { path, qself: None }) if path.is_ident("DefaultState"),
-        );
-        if !is_default_state_type {
-            panic!(
-                "{}: `DEFAULT_STATE` must be typed `DefaultState`",
-                source_path.display(),
-            );
-        }
-        let Expr::Path(ExprPath {
-            path, qself: None, ..
-        }) = &*item_const.expr
-        else {
-            panic!(
-                "{}: `DEFAULT_STATE` initializer must be a `DefaultState` \
-                 variant path (e.g. `DefaultState::Active`); other \
-                 expressions defeat the gen-docs syntactic extraction",
-                source_path.display(),
-            );
-        };
-        let Some(last_segment) = path.segments.last() else {
-            panic!(
-                "{}: `DEFAULT_STATE` initializer has an empty path",
-                source_path.display(),
-            );
-        };
-        return match last_segment.ident.to_string().as_str() {
-            "Active" => DefaultState::Active,
-            "Inactive" => DefaultState::Inactive,
-            other => panic!(
-                "{}: `DEFAULT_STATE` initializer names unknown `DefaultState` \
-                 variant `{other}`; only `Active` and `Inactive` are valid.",
-                source_path.display(),
-            ),
-        };
     }
     DefaultState::Active
+}
+
+/// Validate one `DEFAULT_STATE` constant's type and initializer, and
+/// name the [`DefaultState`] its initializer points at. Every panic
+/// here names the file, since the fix is a source edit in it.
+fn read_default_state(source_path: &Path, ty: &syn::Type, expr: &syn::Expr) -> DefaultState {
+    use syn::{Expr, ExprPath, Type, TypePath};
+
+    let is_default_state_type = matches!(
+        ty,
+        Type::Path(TypePath { path, qself: None }) if path.is_ident("DefaultState"),
+    );
+    if !is_default_state_type {
+        panic!(
+            "{}: `DEFAULT_STATE` must be typed `DefaultState`",
+            source_path.display(),
+        );
+    }
+    let Expr::Path(ExprPath {
+        path, qself: None, ..
+    }) = expr
+    else {
+        panic!(
+            "{}: `DEFAULT_STATE` initializer must be a `DefaultState` \
+             variant path (e.g. `DefaultState::Active`); other \
+             expressions defeat the gen-docs syntactic extraction",
+            source_path.display(),
+        );
+    };
+    let Some(last_segment) = path.segments.last() else {
+        panic!(
+            "{}: `DEFAULT_STATE` initializer has an empty path",
+            source_path.display(),
+        );
+    };
+    match last_segment.ident.to_string().as_str() {
+        "Active" => DefaultState::Active,
+        "Inactive" => DefaultState::Inactive,
+        other => panic!(
+            "{}: `DEFAULT_STATE` initializer names unknown `DefaultState` \
+             variant `{other}`; only `Active` and `Inactive` are valid.",
+            source_path.display(),
+        ),
+    }
 }
 
 /// Return a `syn::File` containing `parent`'s items followed by every

--- a/tools/gen-docs/src/extract/tests.rs
+++ b/tools/gen-docs/src/extract/tests.rs
@@ -1,4 +1,5 @@
 use super::collect_rules;
+use crate::model::DefaultState;
 use std::fs;
 use std::path::PathBuf;
 
@@ -74,6 +75,59 @@ fn collect_rules_finds_config_in_submodule_file() {
     assert_eq!(config.key, "perfectionist::demo_rule");
     let names: Vec<&str> = config.fields.iter().map(|f| f.name.as_str()).collect();
     assert_eq!(names, vec!["knob"]);
+
+    let _ = fs::remove_dir_all(&base);
+}
+
+/// The default-state axis lives in the rule's `Register` impl, so
+/// reading it means walking an associated const rather than a
+/// module-level one. Miss that and every off-by-default rule renders
+/// as shipping on.
+#[test]
+fn collect_rules_reads_default_state_from_the_register_impl() {
+    let base = tempdir("impl-default-state");
+    let rules_dir = base.join("rules");
+    fs::create_dir_all(&rules_dir).unwrap();
+    fs::write(
+        rules_dir.join("demo_rule.rs"),
+        r#"
+            use rustc_session::declare_tool_lint;
+
+            declare_tool_lint! {
+                /// ### What it does
+                /// Demo.
+                pub perfectionist::DEMO_RULE,
+                Warn,
+                "demo description"
+            }
+
+            const CONFIG_KEY: &str = "perfectionist::demo_rule";
+
+            #[derive(serde::Deserialize)]
+            #[serde(default, rename_all = "snake_case")]
+            struct Config {
+                /// Demo knob.
+                knob: bool,
+            }
+
+            impl Register for rule::DemoRule {
+                const DEFAULT_STATE: DefaultState = DefaultState::Inactive;
+
+                fn register_lint(lint_store: &mut LintStore) {}
+
+                fn register_pass(lint_store: &mut LintStore) {}
+            }
+        "#,
+    )
+    .unwrap();
+
+    let rules = collect_rules(&rules_dir);
+    assert_eq!(rules.len(), 1, "exactly one rule should be discovered");
+    assert!(
+        matches!(rules[0].default_state, DefaultState::Inactive),
+        "default state should come from the impl, got {:?}",
+        rules[0].default_state,
+    );
 
     let _ = fs::remove_dir_all(&base);
 }

--- a/tools/gen-docs/src/model.rs
+++ b/tools/gen-docs/src/model.rs
@@ -41,10 +41,9 @@ pub(crate) struct Rule {
     /// Whether the rule's pass is registered out of the box, or only
     /// after the user opts in via
     /// `[perfectionist] enable = ["<rule>"]` in `dylint.toml`. Read
-    /// from a `pub(crate) const DEFAULT_STATE: DefaultState = ...;`
-    /// item in the rule's source file when present; absent
-    /// constants imply [`DefaultState::Active`] (the catalogue
-    /// default). The runtime side uses its own [`DefaultState`] enum
+    /// from the `const DEFAULT_STATE: DefaultState = ...;` item in
+    /// the rule's `Register` impl; a source file stating none implies
+    /// [`DefaultState::Active`] (the catalogue default). The runtime side uses its own [`DefaultState`] enum
     /// of the same shape (`src/common.rs`), so the constant's
     /// initializer is read directly here as an enum-variant path
     /// — no `bool` intermediate. The renderer surfaces this as the
@@ -72,12 +71,11 @@ pub(crate) struct Rule {
 }
 
 /// Whether a rule's pass is installed by default. Mirrors the
-/// `pub(crate) const DEFAULT_STATE: DefaultState = ...;` constant
-/// the extractor reads from the rule's source. The runtime side
-/// defines its own [`DefaultState`] of the same shape; gen-docs has
-/// its own copy because the two crates don't link. Defaults to
-/// [`DefaultState::Active`] when a rule omits the constant — the
-/// common case across the catalogue.
+/// `const DEFAULT_STATE: DefaultState = ...;` constant the extractor
+/// reads from the rule's `Register` impl. The runtime side defines
+/// its own [`DefaultState`] of the same shape; gen-docs has its own
+/// copy because the two crates don't link. Defaults to
+/// [`DefaultState::Active`] for a source file that states none.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DefaultState {
     Active,
@@ -216,9 +214,9 @@ pub(crate) struct StructField {
 /// The set of lint levels rustc / Dylint accept as the second
 /// positional argument to `declare_tool_lint!`. The catalogue's
 /// convention is that every rule declares `Warn`; rules that should
-/// be off out of the box live behind a
-/// `pub(crate) const DEFAULT_STATE: DefaultState =
-/// DefaultState::Inactive;` instead of a stricter or looser level.
+/// be off out of the box live behind a `const DEFAULT_STATE:
+/// DefaultState = DefaultState::Inactive;` in the rule's `Register`
+/// impl instead of a stricter or looser level.
 /// The extractor still parses the identifier so a future rule that
 /// drifts from the convention
 /// trips a clear panic naming the file.

--- a/ui-toml/impure_macro_arguments/disabled_with_allow/fixture.rs
+++ b/ui-toml/impure_macro_arguments/disabled_with_allow/fixture.rs
@@ -1,0 +1,23 @@
+#![feature(register_tool)]
+#![register_tool(perfectionist)]
+
+// Skipped, and the suppression still resolves: the test driver
+// supplies a `[perfectionist] disable = ["impure_macro_arguments"]`
+// global config, so the rule's pass is never installed, while its
+// lint declaration registers either way. Nothing is reported — not
+// the rule, and not rustc's `unknown_lints` for the attribute below.
+
+#[allow(
+    perfectionist::impure_macro_arguments,
+    reason = "the crate turns this rule off globally",
+)]
+fn main() {
+    let mut value: u32 = 0;
+    debug_assert_eq!(replace(&mut value, 1), 0);
+}
+
+fn replace(slot: &mut u32, new: u32) -> u32 {
+    let old = *slot;
+    *slot = new;
+    old
+}


### PR DESCRIPTION
Resolves <https://github.com/KSXGitHub/perfectionist/issues/181>.

`src/rule_index.rs` indexes every rule the plugin ships. Its `rule_index!` invocation names each rule once and expands to a type per rule (in the index's `rule` module), the sorted `LINT_NAMES` set, and `register_all`, which is all that `src/lib.rs::register_lints` now calls.

Each rule module implements the index's `Register` trait for its own type instead of exposing free `register_lint` / `register_pass` functions. The trait also carries `DEFAULT_STATE`, so every rule states its activation baseline in one place; `register_rule` resolves the `dylint.toml` override against it and installs the pass only for a rule that comes back active, which drops the guard and the rule-name string literal that each `register_pass` used to repeat.

`unknown_perfectionist_lints` answers "is this a lint we ship?" from `LINT_NAMES` rather than from the `LintStore` it is registering into. That set is complete before registration starts, so no entry depends on another's position and the list is alphabetical throughout.

`gen-docs` reads `DEFAULT_STATE` from a rule's `Register` impl rather than from a module-level constant; the rendered catalogue is unchanged.

New tests cover the index's invariants — its entries are ascending, and they match the `declare_tool_lint!` blocks under `src/rules/` — that a disabled rule keeps its lint declaration registered so call-site suppressions still resolve, and gen-docs' reading of an off-by-default rule.

`CLAUDE.md` and `planned-rules/IMPLEMENTATION_CONVENTIONS.md` describe registering a rule through the index, and the constant's new home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVxVcoepKSzRuPYUkWikgf