### PR TITLE
refactor: adopt shared `attr_tokens`/`derive_list` helpers

### DIFF
--- a/rules/import_grouping_mismatch.md
+++ b/rules/import_grouping_mismatch.md
@@ -269,7 +269,11 @@ Every other crate.
 
 #### `CfgBlockHandling` (enum)
 
-How a `#[cfg(...)]`-gated import is grouped.
+How a `#[cfg(...)]`-gated import is grouped. An import is gated
+whether the `cfg` is written directly or applied through a
+`#[cfg_attr(<cfg>, cfg(...))]`; a `cfg_attr` that applies any
+other attribute leaves the import unconditionally present and
+does not gate it.
 
 ##### `"trailing"` (Rust: `Trailing`)
 

--- a/src/attr_tokens.rs
+++ b/src/attr_tokens.rs
@@ -9,15 +9,15 @@
 //! attribute: [`attribute_calls`] unwraps a `#[name(...)]` (looking
 //! through `#[cfg_attr(...)]`), [`is_cfg_gated`] answers whether a
 //! `#[cfg(...)]` gates a node, and [`split_top_level_commas`] /
-//! [`ident_name`] / [`str_literal`] read the argument tokens.
+//! [`ident_name`] / [`token_literal`] / [`str_literal`] read the
+//! argument tokens.
 //!
-//! Several rules already do these things by hand on parsed meta-items or
-//! macro-call streams — `unordered_derives` and `clap_help_markdown`
-//! recurse through `cfg_attr`, `import_grouping_mismatch` checks
-//! `cfg`-gating, `crate::macro_template` reads cooked string literals —
-//! so these are the shared forms those call sites can move onto.
+//! The token readers are useful beyond attributes: a macro call's
+//! arguments are the same comma-separated token stream, which is what
+//! `crate::macro_template` and `perfectionist::impure_macro_arguments`
+//! split.
 
-use rustc_ast::token::TokenKind;
+use rustc_ast::token::{Lit, TokenKind};
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
 use rustc_ast::{AttrArgs, AttrKind, Attribute, LitKind};
 use rustc_span::{Span, Symbol, sym};
@@ -137,15 +137,24 @@ pub(crate) fn ident_name(tree: &TokenTree) -> Option<Symbol> {
     token.ident().map(|(ident, _raw)| ident.name)
 }
 
-/// The cooked value of a string literal token, raw and escaped forms
-/// alike — `r"{_0}"` and `"{_0}"` are the same string.
-pub(crate) fn str_literal(tree: &TokenTree) -> Option<String> {
+/// The literal a token tree holds, with the token's span. Callers that
+/// want the literal's *value* decode it further; one that only needs to
+/// point at it — `crate::macro_template` locating a format template —
+/// keeps the span.
+pub(crate) fn token_literal(tree: &TokenTree) -> Option<(Lit, Span)> {
     let TokenTree::Token(token, _) = tree else {
         return None;
     };
     let TokenKind::Literal(literal) = token.kind else {
         return None;
     };
+    Some((literal, token.span))
+}
+
+/// The cooked value of a string literal token, raw and escaped forms
+/// alike — `r"{_0}"` and `"{_0}"` are the same string.
+pub(crate) fn str_literal(tree: &TokenTree) -> Option<String> {
+    let (literal, _span) = token_literal(tree)?;
     let LitKind::Str(symbol, _style) = LitKind::from_token_lit(literal).ok()? else {
         return None;
     };

--- a/src/derive_list.rs
+++ b/src/derive_list.rs
@@ -8,16 +8,24 @@
 //! renamed through `use some_crate::Trait as T;` is not caught.
 //!
 //! Read from tokens rather than parsed meta-items so it works on a
-//! re-parsed module AST. Several rules read derive lists their own way
-//! (`unordered_derives`, `clap_help_markdown`); this is the shared form
-//! for the "which traits are derived" question, where entry spans are
-//! not needed.
+//! re-parsed module AST. [`derive_entries`] is the underlying read of
+//! one `derive(...)` list, and hands back each entry's span alongside
+//! its name for a caller that rewrites the list rather than only asking
+//! which traits are derived.
 
 use crate::attr_tokens::attribute_calls_of;
 use rustc_ast::tokenstream::TokenStream;
-use rustc_ast::{Attribute, MetaItemInner, MetaItemKind};
-use rustc_span::{Symbol, sym};
+use rustc_ast::{Attribute, MetaItemKind};
+use rustc_span::{Span, Symbol, sym};
 use std::collections::HashSet;
+
+/// One entry of a `derive(...)` list.
+pub(crate) struct DeriveEntry {
+    /// Final segment of the derived trait's path.
+    pub(crate) name: Symbol,
+    /// Source span of the entry, covering its full path text.
+    pub(crate) span: Span,
+}
 
 /// Final path segment of every derive on the node, including
 /// `#[cfg_attr(<cfg>, derive(...))]`-gated ones.
@@ -25,21 +33,30 @@ pub(crate) fn derive_names(attrs: &[Attribute]) -> HashSet<Symbol> {
     let mut names = HashSet::new();
     for call in attribute_calls_of(attrs) {
         if call.name == sym::derive {
-            names.extend(derive_entries(call.tokens));
+            names.extend(
+                derive_entries(call.tokens)
+                    .into_iter()
+                    .flatten()
+                    .map(|entry| entry.name),
+            );
         }
     }
     names
 }
 
-/// Final path segment of each entry in a `derive(...)` list.
-fn derive_entries(tokens: &TokenStream) -> Vec<Symbol> {
-    let Some(entries) = MetaItemKind::list_from_tokens(tokens.clone()) else {
-        return Vec::new();
-    };
-    entries
+/// Every entry of a `derive(...)` list, given the `derive`'s argument
+/// tokens. `None` when an entry is not a path: `derive` accepts paths
+/// only, so such a list is malformed, and neither naming nor rewriting
+/// an entry that could not be read is meaningful.
+pub(crate) fn derive_entries(tokens: &TokenStream) -> Option<Vec<DeriveEntry>> {
+    MetaItemKind::list_from_tokens(tokens.clone())?
         .iter()
-        .filter_map(MetaItemInner::meta_item)
-        .filter_map(|meta| meta.path.segments.last())
-        .map(|segment| segment.ident.name)
+        .map(|entry| {
+            let segment = entry.meta_item()?.path.segments.last()?;
+            Some(DeriveEntry {
+                name: segment.ident.name,
+                span: entry.span(),
+            })
+        })
         .collect()
 }

--- a/src/macro_template.rs
+++ b/src/macro_template.rs
@@ -14,7 +14,8 @@
 //!   reach literals that format-args lowering would otherwise hide
 //!   from the late pass.
 
-use rustc_ast::token::{LitKind, TokenKind};
+use crate::attr_tokens::{split_top_level_commas, token_literal};
+use rustc_ast::token::LitKind;
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
 use rustc_span::Span;
 
@@ -34,46 +35,21 @@ use rustc_span::Span;
 /// either folds escapes the raw form has none of, or rewrites *into*
 /// the raw form, so an already-raw literal is never a candidate.
 pub(crate) fn find_template_literal(tokens: &TokenStream) -> Option<Span> {
-    let mut argument_len: usize = 0;
-    let mut argument_lead_literal: Option<Span> = None;
-    let mut found: Option<Span> = None;
-    let finish_argument = |len: usize, lead: Option<Span>, found: &mut Option<Span>| {
-        if found.is_none() && len == 1 {
-            *found = lead;
-        }
-    };
-    for tree in tokens.iter() {
-        if is_top_level_comma(tree) {
-            finish_argument(argument_len, argument_lead_literal, &mut found);
-            argument_len = 0;
-            argument_lead_literal = None;
-            continue;
-        }
-        if argument_len == 0 {
-            argument_lead_literal = cooked_str_literal_span(tree);
-        }
-        argument_len += 1;
-    }
-    finish_argument(argument_len, argument_lead_literal, &mut found);
-    found
-}
-
-fn is_top_level_comma(tree: &TokenTree) -> bool {
-    matches!(tree, TokenTree::Token(token, _) if token.kind == TokenKind::Comma)
+    split_top_level_commas(tokens)
+        .into_iter()
+        .find_map(|argument| match argument.as_slice() {
+            [tree] => cooked_str_literal_span(tree),
+            _ => None,
+        })
 }
 
 fn cooked_str_literal_span(tree: &TokenTree) -> Option<Span> {
-    let TokenTree::Token(token, _) = tree else {
-        return None;
-    };
-    let TokenKind::Literal(literal) = token.kind else {
-        return None;
-    };
+    let (literal, span) = token_literal(tree)?;
     // Cooked (`"..."`) only. A raw string (`r"..."`) treats `\` as an
     // ordinary character, so neither the escape-aware fold in
     // `overly_long_print_macro` nor the escape-elimination scan in
     // `avoidable_string_escapes` may run over one.
-    matches!(literal.kind, LitKind::Str).then_some(token.span)
+    matches!(literal.kind, LitKind::Str).then_some(span)
 }
 
 /// Span of every cooked string literal anywhere in `tokens`, in source

--- a/src/rules/clap_help_markdown/collect.rs
+++ b/src/rules/clap_help_markdown/collect.rs
@@ -15,11 +15,13 @@
 //! block up by its start offset, so a block whose offset is absent
 //! belongs to a non-clap item (or an overridden node) and is skipped.
 
+use crate::attr_tokens::attribute_calls_of;
+use crate::derive_list::derive_names;
 use crate::module_reparse::SpanRange;
 use rustc_ast::{
     AttrKind, Attribute, Crate, Item, ItemKind, MetaItemInner, MetaItemKind, ModKind, VariantData,
 };
-use rustc_span::{Symbol, sym};
+use rustc_span::Symbol;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 /// What the lint should do with a clap-bound, doc-commented node.
@@ -218,55 +220,18 @@ fn has_verbatim(attrs: &[Attribute]) -> bool {
 /// Collect the inner meta items of every `#[clap(...)]` / `#[arg(...)]`
 /// / `#[command(...)]` / `#[value(...)]` attribute on the node, looking
 /// through any `#[cfg_attr(<cfg>, clap(...))]` gate — the form a crate
-/// uses to keep its clap attributes behind a `cli` feature. The derive
-/// detector ([`has_clap_derive`]) already descends into `cfg_attr`;
-/// override and `verbatim_doc_comment` detection must match, or a gated
-/// `#[clap(help = "...")]` is missed and the doc comment is wrongly
-/// flagged as leaking into `--help`.
+/// uses to keep its clap attributes behind a `cli` feature. Gate
+/// handling has to match the derive detector's ([`has_clap_derive`]),
+/// or a gated `#[clap(help = "...")]` is missed and the doc comment is
+/// wrongly flagged as leaking into `--help`; both read their attributes
+/// through [`crate::attr_tokens`].
 fn clap_namespace_items(attrs: &[Attribute]) -> Vec<MetaItemInner> {
-    let mut out = Vec::new();
-    for attr in attrs {
-        if is_clap_namespace(attr) {
-            out.extend(attr.meta_item_list().unwrap_or_default());
-        } else if attr.has_name(sym::cfg_attr)
-            && let Some(list) = attr.meta_item_list()
-        {
-            collect_cfg_attr_clap_items(list.get(1..).unwrap_or_default(), &mut out);
-        }
-    }
-    out
-}
-
-/// Pull the inner items of clap-namespace meta items out of the
-/// conditionally-applied tail of a `#[cfg_attr(...)]`, recursing through
-/// nested `cfg_attr` the same way [`cfg_attr_has_derive`] does.
-fn collect_cfg_attr_clap_items(items: &[MetaItemInner], out: &mut Vec<MetaItemInner>) {
-    for item in items {
-        let Some(meta) = item.meta_item() else {
-            continue;
-        };
-        if let MetaItemKind::List(inner) = &meta.kind {
-            if is_clap_namespace_path(meta) {
-                out.extend(inner.iter().cloned());
-            } else if meta.has_name(sym::cfg_attr) {
-                collect_cfg_attr_clap_items(inner.get(1..).unwrap_or_default(), out);
-            }
-        }
-    }
-}
-
-fn is_clap_namespace(attr: &Attribute) -> bool {
-    CLAP_ATTR_NAMESPACES
-        .iter()
-        .any(|ns| attr.has_name(Symbol::intern(ns)))
-}
-
-fn is_clap_namespace_path(meta: &rustc_ast::MetaItem) -> bool {
-    meta.path.segments.last().is_some_and(|segment| {
-        CLAP_ATTR_NAMESPACES
-            .iter()
-            .any(|ns| segment.ident.name == Symbol::intern(ns))
-    })
+    attribute_calls_of(attrs)
+        .into_iter()
+        .filter(|call| CLAP_ATTR_NAMESPACES.contains(&call.name.as_str()))
+        .filter_map(|call| MetaItemKind::list_from_tokens(call.tokens.clone()))
+        .flatten()
+        .collect()
 }
 
 /// The clap derives that turn a *container's* own (type-level) doc
@@ -279,7 +244,7 @@ const COMMAND_ABOUT_DERIVES: &[&str] = &["Parser", "CommandFactory", "Clap"];
 /// Whether the node's attributes derive a clap help-source trait,
 /// including a `#[cfg_attr(<cfg>, derive(...))]`-gated derive.
 fn has_clap_derive(attrs: &[Attribute]) -> bool {
-    has_derive_matching(attrs, &|name| CLAP_DERIVES.contains(&name))
+    derives_any(&derive_names(attrs), CLAP_DERIVES)
 }
 
 /// Whether an enum's own (type-level) doc comment can reach `--help`. A
@@ -289,47 +254,15 @@ fn has_clap_derive(attrs: &[Attribute]) -> bool {
 /// command-producing trait (`Parser` / `CommandFactory`, or the legacy
 /// `Clap`), which does consume the type doc, the container doc is live.
 fn enum_container_doc_reaches_help(attrs: &[Attribute]) -> bool {
-    !has_derive_matching(attrs, &|name| name == "ValueEnum")
-        || has_derive_matching(attrs, &|name| COMMAND_ABOUT_DERIVES.contains(&name))
+    let derives = derive_names(attrs);
+    !derives_any(&derives, &["ValueEnum"]) || derives_any(&derives, COMMAND_ABOUT_DERIVES)
 }
 
-/// Whether any `#[derive(...)]` on the node — including a
-/// `#[cfg_attr(<cfg>, derive(...))]`-gated one — names a derive matching
-/// `pred`.
-fn has_derive_matching(attrs: &[Attribute], pred: &dyn Fn(&str) -> bool) -> bool {
-    attrs.iter().any(|attr| {
-        if attr.has_name(sym::derive) {
-            attr.meta_item_list()
-                .is_some_and(|entries| derive_entries_match(&entries, pred))
-        } else if attr.has_name(sym::cfg_attr) {
-            attr.meta_item_list()
-                .is_some_and(|args| cfg_attr_has_derive(args.get(1..).unwrap_or(&[]), pred))
-        } else {
-            false
-        }
-    })
-}
-
-fn cfg_attr_has_derive(items: &[MetaItemInner], pred: &dyn Fn(&str) -> bool) -> bool {
-    items.iter().any(|item| {
-        let Some(meta) = item.meta_item() else {
-            return false;
-        };
-        if meta.has_name(sym::derive) {
-            matches!(&meta.kind, MetaItemKind::List(entries) if derive_entries_match(entries, pred))
-        } else if meta.has_name(sym::cfg_attr) {
-            matches!(&meta.kind, MetaItemKind::List(args) if cfg_attr_has_derive(args.get(1..).unwrap_or(&[]), pred))
-        } else {
-            false
-        }
-    })
-}
-
-fn derive_entries_match(entries: &[MetaItemInner], pred: &dyn Fn(&str) -> bool) -> bool {
-    entries.iter().any(|entry| {
-        entry
-            .meta_item()
-            .and_then(|meta| meta.path.segments.last())
-            .is_some_and(|segment| pred(segment.ident.name.as_str()))
-    })
+/// Whether any of `names` — final path segments, as
+/// [`crate::derive_list::derive_names`] yields them — is among the
+/// node's derives.
+fn derives_any(derives: &HashSet<Symbol>, names: &[&str]) -> bool {
+    derives
+        .iter()
+        .any(|derive| names.contains(&derive.as_str()))
 }

--- a/src/rules/import_granularity_mismatch.rs
+++ b/src/rules/import_granularity_mismatch.rs
@@ -304,6 +304,10 @@ fn attr_class(attr: &Attribute) -> AttrClass {
     let is_doc_comment = matches!(attr.kind, AttrKind::DocComment(..))
         || (attr.has_name(sym::doc)
             && matches!(attr.meta_kind(), Some(MetaItemKind::NameValue(_))));
+    // A `cfg_attr` is classified `Cfg` whatever it applies: the question
+    // here is which attributes `respect_cfg_blocks` governs, not whether
+    // the import is conditional, so this is deliberately not
+    // `crate::attr_tokens::is_cfg_gated`.
     if is_doc_comment {
         AttrClass::Doc
     } else if attr.has_name(sym::cfg) || attr.has_name(sym::cfg_attr) {

--- a/src/rules/import_grouping_mismatch.rs
+++ b/src/rules/import_grouping_mismatch.rs
@@ -4,7 +4,7 @@ use rustc_ast::{Item, ItemKind, ModKind, VisibilityKind};
 use rustc_errors::Applicability;
 use rustc_lint::{LateContext, LateLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
-use rustc_span::{BytePos, Span, sym};
+use rustc_span::{BytePos, Span};
 use std::collections::HashSet;
 
 mod check;
@@ -12,6 +12,7 @@ mod classify;
 mod config;
 mod render;
 
+use crate::attr_tokens::is_cfg_gated;
 use crate::common::{DefaultState, resolved_state};
 use crate::enclosing_hir::find_enclosing_hir_ids;
 use crate::module_reparse::{SpanRange, parse_crate_module_files};
@@ -408,11 +409,12 @@ impl ImportGroupingMismatch {
         if item.span.from_expansion() {
             return None;
         }
-        // Only `#[cfg(...)]` gates the import's *existence*, which is what
-        // the trailing cfg group is about. `#[cfg_attr(...)]` conditionally
-        // applies some other attribute — the import itself is always
-        // present — so it does not make a statement cfg-gated for grouping.
-        let is_cfg_gated = item.attrs.iter().any(|attr| attr.has_name(sym::cfg));
+        // A `#[cfg(...)]` gates the import's *existence*, which is what
+        // the trailing cfg group is about — including one applied through
+        // `#[cfg_attr(<cfg>, cfg(...))]`. A `cfg_attr` that applies any
+        // other attribute leaves the import unconditionally present, so
+        // it does not make a statement cfg-gated for grouping.
+        let is_cfg_gated = is_cfg_gated(&item.attrs);
         // A re-export is any `use` with an explicit visibility; only a
         // private (`Inherited`) import is not one. The `reexports` knob
         // keys off this to pull re-exports into their own leading region.

--- a/src/rules/import_grouping_mismatch/config.rs
+++ b/src/rules/import_grouping_mismatch/config.rs
@@ -59,7 +59,11 @@ pub(super) enum Group {
     Thirdparty,
 }
 
-/// How a `#[cfg(...)]`-gated import is grouped.
+/// How a `#[cfg(...)]`-gated import is grouped. An import is gated
+/// whether the `cfg` is written directly or applied through a
+/// `#[cfg_attr(<cfg>, cfg(...))]`; a `cfg_attr` that applies any
+/// other attribute leaves the import unconditionally present and
+/// does not gate it.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum CfgBlockHandling {

--- a/src/rules/impure_macro_arguments/purity.rs
+++ b/src/rules/impure_macro_arguments/purity.rs
@@ -19,6 +19,7 @@
 //! implementation notes. The walker is `take_*`-style per
 //! `planned-rules/IMPLEMENTATION_CONVENTIONS.md`.
 
+use crate::attr_tokens::split_top_level_commas;
 use rustc_ast::token::{Delimiter, IdentIsRaw, Token, TokenKind};
 use rustc_ast::tokenstream::{TokenStream, TokenTree};
 use rustc_span::kw;
@@ -49,23 +50,20 @@ pub(super) struct PurityContext<'a> {
 /// argument's [`looks_like_expression`] check can skip it as a
 /// non-expression position the macro author chose.
 pub(super) fn split_top_level_arguments(stream: &TokenStream) -> Option<Vec<Vec<TokenTree>>> {
-    let mut arguments: Vec<Vec<TokenTree>> = Vec::new();
-    let mut current: Vec<TokenTree> = Vec::new();
-    for tree in stream.iter() {
-        if let TokenTree::Token(token, _) = tree {
-            match token.kind {
-                TokenKind::Semi => return None,
-                TokenKind::Comma => {
-                    arguments.push(core::mem::take(&mut current));
-                    continue;
-                }
-                _ => {}
-            }
-        }
-        current.push(tree.clone());
+    if stream
+        .iter()
+        .any(|tree| matches!(tree, TokenTree::Token(token, _) if token.kind == TokenKind::Semi))
+    {
+        return None;
     }
-    if !current.is_empty() {
-        arguments.push(current);
+    let mut arguments: Vec<Vec<TokenTree>> = split_top_level_commas(stream)
+        .into_iter()
+        .map(|argument| argument.into_iter().cloned().collect())
+        .collect();
+    // A comma opens a new group, so a trailing comma leaves an empty
+    // last group that is not an argument the rule can check.
+    if arguments.last().is_some_and(|argument| argument.is_empty()) {
+        arguments.pop();
     }
     Some(arguments)
 }

--- a/src/rules/unordered_derives.rs
+++ b/src/rules/unordered_derives.rs
@@ -1,5 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
-use rustc_ast::{Attribute, MetaItemInner, MetaItemKind};
+use rustc_ast::Attribute;
+use rustc_ast::tokenstream::TokenStream;
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass, LintContext, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -7,8 +8,10 @@ use rustc_span::sym;
 
 mod ordering;
 
+use crate::attr_tokens::attribute_calls;
 use crate::common::{DefaultState, resolved_state};
-use ordering::{DeriveEntry, Style, desired_order, is_identity};
+use crate::derive_list::derive_entries;
+use ordering::{Style, desired_order, is_identity};
 
 declare_tool_lint! {
     /// ### What it does
@@ -186,75 +189,33 @@ impl EarlyLintPass for UnorderedDerives {
         // still named `cfg_attr` with the `derive(...)` un-applied
         // inside its argument list. A post-expansion pass would never
         // see either, since the derive tokens are consumed during
-        // expansion — that is also why the `cfg_attr` form has to be
-        // unwrapped here rather than waiting for the synthesised
-        // `derive` attribute (which never materialises pre-expansion).
-        if attribute.has_name(sym::derive) {
-            if let Some(entries) = attribute.meta_item_list() {
-                self.check_derive_list(lint_context, &entries);
+        // expansion — that is also why `attribute_calls` has to unwrap
+        // the `cfg_attr` form here rather than waiting for the
+        // synthesised `derive` attribute (which never materialises
+        // pre-expansion).
+        for call in attribute_calls(attribute) {
+            if call.name == sym::derive {
+                self.check_derive_list(lint_context, call.tokens);
             }
-        } else if attribute.has_name(sym::cfg_attr)
-            && let Some(cfg_attr_args) = attribute.meta_item_list()
-        {
-            self.check_cfg_attr_args(lint_context, &cfg_attr_args);
         }
     }
 }
 
 impl UnorderedDerives {
-    /// Order every `derive(...)` gated by a `cfg_attr`, given its
-    /// argument list `cfg_attr(<cfg>, attr_1, attr_2, ...)`. The first
-    /// item is the `cfg` predicate (left untouched); every item after it
-    /// is an attribute the predicate gates. Any of them may be a
-    /// `derive(...)` whose list we must order — or a nested `cfg_attr`
-    /// (`cfg_attr(a, cfg_attr(b, derive(...)))`, equivalent to
-    /// `cfg_attr(all(a, b), derive(...))`), whose own argument list we
-    /// recurse into so a derive wrapped at any nesting depth is reached.
-    fn check_cfg_attr_args(
-        &self,
-        lint_context: &EarlyContext<'_>,
-        cfg_attr_args: &[MetaItemInner],
-    ) {
-        for wrapped_attribute in cfg_attr_args.iter().skip(1) {
-            let Some(wrapped_meta_item) = wrapped_attribute.meta_item() else {
-                continue;
-            };
-            let MetaItemKind::List(entries) = &wrapped_meta_item.kind else {
-                continue;
-            };
-            if wrapped_meta_item.has_name(sym::derive) {
-                self.check_derive_list(lint_context, entries);
-            } else if wrapped_meta_item.has_name(sym::cfg_attr) {
-                self.check_cfg_attr_args(lint_context, entries);
-            }
-        }
-    }
-
-    fn check_derive_list(&self, lint_context: &EarlyContext<'_>, entries: &[MetaItemInner]) {
+    fn check_derive_list(&self, lint_context: &EarlyContext<'_>, tokens: &TokenStream) {
+        // A list with an entry that is not a path is malformed, and
+        // reordering entries we could not read would emit a confusing
+        // suggestion.
+        let Some(parsed) = derive_entries(tokens) else {
+            return;
+        };
         // Fewer than two entries can never be in the wrong order: a
         // zero- or one-entry list is vacuously sorted. The same
         // bail-out also short-circuits the very common case of
         // `#[derive(Foo)]` with a single trait. Two-entry lists
         // *can* be out of order and are analysed in full below.
-        if entries.len() < 2 {
+        if parsed.len() < 2 {
             return;
-        }
-        let mut parsed: Vec<DeriveEntry> = Vec::with_capacity(entries.len());
-        for entry in entries {
-            // `MetaItemInner::Lit` cannot legally appear inside a
-            // `#[derive(...)]` list — derive takes paths only. If we
-            // see one, the attribute is malformed; bail rather than
-            // emit a confusing suggestion.
-            let Some(meta_item) = entry.meta_item() else {
-                return;
-            };
-            let Some(last_segment) = meta_item.path.segments.last() else {
-                return;
-            };
-            parsed.push(DeriveEntry {
-                final_name: last_segment.ident.name.as_str().to_owned(),
-                span: entry.span(),
-            });
         }
         let desired = desired_order(self.style, &self.prefix, &parsed);
         if is_identity(&desired) {
@@ -272,7 +233,7 @@ impl UnorderedDerives {
                 // snippet is unavailable for any reason, fall back
                 // to the final-segment name. The suggestion stays
                 // applicable; only the path prefix is lost.
-                Err(_) => snippets.push(parsed[index].final_name.clone()),
+                Err(_) => snippets.push(parsed[index].name.as_str().to_owned()),
             }
         }
         let new_text = snippets.join(", ");

--- a/src/rules/unordered_derives/ordering.rs
+++ b/src/rules/unordered_derives/ordering.rs
@@ -4,8 +4,8 @@
 //! describing the target source order under a chosen [`Style`]. The
 //! identity permutation means the entries are already in order.
 
+use crate::derive_list::DeriveEntry;
 use core::cmp::Ordering;
-use rustc_span::Span;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -18,16 +18,6 @@ pub(super) enum Style {
     /// listed order; remaining traits are sorted alphabetically
     /// after.
     PrefixThenAlphabetical,
-}
-
-pub(super) struct DeriveEntry {
-    /// Final segment of the entry's path. `serde::Deserialize` is
-    /// represented as `"Deserialize"`. Used for ordering decisions;
-    /// the full path is recovered from `span` via the source map
-    /// when emitting the suggestion.
-    pub(super) final_name: String,
-    /// Source span of the entry, covering its full path text.
-    pub(super) span: Span,
 }
 
 /// Return a permutation of `0..entries.len()` describing the desired
@@ -44,7 +34,7 @@ pub(super) fn desired_order(
             // `slice::sort_by` is stable, so equal-key entries
             // retain their original relative order.
             indices.sort_by(|left, right| {
-                ascii_ci_cmp(&entries[*left].final_name, &entries[*right].final_name)
+                ascii_ci_cmp(entries[*left].name.as_str(), entries[*right].name.as_str())
             });
             indices
         }
@@ -59,7 +49,7 @@ pub(super) fn desired_order(
             // ordering", not "required to be present".
             for prefix_name in prefix {
                 for (index, entry) in entries.iter().enumerate() {
-                    if !used[index] && entry.final_name == *prefix_name {
+                    if !used[index] && entry.name.as_str() == prefix_name.as_str() {
                         order.push(index);
                         used[index] = true;
                         break;
@@ -68,7 +58,7 @@ pub(super) fn desired_order(
             }
             let mut rest: Vec<usize> = (0..entries.len()).filter(|index| !used[*index]).collect();
             rest.sort_by(|left, right| {
-                ascii_ci_cmp(&entries[*left].final_name, &entries[*right].final_name)
+                ascii_ci_cmp(entries[*left].name.as_str(), entries[*right].name.as_str())
             });
             order.extend(rest);
             order

--- a/ui-toml/import_grouping_mismatch/single_block_cfg_trailing/fixture.rs
+++ b/ui-toml/import_grouping_mismatch/single_block_cfg_trailing/fixture.rs
@@ -39,4 +39,14 @@ use std::env::args;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
+struct Sep3;
+
+// Good: a `#[cfg(...)]` applied through a `#[cfg_attr(...)]` gates the
+// import's existence just as a bare one does, so it is hoisted into the
+// trailing block too.
+use std::fmt::Write;
+
+#[cfg_attr(all(), cfg(unix))]
+use std::os::unix::ffi::OsStrExt;
+
 fn main() {}


### PR DESCRIPTION
Resolves <https://github.com/KSXGitHub/perfectionist/issues/390>.

Rules that carried hand-rolled equivalents of `crate::attr_tokens` and `crate::derive_list` now use those helpers instead:

- `unordered_derives` — `attribute_calls` and `derive_entries`, dropping its own `cfg_attr` recursion and its local `DeriveEntry`.
- `clap_help_markdown` — `attribute_calls_of` and `derive_names`, dropping two more `cfg_attr` recursions. Its top-level clap attributes are now matched by final path segment, as its `cfg_attr`-gated ones already were.
- `impure_macro_arguments::split_top_level_arguments` and `macro_template::find_template_literal` — `split_top_level_commas`.
- `import_grouping_mismatch` — `is_cfg_gated`.

Two helpers grew to serve them:

- `derive_list::derive_entries` is `pub(crate)`, yields each entry's span alongside its name, and returns `None` for a list holding a non-path entry.
- `attr_tokens::token_literal` is new: it unwraps a token tree to the literal token it holds, and backs both `attr_tokens::str_literal` and `macro_template`.

One user-visible consequence: an import gated by `#[cfg_attr(<cfg>, cfg(...))]` now joins `import_grouping_mismatch`'s trailing cfg block, while a `cfg_attr` applying any other attribute leaves the import ungated as before. The `CfgBlockHandling` documentation states this.

`import_granularity_mismatch::attr_class` keeps its own check — it decides which attributes `respect_cfg_blocks` governs, not whether an import is conditional — and now carries a comment saying so.