### PR TITLE
docs(rules): headings are titles, not signatures

### DIFF
--- a/rules/allow_attributes.md
+++ b/rules/allow_attributes.md
@@ -79,7 +79,10 @@ fn build_fetcher(/* ... */) {}
 
 Configure via `dylint.toml` under `["perfectionist::allow_attributes"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_exempt_lints`: `[string]` (optional)
+### `extra_exempt_lints`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Extra lints to exempt, on top of the built-in default set (the
 `cfg`-conditional `unused_*` / reachability lints). Names are
@@ -87,20 +90,29 @@ matched against the fully-namespaced lint name shown in
 diagnostics (e.g. `clippy::too_many_arguments`). Merged with the
 defaults rather than replacing them.
 
-### `ignore_exempt_lints`: `[string]` (optional)
+### `ignore_exempt_lints`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Lints to drop from the exempt set, even if they appear in the
 built-in defaults or in `extra_exempt_lints`. Use this to opt a
 default exemption back into rewriting (e.g. `["dead_code"]` in a
 project with no `cfg`-gated dead code).
 
-### `apply_to_outer_scopes`: `boolean` (optional)
+### `apply_to_outer_scopes`
+
+- _Type:_ `boolean`
+- _Optional_
 
 When true, also rewrite crate-level `#![allow(...)]` and
 module-level `#[allow(...)]` attributes. Default `false`
 because `cfg`-conditional bodies inside the scope are common.
 
-### `apply_to_tool_namespaces`: `boolean` (optional)
+### `apply_to_tool_namespaces`
+
+- _Type:_ `boolean`
+- _Optional_
 
 When false, only `clippy::*`, `rustdoc::*`, and built-in lints
 are rewritten; other tool namespaces (`perfectionist::*` and

--- a/rules/allow_attributes.md
+++ b/rules/allow_attributes.md
@@ -79,7 +79,7 @@ fn build_fetcher(/* ... */) {}
 
 Configure via `dylint.toml` under `["perfectionist::allow_attributes"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_exempt_lints`
+### Field: `extra_exempt_lints`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -90,7 +90,7 @@ matched against the fully-namespaced lint name shown in
 diagnostics (e.g. `clippy::too_many_arguments`). Merged with the
 defaults rather than replacing them.
 
-### `ignore_exempt_lints`
+### Field: `ignore_exempt_lints`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -100,7 +100,7 @@ built-in defaults or in `extra_exempt_lints`. Use this to opt a
 default exemption back into rewriting (e.g. `["dead_code"]` in a
 project with no `cfg`-gated dead code).
 
-### `apply_to_outer_scopes`
+### Field: `apply_to_outer_scopes`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -109,7 +109,7 @@ When true, also rewrite crate-level `#![allow(...)]` and
 module-level `#[allow(...)]` attributes. Default `false`
 because `cfg`-conditional bodies inside the scope are common.
 
-### `apply_to_tool_namespaces`
+### Field: `apply_to_tool_namespaces`
 
 - _Type:_ `boolean`
 - _Optional_

--- a/rules/allow_attributes_without_reason.md
+++ b/rules/allow_attributes_without_reason.md
@@ -64,7 +64,10 @@ fn build_fetcher(/* ... */) {}
 
 Configure via `dylint.toml` under `["perfectionist::allow_attributes_without_reason"]`. Every field is optional; the per-field prose below states the default.
 
-### `exempt_lints`: `[string]` (optional)
+### `exempt_lints`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Lints excluded from the requirement. Useful for project-wide
 suppressions whose rationale lives in the project README
@@ -72,7 +75,10 @@ rather than per-site. Each entry is the lint's full name as
 it appears inside the attribute (`clippy::module_name_repetitions`,
 `dead_code`, ...).
 
-### `min_reason_length`: `non-zero unsigned integer` (optional)
+### `min_reason_length`
+
+- _Type:_ `non-zero unsigned integer`
+- _Optional_
 
 Minimum length of the `reason` value. A one- or two-character
 reason (`"x"`, `"ok"`) satisfies the literal presence

--- a/rules/allow_attributes_without_reason.md
+++ b/rules/allow_attributes_without_reason.md
@@ -64,7 +64,7 @@ fn build_fetcher(/* ... */) {}
 
 Configure via `dylint.toml` under `["perfectionist::allow_attributes_without_reason"]`. Every field is optional; the per-field prose below states the default.
 
-### `exempt_lints`
+### Field: `exempt_lints`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -75,7 +75,7 @@ rather than per-site. Each entry is the lint's full name as
 it appears inside the attribute (`clippy::module_name_repetitions`,
 `dead_code`, ...).
 
-### `min_reason_length`
+### Field: `min_reason_length`
 
 - _Type:_ `non-zero unsigned integer`
 - _Optional_

--- a/rules/avoidable_string_escapes.md
+++ b/rules/avoidable_string_escapes.md
@@ -75,7 +75,7 @@ let path = r"C:\Users\foo\bar";
 
 Configure via `dylint.toml` under `["perfectionist::avoidable_string_escapes"]`. Every field is optional; the per-field prose below states the default.
 
-### `min_escapes_to_trigger`
+### Field: `min_escapes_to_trigger`
 
 - _Type:_ `non-zero unsigned integer`
 - _Optional_
@@ -89,7 +89,7 @@ suggesting `r"hello"` for `"hello"` would just trip
 `clippy::needless_raw_strings` on the next pass, and a
 minimum of `1` already excludes that case.
 
-### `eligible_escapes`
+### Field: `eligible_escapes`
 
 - _Type:_ `[string]`
 - _Optional_

--- a/rules/avoidable_string_escapes.md
+++ b/rules/avoidable_string_escapes.md
@@ -75,7 +75,10 @@ let path = r"C:\Users\foo\bar";
 
 Configure via `dylint.toml` under `["perfectionist::avoidable_string_escapes"]`. Every field is optional; the per-field prose below states the default.
 
-### `min_escapes_to_trigger`: `non-zero unsigned integer` (optional)
+### `min_escapes_to_trigger`
+
+- _Type:_ `non-zero unsigned integer`
+- _Optional_
 
 Minimum number of eliminable escapes a string must contain
 before the lint fires. Default `1` catches every escapable
@@ -86,7 +89,10 @@ suggesting `r"hello"` for `"hello"` would just trip
 `clippy::needless_raw_strings` on the next pass, and a
 minimum of `1` already excludes that case.
 
-### `eligible_escapes`: `[string]` (optional)
+### `eligible_escapes`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Escape sequences considered eliminable by switching to raw
 form. Only the three Rust escapes whose decoded character

--- a/rules/bare_email.md
+++ b/rules/bare_email.md
@@ -44,56 +44,81 @@ explicit.
 
 Configure via `dylint.toml` under `["perfectionist::bare_email"]`. Every field is optional; the per-field prose below states the default.
 
-### `style`: `Style` (optional)
+### `style`
+
+- _Type:_ `Style`
+- _Optional_
 
 Required form for compliant email addresses. Defaults to
 `either`.
 
-### `scan_doc_comments`: `boolean` (optional)
+### `scan_doc_comments`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Scan doc comments (`///`, `//!`, `/** */`, `/*! */`).
 Defaults to `true`.
 
-### `scan_regular_comments`: `boolean` (optional)
+### `scan_regular_comments`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Scan regular comments (`//`, `/* */`). Defaults to `true`.
 
-### `skip_addresses`: `[string]` (optional)
+### `skip_addresses`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Skip these exact addresses. Useful for `noreply@github.com`
 and similar placeholders that the project deliberately leaves
 bare in changelog entries. Empty by default.
 
-### `skip_domains`: `[string]` (optional)
+### `skip_domains`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Skip addresses whose domain exactly equals any of these.
 Empty by default.
 
 ### Types
 
-#### `Style` (enum)
+#### `Style`
 
 Required form for compliant email addresses.
 
-##### `"angle_brackets"` (Rust: `AngleBrackets`)
+##### `"angle_brackets"`
+
+- _Rust:_ `AngleBrackets`
 
 Wrap the address with `<` and `>` — `<user@example.com>`.
 
-##### `"mailto"` (Rust: `Mailto`)
+##### `"mailto"`
+
+- _Rust:_ `Mailto`
 
 Prefix the address with `mailto:` — `mailto:user@example.com`.
 
-##### `"both"` (Rust: `Both`)
+##### `"both"`
+
+- _Rust:_ `Both`
 
 Combine both — `<mailto:user@example.com>`.
 
-##### `"either"` (Rust: `Either`)
+##### `"either"`
+
+- _Rust:_ `Either`
 
 Accept any of the three wrapped forms (`<email>`,
 `mailto:email`, or `<mailto:email>`); the autofix emits two
 `MaybeIncorrect` suggestions for the author to pick from.
 
-##### `"forbid"` (Rust: `Forbid`)
+##### `"forbid"`
+
+- _Rust:_ `Forbid`
 
 Forbid email addresses outright — no autofix, just a help
 note recommending the address be moved to an external file

--- a/rules/bare_email.md
+++ b/rules/bare_email.md
@@ -44,7 +44,7 @@ explicit.
 
 Configure via `dylint.toml` under `["perfectionist::bare_email"]`. Every field is optional; the per-field prose below states the default.
 
-### `style`
+### Field: `style`
 
 - _Type:_ `Style`
 - _Optional_
@@ -52,7 +52,7 @@ Configure via `dylint.toml` under `["perfectionist::bare_email"]`. Every field i
 Required form for compliant email addresses. Defaults to
 `either`.
 
-### `scan_doc_comments`
+### Field: `scan_doc_comments`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -60,14 +60,14 @@ Required form for compliant email addresses. Defaults to
 Scan doc comments (`///`, `//!`, `/** */`, `/*! */`).
 Defaults to `true`.
 
-### `scan_regular_comments`
+### Field: `scan_regular_comments`
 
 - _Type:_ `boolean`
 - _Optional_
 
 Scan regular comments (`//`, `/* */`). Defaults to `true`.
 
-### `skip_addresses`
+### Field: `skip_addresses`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -76,7 +76,7 @@ Skip these exact addresses. Useful for `noreply@github.com`
 and similar placeholders that the project deliberately leaves
 bare in changelog entries. Empty by default.
 
-### `skip_domains`
+### Field: `skip_domains`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -86,29 +86,29 @@ Empty by default.
 
 ### Types
 
-#### `Style`
+#### Type: `Style`
 
 Required form for compliant email addresses.
 
-##### `"angle_brackets"`
+##### Choice: `"angle_brackets"`
 
 - _Rust:_ `AngleBrackets`
 
 Wrap the address with `<` and `>` — `<user@example.com>`.
 
-##### `"mailto"`
+##### Choice: `"mailto"`
 
 - _Rust:_ `Mailto`
 
 Prefix the address with `mailto:` — `mailto:user@example.com`.
 
-##### `"both"`
+##### Choice: `"both"`
 
 - _Rust:_ `Both`
 
 Combine both — `<mailto:user@example.com>`.
 
-##### `"either"`
+##### Choice: `"either"`
 
 - _Rust:_ `Either`
 
@@ -116,7 +116,7 @@ Accept any of the three wrapped forms (`<email>`,
 `mailto:email`, or `<mailto:email>`); the autofix emits two
 `MaybeIncorrect` suggestions for the author to pick from.
 
-##### `"forbid"`
+##### Choice: `"forbid"`
 
 - _Rust:_ `Forbid`
 

--- a/rules/bare_identifier_reference.md
+++ b/rules/bare_identifier_reference.md
@@ -64,7 +64,7 @@ write an explicit reference link instead:
 
 Configure via `dylint.toml` under `["perfectionist::bare_identifier_reference"]`. Every field is optional; the per-field prose below states the default.
 
-### `skip_idents`
+### Field: `skip_idents`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -75,7 +75,7 @@ comment deliberately mentions without wanting a cross-reference
 — a historical type kept for context, or a word that happens to
 collide with an in-scope item but is meant as prose.
 
-### `reference_scope`
+### Field: `reference_scope`
 
 - _Type:_ `ReferenceScope`
 - _Optional_
@@ -88,7 +88,7 @@ churn, so a project can narrow (or widen) this. Defaults to
 `crate`: a project's own items are kept linked, but mentions of
 the standard library and third-party crates are left alone.
 
-### `check_pascal_case`
+### Field: `check_pascal_case`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -100,7 +100,7 @@ A mixed or non-conformist name (`fooBar`, `foo_BAR`, `__foo`,
 is rare and, when it matches a local identifier, rarely an
 accident.
 
-### `check_upper_case`
+### Field: `check_upper_case`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -113,7 +113,7 @@ A mixed or non-conformist name (`fooBar`, `foo_BAR`, `__foo`,
 is rare and, when it matches a local identifier, rarely an
 accident.
 
-### `check_snake_case`
+### Field: `check_snake_case`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -125,7 +125,7 @@ A mixed or non-conformist name (`fooBar`, `foo_BAR`, `__foo`,
 is rare and, when it matches a local identifier, rarely an
 accident.
 
-### `min_words`
+### Field: `min_words`
 
 - _Type:_ `non-zero unsigned integer`
 - _Optional_
@@ -142,21 +142,21 @@ an accident.
 
 ### Types
 
-#### `ReferenceScope`
+#### Type: `ReferenceScope`
 
 How far from the documenting item a referenced name may resolve for
 the rule to check it, configured by `reference_scope`. The axis is
 *where the referenced item lives relative to the documenting item's
 module*, not the spelling of the `use` path that brought it in.
 
-##### `"own_module"`
+##### Choice: `"own_module"`
 
 - _Rust:_ `OwnModule`
 
 Only items defined directly in the documenting item's own module.
 Every name reached through a `use` is left alone.
 
-##### `"module_tree"`
+##### Choice: `"module_tree"`
 
 - _Rust:_ `ModuleTree`
 
@@ -165,7 +165,7 @@ through `use self::child::Item`), but still not names that reach
 outside the module — `use super::...`, `use crate::...`, and
 imports from other crates.
 
-##### `"crate"`
+##### Choice: `"crate"`
 
 - _Rust:_ `Crate`
 
@@ -175,7 +175,7 @@ documentation drifts — a rename leaves a stale mention — while the
 standard library and third-party crates are stable and outside the
 project's control, so a bare mention of them is low risk.
 
-##### `"third_party"`
+##### Choice: `"third_party"`
 
 - _Rust:_ `ThirdParty`
 
@@ -184,7 +184,7 @@ standard / built-in libraries (`std`, `core`, `alloc`,
 `proc_macro`, `test`). Use this when dependency references are
 worth checking but the frozen standard library is not.
 
-##### `"anywhere"`
+##### Choice: `"anywhere"`
 
 - _Rust:_ `Anywhere`
 

--- a/rules/bare_identifier_reference.md
+++ b/rules/bare_identifier_reference.md
@@ -64,7 +64,10 @@ write an explicit reference link instead:
 
 Configure via `dylint.toml` under `["perfectionist::bare_identifier_reference"]`. Every field is optional; the per-field prose below states the default.
 
-### `skip_idents`: `[string]` (optional)
+### `skip_idents`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Identifiers the rule never suggests linking, even when they
 resolve in scope. Empty by default. Use this for a name a doc
@@ -72,7 +75,10 @@ comment deliberately mentions without wanting a cross-reference
 — a historical type kept for context, or a word that happens to
 collide with an in-scope item but is meant as prose.
 
-### `reference_scope`: `ReferenceScope` (optional)
+### `reference_scope`
+
+- _Type:_ `ReferenceScope`
+- _Optional_
 
 How far from the documenting item a referenced name may resolve
 for the rule to check it, by where the referenced item lives in
@@ -82,7 +88,10 @@ churn, so a project can narrow (or widen) this. Defaults to
 `crate`: a project's own items are kept linked, but mentions of
 the standard library and third-party crates are left alone.
 
-### `check_pascal_case`: `boolean` (optional)
+### `check_pascal_case`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Whether to check `PascalCase` names. Defaults to `true`.
 
@@ -91,7 +100,10 @@ A mixed or non-conformist name (`fooBar`, `foo_BAR`, `__foo`,
 is rare and, when it matches a local identifier, rarely an
 accident.
 
-### `check_upper_case`: `boolean` (optional)
+### `check_upper_case`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Whether to check `UPPER_CASE` (`SCREAMING_SNAKE_CASE`) names.
 Defaults to `true`.
@@ -101,7 +113,10 @@ A mixed or non-conformist name (`fooBar`, `foo_BAR`, `__foo`,
 is rare and, when it matches a local identifier, rarely an
 accident.
 
-### `check_snake_case`: `boolean` (optional)
+### `check_snake_case`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Whether to check `snake_case` names. Defaults to `true`.
 
@@ -110,7 +125,10 @@ A mixed or non-conformist name (`fooBar`, `foo_BAR`, `__foo`,
 is rare and, when it matches a local identifier, rarely an
 accident.
 
-### `min_words`: `non-zero unsigned integer` (optional)
+### `min_words`
+
+- _Type:_ `non-zero unsigned integer`
+- _Optional_
 
 Minimum number of words a name must have to be checked. Defaults
 to `1` (check everything). At `3`, `foo`, `foo_bar`, `Foo`,
@@ -124,26 +142,32 @@ an accident.
 
 ### Types
 
-#### `ReferenceScope` (enum)
+#### `ReferenceScope`
 
 How far from the documenting item a referenced name may resolve for
 the rule to check it, configured by `reference_scope`. The axis is
 *where the referenced item lives relative to the documenting item's
 module*, not the spelling of the `use` path that brought it in.
 
-##### `"own_module"` (Rust: `OwnModule`)
+##### `"own_module"`
+
+- _Rust:_ `OwnModule`
 
 Only items defined directly in the documenting item's own module.
 Every name reached through a `use` is left alone.
 
-##### `"module_tree"` (Rust: `ModuleTree`)
+##### `"module_tree"`
+
+- _Rust:_ `ModuleTree`
 
 Also items from within that module's own subtree (e.g. reached
 through `use self::child::Item`), but still not names that reach
 outside the module — `use super::...`, `use crate::...`, and
 imports from other crates.
 
-##### `"crate"` (Rust: `Crate`)
+##### `"crate"`
+
+- _Rust:_ `Crate`
 
 Any item defined anywhere in the current crate (first-party), but
 nothing from another crate. A project's own items are where
@@ -151,14 +175,18 @@ documentation drifts — a rename leaves a stale mention — while the
 standard library and third-party crates are stable and outside the
 project's control, so a bare mention of them is low risk.
 
-##### `"third_party"` (Rust: `ThirdParty`)
+##### `"third_party"`
+
+- _Rust:_ `ThirdParty`
 
 The current crate and its third-party dependencies, but not the
 standard / built-in libraries (`std`, `core`, `alloc`,
 `proc_macro`, `test`). Use this when dependency references are
 worth checking but the frozen standard library is not.
 
-##### `"anywhere"` (Rust: `Anywhere`)
+##### `"anywhere"`
+
+- _Rust:_ `Anywhere`
 
 Any name that resolves in scope, however it got there — including
 the standard library.

--- a/rules/bare_issue_reference.md
+++ b/rules/bare_issue_reference.md
@@ -57,7 +57,7 @@ and the pull-request link for the other:
 
 Configure via `dylint.toml` under `["perfectionist::bare_issue_reference"]`. Every field is optional; the per-field prose below states the default.
 
-### `forge`
+### Field: `forge`
 
 - _Type:_ `Forge`
 - _Optional_
@@ -73,7 +73,7 @@ host that gives no such hint (e.g. `git.example.com`). If it is
 neither set nor detected from the host, no issue / PR link is
 suggested.
 
-### `repository`
+### Field: `repository`
 
 - _Type:_ `string`
 - _Optional_
@@ -84,7 +84,7 @@ The repository's URL, in any form you'd clone or paste: an
 scp-like shorthand (`"git@github.com:owner/repo.git"`). No
 fixed default.
 
-### `suggest_issue_url`
+### Field: `suggest_issue_url`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -92,7 +92,7 @@ fixed default.
 Offer a suggestion that links the reference as an *issue*.
 Defaults to `true`.
 
-### `suggest_pr_url`
+### Field: `suggest_pr_url`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -102,7 +102,7 @@ request*. Defaults to `true`. Ignored on GitLab, where a bare
 `#NNN` is always an issue (merge requests are written `!NNN`),
 so only the issue suggestion is offered there.
 
-### `doc_comment_form`
+### Field: `doc_comment_form`
 
 - _Type:_ `DocForm`
 - _Optional_
@@ -114,7 +114,7 @@ the `#N` token is rewritten and the definition is left to the
 author). Defaults to `inline`. Ignored for plain-comment fixes
 — those follow `plain_comment_form` instead.
 
-### `include_plain_comments`
+### Field: `include_plain_comments`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -125,7 +125,7 @@ shape (since plain comments aren't markdown). Plain block
 comments (`/* ... */`) are out of scope regardless.
 Defaults to `false`.
 
-### `plain_comment_form`
+### Field: `plain_comment_form`
 
 - _Type:_ `PlainForm`
 - _Optional_
@@ -137,46 +137,46 @@ configured.
 
 ### Types
 
-#### `Forge`
+#### Type: `Forge`
 
 A recognised git-hosting service. The chosen forge fixes the
 issue / PR URL layout. It can be given explicitly (needed for a
 self-hosted instance, whose host isn't recognised) or left unset
 and detected from the `repository` host.
 
-##### `"github"`
+##### Choice: `"github"`
 
 - _Rust:_ `GitHub`
 
 GitHub or a GitHub Enterprise instance. Paths:
 `/issues/{number}`, `/pull/{number}`.
 
-##### `"gitlab"`
+##### Choice: `"gitlab"`
 
 - _Rust:_ `GitLab`
 
 GitLab (gitlab.com or self-hosted). Paths:
 `/-/issues/{number}`, `/-/merge_requests/{number}`.
 
-##### `"gitea"`
+##### Choice: `"gitea"`
 
 - _Rust:_ `Gitea`
 
 Gitea / Forgejo (including Codeberg). Paths:
 `/issues/{number}`, `/pulls/{number}`.
 
-#### `DocForm`
+#### Type: `DocForm`
 
 Markdown-link shape produced by the autofix inside doc comments.
 
-##### `"inline"`
+##### Choice: `"inline"`
 
 - _Rust:_ `Inline`
 
 `[#123](URL)` — the URL is inlined. Keeps `#123` as the
 visible link text.
 
-##### `"reference"`
+##### Choice: `"reference"`
 
 - _Rust:_ `Reference`
 
@@ -186,7 +186,7 @@ definition). In a `/** */` block doc comment the definition
 can't be placed safely, so there the fix rewrites only the
 `#123` token and leaves the definition to the author.
 
-##### `"bare_url"`
+##### Choice: `"bare_url"`
 
 - _Rust:_ `BareUrl`
 
@@ -196,19 +196,19 @@ comment the sibling `perfectionist::bare_url` lint then flags
 the substituted URL; pick `bracketed_url` for a form it
 accepts.
 
-##### `"bracketed_url"`
+##### Choice: `"bracketed_url"`
 
 - _Rust:_ `BracketedUrl`
 
 `<https://.../issues/123>` — a markdown autolink replaces the
 `#123` token outright. `bare_url` accepts this form.
 
-#### `PlainForm`
+#### Type: `PlainForm`
 
 URL shape used inside plain `//` comments when
 `include_plain_comments = true`.
 
-##### `"bare_url"`
+##### Choice: `"bare_url"`
 
 - _Rust:_ `BareUrl`
 
@@ -218,7 +218,7 @@ sibling `perfectionist::bare_url` lint, whose default also
 scans regular comments, will then flag the substituted URL —
 pick `bracketed_url` to produce a form both rules accept.
 
-##### `"bracketed_url"`
+##### Choice: `"bracketed_url"`
 
 - _Rust:_ `BracketedUrl`
 

--- a/rules/bare_issue_reference.md
+++ b/rules/bare_issue_reference.md
@@ -57,7 +57,10 @@ and the pull-request link for the other:
 
 Configure via `dylint.toml` under `["perfectionist::bare_issue_reference"]`. Every field is optional; the per-field prose below states the default.
 
-### `forge`: `Forge` (optional)
+### `forge`
+
+- _Type:_ `Forge`
+- _Optional_
 
 Git-hosting service the repository is on — one of `github`,
 `gitlab`, `gitea` — which fixes the issue / PR path layout.
@@ -70,7 +73,10 @@ host that gives no such hint (e.g. `git.example.com`). If it is
 neither set nor detected from the host, no issue / PR link is
 suggested.
 
-### `repository`: `string` (optional)
+### `repository`
+
+- _Type:_ `string`
+- _Optional_
 
 The repository's URL, in any form you'd clone or paste: an
 `http(s)://` URL (`"https://github.com/owner/repo"`), an
@@ -78,19 +84,28 @@ The repository's URL, in any form you'd clone or paste: an
 scp-like shorthand (`"git@github.com:owner/repo.git"`). No
 fixed default.
 
-### `suggest_issue_url`: `boolean` (optional)
+### `suggest_issue_url`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Offer a suggestion that links the reference as an *issue*.
 Defaults to `true`.
 
-### `suggest_pr_url`: `boolean` (optional)
+### `suggest_pr_url`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Offer a suggestion that links the reference as a *pull
 request*. Defaults to `true`. Ignored on GitLab, where a bare
 `#NNN` is always an issue (merge requests are written `!NNN`),
 so only the issue suggestion is offered there.
 
-### `doc_comment_form`: `DocForm` (optional)
+### `doc_comment_form`
+
+- _Type:_ `DocForm`
+- _Optional_
 
 Doc-comment fix form: `inline` for `[#N](URL)`, `reference`
 for the two-piece `[#N]` + `[#N]: URL` form (the definition is
@@ -99,7 +114,10 @@ the `#N` token is rewritten and the definition is left to the
 author). Defaults to `inline`. Ignored for plain-comment fixes
 — those follow `plain_comment_form` instead.
 
-### `include_plain_comments`: `boolean` (optional)
+### `include_plain_comments`
+
+- _Type:_ `boolean`
+- _Optional_
 
 When `true`, also lint plain `//` line comments. The
 autofix in plain comments uses `plain_comment_form`'s URL
@@ -107,7 +125,10 @@ shape (since plain comments aren't markdown). Plain block
 comments (`/* ... */`) are out of scope regardless.
 Defaults to `false`.
 
-### `plain_comment_form`: `PlainForm` (optional)
+### `plain_comment_form`
+
+- _Type:_ `PlainForm`
+- _Optional_
 
 Replacement form used inside plain `//` comments when
 `include_plain_comments = true`. Defaults to `bare_url`.
@@ -116,38 +137,48 @@ configured.
 
 ### Types
 
-#### `Forge` (enum)
+#### `Forge`
 
 A recognised git-hosting service. The chosen forge fixes the
 issue / PR URL layout. It can be given explicitly (needed for a
 self-hosted instance, whose host isn't recognised) or left unset
 and detected from the `repository` host.
 
-##### `"github"` (Rust: `GitHub`)
+##### `"github"`
+
+- _Rust:_ `GitHub`
 
 GitHub or a GitHub Enterprise instance. Paths:
 `/issues/{number}`, `/pull/{number}`.
 
-##### `"gitlab"` (Rust: `GitLab`)
+##### `"gitlab"`
+
+- _Rust:_ `GitLab`
 
 GitLab (gitlab.com or self-hosted). Paths:
 `/-/issues/{number}`, `/-/merge_requests/{number}`.
 
-##### `"gitea"` (Rust: `Gitea`)
+##### `"gitea"`
+
+- _Rust:_ `Gitea`
 
 Gitea / Forgejo (including Codeberg). Paths:
 `/issues/{number}`, `/pulls/{number}`.
 
-#### `DocForm` (enum)
+#### `DocForm`
 
 Markdown-link shape produced by the autofix inside doc comments.
 
-##### `"inline"` (Rust: `Inline`)
+##### `"inline"`
+
+- _Rust:_ `Inline`
 
 `[#123](URL)` — the URL is inlined. Keeps `#123` as the
 visible link text.
 
-##### `"reference"` (Rust: `Reference`)
+##### `"reference"`
+
+- _Rust:_ `Reference`
 
 `[#123]`, with a matching `[#123]: URL` definition appended to
 the end of the doc block (after a blank line so it parses as a
@@ -155,7 +186,9 @@ definition). In a `/** */` block doc comment the definition
 can't be placed safely, so there the fix rewrites only the
 `#123` token and leaves the definition to the author.
 
-##### `"bare_url"` (Rust: `BareUrl`)
+##### `"bare_url"`
+
+- _Rust:_ `BareUrl`
 
 `https://.../issues/123` — the bare URL replaces the `#123`
 token outright (the `#123` text is not kept). NB: in a doc
@@ -163,17 +196,21 @@ comment the sibling `perfectionist::bare_url` lint then flags
 the substituted URL; pick `bracketed_url` for a form it
 accepts.
 
-##### `"bracketed_url"` (Rust: `BracketedUrl`)
+##### `"bracketed_url"`
+
+- _Rust:_ `BracketedUrl`
 
 `<https://.../issues/123>` — a markdown autolink replaces the
 `#123` token outright. `bare_url` accepts this form.
 
-#### `PlainForm` (enum)
+#### `PlainForm`
 
 URL shape used inside plain `//` comments when
 `include_plain_comments = true`.
 
-##### `"bare_url"` (Rust: `BareUrl`)
+##### `"bare_url"`
+
+- _Rust:_ `BareUrl`
 
 Substitute the URL itself (`https://...`), unwrapped.
 Many editors auto-detect a bare URL as clickable. NB: the
@@ -181,7 +218,9 @@ sibling `perfectionist::bare_url` lint, whose default also
 scans regular comments, will then flag the substituted URL —
 pick `bracketed_url` to produce a form both rules accept.
 
-##### `"bracketed_url"` (Rust: `BracketedUrl`)
+##### `"bracketed_url"`
+
+- _Rust:_ `BracketedUrl`
 
 Substitute `<https://...>`. The angle-bracket delimiter gives
 the URL a clear boundary when it abuts surrounding

--- a/rules/bare_url.md
+++ b/rules/bare_url.md
@@ -40,16 +40,25 @@ them, GitHub renders them, but plain CommonMark does not. The
 
 Configure via `dylint.toml` under `["perfectionist::bare_url"]`. Every field is optional; the per-field prose below states the default.
 
-### `scan_doc_comments`: `boolean` (optional)
+### `scan_doc_comments`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Scan doc comments (`///`, `//!`, `/** */`, `/*! */`).
 Defaults to `true`.
 
-### `scan_regular_comments`: `boolean` (optional)
+### `scan_regular_comments`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Scan regular comments (`//`, `/* */`). Defaults to `true`.
 
-### `safe_trailing_chars`: `[single-character string]` (optional)
+### `safe_trailing_chars`
+
+- _Type:_ `[single-character string]`
+- _Optional_
 
 Characters that, when the URL ends in one of them, keep the
 autofix at `MachineApplicable`. Defaults to `["/", "_", "-",
@@ -57,7 +66,10 @@ autofix at `MachineApplicable`. Defaults to `["/", "_", "-",
 treated as safe regardless of this list; entries here
 supplement that built-in set.
 
-### `skip_hosts`: `[string]` (optional)
+### `skip_hosts`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Hosts to skip, compared case-insensitively. Defaults to
 `["localhost"]`.

--- a/rules/bare_url.md
+++ b/rules/bare_url.md
@@ -40,7 +40,7 @@ them, GitHub renders them, but plain CommonMark does not. The
 
 Configure via `dylint.toml` under `["perfectionist::bare_url"]`. Every field is optional; the per-field prose below states the default.
 
-### `scan_doc_comments`
+### Field: `scan_doc_comments`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -48,14 +48,14 @@ Configure via `dylint.toml` under `["perfectionist::bare_url"]`. Every field is 
 Scan doc comments (`///`, `//!`, `/** */`, `/*! */`).
 Defaults to `true`.
 
-### `scan_regular_comments`
+### Field: `scan_regular_comments`
 
 - _Type:_ `boolean`
 - _Optional_
 
 Scan regular comments (`//`, `/* */`). Defaults to `true`.
 
-### `safe_trailing_chars`
+### Field: `safe_trailing_chars`
 
 - _Type:_ `[single-character string]`
 - _Optional_
@@ -66,7 +66,7 @@ autofix at `MachineApplicable`. Defaults to `["/", "_", "-",
 treated as safe regardless of this list; entries here
 supplement that built-in set.
 
-### `skip_hosts`
+### Field: `skip_hosts`
 
 - _Type:_ `[string]`
 - _Optional_

--- a/rules/clap_help_markdown.md
+++ b/rules/clap_help_markdown.md
@@ -89,7 +89,10 @@ struct Cli {
 
 Configure via `dylint.toml` under `["perfectionist::clap_help_markdown"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_constructs`: `[ConstructCategory]` (optional)
+### `extra_constructs`
+
+- _Type:_ `[ConstructCategory]`
+- _Optional_
 
 Markdown constructs to forbid in addition to the built-in default
 set (`html`, `inline_link`, `reference_link`, `intra_doc_link`,
@@ -97,7 +100,10 @@ set (`html`, `inline_link`, `reference_link`, `intra_doc_link`,
 `italic`, and `list` are the usual additions — clap renders them
 acceptably, so they are off by default.
 
-### `ignore_constructs`: `[ConstructCategory]` (optional)
+### `ignore_constructs`
+
+- _Type:_ `[ConstructCategory]`
+- _Optional_
 
 Constructs to drop from the forbidden set, even if they appear in
 the built-in defaults. Empty by default; applied after the merge
@@ -105,7 +111,10 @@ with `extra_constructs`, so this knob always wins. Use it to
 permit a construct in help text, e.g.
 `ignore_constructs = ["code_span"]`.
 
-### `require_help_override`: `boolean` (optional)
+### `require_help_override`
+
+- _Type:_ `boolean`
+- _Optional_
 
 For projects that never let a doc comment become `--help` text,
 preferring an explicit clap override (`#[arg(help = "...")]`,
@@ -124,7 +133,7 @@ a missing override rather than per markdown construct. Defaults to
 
 ### Types
 
-#### `ConstructCategory` (enum)
+#### `ConstructCategory`
 
 A markdown construct category the rule can be configured to forbid,
 as it appears in the `extra_constructs` / `ignore_constructs` arrays
@@ -133,43 +142,63 @@ names: `reference_link` covers both a `[text][id]` link and its
 `[id]: dest` definition, while an autolink (`<https://example.com>`)
 falls under no category at all and is never forbidden.
 
-##### `"html"` (Rust: `Html`)
+##### `"html"`
+
+- _Rust:_ `Html`
 
 Raw HTML tags (`<br>`, `<code>`, `<a href="...">`, ...).
 
-##### `"inline_link"` (Rust: `InlineLink`)
+##### `"inline_link"`
+
+- _Rust:_ `InlineLink`
 
 Inline links: `[text](https://example.com)`.
 
-##### `"reference_link"` (Rust: `ReferenceLink`)
+##### `"reference_link"`
+
+- _Rust:_ `ReferenceLink`
 
 Reference links (`[text][id]`) and their `[id]: ...`
 definitions.
 
-##### `"intra_doc_link"` (Rust: `IntraDocLink`)
+##### `"intra_doc_link"`
+
+- _Rust:_ `IntraDocLink`
 
 Intra-doc links: `` [`Type`] `` and `[Type]`.
 
-##### `"code_block"` (Rust: `CodeBlock`)
+##### `"code_block"`
+
+- _Rust:_ `CodeBlock`
 
 Fenced, `~~~`-fenced, or four-space-indented code blocks.
 
-##### `"code_span"` (Rust: `CodeSpan`)
+##### `"code_span"`
+
+- _Rust:_ `CodeSpan`
 
 Inline code spans: `` `value` ``.
 
-##### `"heading"` (Rust: `Heading`)
+##### `"heading"`
+
+- _Rust:_ `Heading`
 
 ATX (`# Heading`) and Setext (`Heading\n=====`) headings.
 
-##### `"bold"` (Rust: `Bold`)
+##### `"bold"`
+
+- _Rust:_ `Bold`
 
 `**bold**` / `__bold__` strong emphasis.
 
-##### `"italic"` (Rust: `Italic`)
+##### `"italic"`
+
+- _Rust:_ `Italic`
 
 `*italic*` / `_italic_` emphasis.
 
-##### `"list"` (Rust: `List`)
+##### `"list"`
+
+- _Rust:_ `List`
 
 Bullet and ordered list markers.

--- a/rules/clap_help_markdown.md
+++ b/rules/clap_help_markdown.md
@@ -89,7 +89,7 @@ struct Cli {
 
 Configure via `dylint.toml` under `["perfectionist::clap_help_markdown"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_constructs`
+### Field: `extra_constructs`
 
 - _Type:_ `[ConstructCategory]`
 - _Optional_
@@ -100,7 +100,7 @@ set (`html`, `inline_link`, `reference_link`, `intra_doc_link`,
 `italic`, and `list` are the usual additions — clap renders them
 acceptably, so they are off by default.
 
-### `ignore_constructs`
+### Field: `ignore_constructs`
 
 - _Type:_ `[ConstructCategory]`
 - _Optional_
@@ -111,7 +111,7 @@ with `extra_constructs`, so this knob always wins. Use it to
 permit a construct in help text, e.g.
 `ignore_constructs = ["code_span"]`.
 
-### `require_help_override`
+### Field: `require_help_override`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -133,7 +133,7 @@ a missing override rather than per markdown construct. Defaults to
 
 ### Types
 
-#### `ConstructCategory`
+#### Type: `ConstructCategory`
 
 A markdown construct category the rule can be configured to forbid,
 as it appears in the `extra_constructs` / `ignore_constructs` arrays
@@ -142,62 +142,62 @@ names: `reference_link` covers both a `[text][id]` link and its
 `[id]: dest` definition, while an autolink (`<https://example.com>`)
 falls under no category at all and is never forbidden.
 
-##### `"html"`
+##### Choice: `"html"`
 
 - _Rust:_ `Html`
 
 Raw HTML tags (`<br>`, `<code>`, `<a href="...">`, ...).
 
-##### `"inline_link"`
+##### Choice: `"inline_link"`
 
 - _Rust:_ `InlineLink`
 
 Inline links: `[text](https://example.com)`.
 
-##### `"reference_link"`
+##### Choice: `"reference_link"`
 
 - _Rust:_ `ReferenceLink`
 
 Reference links (`[text][id]`) and their `[id]: ...`
 definitions.
 
-##### `"intra_doc_link"`
+##### Choice: `"intra_doc_link"`
 
 - _Rust:_ `IntraDocLink`
 
 Intra-doc links: `` [`Type`] `` and `[Type]`.
 
-##### `"code_block"`
+##### Choice: `"code_block"`
 
 - _Rust:_ `CodeBlock`
 
 Fenced, `~~~`-fenced, or four-space-indented code blocks.
 
-##### `"code_span"`
+##### Choice: `"code_span"`
 
 - _Rust:_ `CodeSpan`
 
 Inline code spans: `` `value` ``.
 
-##### `"heading"`
+##### Choice: `"heading"`
 
 - _Rust:_ `Heading`
 
 ATX (`# Heading`) and Setext (`Heading\n=====`) headings.
 
-##### `"bold"`
+##### Choice: `"bold"`
 
 - _Rust:_ `Bold`
 
 `**bold**` / `__bold__` strong emphasis.
 
-##### `"italic"`
+##### Choice: `"italic"`
 
 - _Rust:_ `Italic`
 
 `*italic*` / `_italic_` emphasis.
 
-##### `"list"`
+##### Choice: `"list"`
 
 - _Rust:_ `List`
 

--- a/rules/excessive_inline_tests.md
+++ b/rules/excessive_inline_tests.md
@@ -72,7 +72,7 @@ mod tests;
 
 Configure via `dylint.toml` under `["perfectionist::excessive_inline_tests"]`. Every field is optional; the per-field prose below states the default.
 
-### `inline_style`
+### Field: `inline_style`
 
 - _Type:_ `InlineStyle`
 - _Optional_
@@ -80,7 +80,7 @@ Configure via `dylint.toml` under `["perfectionist::excessive_inline_tests"]`. E
 How inline test code is handled. Defaults to
 `external_when_long`.
 
-### `inline_max_lines`
+### Field: `inline_max_lines`
 
 - _Type:_ `unsigned integer`
 - _Optional_
@@ -88,7 +88,7 @@ How inline test code is handled. Defaults to
 Absolute cap, in lines, on the summed inline-test footprint of a
 file under `external_when_long`; always active. Defaults to `50`.
 
-### `inline_max_fraction_of_file`
+### Field: `inline_max_fraction_of_file`
 
 - _Type:_ `float`
 - _Optional_
@@ -100,18 +100,18 @@ relative cap (the default).
 
 ### Types
 
-#### `InlineStyle`
+#### Type: `InlineStyle`
 
 How inline test code is treated (the `inline_style` knob).
 
-##### `"external_only"`
+##### Choice: `"external_only"`
 
 - _Rust:_ `ExternalOnly`
 
 Every inline test item is flagged; all test code must move to an
 external `mod <name>;`, whatever its length.
 
-##### `"external_when_long"`
+##### Choice: `"external_when_long"`
 
 - _Rust:_ `ExternalWhenLong`
 

--- a/rules/excessive_inline_tests.md
+++ b/rules/excessive_inline_tests.md
@@ -72,17 +72,26 @@ mod tests;
 
 Configure via `dylint.toml` under `["perfectionist::excessive_inline_tests"]`. Every field is optional; the per-field prose below states the default.
 
-### `inline_style`: `InlineStyle` (optional)
+### `inline_style`
+
+- _Type:_ `InlineStyle`
+- _Optional_
 
 How inline test code is handled. Defaults to
 `external_when_long`.
 
-### `inline_max_lines`: `unsigned integer` (optional)
+### `inline_max_lines`
+
+- _Type:_ `unsigned integer`
+- _Optional_
 
 Absolute cap, in lines, on the summed inline-test footprint of a
 file under `external_when_long`; always active. Defaults to `50`.
 
-### `inline_max_fraction_of_file`: `float` (optional)
+### `inline_max_fraction_of_file`
+
+- _Type:_ `float`
+- _Optional_
 
 Optional relative cap: the share `inline_test_lines / file_lines`
 a file's inline tests may occupy under `external_when_long`.
@@ -91,16 +100,20 @@ relative cap (the default).
 
 ### Types
 
-#### `InlineStyle` (enum)
+#### `InlineStyle`
 
 How inline test code is treated (the `inline_style` knob).
 
-##### `"external_only"` (Rust: `ExternalOnly`)
+##### `"external_only"`
+
+- _Rust:_ `ExternalOnly`
 
 Every inline test item is flagged; all test code must move to an
 external `mod <name>;`, whatever its length.
 
-##### `"external_when_long"` (Rust: `ExternalWhenLong`)
+##### `"external_when_long"`
+
+- _Rust:_ `ExternalWhenLong`
 
 Inline test code is allowed up to the configured budget; beyond
 that it must move to an external `mod <name>;`.

--- a/rules/exhaustive_error_enums.md
+++ b/rules/exhaustive_error_enums.md
@@ -77,14 +77,14 @@ pub enum RuntimeError {
 
 Configure via `dylint.toml` under `["perfectionist::exhaustive_error_enums"]`. Every field is optional; the per-field prose below states the default.
 
-### `require_for`
+### Field: `require_for`
 
 - _Type:_ `RequireFor`
 - _Optional_
 
 Visibility threshold for the rule.
 
-### `extra_suffixes`
+### Field: `extra_suffixes`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -96,7 +96,7 @@ implementations. Merged with the built-in defaults
 vocabulary here (`Failure`, `Fault`, ...) without having to
 re-state the standard suffix.
 
-### `ignore_suffixes`
+### Field: `ignore_suffixes`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -112,9 +112,9 @@ the by-name branch — types that implement
 
 ### Types
 
-#### `RequireFor`
+#### Type: `RequireFor`
 
-##### `"pub"`
+##### Choice: `"pub"`
 
 - _Rust:_ `Pub`
 
@@ -124,7 +124,7 @@ reachable from outside the crate (declared `pub`, re-exported
 `pub enum FooError` inside a non-`pub` module is not flagged
 because it cannot be matched on by any downstream crate.
 
-##### `"pub_crate"`
+##### Choice: `"pub_crate"`
 
 - _Rust:_ `PubCrate`
 
@@ -134,7 +134,7 @@ to the crate root). Items declared `pub(in some::module)`
 are not promoted by this mode even if their effective reach
 happens to extend to the crate root.
 
-##### `"all"`
+##### Choice: `"all"`
 
 - _Rust:_ `All`
 

--- a/rules/exhaustive_error_enums.md
+++ b/rules/exhaustive_error_enums.md
@@ -77,11 +77,17 @@ pub enum RuntimeError {
 
 Configure via `dylint.toml` under `["perfectionist::exhaustive_error_enums"]`. Every field is optional; the per-field prose below states the default.
 
-### `require_for`: `RequireFor` (optional)
+### `require_for`
+
+- _Type:_ `RequireFor`
+- _Optional_
 
 Visibility threshold for the rule.
 
-### `extra_suffixes`: `[string]` (optional)
+### `extra_suffixes`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Additional identifier suffixes that mark a type as "an
 error" purely by name, without inspecting its trait
@@ -90,7 +96,10 @@ implementations. Merged with the built-in defaults
 vocabulary here (`Failure`, `Fault`, ...) without having to
 re-state the standard suffix.
 
-### `ignore_suffixes`: `[string]` (optional)
+### `ignore_suffixes`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Identifier suffixes to drop from the by-name match set,
 even if they appear in the built-in defaults or in
@@ -103,9 +112,11 @@ the by-name branch — types that implement
 
 ### Types
 
-#### `RequireFor` (enum)
+#### `RequireFor`
 
-##### `"pub"` (Rust: `Pub`)
+##### `"pub"`
+
+- _Rust:_ `Pub`
 
 Require `#[non_exhaustive]` on items that are *effectively*
 reachable from outside the crate (declared `pub`, re-exported
@@ -113,7 +124,9 @@ reachable from outside the crate (declared `pub`, re-exported
 `pub enum FooError` inside a non-`pub` module is not flagged
 because it cannot be matched on by any downstream crate.
 
-##### `"pub_crate"` (Rust: `PubCrate`)
+##### `"pub_crate"`
+
+- _Rust:_ `PubCrate`
 
 In addition to the `Pub` case, require `#[non_exhaustive]`
 on items literally declared `pub(crate)` (i.e., restricted
@@ -121,7 +134,9 @@ to the crate root). Items declared `pub(in some::module)`
 are not promoted by this mode even if their effective reach
 happens to extend to the crate root.
 
-##### `"all"` (Rust: `All`)
+##### `"all"`
+
+- _Rust:_ `All`
 
 Require `#[non_exhaustive]` on every error-shaped item
 regardless of visibility.

--- a/rules/import_granularity_mismatch.md
+++ b/rules/import_granularity_mismatch.md
@@ -99,14 +99,20 @@ use std::collections::HashMap;
 
 Configure via `dylint.toml` under `["perfectionist::import_granularity_mismatch"]`. Every field is optional; the per-field prose below states the default.
 
-### `style`: `Style` (optional)
+### `style`
+
+- _Type:_ `Style`
+- _Optional_
 
 Import-granularity style to enforce. Defaults to `module` — the
 shape that scales best as a `use` block grows. Set `crate` to
 collapse every crate root into one nested `use`, or `item` to
 put every imported name on its own line.
 
-### `respect_cfg_blocks`: `boolean` (optional)
+### `respect_cfg_blocks`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Never merge `use` statements that carry differing `#[cfg(...)]`
 / `#[cfg_attr(...)]` attributes. Defaults to `true`: a
@@ -114,21 +120,30 @@ platform-gated import is never folded together with an
 unconditional one. Set `false` to ignore cfg attributes when
 deciding what may merge.
 
-### `respect_visibility`: `boolean` (optional)
+### `respect_visibility`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Never merge a `pub use` (or `pub(crate) use`, etc.) with a
 plain `use`, or two re-exports whose visibility differs.
 Defaults to `true`. Set `false` to ignore visibility when
 deciding what may merge.
 
-### `respect_doc_comments`: `boolean` (optional)
+### `respect_doc_comments`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Never merge a `use` that carries its own doc comment (`///` or
 `#[doc = "..."]`) into a neighbouring statement, so the comment
 keeps describing exactly the import it was written above.
 Defaults to `true`. Set `false` to allow such a `use` to merge.
 
-### `self_merge`: `SelfMerge` (optional)
+### `self_merge`
+
+- _Type:_ `SelfMerge`
+- _Optional_
 
 Under `style = "crate"`, force one shape when a path segment
 names both an item and a module (`use crate::thing;` next to
@@ -142,31 +157,37 @@ Ignored under `module` and `item` style.
 
 ### Types
 
-#### `Style` (enum)
+#### `Style`
 
 Import-granularity style. The three values map one-to-one onto
 rustfmt's unstable `imports_granularity` option (`Crate`, `Module`,
 `Item`).
 
-##### `"crate"` (Rust: `Crate`)
+##### `"crate"`
+
+- _Rust:_ `Crate`
 
 One `use` per crate root. Every shared prefix is collapsed into
 nested braces, e.g.
 `use std::{collections::HashMap, io::{Error, ErrorKind}};`.
 
-##### `"module"` (Rust: `Module`)
+##### `"module"`
+
+- _Rust:_ `Module`
 
 One `use` per leaf module. Items pulled from the same module are
 merged into a single braced list; items from sibling modules sit
 on their own `use` lines, e.g.
 `use std::collections::{BTreeMap, HashMap};`.
 
-##### `"item"` (Rust: `Item`)
+##### `"item"`
+
+- _Rust:_ `Item`
 
 One `use` per leaf item. Every imported name lives on its own
 line, e.g. `use std::collections::BTreeMap;`.
 
-#### `SelfMerge` (enum)
+#### `SelfMerge`
 
 How to resolve a path segment that names **both** an item and a
 module under `crate` style — `use crate::thing;` next to
@@ -174,13 +195,17 @@ module under `crate` style — `use crate::thing;` next to
 interchangeable, so unless this knob is set the rule offers both and
 the author picks. Only consulted under `style = "crate"`.
 
-##### `"fold"` (Rust: `Fold`)
+##### `"fold"`
+
+- _Rust:_ `Fold`
 
 Always enforce the `self`-fold `use crate::thing::{self, T};` —
 the shape rustfmt's `imports_granularity = "Crate"` produces. The
 sibling-split form is flagged and rewritten to it.
 
-##### `"split"` (Rust: `Split`)
+##### `"split"`
+
+- _Rust:_ `Split`
 
 Always enforce the sibling-split `use crate::{thing, thing::T};`.
 The `self`-fold form is flagged and rewritten to it.

--- a/rules/import_granularity_mismatch.md
+++ b/rules/import_granularity_mismatch.md
@@ -99,7 +99,7 @@ use std::collections::HashMap;
 
 Configure via `dylint.toml` under `["perfectionist::import_granularity_mismatch"]`. Every field is optional; the per-field prose below states the default.
 
-### `style`
+### Field: `style`
 
 - _Type:_ `Style`
 - _Optional_
@@ -109,7 +109,7 @@ shape that scales best as a `use` block grows. Set `crate` to
 collapse every crate root into one nested `use`, or `item` to
 put every imported name on its own line.
 
-### `respect_cfg_blocks`
+### Field: `respect_cfg_blocks`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -120,7 +120,7 @@ platform-gated import is never folded together with an
 unconditional one. Set `false` to ignore cfg attributes when
 deciding what may merge.
 
-### `respect_visibility`
+### Field: `respect_visibility`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -130,7 +130,7 @@ plain `use`, or two re-exports whose visibility differs.
 Defaults to `true`. Set `false` to ignore visibility when
 deciding what may merge.
 
-### `respect_doc_comments`
+### Field: `respect_doc_comments`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -140,7 +140,7 @@ Never merge a `use` that carries its own doc comment (`///` or
 keeps describing exactly the import it was written above.
 Defaults to `true`. Set `false` to allow such a `use` to merge.
 
-### `self_merge`
+### Field: `self_merge`
 
 - _Type:_ `SelfMerge`
 - _Optional_
@@ -157,13 +157,13 @@ Ignored under `module` and `item` style.
 
 ### Types
 
-#### `Style`
+#### Type: `Style`
 
 Import-granularity style. The three values map one-to-one onto
 rustfmt's unstable `imports_granularity` option (`Crate`, `Module`,
 `Item`).
 
-##### `"crate"`
+##### Choice: `"crate"`
 
 - _Rust:_ `Crate`
 
@@ -171,7 +171,7 @@ One `use` per crate root. Every shared prefix is collapsed into
 nested braces, e.g.
 `use std::{collections::HashMap, io::{Error, ErrorKind}};`.
 
-##### `"module"`
+##### Choice: `"module"`
 
 - _Rust:_ `Module`
 
@@ -180,14 +180,14 @@ merged into a single braced list; items from sibling modules sit
 on their own `use` lines, e.g.
 `use std::collections::{BTreeMap, HashMap};`.
 
-##### `"item"`
+##### Choice: `"item"`
 
 - _Rust:_ `Item`
 
 One `use` per leaf item. Every imported name lives on its own
 line, e.g. `use std::collections::BTreeMap;`.
 
-#### `SelfMerge`
+#### Type: `SelfMerge`
 
 How to resolve a path segment that names **both** an item and a
 module under `crate` style — `use crate::thing;` next to
@@ -195,7 +195,7 @@ module under `crate` style — `use crate::thing;` next to
 interchangeable, so unless this knob is set the rule offers both and
 the author picks. Only consulted under `style = "crate"`.
 
-##### `"fold"`
+##### Choice: `"fold"`
 
 - _Rust:_ `Fold`
 
@@ -203,7 +203,7 @@ Always enforce the `self`-fold `use crate::thing::{self, T};` —
 the shape rustfmt's `imports_granularity = "Crate"` produces. The
 sibling-split form is flagged and rewritten to it.
 
-##### `"split"`
+##### Choice: `"split"`
 
 - _Rust:_ `Split`
 

--- a/rules/import_grouping_mismatch.md
+++ b/rules/import_grouping_mismatch.md
@@ -168,7 +168,7 @@ pub use Reflection as HardlinkListReflection;
 
 Configure via `dylint.toml` under `["perfectionist::import_grouping_mismatch"]`. A field marked mandatory must be set; an optional field can be omitted and the per-field prose below states its default.
 
-### `style`
+### Field: `style`
 
 - _Type:_ `Style`
 - _Mandatory_
@@ -177,7 +177,7 @@ The grouping style to enforce: `single_block` or `multi_block`. It
 has no default — a project enabling the rule states which layout
 it wants — so it must be set when the rule is enabled.
 
-### `reexports`
+### Field: `reexports`
 
 - _Type:_ `ReexportGrouping`
 - _Mandatory_
@@ -192,7 +192,7 @@ re-exports (`pub use Item;` / `pub use Item as Alias;`); `by_path`
 gives re-exports no dedicated block at all, classifying each by its
 path like a private import.
 
-### `order`
+### Field: `order`
 
 - _Type:_ `[Group]`
 - _Optional_
@@ -200,7 +200,7 @@ path like a private import.
 The order the groups appear in, top to bottom. Defaults to
 `["std", "internal", "thirdparty"]`.
 
-### `cfg_block_handling`
+### Field: `cfg_block_handling`
 
 - _Type:_ `CfgBlockHandling`
 - _Optional_
@@ -213,18 +213,18 @@ block under `single_block`.
 
 ### Types
 
-#### `Style`
+#### Type: `Style`
 
 How `use` statements are partitioned into blocks.
 
-##### `"single_block"`
+##### Choice: `"single_block"`
 
 - _Rust:_ `SingleBlock`
 
 Every `use` statement sits in one contiguous block, with no
 blank lines between imports.
 
-##### `"multi_block"`
+##### Choice: `"multi_block"`
 
 - _Rust:_ `MultiBlock`
 
@@ -233,14 +233,14 @@ one blank line. The group set is
 std (`std` / `core` / `alloc` / `proc_macro` / `test`), internal
 (`crate` / `super` / `self`), and third-party (every other crate).
 
-#### `ReexportGrouping`
+#### Type: `ReexportGrouping`
 
 How `pub` re-exports are grouped relative to the private imports. A
 re-export is any `use` with an explicit visibility (`pub`,
 `pub(crate)`, `pub(super)`, `pub(in ...)`); a private (`Inherited`)
 import is not one.
 
-##### `"by_path"`
+##### Choice: `"by_path"`
 
 - _Rust:_ `ByPath`
 
@@ -248,7 +248,7 @@ Re-exports get no dedicated block: each is classified purely by
 its path, exactly like a private import, so a `pub use child::Item`
 sits in the same block as a private import of the same origin.
 
-##### `"grouped"`
+##### Choice: `"grouped"`
 
 - _Rust:_ `Grouped`
 
@@ -257,7 +257,7 @@ all private imports, separated by a blank line. A cfg-gated
 re-export stays in this block rather than the trailing cfg block:
 visibility takes precedence, keeping the public surface together.
 
-##### `"split"`
+##### Choice: `"split"`
 
 - _Rust:_ `Split`
 
@@ -272,34 +272,34 @@ crate counts as an alias re-export. As under `grouped`, a cfg-gated
 re-export stays in its re-export sub-block rather than the trailing
 cfg block.
 
-#### `Group`
+#### Type: `Group`
 
 One of the three groups a `use` statement is classified into. The
 `order` knob is a permutation of these three values.
 
-##### `"std"`
+##### Choice: `"std"`
 
 - _Rust:_ `Std`
 
 `std`, `core`, `alloc`, `proc_macro`, `test`.
 
-##### `"internal"`
+##### Choice: `"internal"`
 
 - _Rust:_ `Internal`
 
 `crate`, `super`, `self`.
 
-##### `"thirdparty"`
+##### Choice: `"thirdparty"`
 
 - _Rust:_ `Thirdparty`
 
 Every other crate.
 
-#### `CfgBlockHandling`
+#### Type: `CfgBlockHandling`
 
 How a `#[cfg(...)]`-gated import is grouped.
 
-##### `"trailing"`
+##### Choice: `"trailing"`
 
 - _Rust:_ `Trailing`
 
@@ -308,7 +308,7 @@ regardless of the imported path: an always-last group under
 `multi_block`, a trailing block below the single block under
 `single_block`.
 
-##### `"merge"`
+##### Choice: `"merge"`
 
 - _Rust:_ `Merge`
 

--- a/rules/import_grouping_mismatch.md
+++ b/rules/import_grouping_mismatch.md
@@ -168,13 +168,19 @@ pub use Reflection as HardlinkListReflection;
 
 Configure via `dylint.toml` under `["perfectionist::import_grouping_mismatch"]`. A field marked mandatory must be set; an optional field can be omitted and the per-field prose below states its default.
 
-### `style`: `Style` (mandatory)
+### `style`
+
+- _Type:_ `Style`
+- _Mandatory_
 
 The grouping style to enforce: `single_block` or `multi_block`. It
 has no default — a project enabling the rule states which layout
 it wants — so it must be set when the rule is enabled.
 
-### `reexports`: `ReexportGrouping` (mandatory)
+### `reexports`
+
+- _Type:_ `ReexportGrouping`
+- _Mandatory_
 
 How `pub` re-exports are grouped: `grouped`, `split`, or `by_path`.
 Like `style` it has no default — a project enabling the rule states
@@ -186,12 +192,18 @@ re-exports (`pub use Item;` / `pub use Item as Alias;`); `by_path`
 gives re-exports no dedicated block at all, classifying each by its
 path like a private import.
 
-### `order`: `[Group]` (optional)
+### `order`
+
+- _Type:_ `[Group]`
+- _Optional_
 
 The order the groups appear in, top to bottom. Defaults to
 `["std", "internal", "thirdparty"]`.
 
-### `cfg_block_handling`: `CfgBlockHandling` (optional)
+### `cfg_block_handling`
+
+- _Type:_ `CfgBlockHandling`
+- _Optional_
 
 How `#[cfg(...)]`-gated imports are grouped. Defaults to
 `trailing`: a cfg-gated import forms its own trailing block under
@@ -201,43 +213,53 @@ block under `single_block`.
 
 ### Types
 
-#### `Style` (enum)
+#### `Style`
 
 How `use` statements are partitioned into blocks.
 
-##### `"single_block"` (Rust: `SingleBlock`)
+##### `"single_block"`
+
+- _Rust:_ `SingleBlock`
 
 Every `use` statement sits in one contiguous block, with no
 blank lines between imports.
 
-##### `"multi_block"` (Rust: `MultiBlock`)
+##### `"multi_block"`
+
+- _Rust:_ `MultiBlock`
 
 Imports are partitioned into ordered groups separated by exactly
 one blank line. The group set is
 std (`std` / `core` / `alloc` / `proc_macro` / `test`), internal
 (`crate` / `super` / `self`), and third-party (every other crate).
 
-#### `ReexportGrouping` (enum)
+#### `ReexportGrouping`
 
 How `pub` re-exports are grouped relative to the private imports. A
 re-export is any `use` with an explicit visibility (`pub`,
 `pub(crate)`, `pub(super)`, `pub(in ...)`); a private (`Inherited`)
 import is not one.
 
-##### `"by_path"` (Rust: `ByPath`)
+##### `"by_path"`
+
+- _Rust:_ `ByPath`
 
 Re-exports get no dedicated block: each is classified purely by
 its path, exactly like a private import, so a `pub use child::Item`
 sits in the same block as a private import of the same origin.
 
-##### `"grouped"` (Rust: `Grouped`)
+##### `"grouped"`
+
+- _Rust:_ `Grouped`
 
 Every re-export is pulled into one contiguous leading block above
 all private imports, separated by a blank line. A cfg-gated
 re-export stays in this block rather than the trailing cfg block:
 visibility takes precedence, keeping the public surface together.
 
-##### `"split"` (Rust: `Split`)
+##### `"split"`
+
+- _Rust:_ `Split`
 
 Re-exports form a leading region split into two blank-separated
 blocks: *submodule* re-exports (a multi-segment path such as
@@ -250,35 +272,45 @@ crate counts as an alias re-export. As under `grouped`, a cfg-gated
 re-export stays in its re-export sub-block rather than the trailing
 cfg block.
 
-#### `Group` (enum)
+#### `Group`
 
 One of the three groups a `use` statement is classified into. The
 `order` knob is a permutation of these three values.
 
-##### `"std"` (Rust: `Std`)
+##### `"std"`
+
+- _Rust:_ `Std`
 
 `std`, `core`, `alloc`, `proc_macro`, `test`.
 
-##### `"internal"` (Rust: `Internal`)
+##### `"internal"`
+
+- _Rust:_ `Internal`
 
 `crate`, `super`, `self`.
 
-##### `"thirdparty"` (Rust: `Thirdparty`)
+##### `"thirdparty"`
+
+- _Rust:_ `Thirdparty`
 
 Every other crate.
 
-#### `CfgBlockHandling` (enum)
+#### `CfgBlockHandling`
 
 How a `#[cfg(...)]`-gated import is grouped.
 
-##### `"trailing"` (Rust: `Trailing`)
+##### `"trailing"`
+
+- _Rust:_ `Trailing`
 
 Give every `#[cfg(...)]`-gated import its own trailing block,
 regardless of the imported path: an always-last group under
 `multi_block`, a trailing block below the single block under
 `single_block`.
 
-##### `"merge"` (Rust: `Merge`)
+##### `"merge"`
+
+- _Rust:_ `Merge`
 
 Keep a cfg-gated import with the rest: slotted into its natural
 path group under `multi_block`, or left in the single block under

--- a/rules/impure_macro_arguments.md
+++ b/rules/impure_macro_arguments.md
@@ -104,14 +104,14 @@ debug_assert_eq!(ejected, None, "duplicate");
 
 Configure via `dylint.toml` under `["perfectionist::impure_macro_arguments"]`. Every field is optional; the per-field prose below states the default.
 
-### `mode`
+### Field: `mode`
 
 - _Type:_ `Mode`
 - _Optional_
 
 Eligibility mode. Defaults to `allow_and_deny`.
 
-### `deny_extra`
+### Field: `deny_extra`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -120,7 +120,7 @@ Macros added to the built-in deny set. Each entry is a
 fully-qualified macro path (no trailing `!`) or a bare macro
 name to match by final segment only.
 
-### `allow_extra`
+### Field: `allow_extra`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -131,7 +131,7 @@ name to match by final segment only. Only meaningful in
 `AllowAndDeny` and `Blanket` modes; in `DenyOnly` the allow
 set is unused.
 
-### `ignore`
+### Field: `ignore`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -141,7 +141,7 @@ otherwise match. Each entry is a fully-qualified macro path
 (no trailing `!`) or a bare macro name to match by final
 segment only.
 
-### `extra_pure_methods`
+### Field: `extra_pure_methods`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -156,7 +156,7 @@ for the surrounding macro to drop or duplicate the call
 `O(1)` side-effect-free getter that the lint's syntactic
 classification can't otherwise see.
 
-### `ignore_pure_methods`
+### Field: `ignore_pure_methods`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -169,7 +169,7 @@ the project does not consider pure — for example, removing
 `as_ref` for a project that wraps it in an impure
 implementation.
 
-### `extra_pure_macros`
+### Field: `extra_pure_macros`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -186,7 +186,7 @@ rule's pure-as-drop-or-duplicate-safe definition trivially,
 since there is no runtime expression for the surrounding
 macro to drop or duplicate.
 
-### `ignore_pure_macros`
+### Field: `ignore_pure_macros`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -197,18 +197,18 @@ Checked after the merge, so this knob always wins.
 
 ### Types
 
-#### `Mode`
+#### Type: `Mode`
 
 Eligibility mode.
 
-##### `"deny_only"`
+##### Choice: `"deny_only"`
 
 - _Rust:_ `DenyOnly`
 
 Flag only invocations of the curated deny set (`debug_assert*`
 plus `deny_extra`). Every other macro is silently accepted.
 
-##### `"blanket"`
+##### Choice: `"blanket"`
 
 - _Rust:_ `Blanket`
 
@@ -218,7 +218,7 @@ classification — unless the invocation matches an `allow_extra`
 entry. The built-in allow set is deliberately ignored in this
 mode; project exceptions go in `allow_extra`.
 
-##### `"allow_and_deny"`
+##### Choice: `"allow_and_deny"`
 
 - _Rust:_ `AllowAndDeny`
 

--- a/rules/impure_macro_arguments.md
+++ b/rules/impure_macro_arguments.md
@@ -104,17 +104,26 @@ debug_assert_eq!(ejected, None, "duplicate");
 
 Configure via `dylint.toml` under `["perfectionist::impure_macro_arguments"]`. Every field is optional; the per-field prose below states the default.
 
-### `mode`: `Mode` (optional)
+### `mode`
+
+- _Type:_ `Mode`
+- _Optional_
 
 Eligibility mode. Defaults to `allow_and_deny`.
 
-### `deny_extra`: `[string]` (optional)
+### `deny_extra`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Macros added to the built-in deny set. Each entry is a
 fully-qualified macro path (no trailing `!`) or a bare macro
 name to match by final segment only.
 
-### `allow_extra`: `[string]` (optional)
+### `allow_extra`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Macros added to the built-in allow set. Each entry is a
 fully-qualified macro path (no trailing `!`) or a bare macro
@@ -122,14 +131,20 @@ name to match by final segment only. Only meaningful in
 `AllowAndDeny` and `Blanket` modes; in `DenyOnly` the allow
 set is unused.
 
-### `ignore`: `[string]` (optional)
+### `ignore`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Macros to skip entirely, regardless of which set they would
 otherwise match. Each entry is a fully-qualified macro path
 (no trailing `!`) or a bare macro name to match by final
 segment only.
 
-### `extra_pure_methods`: `[string]` (optional)
+### `extra_pure_methods`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Method names added to the built-in pure-method list. Each
 entry is a bare method identifier (no `()`, no receiver). A
@@ -141,7 +156,10 @@ for the surrounding macro to drop or duplicate the call
 `O(1)` side-effect-free getter that the lint's syntactic
 classification can't otherwise see.
 
-### `ignore_pure_methods`: `[string]` (optional)
+### `ignore_pure_methods`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Method names to drop from the pure-method list, even if they
 appear in the built-in defaults or in `extra_pure_methods`.
@@ -151,7 +169,10 @@ the project does not consider pure — for example, removing
 `as_ref` for a project that wraps it in an impure
 implementation.
 
-### `extra_pure_macros`: `[string]` (optional)
+### `extra_pure_macros`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Macro names added to the built-in pure-macro list. Each
 entry is matched against the invocation's final path segment
@@ -165,7 +186,10 @@ rule's pure-as-drop-or-duplicate-safe definition trivially,
 since there is no runtime expression for the surrounding
 macro to drop or duplicate.
 
-### `ignore_pure_macros`: `[string]` (optional)
+### `ignore_pure_macros`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Macro names to drop from the pure-macro list, even if they
 appear in the built-in defaults or in `extra_pure_macros`.
@@ -173,16 +197,20 @@ Checked after the merge, so this knob always wins.
 
 ### Types
 
-#### `Mode` (enum)
+#### `Mode`
 
 Eligibility mode.
 
-##### `"deny_only"` (Rust: `DenyOnly`)
+##### `"deny_only"`
+
+- _Rust:_ `DenyOnly`
 
 Flag only invocations of the curated deny set (`debug_assert*`
 plus `deny_extra`). Every other macro is silently accepted.
 
-##### `"blanket"` (Rust: `Blanket`)
+##### `"blanket"`
+
+- _Rust:_ `Blanket`
 
 Flag every function-like or array-like invocation that carries
 an impure top-level argument, regardless of any built-in
@@ -190,7 +218,9 @@ classification — unless the invocation matches an `allow_extra`
 entry. The built-in allow set is deliberately ignored in this
 mode; project exceptions go in `allow_extra`.
 
-##### `"allow_and_deny"` (Rust: `AllowAndDeny`)
+##### `"allow_and_deny"`
+
+- _Rust:_ `AllowAndDeny`
 
 Curated deny set plus curated allow set, both extensible via
 `deny_extra` / `allow_extra`. Macros classified by neither are

--- a/rules/macro_trailing_comma.md
+++ b/rules/macro_trailing_comma.md
@@ -69,7 +69,10 @@ let ys = vec![1, 2, 3];
 
 Configure via `dylint.toml` under `["perfectionist::macro_trailing_comma"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_macros`: `[string]` (optional)
+### `extra_macros`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Additional macro paths to treat as name-based eligible, on top
 of the curated built-in list. Each entry is matched by its
@@ -80,7 +83,10 @@ syntactically optional at the top level; macros that treat
 the comma as a fully optional separator throughout (rather
 than only at the tail) should not be listed here.
 
-### `ignore`: `[string]` (optional)
+### `ignore`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Macro paths to opt out of the rule, even if they would
 otherwise be eligible via the built-in list or

--- a/rules/macro_trailing_comma.md
+++ b/rules/macro_trailing_comma.md
@@ -69,7 +69,7 @@ let ys = vec![1, 2, 3];
 
 Configure via `dylint.toml` under `["perfectionist::macro_trailing_comma"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_macros`
+### Field: `extra_macros`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -83,7 +83,7 @@ syntactically optional at the top level; macros that treat
 the comma as a fully optional separator throughout (rather
 than only at the tail) should not be listed here.
 
-### `ignore`
+### Field: `ignore`
 
 - _Type:_ `[string]`
 - _Optional_

--- a/rules/named_prelude_imports.md
+++ b/rules/named_prelude_imports.md
@@ -62,13 +62,19 @@ use diesel::prelude::*;
 
 Configure via `dylint.toml` under `["perfectionist::named_prelude_imports"]`. Every field is optional; the per-field prose below states the default.
 
-### `prelude_segment_names`: `[string]` (optional)
+### `prelude_segment_names`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Path segment names recognised as preludes. Matches the knob of
 the same name on `perfectionist::wildcard_imports`, so a project
 can flip both rules with one value. Defaults to `["prelude"]`.
 
-### `allowed_paths`: `[string]` (optional)
+### `allowed_paths`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Prelude module paths whose named imports are never flagged — the
 module path leading up to and including the prelude segment. Each

--- a/rules/named_prelude_imports.md
+++ b/rules/named_prelude_imports.md
@@ -62,7 +62,7 @@ use diesel::prelude::*;
 
 Configure via `dylint.toml` under `["perfectionist::named_prelude_imports"]`. Every field is optional; the per-field prose below states the default.
 
-### `prelude_segment_names`
+### Field: `prelude_segment_names`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -71,7 +71,7 @@ Path segment names recognised as preludes. Matches the knob of
 the same name on `perfectionist::wildcard_imports`, so a project
 can flip both rules with one value. Defaults to `["prelude"]`.
 
-### `allowed_paths`
+### Field: `allowed_paths`
 
 - _Type:_ `[string]`
 - _Optional_

--- a/rules/needless_borrowed_parameters.md
+++ b/rules/needless_borrowed_parameters.md
@@ -74,7 +74,10 @@ fn push_path(list: &mut Vec<PathBuf>, item: PathBuf) {
 
 Configure via `dylint.toml` under `["perfectionist::needless_borrowed_parameters"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_conversion_methods`: `[string]` (optional)
+### `extra_conversion_methods`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Additional method names that count as a conversion of the
 borrowed parameter to its owned form. Merged with the built-in
@@ -84,21 +87,30 @@ flagged conversion must still actually produce the owned
 counterpart of the parameter's type, so listing an unrelated
 method here never widens the lint beyond owned-producing calls.
 
-### `ignore_conversion_methods`: `[string]` (optional)
+### `ignore_conversion_methods`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Method names to drop from the conversion set, even if they
 appear in the built-in defaults or in
 `extra_conversion_methods`. Empty by default; checked after the
 merge with the built-ins, so this knob always wins.
 
-### `test_code_exception`: `boolean` (optional)
+### `test_code_exception`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Whether test code is exempt: anything gated to test builds by
 `#[cfg(test)]` (or a compound predicate implying it), anything
 inside a `#[test]` function, and every `tests/` or `benches/`
 crate. An `examples/` crate is not covered. Defaults to `true`.
 
-### `build_script_exception`: `boolean` (optional)
+### `build_script_exception`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Whether a build script — `build.rs`, or whatever `Cargo.toml`'s
 `build` key names — is exempt. Defaults to `true`.

--- a/rules/needless_borrowed_parameters.md
+++ b/rules/needless_borrowed_parameters.md
@@ -74,7 +74,7 @@ fn push_path(list: &mut Vec<PathBuf>, item: PathBuf) {
 
 Configure via `dylint.toml` under `["perfectionist::needless_borrowed_parameters"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_conversion_methods`
+### Field: `extra_conversion_methods`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -87,7 +87,7 @@ flagged conversion must still actually produce the owned
 counterpart of the parameter's type, so listing an unrelated
 method here never widens the lint beyond owned-producing calls.
 
-### `ignore_conversion_methods`
+### Field: `ignore_conversion_methods`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -97,7 +97,7 @@ appear in the built-in defaults or in
 `extra_conversion_methods`. Empty by default; checked after the
 merge with the built-ins, so this knob always wins.
 
-### `test_code_exception`
+### Field: `test_code_exception`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -107,7 +107,7 @@ Whether test code is exempt: anything gated to test builds by
 inside a `#[test]` function, and every `tests/` or `benches/`
 crate. An `examples/` crate is not covered. Defaults to `true`.
 
-### `build_script_exception`
+### Field: `build_script_exception`
 
 - _Type:_ `boolean`
 - _Optional_

--- a/rules/overly_long_print_macro.md
+++ b/rules/overly_long_print_macro.md
@@ -67,7 +67,10 @@ println!(
 
 Configure via `dylint.toml` under `["perfectionist::overly_long_print_macro"]`. Every field is optional; the per-field prose below states the default.
 
-### `max_line_width`: `unsigned integer` (optional)
+### `max_line_width`
+
+- _Type:_ `unsigned integer`
+- _Optional_
 
 Source-line width that triggers the rule. The width is the
 Unicode *display* width of the line containing the macro
@@ -75,7 +78,10 @@ invocation, not its byte length, so a line of CJK text is
 measured the way a terminal renders it. Common alternatives to
 the default `100` are `80` (terminal) or `120` (wide editors).
 
-### `target_macros`: `[string]` (optional)
+### `target_macros`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Macros eligible for folding, each a `"a::b::c"`-style path (no
 trailing `!`). A single-segment entry matches by the

--- a/rules/overly_long_print_macro.md
+++ b/rules/overly_long_print_macro.md
@@ -67,7 +67,7 @@ println!(
 
 Configure via `dylint.toml` under `["perfectionist::overly_long_print_macro"]`. Every field is optional; the per-field prose below states the default.
 
-### `max_line_width`
+### Field: `max_line_width`
 
 - _Type:_ `unsigned integer`
 - _Optional_
@@ -78,7 +78,7 @@ invocation, not its byte length, so a line of CJK text is
 measured the way a terminal renders it. Common alternatives to
 the default `100` are `80` (terminal) or `120` (wide editors).
 
-### `target_macros`
+### Field: `target_macros`
 
 - _Type:_ `[string]`
 - _Optional_

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -94,7 +94,10 @@ the one-knob sweep.
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_closure_param"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_trivial_callback_methods`: `[string]` (optional)
+### `extra_trivial_callback_methods`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Additional method / function names whose closure argument
 may carry single-letter parameters when the body is a
@@ -105,7 +108,10 @@ project-specific DSL helpers (`when`, `iter_by`, third-party
 callbacks such as `into_sorted_by`, ...) here without having
 to re-state the standard ones.
 
-### `ignore_trivial_callback_methods`: `[string]` (optional)
+### `ignore_trivial_callback_methods`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Method / function names to drop from the trivial-callback
 set, even if they appear in the built-in defaults or in
@@ -114,7 +120,10 @@ after the merge with the built-ins, so this knob always
 wins. Useful for opting back into linting on a default
 entry the project does not consider trivial.
 
-### `extra_allowed_idents`: `[single-letter string]` (optional)
+### `extra_allowed_idents`
+
+- _Type:_ `[single-letter string]`
+- _Optional_
 
 Additional identifiers to allow as closure parameter names.
 Merged with the built-in defaults
@@ -124,7 +133,10 @@ having to re-state the standard ones. Each entry is a
 single ASCII letter (`a`-`z`, `A`-`Z`); any other
 character is rejected at config-parse time.
 
-### `extra_denied_idents`: `[single-letter string]` (optional)
+### `extra_denied_idents`
+
+- _Type:_ `[single-letter string]`
+- _Optional_
 
 Identifiers to deny (always flag), removing them from the
 exempt set even if they appear in the built-in defaults or

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -94,7 +94,7 @@ the one-knob sweep.
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_closure_param"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_trivial_callback_methods`
+### Field: `extra_trivial_callback_methods`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -108,7 +108,7 @@ project-specific DSL helpers (`when`, `iter_by`, third-party
 callbacks such as `into_sorted_by`, ...) here without having
 to re-state the standard ones.
 
-### `ignore_trivial_callback_methods`
+### Field: `ignore_trivial_callback_methods`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -120,7 +120,7 @@ after the merge with the built-ins, so this knob always
 wins. Useful for opting back into linting on a default
 entry the project does not consider trivial.
 
-### `extra_allowed_idents`
+### Field: `extra_allowed_idents`
 
 - _Type:_ `[single-letter string]`
 - _Optional_
@@ -133,7 +133,7 @@ having to re-state the standard ones. Each entry is a
 single ASCII letter (`a`-`z`, `A`-`Z`); any other
 character is rejected at config-parse time.
 
-### `extra_denied_idents`
+### Field: `extra_denied_idents`
 
 - _Type:_ `[single-letter string]`
 - _Optional_

--- a/rules/single_letter_const_generic.md
+++ b/rules/single_letter_const_generic.md
@@ -54,7 +54,10 @@ struct Data<Left, Right, const LEFT_LEN: usize, const RIGHT_LEN: usize> {
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_const_generic"]`. Every field is optional; the per-field prose below states the default.
 
-### `allowed_idents`: `[single-letter string]` (optional)
+### `allowed_idents`
+
+- _Type:_ `[single-letter string]`
+- _Optional_
 
 Identifiers the rule will not flag. Empty by default. Each
 entry is a single ASCII letter (`a`-`z`, `A`-`Z`); any other

--- a/rules/single_letter_const_generic.md
+++ b/rules/single_letter_const_generic.md
@@ -54,7 +54,7 @@ struct Data<Left, Right, const LEFT_LEN: usize, const RIGHT_LEN: usize> {
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_const_generic"]`. Every field is optional; the per-field prose below states the default.
 
-### `allowed_idents`
+### Field: `allowed_idents`
 
 - _Type:_ `[single-letter string]`
 - _Optional_

--- a/rules/single_letter_const_item.md
+++ b/rules/single_letter_const_item.md
@@ -52,7 +52,7 @@ const DIMENSION_COUNT: usize = 2;
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_const_item"]`. Every field is optional; the per-field prose below states the default.
 
-### `allowed_idents`
+### Field: `allowed_idents`
 
 - _Type:_ `[single-letter string]`
 - _Optional_

--- a/rules/single_letter_const_item.md
+++ b/rules/single_letter_const_item.md
@@ -52,7 +52,10 @@ const DIMENSION_COUNT: usize = 2;
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_const_item"]`. Every field is optional; the per-field prose below states the default.
 
-### `allowed_idents`: `[single-letter string]` (optional)
+### `allowed_idents`
+
+- _Type:_ `[single-letter string]`
+- _Optional_
 
 Identifiers the rule will not flag. Empty by default. Each
 entry is a single ASCII letter (`a`-`z`, `A`-`Z`); any other

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -53,7 +53,10 @@ fn write_row(writer: &mut Writer, tree_row: &TreeRow) -> io::Result<()> { ... }
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_function_param"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_allowed_idents`: `[single-letter string]` (optional)
+### `extra_allowed_idents`
+
+- _Type:_ `[single-letter string]`
+- _Optional_
 
 Additional identifiers to allow as function or method
 parameter names. Merged with the built-in defaults
@@ -63,7 +66,10 @@ having to re-state the standard ones. Each entry is a
 single ASCII letter (`a`-`z`, `A`-`Z`); any other
 character is rejected at config-parse time.
 
-### `extra_denied_idents`: `[single-letter string]` (optional)
+### `extra_denied_idents`
+
+- _Type:_ `[single-letter string]`
+- _Optional_
 
 Identifiers to deny (always flag), removing them from the
 exempt set even if they appear in the built-in defaults or

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -53,7 +53,7 @@ fn write_row(writer: &mut Writer, tree_row: &TreeRow) -> io::Result<()> { ... }
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_function_param"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_allowed_idents`
+### Field: `extra_allowed_idents`
 
 - _Type:_ `[single-letter string]`
 - _Optional_
@@ -66,7 +66,7 @@ having to re-state the standard ones. Each entry is a
 single ASCII letter (`a`-`z`, `A`-`Z`); any other
 character is rejected at config-parse time.
 
-### `extra_denied_idents`
+### Field: `extra_denied_idents`
 
 - _Type:_ `[single-letter string]`
 - _Optional_

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -50,7 +50,7 @@ let metadata = entry.metadata()?;
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_let_binding"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_allowed_idents`
+### Field: `extra_allowed_idents`
 
 - _Type:_ `[single-letter string]`
 - _Optional_
@@ -63,7 +63,7 @@ standard ones. Each entry is a single ASCII letter
 (`a`-`z`, `A`-`Z`); any other character is rejected at
 config-parse time.
 
-### `extra_denied_idents`
+### Field: `extra_denied_idents`
 
 - _Type:_ `[single-letter string]`
 - _Optional_

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -50,7 +50,10 @@ let metadata = entry.metadata()?;
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_let_binding"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_allowed_idents`: `[single-letter string]` (optional)
+### `extra_allowed_idents`
+
+- _Type:_ `[single-letter string]`
+- _Optional_
 
 Additional identifiers to allow as `let` binding names.
 Merged with the built-in defaults (`["n"]`); empty by
@@ -60,7 +63,10 @@ standard ones. Each entry is a single ASCII letter
 (`a`-`z`, `A`-`Z`); any other character is rejected at
 config-parse time.
 
-### `extra_denied_idents`: `[single-letter string]` (optional)
+### `extra_denied_idents`
+
+- _Type:_ `[single-letter string]`
+- _Optional_
 
 Identifiers to deny (always flag), removing them from the
 exempt set even if they appear in the built-in defaults or

--- a/rules/single_letter_static_item.md
+++ b/rules/single_letter_static_item.md
@@ -51,7 +51,7 @@ static REQUEST_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_static_item"]`. Every field is optional; the per-field prose below states the default.
 
-### `allowed_idents`
+### Field: `allowed_idents`
 
 - _Type:_ `[single-letter string]`
 - _Optional_

--- a/rules/single_letter_static_item.md
+++ b/rules/single_letter_static_item.md
@@ -51,7 +51,10 @@ static REQUEST_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 Configure via `dylint.toml` under `["perfectionist::single_letter_static_item"]`. Every field is optional; the per-field prose below states the default.
 
-### `allowed_idents`: `[single-letter string]` (optional)
+### `allowed_idents`
+
+- _Type:_ `[single-letter string]`
+- _Optional_
 
 Identifiers the rule will not flag. Empty by default. Each
 entry is a single ASCII letter (`a`-`z`, `A`-`Z`); any other

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -39,17 +39,26 @@ by accident from autocorrect.
 
 Configure via `dylint.toml` under `["perfectionist::unicode_ellipsis_in_comments"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_flagged_chars`: `[single-character string]` (optional)
+### `extra_flagged_chars`
+
+- _Type:_ `[single-character string]`
+- _Optional_
 
 Extra characters to flag alongside U+2026. Useful for catching
 near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)
 or U+2025 TWO DOT LEADER (`‥`) that the same autocorrect
 pipelines occasionally insert. Empty by default.
 
-### `scan_line_comments`: `boolean` (optional)
+### `scan_line_comments`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Scan `//` line comments. Defaults to `true`.
 
-### `scan_block_comments`: `boolean` (optional)
+### `scan_block_comments`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Scan `/* ... */` block comments. Defaults to `true`.

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -39,7 +39,7 @@ by accident from autocorrect.
 
 Configure via `dylint.toml` under `["perfectionist::unicode_ellipsis_in_comments"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_flagged_chars`
+### Field: `extra_flagged_chars`
 
 - _Type:_ `[single-character string]`
 - _Optional_
@@ -49,14 +49,14 @@ near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)
 or U+2025 TWO DOT LEADER (`‥`) that the same autocorrect
 pipelines occasionally insert. Empty by default.
 
-### `scan_line_comments`
+### Field: `scan_line_comments`
 
 - _Type:_ `boolean`
 - _Optional_
 
 Scan `//` line comments. Defaults to `true`.
 
-### `scan_block_comments`
+### Field: `scan_block_comments`
 
 - _Type:_ `boolean`
 - _Optional_

--- a/rules/unicode_ellipsis_in_docs.md
+++ b/rules/unicode_ellipsis_in_docs.md
@@ -44,14 +44,20 @@ technical writing.
 
 Configure via `dylint.toml` under `["perfectionist::unicode_ellipsis_in_docs"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_flagged_chars`: `[single-character string]` (optional)
+### `extra_flagged_chars`
+
+- _Type:_ `[single-character string]`
+- _Optional_
 
 Extra characters to flag alongside U+2026. Useful for catching
 near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)
 or U+2025 TWO DOT LEADER (`‥`) that the same autocorrect
 pipelines occasionally insert. Empty by default.
 
-### `scan_code_spans`: `boolean` (optional)
+### `scan_code_spans`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Whether to also flag a character inside an inline code span
 (`` `...` ``). Defaults to `false`: code spans often quote example

--- a/rules/unicode_ellipsis_in_docs.md
+++ b/rules/unicode_ellipsis_in_docs.md
@@ -44,7 +44,7 @@ technical writing.
 
 Configure via `dylint.toml` under `["perfectionist::unicode_ellipsis_in_docs"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_flagged_chars`
+### Field: `extra_flagged_chars`
 
 - _Type:_ `[single-character string]`
 - _Optional_
@@ -54,7 +54,7 @@ near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)
 or U+2025 TWO DOT LEADER (`‥`) that the same autocorrect
 pipelines occasionally insert. Empty by default.
 
-### `scan_code_spans`
+### Field: `scan_code_spans`
 
 - _Type:_ `boolean`
 - _Optional_

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -69,7 +69,10 @@ deliberately does not do.
 
 Configure via `dylint.toml` under `["perfectionist::unicode_ellipsis_in_panic_messages"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_macros`: `[string]` (optional)
+### `extra_macros`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Additional macros whose call site should be scanned for the
 flagged characters. Empty by default, and merged with the
@@ -80,7 +83,10 @@ of each of those that has one (`debug_unreachable`,
 this to add project-specific assertion-shaped macros without
 having to re-state the standard ones.
 
-### `ignore_macros`: `[string]` (optional)
+### `ignore_macros`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Macros to drop from the scanned set, even if they appear in
 the built-in defaults or in `extra_macros`. Empty by
@@ -88,7 +94,10 @@ default; checked after the merge with the built-ins, so
 this knob always wins. Use it when a project deliberately
 uses `…` in one of the default macros.
 
-### `extra_methods`: `[string]` (optional)
+### `extra_methods`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Additional method names on `Option` / `Result` whose first
 argument is the panic message. Merged with the built-in
@@ -96,14 +105,20 @@ defaults (`expect`, `expect_err`); empty by default. Use
 this to add project-specific `expect`-shaped wrappers
 without having to re-state the standard pair.
 
-### `ignore_methods`: `[string]` (optional)
+### `ignore_methods`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Methods to drop from the scanned set, even if they appear
 in the built-in defaults or in `extra_methods`. Empty by
 default; checked after the merge with the built-ins, so
 this knob always wins.
 
-### `extra_flagged_chars`: `[single-character string]` (optional)
+### `extra_flagged_chars`
+
+- _Type:_ `[single-character string]`
+- _Optional_
 
 Extra characters to flag alongside U+2026. Useful for catching
 near-relatives such as U+22EF MIDLINE HORIZONTAL ELLIPSIS (`⋯`)

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -69,7 +69,7 @@ deliberately does not do.
 
 Configure via `dylint.toml` under `["perfectionist::unicode_ellipsis_in_panic_messages"]`. Every field is optional; the per-field prose below states the default.
 
-### `extra_macros`
+### Field: `extra_macros`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -83,7 +83,7 @@ of each of those that has one (`debug_unreachable`,
 this to add project-specific assertion-shaped macros without
 having to re-state the standard ones.
 
-### `ignore_macros`
+### Field: `ignore_macros`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -94,7 +94,7 @@ default; checked after the merge with the built-ins, so
 this knob always wins. Use it when a project deliberately
 uses `…` in one of the default macros.
 
-### `extra_methods`
+### Field: `extra_methods`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -105,7 +105,7 @@ defaults (`expect`, `expect_err`); empty by default. Use
 this to add project-specific `expect`-shaped wrappers
 without having to re-state the standard pair.
 
-### `ignore_methods`
+### Field: `ignore_methods`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -115,7 +115,7 @@ in the built-in defaults or in `extra_methods`. Empty by
 default; checked after the merge with the built-ins, so
 this knob always wins.
 
-### `extra_flagged_chars`
+### Field: `extra_flagged_chars`
 
 - _Type:_ `[single-character string]`
 - _Optional_

--- a/rules/unordered_derives.md
+++ b/rules/unordered_derives.md
@@ -86,7 +86,7 @@ struct Point;
 
 Configure via `dylint.toml` under `["perfectionist::unordered_derives"]`. Every field is optional; the per-field prose below states the default.
 
-### `style`
+### Field: `style`
 
 - _Type:_ `Style`
 - _Optional_
@@ -95,7 +95,7 @@ Ordering policy. Defaults to `alphabetical`; set
 `prefix_then_alphabetical` to pin a configured `prefix` list
 of traits ahead of the alphabetised tail.
 
-### `prefix`
+### Field: `prefix`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -108,16 +108,16 @@ path segment, so a configured `"Debug"` matches both
 
 ### Types
 
-#### `Style`
+#### Type: `Style`
 
-##### `"alphabetical"`
+##### Choice: `"alphabetical"`
 
 - _Rust:_ `Alphabetical`
 
 Every trait name must appear in ASCII-case-insensitive
 alphabetical order.
 
-##### `"prefix_then_alphabetical"`
+##### Choice: `"prefix_then_alphabetical"`
 
 - _Rust:_ `PrefixThenAlphabetical`
 

--- a/rules/unordered_derives.md
+++ b/rules/unordered_derives.md
@@ -86,13 +86,19 @@ struct Point;
 
 Configure via `dylint.toml` under `["perfectionist::unordered_derives"]`. Every field is optional; the per-field prose below states the default.
 
-### `style`: `Style` (optional)
+### `style`
+
+- _Type:_ `Style`
+- _Optional_
 
 Ordering policy. Defaults to `alphabetical`; set
 `prefix_then_alphabetical` to pin a configured `prefix` list
 of traits ahead of the alphabetised tail.
 
-### `prefix`: `[string]` (optional)
+### `prefix`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Trait names that must appear first under the
 `prefix_then_alphabetical` style, in the order they should
@@ -102,14 +108,18 @@ path segment, so a configured `"Debug"` matches both
 
 ### Types
 
-#### `Style` (enum)
+#### `Style`
 
-##### `"alphabetical"` (Rust: `Alphabetical`)
+##### `"alphabetical"`
+
+- _Rust:_ `Alphabetical`
 
 Every trait name must appear in ASCII-case-insensitive
 alphabetical order.
 
-##### `"prefix_then_alphabetical"` (Rust: `PrefixThenAlphabetical`)
+##### `"prefix_then_alphabetical"`
+
+- _Rust:_ `PrefixThenAlphabetical`
 
 Traits listed in the configured `prefix` come first, in the
 listed order; remaining traits are sorted alphabetically

--- a/rules/unpinned_repo_ref.md
+++ b/rules/unpinned_repo_ref.md
@@ -52,7 +52,7 @@ ref that always denotes the exact content the author linked to.
 
 Configure via `dylint.toml` under `["perfectionist::unpinned_repo_ref"]`. Every field is optional; the per-field prose below states the default.
 
-### `scan_doc_comments`
+### Field: `scan_doc_comments`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -60,21 +60,21 @@ Configure via `dylint.toml` under `["perfectionist::unpinned_repo_ref"]`. Every 
 Scan doc comments (`///`, `//!`, `/** */`, `/*! */`).
 Defaults to `true`.
 
-### `scan_regular_comments`
+### Field: `scan_regular_comments`
 
 - _Type:_ `boolean`
 - _Optional_
 
 Scan regular comments (`//`, `/* */`). Defaults to `true`.
 
-### `scan_string_literals`
+### Field: `scan_string_literals`
 
 - _Type:_ `boolean`
 - _Optional_
 
 Scan string literals (`"..."`, `r"..."`). Defaults to `false`.
 
-### `sha_recognition_length`
+### Field: `sha_recognition_length`
 
 - _Type:_ `unsigned integer`
 - _Optional_
@@ -87,7 +87,7 @@ which trades a small false-negative window (branch names like
 branch names that merely look hex-ish. Set to `1` to treat any
 pure-hex ref as a SHA.
 
-### `allow_version_patterns`
+### Field: `allow_version_patterns`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -99,7 +99,7 @@ commit SHA. Defaults to `false`; tags can move, and a
 version-shaped branch name is valid Git, so projects must opt in
 to this convenience explicitly.
 
-### `hosts`
+### Field: `hosts`
 
 - _Type:_ `[HostEntry]`
 - _Optional_
@@ -112,7 +112,7 @@ Register a self-hosted instance by adding an entry with the
 matching `kind`. Supplying this field replaces the built-in
 list rather than extending it.
 
-### `skip_hosts`
+### Field: `skip_hosts`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -124,12 +124,12 @@ Defaults to `[]`.
 
 ### Types
 
-#### `HostEntry`
+#### Type: `HostEntry`
 
 One row of the `hosts` table: a hostname (or glob) and the forge
 kind whose URL shape applies to it.
 
-##### `hostname`
+##### Field: `hostname`
 
 - _Type:_ `string`
 
@@ -137,7 +137,7 @@ Hostname to match, compared case-insensitively. A `*` wildcard
 matches any run of characters, so `gitlab.*.example.com`
 covers every subdomain in one entry.
 
-##### `kind`
+##### Field: `kind`
 
 - _Type:_ `ForgeKind`
 

--- a/rules/unpinned_repo_ref.md
+++ b/rules/unpinned_repo_ref.md
@@ -52,20 +52,32 @@ ref that always denotes the exact content the author linked to.
 
 Configure via `dylint.toml` under `["perfectionist::unpinned_repo_ref"]`. Every field is optional; the per-field prose below states the default.
 
-### `scan_doc_comments`: `boolean` (optional)
+### `scan_doc_comments`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Scan doc comments (`///`, `//!`, `/** */`, `/*! */`).
 Defaults to `true`.
 
-### `scan_regular_comments`: `boolean` (optional)
+### `scan_regular_comments`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Scan regular comments (`//`, `/* */`). Defaults to `true`.
 
-### `scan_string_literals`: `boolean` (optional)
+### `scan_string_literals`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Scan string literals (`"..."`, `r"..."`). Defaults to `false`.
 
-### `sha_recognition_length`: `unsigned integer` (optional)
+### `sha_recognition_length`
+
+- _Type:_ `unsigned integer`
+- _Optional_
 
 Minimum hex length for a ref to be recognised as a commit SHA.
 A pure-hex ref shorter than this is treated as a branch and
@@ -75,7 +87,10 @@ which trades a small false-negative window (branch names like
 branch names that merely look hex-ish. Set to `1` to treat any
 pure-hex ref as a SHA.
 
-### `allow_version_patterns`: `boolean` (optional)
+### `allow_version_patterns`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Whether refs shaped like version patterns (`1.2.3`, `v1.2.3`, or
 either form with a non-empty `-suffix` of ASCII letters, ASCII
@@ -84,7 +99,10 @@ commit SHA. Defaults to `false`; tags can move, and a
 version-shaped branch name is valid Git, so projects must opt in
 to this convenience explicitly.
 
-### `hosts`: `[HostEntry]` (optional)
+### `hosts`
+
+- _Type:_ `[HostEntry]`
+- _Optional_
 
 Hostnames to scan, each mapped to the forge kind that fixes its
 URL shape. Defaults to the common public forges:
@@ -94,7 +112,10 @@ Register a self-hosted instance by adding an entry with the
 matching `kind`. Supplying this field replaces the built-in
 list rather than extending it.
 
-### `skip_hosts`: `[string]` (optional)
+### `skip_hosts`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Hostnames to skip, as `*`-glob patterns compared
 case-insensitively against the URL host. A host matching any
@@ -103,18 +124,22 @@ Defaults to `[]`.
 
 ### Types
 
-#### `HostEntry` (struct)
+#### `HostEntry`
 
 One row of the `hosts` table: a hostname (or glob) and the forge
 kind whose URL shape applies to it.
 
-##### `hostname`: `string`
+##### `hostname`
+
+- _Type:_ `string`
 
 Hostname to match, compared case-insensitively. A `*` wildcard
 matches any run of characters, so `gitlab.*.example.com`
 covers every subdomain in one entry.
 
-##### `kind`: `ForgeKind`
+##### `kind`
+
+- _Type:_ `ForgeKind`
 
 Forge kind whose URL shape applies to this hostname: one of
 `github` (also covers gitee), `gitlab`, `bitbucket`, `gitea`

--- a/rules/wildcard_imports.md
+++ b/rules/wildcard_imports.md
@@ -94,25 +94,37 @@ pub use submodule::*;
 
 Configure via `dylint.toml` under `["perfectionist::wildcard_imports"]`. Every field is optional; the per-field prose below states the default.
 
-### `prelude_exception`: `boolean` (optional)
+### `prelude_exception`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Whether a glob whose final non-glob path segment names a prelude
 module (`use rayon::prelude::*;`) is exempt. The recognised
 segment names come from `prelude_segment_names`. Defaults to
 `true`; set `false` to flag prelude globs too.
 
-### `root_reexport_exception`: `boolean` (optional)
+### `root_reexport_exception`
+
+- _Type:_ `boolean`
+- _Optional_
 
 Whether a bare-`pub` re-export glob (`pub use submodule::*;`) at
 the top level of a module body is exempt. Defaults to `true`; set
 `false` to flag re-export globs too.
 
-### `prelude_segment_names`: `[string]` (optional)
+### `prelude_segment_names`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Path segment names recognised as preludes for the `prelude`
 exception. Defaults to `["prelude"]`.
 
-### `allowed_paths`: `[string]` (optional)
+### `allowed_paths`
+
+- _Type:_ `[string]`
+- _Optional_
 
 Module paths whose glob import is never flagged, regardless of the
 exceptions above — the path before the `::*` of a `use <path>::*`.

--- a/rules/wildcard_imports.md
+++ b/rules/wildcard_imports.md
@@ -94,7 +94,7 @@ pub use submodule::*;
 
 Configure via `dylint.toml` under `["perfectionist::wildcard_imports"]`. Every field is optional; the per-field prose below states the default.
 
-### `prelude_exception`
+### Field: `prelude_exception`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -104,7 +104,7 @@ module (`use rayon::prelude::*;`) is exempt. The recognised
 segment names come from `prelude_segment_names`. Defaults to
 `true`; set `false` to flag prelude globs too.
 
-### `root_reexport_exception`
+### Field: `root_reexport_exception`
 
 - _Type:_ `boolean`
 - _Optional_
@@ -113,7 +113,7 @@ Whether a bare-`pub` re-export glob (`pub use submodule::*;`) at
 the top level of a module body is exempt. Defaults to `true`; set
 `false` to flag re-export globs too.
 
-### `prelude_segment_names`
+### Field: `prelude_segment_names`
 
 - _Type:_ `[string]`
 - _Optional_
@@ -121,7 +121,7 @@ the top level of a module body is exempt. Defaults to `true`; set
 Path segment names recognised as preludes for the `prelude`
 exception. Defaults to `["prelude"]`.
 
-### `allowed_paths`
+### Field: `allowed_paths`
 
 - _Type:_ `[string]`
 - _Optional_

--- a/tools/gen-docs/src/model.rs
+++ b/tools/gen-docs/src/model.rs
@@ -152,15 +152,27 @@ pub(crate) struct ConfigField {
 }
 
 /// Whether a [`ConfigField`] is optional or mandatory in TOML. Its
-/// string form (`"optional"` / `"mandatory"`) doubles as the rendered
-/// badge label and — prefixed with `badge-` — the badge's CSS class, so
-/// the renderers read it off the `strum`-derived `AsRef<str>` rather
-/// than hand-writing the two words.
+/// lower-case string form (`"optional"` / `"mandatory"`) doubles as
+/// the HTML badge label and — prefixed with `badge-` — the badge's CSS
+/// class, so the HTML renderer reads it off the `strum`-derived
+/// `AsRef<str>` rather than hand-writing the two words. The markdown
+/// catalogue, where the word opens a sentence-like bullet instead of
+/// filling a badge, uses [`Optionality::label`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, AsRefStr)]
 #[strum(serialize_all = "snake_case")]
 pub(crate) enum Optionality {
     Optional,
     Mandatory,
+}
+
+impl Optionality {
+    /// Sentence-case form of the same word.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Optionality::Optional => "Optional",
+            Optionality::Mandatory => "Mandatory",
+        }
+    }
 }
 
 /// A non-built-in type that one of the `Config` fields references.

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -8,11 +8,16 @@
 //! so that PRs that touch a rule get an in-tree doc diff for
 //! review.
 //!
-//! A heading holds the item's name and nothing else. It doubles as
-//! a link target and a URL fragment, so a TOML type, an optionality
-//! marker, or the Rust identifier behind a renamed variant goes into
-//! a metadata list underneath the heading instead of decorating the
-//! title text.
+//! A heading names one item and says what kind of item it is —
+//! `Field:`, `Type:`, `Choice:` — and carries nothing else. It
+//! doubles as a link target and a URL fragment, so the two things a
+//! heading may hold are the ones fixed for as long as the item
+//! exists: its name, and what it is. Everything that varies
+//! independently of the item — its TOML type, whether it is
+//! optional, the Rust identifier behind a renamed variant — goes
+//! into a metadata list underneath, where changing it can't break an
+//! inbound link. The kind word doubles as a namespace, keeping a
+//! field and a same-named type from slugifying to one anchor.
 //!
 //! Every rendered string ends with exactly one trailing newline so
 //! the `check-md` byte-comparison stays stable across editors that
@@ -195,7 +200,7 @@ fn render_config_section(config: &ConfigDoc, out: &mut String) {
 }
 
 fn render_field(field: &ConfigField, out: &mut String) {
-    let _ = writeln!(out, "### `{name}`", name = field.name);
+    let _ = writeln!(out, "### Field: `{name}`", name = field.name);
     out.push('\n');
     write_metadata(out, "Type", Some(&field.type_label));
     write_metadata(out, field.optionality.label(), None);
@@ -204,7 +209,7 @@ fn render_field(field: &ConfigField, out: &mut String) {
 }
 
 fn render_type(ty: &TypeDoc, out: &mut String) {
-    let _ = writeln!(out, "#### `{name}`", name = ty.name);
+    let _ = writeln!(out, "#### Type: `{name}`", name = ty.name);
     out.push('\n');
     if !ty.doc_markdown.is_empty() {
         out.push_str(&ty.doc_markdown);
@@ -228,7 +233,7 @@ fn render_type(ty: &TypeDoc, out: &mut String) {
 }
 
 fn render_variant(variant: &EnumVariant, out: &mut String) {
-    let _ = writeln!(out, r#"##### `"{}"`"#, variant.serialized);
+    let _ = writeln!(out, r#"##### Choice: `"{}"`"#, variant.serialized);
     out.push('\n');
     // The Rust identifier is worth naming only where it differs
     // from the string a TOML author writes; when the two coincide
@@ -241,7 +246,7 @@ fn render_variant(variant: &EnumVariant, out: &mut String) {
 }
 
 fn render_struct_field(field: &StructField, out: &mut String) {
-    let _ = writeln!(out, "##### `{name}`", name = field.name);
+    let _ = writeln!(out, "##### Field: `{name}`", name = field.name);
     out.push('\n');
     write_metadata(out, "Type", Some(&field.type_label));
     out.push('\n');

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -8,6 +8,12 @@
 //! so that PRs that touch a rule get an in-tree doc diff for
 //! review.
 //!
+//! A heading holds the item's name and nothing else. It doubles as
+//! a link target and a URL fragment, so a TOML type, an optionality
+//! marker, or the Rust identifier behind a renamed variant goes into
+//! a metadata list underneath the heading instead of decorating the
+//! title text.
+//!
 //! Every rendered string ends with exactly one trailing newline so
 //! the `check-md` byte-comparison stays stable across editors that
 //! strip or add a final newline. Inline doc-comment prose is taken
@@ -189,26 +195,16 @@ fn render_config_section(config: &ConfigDoc, out: &mut String) {
 }
 
 fn render_field(field: &ConfigField, out: &mut String) {
-    // `name: type` rather than `name — type`: the em dash isn't a
-    // separator in English typography, it sets off parenthetical
-    // prose. The HTML renderer uses `:` for the same reason.
-    let _ = writeln!(
-        out,
-        "### `{name}`: `{ty}` ({optionality})",
-        name = field.name,
-        ty = field.type_label,
-        optionality = field.optionality.as_ref(),
-    );
+    let _ = writeln!(out, "### `{name}`", name = field.name);
+    out.push('\n');
+    write_metadata(out, "Type", Some(&field.type_label));
+    write_metadata(out, field.optionality.label(), None);
     out.push('\n');
     append_doc(&field.doc_markdown, out);
 }
 
 fn render_type(ty: &TypeDoc, out: &mut String) {
-    let kind_label = match ty.kind {
-        TypeKind::Enum { .. } => "enum",
-        TypeKind::Struct { .. } => "struct",
-    };
-    let _ = writeln!(out, "#### `{name}` ({kind_label})", name = ty.name);
+    let _ = writeln!(out, "#### `{name}`", name = ty.name);
     out.push('\n');
     if !ty.doc_markdown.is_empty() {
         out.push_str(&ty.doc_markdown);
@@ -232,28 +228,36 @@ fn render_type(ty: &TypeDoc, out: &mut String) {
 }
 
 fn render_variant(variant: &EnumVariant, out: &mut String) {
-    if variant.rust_name == variant.serialized {
-        let _ = writeln!(out, r#"##### `"{}"`"#, variant.serialized);
-    } else {
-        let _ = writeln!(
-            out,
-            r#"##### `"{}"` (Rust: `{}`)"#,
-            variant.serialized, variant.rust_name,
-        );
-    }
+    let _ = writeln!(out, r#"##### `"{}"`"#, variant.serialized);
     out.push('\n');
+    // The Rust identifier is worth naming only where it differs
+    // from the string a TOML author writes; when the two coincide
+    // the bullet would repeat the heading.
+    if variant.rust_name != variant.serialized {
+        write_metadata(out, "Rust", Some(&variant.rust_name));
+        out.push('\n');
+    }
     append_doc(&variant.doc_markdown, out);
 }
 
 fn render_struct_field(field: &StructField, out: &mut String) {
-    let _ = writeln!(
-        out,
-        "##### `{name}`: `{ty}`",
-        name = field.name,
-        ty = field.type_label,
-    );
+    let _ = writeln!(out, "##### `{name}`", name = field.name);
+    out.push('\n');
+    write_metadata(out, "Type", Some(&field.type_label));
     out.push('\n');
     append_doc(&field.doc_markdown, out);
+}
+
+/// Write one bullet of the metadata list that sits between an item's
+/// heading and its prose. `value` is rendered in backticks after an
+/// italicised `label:`; passing `None` renders the label alone, for
+/// the standalone words (`Optional`, `Mandatory`) that qualify the
+/// item rather than naming a property of it.
+fn write_metadata(out: &mut String, label: &str, value: Option<&str>) {
+    let _ = match value {
+        Some(value) => writeln!(out, "- _{label}:_ `{value}`"),
+        None => writeln!(out, "- _{label}_"),
+    };
 }
 
 /// Append a doc-comment block, normalising trailing whitespace so

--- a/tools/gen-docs/src/render_md/tests.rs
+++ b/tools/gen-docs/src/render_md/tests.rs
@@ -99,31 +99,32 @@ fn rule_md_with_config_lists_fields_and_types() {
         md.contains("A field marked mandatory must be set;"),
         "got:\n{md}",
     );
-    // Every heading is the item's bare name; the type, the
-    // optionality and the kind ride in the metadata list below it.
+    // A heading names the item and what kind of item it is; the
+    // type, the optionality and the enum/struct kind ride in the
+    // metadata list below it.
     assert!(
-        md.contains("### `style`\n\n- _Type:_ `Style`\n- _Mandatory_\n\n"),
+        md.contains("### Field: `style`\n\n- _Type:_ `Style`\n- _Mandatory_\n\n"),
         "got:\n{md}",
     );
     assert!(
-        !md.contains("### `style`\n\n- _Type:_ `Style`\n- _Optional_"),
+        !md.contains("### Field: `style`\n\n- _Type:_ `Style`\n- _Optional_"),
         "got:\n{md}",
     );
     assert!(
-        md.contains("### `extras`\n\n- _Type:_ `[string]`\n- _Optional_\n\n"),
+        md.contains("### Field: `extras`\n\n- _Type:_ `[string]`\n- _Optional_\n\n"),
         "got:\n{md}",
     );
     assert!(md.contains("Pick a style."));
-    assert!(md.contains("#### `Style`\n"), "got:\n{md}");
+    assert!(md.contains("#### Type: `Style`\n"), "got:\n{md}");
     assert!(!md.contains("(enum)"), "got:\n{md}");
     // Renamed variant carries the Rust-side annotation below the
     // heading.
     assert!(
-        md.contains("##### `\"preserve\"`\n\n- _Rust:_ `Preserve`\n\n"),
+        md.contains("##### Choice: `\"preserve\"`\n\n- _Rust:_ `Preserve`\n\n"),
         "got:\n{md}",
     );
     // Same-named variant doesn't.
-    assert!(md.contains(r#"##### `"Same"`"#));
+    assert!(md.contains(r#"##### Choice: `"Same"`"#));
     assert!(!md.contains("_Rust:_ `Same`"));
     // Empty doc fall-back.
     assert!(md.contains("*Undocumented.*"));
@@ -132,8 +133,8 @@ fn rule_md_with_config_lists_fields_and_types() {
 #[test]
 fn rule_md_struct_type_fields_carry_a_type_bullet() {
     // The struct branch of the Types section follows the same
-    // heading convention as the enum branch: the field name alone
-    // in the heading, its TOML type in the metadata list.
+    // heading convention as the enum branch: a kind word and the
+    // name in the heading, the TOML type in the metadata list.
     let mut rule = fake_rule();
     rule.config = ConfigDoc {
         key: "perfectionist::demo_rule".to_owned(),
@@ -156,10 +157,10 @@ fn rule_md_struct_type_fields_carry_a_type_bullet() {
         }],
     };
     let md = render_rule_md(&rule, "../");
-    assert!(md.contains("#### `HostEntry`\n"), "got:\n{md}");
+    assert!(md.contains("#### Type: `HostEntry`\n"), "got:\n{md}");
     assert!(!md.contains("(struct)"), "got:\n{md}");
     assert!(
-        md.contains("##### `host`\n\n- _Type:_ `string`\n\nThe hostname.\n"),
+        md.contains("##### Field: `host`\n\n- _Type:_ `string`\n\nThe hostname.\n"),
         "got:\n{md}",
     );
 }

--- a/tools/gen-docs/src/render_md/tests.rs
+++ b/tools/gen-docs/src/render_md/tests.rs
@@ -1,6 +1,7 @@
 use super::{promote_headings, render_index_md, render_rule_md, rule_file_name};
 use crate::model::{
-    ConfigDoc, ConfigField, DefaultState, EnumVariant, Optionality, Rule, TypeDoc, TypeKind,
+    ConfigDoc, ConfigField, DefaultState, EnumVariant, Optionality, Rule, StructField, TypeDoc,
+    TypeKind,
 };
 use std::path::PathBuf;
 
@@ -98,20 +99,69 @@ fn rule_md_with_config_lists_fields_and_types() {
         md.contains("A field marked mandatory must be set;"),
         "got:\n{md}",
     );
-    // A `required` field renders the `mandatory` marker, not `optional`.
-    assert!(md.contains("### `style`: `Style` (mandatory)"));
-    assert!(!md.contains("### `style`: `Style` (optional)"));
-    // An ordinary field still renders `optional`.
-    assert!(md.contains("### `extras`: `[string]` (optional)"));
+    // Every heading is the item's bare name; the type, the
+    // optionality and the kind ride in the metadata list below it.
+    assert!(
+        md.contains("### `style`\n\n- _Type:_ `Style`\n- _Mandatory_\n\n"),
+        "got:\n{md}",
+    );
+    assert!(
+        !md.contains("### `style`\n\n- _Type:_ `Style`\n- _Optional_"),
+        "got:\n{md}",
+    );
+    assert!(
+        md.contains("### `extras`\n\n- _Type:_ `[string]`\n- _Optional_\n\n"),
+        "got:\n{md}",
+    );
     assert!(md.contains("Pick a style."));
-    assert!(md.contains("#### `Style` (enum)"));
-    // Renamed variant carries the Rust-side annotation.
-    assert!(md.contains(r#"##### `"preserve"`"#));
+    assert!(md.contains("#### `Style`\n"), "got:\n{md}");
+    assert!(!md.contains("(enum)"), "got:\n{md}");
+    // Renamed variant carries the Rust-side annotation below the
+    // heading.
+    assert!(
+        md.contains("##### `\"preserve\"`\n\n- _Rust:_ `Preserve`\n\n"),
+        "got:\n{md}",
+    );
     // Same-named variant doesn't.
     assert!(md.contains(r#"##### `"Same"`"#));
-    assert!(!md.contains("(Rust: `Same`)"));
+    assert!(!md.contains("_Rust:_ `Same`"));
     // Empty doc fall-back.
     assert!(md.contains("*Undocumented.*"));
+}
+
+#[test]
+fn rule_md_struct_type_fields_carry_a_type_bullet() {
+    // The struct branch of the Types section follows the same
+    // heading convention as the enum branch: the field name alone
+    // in the heading, its TOML type in the metadata list.
+    let mut rule = fake_rule();
+    rule.config = ConfigDoc {
+        key: "perfectionist::demo_rule".to_owned(),
+        fields: vec![ConfigField {
+            name: "hosts".to_owned(),
+            type_label: "[HostEntry]".to_owned(),
+            doc_markdown: "Known hosts.".to_owned(),
+            optionality: Optionality::Optional,
+        }],
+        custom_types: vec![TypeDoc {
+            name: "HostEntry".to_owned(),
+            doc_markdown: "One host.".to_owned(),
+            kind: TypeKind::Struct {
+                fields: vec![StructField {
+                    name: "host".to_owned(),
+                    type_label: "string".to_owned(),
+                    doc_markdown: "The hostname.".to_owned(),
+                }],
+            },
+        }],
+    };
+    let md = render_rule_md(&rule, "../");
+    assert!(md.contains("#### `HostEntry`\n"), "got:\n{md}");
+    assert!(!md.contains("(struct)"), "got:\n{md}");
+    assert!(
+        md.contains("##### `host`\n\n- _Type:_ `string`\n\nThe hostname.\n"),
+        "got:\n{md}",
+    );
 }
 
 #[test]


### PR DESCRIPTION
The generated rule catalogue decorated its headings with metadata, so an anchor changed whenever the metadata did: relabelling a field's type or flipping it to mandatory rewrote `#foo-foo-optional` and broke any link to it.

A heading now names one item and says what kind of item it is, and carries nothing else:

```markdown
### Field: `foo`

- _Type:_ `Foo`
- _Optional_

#### Type: `SomeEnum`

##### Choice: `"some-variant"`

- _Rust:_ `SomeVariant`
```

A field's TOML type, its optionality, and the Rust identifier behind a renamed variant move into that metadata list, where changing one cannot break an inbound link. The `(enum)` / `(struct)` kind is dropped, since the members' own form conveys it. A struct's fields take `Field:` as well. The kind word doubles as a namespace: the config field `style` and the enum `Style` in `import_grouping_mismatch` no longer slugify to one anchor.

`render_md.rs` emits the headings and the metadata list; `model.rs` gains a sentence-case `Optionality` label, the lower-case form still backing the HTML badge and its CSS class. The HTML catalogue is unchanged, rendering the same data as a description list where nothing becomes an anchor. Every file under `rules/` is regenerated.

Resolves <https://github.com/KSXGitHub/perfectionist/issues/182>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012q3ducXUPtusfWpoL1p2RY