### PR TITLE
style: adopt `arbitrary_source_item_ordering` in this crate

### DIFF
--- a/dylint.toml
+++ b/dylint.toml
@@ -5,14 +5,8 @@ libraries = [
 
 # `import_grouping_mismatch` is inactive by default, so it must be enabled here
 # for the self-lint to keep enforcing this crate's import layout.
-#
-# `arbitrary_source_item_ordering` is active by default and this crate does not
-# yet satisfy it. Adopting the layout is a source change of its own, kept out of
-# the commit that adds the rule so each reviews on its own terms; drop this entry
-# in the same change that reorders the offending module bodies.
 [perfectionist]
 enable = ["import_grouping_mismatch"]
-disable = ["arbitrary_source_item_ordering"]
 
 ["perfectionist::unicode_ellipsis_in_docs"]
 scan_code_spans = true

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -5,10 +5,6 @@
 //! in isolation from any test workspace and has no access to the
 //! caller's `CARGO_TARGET_DIR` or `CARGO_MANIFEST_DIR`.
 
-pub use tempfile::TempDir;
-
-use std::path::Path;
-
 pub mod dylint;
 pub mod manifest;
 pub mod project;
@@ -18,6 +14,9 @@ pub use manifest::{
     DylintLibrary, DylintMetadata, DylintWorkspaceMetadata, fixture_cargo_toml, fixture_dylint_toml,
 };
 pub use project::{build_project, build_project_with_config};
+pub use tempfile::TempDir;
+
+use std::path::Path;
 
 /// Materialise a fixture project in a fresh [`TempDir`], run
 /// `cargo dylint --all` against it (sharing the warmed `target/`), and


### PR DESCRIPTION
Stacked on KSXGitHub/perfectionist#396, which it targets — the dogfooding half of that rule, split out so the rule's implementation and this crate's adoption of it review separately.

KSXGitHub/perfectionist#396 leaves `arbitrary_source_item_ordering` active by default for consumers but turns it off for this crate's own self-lint, via a `disable` entry in the root `dylint.toml`. This PR drops that entry and reorders the one module body that did not satisfy the rule.

## What changed

- **`dylint.toml`** — removes `disable = ["arbitrary_source_item_ordering"]` and the comment that deferred the adoption, so `just self-lint` enforces the rule on this crate.
- **`utils/src/lib.rs`** — reordered to `pub mod` declarations, then `pub use` re-exports, then the private import. Its crate root previously led with `pub use tempfile::TempDir;` and `use std::path::Path;`, leaving the three `pub mod` declarations and the other three `pub use` re-exports below both.

## Scope

All six findings were in that one file; the rest of the workspace — the plugin, its tests, `tools/*` — already had the layout. Nothing else needed touching, which is why the diff is this small.

The fixture-side suppressions stay in KSXGitHub/perfectionist#396 where they belong: `ui/` fixtures allow the rule at the crate root and the `ui-toml/` harnesses disable it in the `dylint.toml` they pass, because those fixtures deliberately arrange items to exercise a *different* rule. That is test scaffolding, not this crate declining its own rule.

## Verification

`just all` — `cargo fmt --check`, `build`, `doc` (`gen-docs`, `check-rules-md`, `cargo doc` under `RUSTFLAGS=-D warnings`), `clippy -D warnings`, the full test suite, and `self-lint` — all pass on this branch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TW2yoFCfgSXwddXvKgTZ3S


---
_Generated by [Claude Code](https://claude.ai/code/session_01TW2yoFCfgSXwddXvKgTZ3S)_