### PR TITLE
fix(gen-docs): render the rule header metadata as a list

### DIFF
--- a/rules/allow_attributes.md
+++ b/rules/allow_attributes.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::allow_attributes`
 
-**Default state:** `active`\
-**Source:** [`src/rules/allow_attributes.rs`](../src/rules/allow_attributes.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/allow_attributes.rs`](../src/rules/allow_attributes.rs)
 
 > `#[allow]` for a deterministically-firing lint should be removed or be `#[expect]`
 

--- a/rules/allow_attributes.md
+++ b/rules/allow_attributes.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::allow_attributes`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/allow_attributes.rs`](../src/rules/allow_attributes.rs)
+**Default state:** `active`
+**Source:** [`src/rules/allow_attributes.rs`](../src/rules/allow_attributes.rs)
 
 > `#[allow]` for a deterministically-firing lint should be removed or be `#[expect]`
 

--- a/rules/allow_attributes.md
+++ b/rules/allow_attributes.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::allow_attributes`
 
-**Default state:** `active`
-**Source:** [`src/rules/allow_attributes.rs`](../src/rules/allow_attributes.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/allow_attributes.rs`](../src/rules/allow_attributes.rs)
 
 > `#[allow]` for a deterministically-firing lint should be removed or be `#[expect]`
 

--- a/rules/allow_attributes.md
+++ b/rules/allow_attributes.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::allow_attributes`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/allow_attributes.rs`](../src/rules/allow_attributes.rs)
 
 > `#[allow]` for a deterministically-firing lint should be removed or be `#[expect]`

--- a/rules/allow_attributes_without_reason.md
+++ b/rules/allow_attributes_without_reason.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::allow_attributes_without_reason`
 
-**Default state:** `active`
-**Source:** [`src/rules/allow_attributes_without_reason.rs`](../src/rules/allow_attributes_without_reason.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/allow_attributes_without_reason.rs`](../src/rules/allow_attributes_without_reason.rs)
 
 > `#[allow]` / `#[expect]` attribute lacks an explanatory `reason = "..."` field
 

--- a/rules/allow_attributes_without_reason.md
+++ b/rules/allow_attributes_without_reason.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::allow_attributes_without_reason`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/allow_attributes_without_reason.rs`](../src/rules/allow_attributes_without_reason.rs)
 
 > `#[allow]` / `#[expect]` attribute lacks an explanatory `reason = "..."` field

--- a/rules/allow_attributes_without_reason.md
+++ b/rules/allow_attributes_without_reason.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::allow_attributes_without_reason`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/allow_attributes_without_reason.rs`](../src/rules/allow_attributes_without_reason.rs)
+**Default state:** `active`
+**Source:** [`src/rules/allow_attributes_without_reason.rs`](../src/rules/allow_attributes_without_reason.rs)
 
 > `#[allow]` / `#[expect]` attribute lacks an explanatory `reason = "..."` field
 

--- a/rules/allow_attributes_without_reason.md
+++ b/rules/allow_attributes_without_reason.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::allow_attributes_without_reason`
 
-**Default state:** `active`\
-**Source:** [`src/rules/allow_attributes_without_reason.rs`](../src/rules/allow_attributes_without_reason.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/allow_attributes_without_reason.rs`](../src/rules/allow_attributes_without_reason.rs)
 
 > `#[allow]` / `#[expect]` attribute lacks an explanatory `reason = "..."` field
 

--- a/rules/arbitrary_source_item_ordering.md
+++ b/rules/arbitrary_source_item_ordering.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::arbitrary_source_item_ordering`
 
-**Default state:** `active`
-**Source:** [`src/rules/arbitrary_source_item_ordering.rs`](../src/rules/arbitrary_source_item_ordering.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/arbitrary_source_item_ordering.rs`](../src/rules/arbitrary_source_item_ordering.rs)
 
 > item in a module body sits below a section it belongs above: `pub mod`, then `pub use`, then private imports and other items
 

--- a/rules/arbitrary_source_item_ordering.md
+++ b/rules/arbitrary_source_item_ordering.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::arbitrary_source_item_ordering`
 
-**Default state:** `active`\
-**Source:** [`src/rules/arbitrary_source_item_ordering.rs`](../src/rules/arbitrary_source_item_ordering.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/arbitrary_source_item_ordering.rs`](../src/rules/arbitrary_source_item_ordering.rs)
 
 > item in a module body sits below a section it belongs above: `pub mod`, then `pub use`, then private imports and other items
 

--- a/rules/arbitrary_source_item_ordering.md
+++ b/rules/arbitrary_source_item_ordering.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::arbitrary_source_item_ordering`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/arbitrary_source_item_ordering.rs`](../src/rules/arbitrary_source_item_ordering.rs)
 
 > item in a module body sits below a section it belongs above: `pub mod`, then `pub use`, then private imports and other items

--- a/rules/arbitrary_source_item_ordering.md
+++ b/rules/arbitrary_source_item_ordering.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::arbitrary_source_item_ordering`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/arbitrary_source_item_ordering.rs`](../src/rules/arbitrary_source_item_ordering.rs)
+**Default state:** `active`
+**Source:** [`src/rules/arbitrary_source_item_ordering.rs`](../src/rules/arbitrary_source_item_ordering.rs)
 
 > item in a module body sits below a section it belongs above: `pub mod`, then `pub use`, then private imports and other items
 

--- a/rules/avoidable_string_escapes.md
+++ b/rules/avoidable_string_escapes.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::avoidable_string_escapes`
 
-**Default state:** `active`
-**Source:** [`src/rules/avoidable_string_escapes.rs`](../src/rules/avoidable_string_escapes.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/avoidable_string_escapes.rs`](../src/rules/avoidable_string_escapes.rs)
 
 > string literal contains only raw-expressible escapes; prefer the raw-string form
 

--- a/rules/avoidable_string_escapes.md
+++ b/rules/avoidable_string_escapes.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::avoidable_string_escapes`
 
-**Default state:** `active`\
-**Source:** [`src/rules/avoidable_string_escapes.rs`](../src/rules/avoidable_string_escapes.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/avoidable_string_escapes.rs`](../src/rules/avoidable_string_escapes.rs)
 
 > string literal contains only raw-expressible escapes; prefer the raw-string form
 

--- a/rules/avoidable_string_escapes.md
+++ b/rules/avoidable_string_escapes.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::avoidable_string_escapes`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/avoidable_string_escapes.rs`](../src/rules/avoidable_string_escapes.rs)
 
 > string literal contains only raw-expressible escapes; prefer the raw-string form

--- a/rules/avoidable_string_escapes.md
+++ b/rules/avoidable_string_escapes.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::avoidable_string_escapes`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/avoidable_string_escapes.rs`](../src/rules/avoidable_string_escapes.rs)
+**Default state:** `active`
+**Source:** [`src/rules/avoidable_string_escapes.rs`](../src/rules/avoidable_string_escapes.rs)
 
 > string literal contains only raw-expressible escapes; prefer the raw-string form
 

--- a/rules/bare_email.md
+++ b/rules/bare_email.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_email`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/bare_email.rs`](../src/rules/bare_email.rs)
+**Default state:** `active`
+**Source:** [`src/rules/bare_email.rs`](../src/rules/bare_email.rs)
 
 > bare email address in comment or doc comment; wrap in `<...>` or prefix with `mailto:`
 

--- a/rules/bare_email.md
+++ b/rules/bare_email.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_email`
 
-**Default state:** `active`
-**Source:** [`src/rules/bare_email.rs`](../src/rules/bare_email.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/bare_email.rs`](../src/rules/bare_email.rs)
 
 > bare email address in comment or doc comment; wrap in `<...>` or prefix with `mailto:`
 

--- a/rules/bare_email.md
+++ b/rules/bare_email.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_email`
 
-**Default state:** `active`\
-**Source:** [`src/rules/bare_email.rs`](../src/rules/bare_email.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/bare_email.rs`](../src/rules/bare_email.rs)
 
 > bare email address in comment or doc comment; wrap in `<...>` or prefix with `mailto:`
 

--- a/rules/bare_email.md
+++ b/rules/bare_email.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::bare_email`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/bare_email.rs`](../src/rules/bare_email.rs)
 
 > bare email address in comment or doc comment; wrap in `<...>` or prefix with `mailto:`

--- a/rules/bare_identifier_reference.md
+++ b/rules/bare_identifier_reference.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_identifier_reference`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/bare_identifier_reference.rs`](../src/rules/bare_identifier_reference.rs)
+**Default state:** `active`
+**Source:** [`src/rules/bare_identifier_reference.rs`](../src/rules/bare_identifier_reference.rs)
 
 > backticked identifier in a doc comment that resolves in scope should be an intra-doc link
 

--- a/rules/bare_identifier_reference.md
+++ b/rules/bare_identifier_reference.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::bare_identifier_reference`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/bare_identifier_reference.rs`](../src/rules/bare_identifier_reference.rs)
 
 > backticked identifier in a doc comment that resolves in scope should be an intra-doc link

--- a/rules/bare_identifier_reference.md
+++ b/rules/bare_identifier_reference.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_identifier_reference`
 
-**Default state:** `active`
-**Source:** [`src/rules/bare_identifier_reference.rs`](../src/rules/bare_identifier_reference.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/bare_identifier_reference.rs`](../src/rules/bare_identifier_reference.rs)
 
 > backticked identifier in a doc comment that resolves in scope should be an intra-doc link
 

--- a/rules/bare_identifier_reference.md
+++ b/rules/bare_identifier_reference.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_identifier_reference`
 
-**Default state:** `active`\
-**Source:** [`src/rules/bare_identifier_reference.rs`](../src/rules/bare_identifier_reference.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/bare_identifier_reference.rs`](../src/rules/bare_identifier_reference.rs)
 
 > backticked identifier in a doc comment that resolves in scope should be an intra-doc link
 

--- a/rules/bare_issue_reference.md
+++ b/rules/bare_issue_reference.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_issue_reference`
 
-**Default state:** `active`
-**Source:** [`src/rules/bare_issue_reference.rs`](../src/rules/bare_issue_reference.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/bare_issue_reference.rs`](../src/rules/bare_issue_reference.rs)
 
 > ambiguous bare `#NNN` issue / PR reference in comment
 

--- a/rules/bare_issue_reference.md
+++ b/rules/bare_issue_reference.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::bare_issue_reference`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/bare_issue_reference.rs`](../src/rules/bare_issue_reference.rs)
 
 > ambiguous bare `#NNN` issue / PR reference in comment

--- a/rules/bare_issue_reference.md
+++ b/rules/bare_issue_reference.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_issue_reference`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/bare_issue_reference.rs`](../src/rules/bare_issue_reference.rs)
+**Default state:** `active`
+**Source:** [`src/rules/bare_issue_reference.rs`](../src/rules/bare_issue_reference.rs)
 
 > ambiguous bare `#NNN` issue / PR reference in comment
 

--- a/rules/bare_issue_reference.md
+++ b/rules/bare_issue_reference.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_issue_reference`
 
-**Default state:** `active`\
-**Source:** [`src/rules/bare_issue_reference.rs`](../src/rules/bare_issue_reference.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/bare_issue_reference.rs`](../src/rules/bare_issue_reference.rs)
 
 > ambiguous bare `#NNN` issue / PR reference in comment
 

--- a/rules/bare_url.md
+++ b/rules/bare_url.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::bare_url`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/bare_url.rs`](../src/rules/bare_url.rs)
 
 > bare URL in comment or doc comment; wrap in `<...>` or use a labelled markdown link

--- a/rules/bare_url.md
+++ b/rules/bare_url.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_url`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/bare_url.rs`](../src/rules/bare_url.rs)
+**Default state:** `active`
+**Source:** [`src/rules/bare_url.rs`](../src/rules/bare_url.rs)
 
 > bare URL in comment or doc comment; wrap in `<...>` or use a labelled markdown link
 

--- a/rules/bare_url.md
+++ b/rules/bare_url.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_url`
 
-**Default state:** `active`\
-**Source:** [`src/rules/bare_url.rs`](../src/rules/bare_url.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/bare_url.rs`](../src/rules/bare_url.rs)
 
 > bare URL in comment or doc comment; wrap in `<...>` or use a labelled markdown link
 

--- a/rules/bare_url.md
+++ b/rules/bare_url.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::bare_url`
 
-**Default state:** `active`
-**Source:** [`src/rules/bare_url.rs`](../src/rules/bare_url.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/bare_url.rs`](../src/rules/bare_url.rs)
 
 > bare URL in comment or doc comment; wrap in `<...>` or use a labelled markdown link
 

--- a/rules/clap_help_markdown.md
+++ b/rules/clap_help_markdown.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::clap_help_markdown`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/clap_help_markdown.rs`](../src/rules/clap_help_markdown.rs)
 
 > markdown construct in a clap-derived doc comment leaks into `--help` output

--- a/rules/clap_help_markdown.md
+++ b/rules/clap_help_markdown.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::clap_help_markdown`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/clap_help_markdown.rs`](../src/rules/clap_help_markdown.rs)
+**Default state:** `active`
+**Source:** [`src/rules/clap_help_markdown.rs`](../src/rules/clap_help_markdown.rs)
 
 > markdown construct in a clap-derived doc comment leaks into `--help` output
 

--- a/rules/clap_help_markdown.md
+++ b/rules/clap_help_markdown.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::clap_help_markdown`
 
-**Default state:** `active`
-**Source:** [`src/rules/clap_help_markdown.rs`](../src/rules/clap_help_markdown.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/clap_help_markdown.rs`](../src/rules/clap_help_markdown.rs)
 
 > markdown construct in a clap-derived doc comment leaks into `--help` output
 

--- a/rules/clap_help_markdown.md
+++ b/rules/clap_help_markdown.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::clap_help_markdown`
 
-**Default state:** `active`\
-**Source:** [`src/rules/clap_help_markdown.rs`](../src/rules/clap_help_markdown.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/clap_help_markdown.rs`](../src/rules/clap_help_markdown.rs)
 
 > markdown construct in a clap-derived doc comment leaks into `--help` output
 

--- a/rules/core_instead_of_std.md
+++ b/rules/core_instead_of_std.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::core_instead_of_std`
 
-**Default state:** `inactive`\
-**Source:** [`src/rules/core_instead_of_std.rs`](../src/rules/core_instead_of_std.rs)
+- _Default state:_ `inactive`
+- _Source:_ [`src/rules/core_instead_of_std.rs`](../src/rules/core_instead_of_std.rs)
 
 > item named through `core` or `alloc` instead of `std`
 

--- a/rules/core_instead_of_std.md
+++ b/rules/core_instead_of_std.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::core_instead_of_std`
 
-**Default state:** `inactive`
-**Source:** [`src/rules/core_instead_of_std.rs`](../src/rules/core_instead_of_std.rs)
+- _Default state:_ `inactive`
+- _Source:_ [`src/rules/core_instead_of_std.rs`](../src/rules/core_instead_of_std.rs)
 
 > item named through `core` or `alloc` instead of `std`
 

--- a/rules/core_instead_of_std.md
+++ b/rules/core_instead_of_std.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::core_instead_of_std`
 
-- _Default state:_ `inactive`
-- _Source:_ [`src/rules/core_instead_of_std.rs`](../src/rules/core_instead_of_std.rs)
+**Default state:** `inactive`
+**Source:** [`src/rules/core_instead_of_std.rs`](../src/rules/core_instead_of_std.rs)
 
 > item named through `core` or `alloc` instead of `std`
 

--- a/rules/core_instead_of_std.md
+++ b/rules/core_instead_of_std.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::core_instead_of_std`
 
-**Default state:** `inactive`  
+**Default state:** `inactive`\
 **Source:** [`src/rules/core_instead_of_std.rs`](../src/rules/core_instead_of_std.rs)
 
 > item named through `core` or `alloc` instead of `std`

--- a/rules/excessive_cognitive_complexity.md
+++ b/rules/excessive_cognitive_complexity.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::excessive_cognitive_complexity`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/excessive_cognitive_complexity.rs`](../src/rules/excessive_cognitive_complexity.rs)
 
 > function body has a cognitive complexity above the configured maximum

--- a/rules/excessive_cognitive_complexity.md
+++ b/rules/excessive_cognitive_complexity.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::excessive_cognitive_complexity`
 
-**Default state:** `active`\
-**Source:** [`src/rules/excessive_cognitive_complexity.rs`](../src/rules/excessive_cognitive_complexity.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/excessive_cognitive_complexity.rs`](../src/rules/excessive_cognitive_complexity.rs)
 
 > function body has a cognitive complexity above the configured maximum
 

--- a/rules/excessive_cognitive_complexity.md
+++ b/rules/excessive_cognitive_complexity.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::excessive_cognitive_complexity`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/excessive_cognitive_complexity.rs`](../src/rules/excessive_cognitive_complexity.rs)
+**Default state:** `active`
+**Source:** [`src/rules/excessive_cognitive_complexity.rs`](../src/rules/excessive_cognitive_complexity.rs)
 
 > function body has a cognitive complexity above the configured maximum
 

--- a/rules/excessive_cognitive_complexity.md
+++ b/rules/excessive_cognitive_complexity.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::excessive_cognitive_complexity`
 
-**Default state:** `active`
-**Source:** [`src/rules/excessive_cognitive_complexity.rs`](../src/rules/excessive_cognitive_complexity.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/excessive_cognitive_complexity.rs`](../src/rules/excessive_cognitive_complexity.rs)
 
 > function body has a cognitive complexity above the configured maximum
 

--- a/rules/excessive_inline_tests.md
+++ b/rules/excessive_inline_tests.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::excessive_inline_tests`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/excessive_inline_tests.rs`](../src/rules/excessive_inline_tests.rs)
 
 > inline test code should be extracted to a separate file

--- a/rules/excessive_inline_tests.md
+++ b/rules/excessive_inline_tests.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::excessive_inline_tests`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/excessive_inline_tests.rs`](../src/rules/excessive_inline_tests.rs)
+**Default state:** `active`
+**Source:** [`src/rules/excessive_inline_tests.rs`](../src/rules/excessive_inline_tests.rs)
 
 > inline test code should be extracted to a separate file
 

--- a/rules/excessive_inline_tests.md
+++ b/rules/excessive_inline_tests.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::excessive_inline_tests`
 
-**Default state:** `active`
-**Source:** [`src/rules/excessive_inline_tests.rs`](../src/rules/excessive_inline_tests.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/excessive_inline_tests.rs`](../src/rules/excessive_inline_tests.rs)
 
 > inline test code should be extracted to a separate file
 

--- a/rules/excessive_inline_tests.md
+++ b/rules/excessive_inline_tests.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::excessive_inline_tests`
 
-**Default state:** `active`\
-**Source:** [`src/rules/excessive_inline_tests.rs`](../src/rules/excessive_inline_tests.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/excessive_inline_tests.rs`](../src/rules/excessive_inline_tests.rs)
 
 > inline test code should be extracted to a separate file
 

--- a/rules/exhaustive_error_enums.md
+++ b/rules/exhaustive_error_enums.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::exhaustive_error_enums`
 
-**Default state:** `inactive`
-**Source:** [`src/rules/exhaustive_error_enums.rs`](../src/rules/exhaustive_error_enums.rs)
+- _Default state:_ `inactive`
+- _Source:_ [`src/rules/exhaustive_error_enums.rs`](../src/rules/exhaustive_error_enums.rs)
 
 > error-shaped type is missing `#[non_exhaustive]`
 

--- a/rules/exhaustive_error_enums.md
+++ b/rules/exhaustive_error_enums.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::exhaustive_error_enums`
 
-- _Default state:_ `inactive`
-- _Source:_ [`src/rules/exhaustive_error_enums.rs`](../src/rules/exhaustive_error_enums.rs)
+**Default state:** `inactive`
+**Source:** [`src/rules/exhaustive_error_enums.rs`](../src/rules/exhaustive_error_enums.rs)
 
 > error-shaped type is missing `#[non_exhaustive]`
 

--- a/rules/exhaustive_error_enums.md
+++ b/rules/exhaustive_error_enums.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::exhaustive_error_enums`
 
-**Default state:** `inactive`  
+**Default state:** `inactive`\
 **Source:** [`src/rules/exhaustive_error_enums.rs`](../src/rules/exhaustive_error_enums.rs)
 
 > error-shaped type is missing `#[non_exhaustive]`

--- a/rules/exhaustive_error_enums.md
+++ b/rules/exhaustive_error_enums.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::exhaustive_error_enums`
 
-**Default state:** `inactive`\
-**Source:** [`src/rules/exhaustive_error_enums.rs`](../src/rules/exhaustive_error_enums.rs)
+- _Default state:_ `inactive`
+- _Source:_ [`src/rules/exhaustive_error_enums.rs`](../src/rules/exhaustive_error_enums.rs)
 
 > error-shaped type is missing `#[non_exhaustive]`
 

--- a/rules/import_granularity_mismatch.md
+++ b/rules/import_granularity_mismatch.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::import_granularity_mismatch`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/import_granularity_mismatch.rs`](../src/rules/import_granularity_mismatch.rs)
+**Default state:** `active`
+**Source:** [`src/rules/import_granularity_mismatch.rs`](../src/rules/import_granularity_mismatch.rs)
 
 > import granularity does not match the configured `import_granularity_mismatch.style`
 

--- a/rules/import_granularity_mismatch.md
+++ b/rules/import_granularity_mismatch.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::import_granularity_mismatch`
 
-**Default state:** `active`
-**Source:** [`src/rules/import_granularity_mismatch.rs`](../src/rules/import_granularity_mismatch.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/import_granularity_mismatch.rs`](../src/rules/import_granularity_mismatch.rs)
 
 > import granularity does not match the configured `import_granularity_mismatch.style`
 

--- a/rules/import_granularity_mismatch.md
+++ b/rules/import_granularity_mismatch.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::import_granularity_mismatch`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/import_granularity_mismatch.rs`](../src/rules/import_granularity_mismatch.rs)
 
 > import granularity does not match the configured `import_granularity_mismatch.style`

--- a/rules/import_granularity_mismatch.md
+++ b/rules/import_granularity_mismatch.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::import_granularity_mismatch`
 
-**Default state:** `active`\
-**Source:** [`src/rules/import_granularity_mismatch.rs`](../src/rules/import_granularity_mismatch.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/import_granularity_mismatch.rs`](../src/rules/import_granularity_mismatch.rs)
 
 > import granularity does not match the configured `import_granularity_mismatch.style`
 

--- a/rules/import_grouping_mismatch.md
+++ b/rules/import_grouping_mismatch.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::import_grouping_mismatch`
 
-- _Default state:_ `inactive`
-- _Source:_ [`src/rules/import_grouping_mismatch.rs`](../src/rules/import_grouping_mismatch.rs)
+**Default state:** `inactive`
+**Source:** [`src/rules/import_grouping_mismatch.rs`](../src/rules/import_grouping_mismatch.rs)
 
 > import grouping does not match the configured `import_grouping_mismatch.style`
 

--- a/rules/import_grouping_mismatch.md
+++ b/rules/import_grouping_mismatch.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::import_grouping_mismatch`
 
-**Default state:** `inactive`\
-**Source:** [`src/rules/import_grouping_mismatch.rs`](../src/rules/import_grouping_mismatch.rs)
+- _Default state:_ `inactive`
+- _Source:_ [`src/rules/import_grouping_mismatch.rs`](../src/rules/import_grouping_mismatch.rs)
 
 > import grouping does not match the configured `import_grouping_mismatch.style`
 

--- a/rules/import_grouping_mismatch.md
+++ b/rules/import_grouping_mismatch.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::import_grouping_mismatch`
 
-**Default state:** `inactive`
-**Source:** [`src/rules/import_grouping_mismatch.rs`](../src/rules/import_grouping_mismatch.rs)
+- _Default state:_ `inactive`
+- _Source:_ [`src/rules/import_grouping_mismatch.rs`](../src/rules/import_grouping_mismatch.rs)
 
 > import grouping does not match the configured `import_grouping_mismatch.style`
 

--- a/rules/import_grouping_mismatch.md
+++ b/rules/import_grouping_mismatch.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::import_grouping_mismatch`
 
-**Default state:** `inactive`  
+**Default state:** `inactive`\
 **Source:** [`src/rules/import_grouping_mismatch.rs`](../src/rules/import_grouping_mismatch.rs)
 
 > import grouping does not match the configured `import_grouping_mismatch.style`

--- a/rules/impure_macro_arguments.md
+++ b/rules/impure_macro_arguments.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::impure_macro_arguments`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/impure_macro_arguments.rs`](../src/rules/impure_macro_arguments.rs)
+**Default state:** `active`
+**Source:** [`src/rules/impure_macro_arguments.rs`](../src/rules/impure_macro_arguments.rs)
 
 > macro invocation passes an impure expression that should be bound to a `let` first
 

--- a/rules/impure_macro_arguments.md
+++ b/rules/impure_macro_arguments.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::impure_macro_arguments`
 
-**Default state:** `active`
-**Source:** [`src/rules/impure_macro_arguments.rs`](../src/rules/impure_macro_arguments.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/impure_macro_arguments.rs`](../src/rules/impure_macro_arguments.rs)
 
 > macro invocation passes an impure expression that should be bound to a `let` first
 

--- a/rules/impure_macro_arguments.md
+++ b/rules/impure_macro_arguments.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::impure_macro_arguments`
 
-**Default state:** `active`\
-**Source:** [`src/rules/impure_macro_arguments.rs`](../src/rules/impure_macro_arguments.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/impure_macro_arguments.rs`](../src/rules/impure_macro_arguments.rs)
 
 > macro invocation passes an impure expression that should be bound to a `let` first
 

--- a/rules/impure_macro_arguments.md
+++ b/rules/impure_macro_arguments.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::impure_macro_arguments`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/impure_macro_arguments.rs`](../src/rules/impure_macro_arguments.rs)
 
 > macro invocation passes an impure expression that should be bound to a `let` first

--- a/rules/lint_attribute_trailing_comment.md
+++ b/rules/lint_attribute_trailing_comment.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::lint_attribute_trailing_comment`
 
-**Default state:** `active`\
-**Source:** [`src/rules/lint_attribute_trailing_comment.rs`](../src/rules/lint_attribute_trailing_comment.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/lint_attribute_trailing_comment.rs`](../src/rules/lint_attribute_trailing_comment.rs)
 
 > trailing comment on a lint-level attribute should be lifted into a `reason = "..."` field
 

--- a/rules/lint_attribute_trailing_comment.md
+++ b/rules/lint_attribute_trailing_comment.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::lint_attribute_trailing_comment`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/lint_attribute_trailing_comment.rs`](../src/rules/lint_attribute_trailing_comment.rs)
 
 > trailing comment on a lint-level attribute should be lifted into a `reason = "..."` field

--- a/rules/lint_attribute_trailing_comment.md
+++ b/rules/lint_attribute_trailing_comment.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::lint_attribute_trailing_comment`
 
-**Default state:** `active`
-**Source:** [`src/rules/lint_attribute_trailing_comment.rs`](../src/rules/lint_attribute_trailing_comment.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/lint_attribute_trailing_comment.rs`](../src/rules/lint_attribute_trailing_comment.rs)
 
 > trailing comment on a lint-level attribute should be lifted into a `reason = "..."` field
 

--- a/rules/lint_attribute_trailing_comment.md
+++ b/rules/lint_attribute_trailing_comment.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::lint_attribute_trailing_comment`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/lint_attribute_trailing_comment.rs`](../src/rules/lint_attribute_trailing_comment.rs)
+**Default state:** `active`
+**Source:** [`src/rules/lint_attribute_trailing_comment.rs`](../src/rules/lint_attribute_trailing_comment.rs)
 
 > trailing comment on a lint-level attribute should be lifted into a `reason = "..."` field
 

--- a/rules/macro_trailing_comma.md
+++ b/rules/macro_trailing_comma.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::macro_trailing_comma`
 
-**Default state:** `active`\
-**Source:** [`src/rules/macro_trailing_comma.rs`](../src/rules/macro_trailing_comma.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/macro_trailing_comma.rs`](../src/rules/macro_trailing_comma.rs)
 
 > macro invocation does not follow rustfmt's vertical trailing-comma policy
 

--- a/rules/macro_trailing_comma.md
+++ b/rules/macro_trailing_comma.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::macro_trailing_comma`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/macro_trailing_comma.rs`](../src/rules/macro_trailing_comma.rs)
 
 > macro invocation does not follow rustfmt's vertical trailing-comma policy

--- a/rules/macro_trailing_comma.md
+++ b/rules/macro_trailing_comma.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::macro_trailing_comma`
 
-**Default state:** `active`
-**Source:** [`src/rules/macro_trailing_comma.rs`](../src/rules/macro_trailing_comma.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/macro_trailing_comma.rs`](../src/rules/macro_trailing_comma.rs)
 
 > macro invocation does not follow rustfmt's vertical trailing-comma policy
 

--- a/rules/macro_trailing_comma.md
+++ b/rules/macro_trailing_comma.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::macro_trailing_comma`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/macro_trailing_comma.rs`](../src/rules/macro_trailing_comma.rs)
+**Default state:** `active`
+**Source:** [`src/rules/macro_trailing_comma.rs`](../src/rules/macro_trailing_comma.rs)
 
 > macro invocation does not follow rustfmt's vertical trailing-comma policy
 

--- a/rules/named_prelude_imports.md
+++ b/rules/named_prelude_imports.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::named_prelude_imports`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/named_prelude_imports.rs`](../src/rules/named_prelude_imports.rs)
+**Default state:** `active`
+**Source:** [`src/rules/named_prelude_imports.rs`](../src/rules/named_prelude_imports.rs)
 
 > named item cherry-picked from a prelude module instead of glob-imported
 

--- a/rules/named_prelude_imports.md
+++ b/rules/named_prelude_imports.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::named_prelude_imports`
 
-**Default state:** `active`\
-**Source:** [`src/rules/named_prelude_imports.rs`](../src/rules/named_prelude_imports.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/named_prelude_imports.rs`](../src/rules/named_prelude_imports.rs)
 
 > named item cherry-picked from a prelude module instead of glob-imported
 

--- a/rules/named_prelude_imports.md
+++ b/rules/named_prelude_imports.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::named_prelude_imports`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/named_prelude_imports.rs`](../src/rules/named_prelude_imports.rs)
 
 > named item cherry-picked from a prelude module instead of glob-imported

--- a/rules/named_prelude_imports.md
+++ b/rules/named_prelude_imports.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::named_prelude_imports`
 
-**Default state:** `active`
-**Source:** [`src/rules/named_prelude_imports.rs`](../src/rules/named_prelude_imports.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/named_prelude_imports.rs`](../src/rules/named_prelude_imports.rs)
 
 > named item cherry-picked from a prelude module instead of glob-imported
 

--- a/rules/needless_borrowed_parameters.md
+++ b/rules/needless_borrowed_parameters.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::needless_borrowed_parameters`
 
-**Default state:** `active`\
-**Source:** [`src/rules/needless_borrowed_parameters.rs`](../src/rules/needless_borrowed_parameters.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/needless_borrowed_parameters.rs`](../src/rules/needless_borrowed_parameters.rs)
 
 > borrowed parameter is only used to produce its owned form
 

--- a/rules/needless_borrowed_parameters.md
+++ b/rules/needless_borrowed_parameters.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::needless_borrowed_parameters`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/needless_borrowed_parameters.rs`](../src/rules/needless_borrowed_parameters.rs)
 
 > borrowed parameter is only used to produce its owned form

--- a/rules/needless_borrowed_parameters.md
+++ b/rules/needless_borrowed_parameters.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::needless_borrowed_parameters`
 
-**Default state:** `active`
-**Source:** [`src/rules/needless_borrowed_parameters.rs`](../src/rules/needless_borrowed_parameters.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/needless_borrowed_parameters.rs`](../src/rules/needless_borrowed_parameters.rs)
 
 > borrowed parameter is only used to produce its owned form
 

--- a/rules/needless_borrowed_parameters.md
+++ b/rules/needless_borrowed_parameters.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::needless_borrowed_parameters`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/needless_borrowed_parameters.rs`](../src/rules/needless_borrowed_parameters.rs)
+**Default state:** `active`
+**Source:** [`src/rules/needless_borrowed_parameters.rs`](../src/rules/needless_borrowed_parameters.rs)
 
 > borrowed parameter is only used to produce its owned form
 

--- a/rules/overly_long_print_macro.md
+++ b/rules/overly_long_print_macro.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::overly_long_print_macro`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/overly_long_print_macro.rs`](../src/rules/overly_long_print_macro.rs)
 
 > splittable print macro with an embedded-newline template exceeds the configured line width

--- a/rules/overly_long_print_macro.md
+++ b/rules/overly_long_print_macro.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::overly_long_print_macro`
 
-**Default state:** `active`\
-**Source:** [`src/rules/overly_long_print_macro.rs`](../src/rules/overly_long_print_macro.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/overly_long_print_macro.rs`](../src/rules/overly_long_print_macro.rs)
 
 > splittable print macro with an embedded-newline template exceeds the configured line width
 

--- a/rules/overly_long_print_macro.md
+++ b/rules/overly_long_print_macro.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::overly_long_print_macro`
 
-**Default state:** `active`
-**Source:** [`src/rules/overly_long_print_macro.rs`](../src/rules/overly_long_print_macro.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/overly_long_print_macro.rs`](../src/rules/overly_long_print_macro.rs)
 
 > splittable print macro with an embedded-newline template exceeds the configured line width
 

--- a/rules/overly_long_print_macro.md
+++ b/rules/overly_long_print_macro.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::overly_long_print_macro`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/overly_long_print_macro.rs`](../src/rules/overly_long_print_macro.rs)
+**Default state:** `active`
+**Source:** [`src/rules/overly_long_print_macro.rs`](../src/rules/overly_long_print_macro.rs)
 
 > splittable print macro with an embedded-newline template exceeds the configured line width
 

--- a/rules/redundant_derive_more_forward_template.md
+++ b/rules/redundant_derive_more_forward_template.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::redundant_derive_more_forward_template`
 
-**Default state:** `active`
-**Source:** [`src/rules/redundant_derive_more_forward_template.rs`](../src/rules/redundant_derive_more_forward_template.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/redundant_derive_more_forward_template.rs`](../src/rules/redundant_derive_more_forward_template.rs)
 
 > `derive_more` formatting template only restates the forward the derive already performs
 

--- a/rules/redundant_derive_more_forward_template.md
+++ b/rules/redundant_derive_more_forward_template.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::redundant_derive_more_forward_template`
 
-**Default state:** `active`\
-**Source:** [`src/rules/redundant_derive_more_forward_template.rs`](../src/rules/redundant_derive_more_forward_template.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/redundant_derive_more_forward_template.rs`](../src/rules/redundant_derive_more_forward_template.rs)
 
 > `derive_more` formatting template only restates the forward the derive already performs
 

--- a/rules/redundant_derive_more_forward_template.md
+++ b/rules/redundant_derive_more_forward_template.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::redundant_derive_more_forward_template`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/redundant_derive_more_forward_template.rs`](../src/rules/redundant_derive_more_forward_template.rs)
+**Default state:** `active`
+**Source:** [`src/rules/redundant_derive_more_forward_template.rs`](../src/rules/redundant_derive_more_forward_template.rs)
 
 > `derive_more` formatting template only restates the forward the derive already performs
 

--- a/rules/redundant_derive_more_forward_template.md
+++ b/rules/redundant_derive_more_forward_template.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::redundant_derive_more_forward_template`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/redundant_derive_more_forward_template.rs`](../src/rules/redundant_derive_more_forward_template.rs)
 
 > `derive_more` formatting template only restates the forward the derive already performs

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_closure_param`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/single_letter_closure_param.rs`](../src/rules/single_letter_closure_param.rs)
+**Default state:** `active`
+**Source:** [`src/rules/single_letter_closure_param.rs`](../src/rules/single_letter_closure_param.rs)
 
 > closure parameter has a single-letter name
 

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_closure_param`
 
-**Default state:** `active`
-**Source:** [`src/rules/single_letter_closure_param.rs`](../src/rules/single_letter_closure_param.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_closure_param.rs`](../src/rules/single_letter_closure_param.rs)
 
 > closure parameter has a single-letter name
 

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_closure_param`
 
-**Default state:** `active`\
-**Source:** [`src/rules/single_letter_closure_param.rs`](../src/rules/single_letter_closure_param.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_closure_param.rs`](../src/rules/single_letter_closure_param.rs)
 
 > closure parameter has a single-letter name
 

--- a/rules/single_letter_closure_param.md
+++ b/rules/single_letter_closure_param.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::single_letter_closure_param`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/single_letter_closure_param.rs`](../src/rules/single_letter_closure_param.rs)
 
 > closure parameter has a single-letter name

--- a/rules/single_letter_const_generic.md
+++ b/rules/single_letter_const_generic.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_const_generic`
 
-**Default state:** `active`
-**Source:** [`src/rules/single_letter_const_generic.rs`](../src/rules/single_letter_const_generic.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_const_generic.rs`](../src/rules/single_letter_const_generic.rs)
 
 > const generic parameter has a single-letter name
 

--- a/rules/single_letter_const_generic.md
+++ b/rules/single_letter_const_generic.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::single_letter_const_generic`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/single_letter_const_generic.rs`](../src/rules/single_letter_const_generic.rs)
 
 > const generic parameter has a single-letter name

--- a/rules/single_letter_const_generic.md
+++ b/rules/single_letter_const_generic.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_const_generic`
 
-**Default state:** `active`\
-**Source:** [`src/rules/single_letter_const_generic.rs`](../src/rules/single_letter_const_generic.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_const_generic.rs`](../src/rules/single_letter_const_generic.rs)
 
 > const generic parameter has a single-letter name
 

--- a/rules/single_letter_const_generic.md
+++ b/rules/single_letter_const_generic.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_const_generic`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/single_letter_const_generic.rs`](../src/rules/single_letter_const_generic.rs)
+**Default state:** `active`
+**Source:** [`src/rules/single_letter_const_generic.rs`](../src/rules/single_letter_const_generic.rs)
 
 > const generic parameter has a single-letter name
 

--- a/rules/single_letter_const_item.md
+++ b/rules/single_letter_const_item.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_const_item`
 
-**Default state:** `active`\
-**Source:** [`src/rules/single_letter_const_item.rs`](../src/rules/single_letter_const_item.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_const_item.rs`](../src/rules/single_letter_const_item.rs)
 
 > const item has a single-letter name
 

--- a/rules/single_letter_const_item.md
+++ b/rules/single_letter_const_item.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_const_item`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/single_letter_const_item.rs`](../src/rules/single_letter_const_item.rs)
+**Default state:** `active`
+**Source:** [`src/rules/single_letter_const_item.rs`](../src/rules/single_letter_const_item.rs)
 
 > const item has a single-letter name
 

--- a/rules/single_letter_const_item.md
+++ b/rules/single_letter_const_item.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_const_item`
 
-**Default state:** `active`
-**Source:** [`src/rules/single_letter_const_item.rs`](../src/rules/single_letter_const_item.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_const_item.rs`](../src/rules/single_letter_const_item.rs)
 
 > const item has a single-letter name
 

--- a/rules/single_letter_const_item.md
+++ b/rules/single_letter_const_item.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::single_letter_const_item`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/single_letter_const_item.rs`](../src/rules/single_letter_const_item.rs)
 
 > const item has a single-letter name

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::single_letter_function_param`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/single_letter_function_param.rs`](../src/rules/single_letter_function_param.rs)
 
 > function parameter has a single-letter name

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_function_param`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/single_letter_function_param.rs`](../src/rules/single_letter_function_param.rs)
+**Default state:** `active`
+**Source:** [`src/rules/single_letter_function_param.rs`](../src/rules/single_letter_function_param.rs)
 
 > function parameter has a single-letter name
 

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_function_param`
 
-**Default state:** `active`\
-**Source:** [`src/rules/single_letter_function_param.rs`](../src/rules/single_letter_function_param.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_function_param.rs`](../src/rules/single_letter_function_param.rs)
 
 > function parameter has a single-letter name
 

--- a/rules/single_letter_function_param.md
+++ b/rules/single_letter_function_param.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_function_param`
 
-**Default state:** `active`
-**Source:** [`src/rules/single_letter_function_param.rs`](../src/rules/single_letter_function_param.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_function_param.rs`](../src/rules/single_letter_function_param.rs)
 
 > function parameter has a single-letter name
 

--- a/rules/single_letter_generic.md
+++ b/rules/single_letter_generic.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_generic`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/single_letter_generic.rs`](../src/rules/single_letter_generic.rs)
+**Default state:** `active`
+**Source:** [`src/rules/single_letter_generic.rs`](../src/rules/single_letter_generic.rs)
 
 > generic type parameter has a single-letter name
 

--- a/rules/single_letter_generic.md
+++ b/rules/single_letter_generic.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_generic`
 
-**Default state:** `active`\
-**Source:** [`src/rules/single_letter_generic.rs`](../src/rules/single_letter_generic.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_generic.rs`](../src/rules/single_letter_generic.rs)
 
 > generic type parameter has a single-letter name
 

--- a/rules/single_letter_generic.md
+++ b/rules/single_letter_generic.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_generic`
 
-**Default state:** `active`
-**Source:** [`src/rules/single_letter_generic.rs`](../src/rules/single_letter_generic.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_generic.rs`](../src/rules/single_letter_generic.rs)
 
 > generic type parameter has a single-letter name
 

--- a/rules/single_letter_generic.md
+++ b/rules/single_letter_generic.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::single_letter_generic`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/single_letter_generic.rs`](../src/rules/single_letter_generic.rs)
 
 > generic type parameter has a single-letter name

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_let_binding`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/single_letter_let_binding.rs`](../src/rules/single_letter_let_binding.rs)
+**Default state:** `active`
+**Source:** [`src/rules/single_letter_let_binding.rs`](../src/rules/single_letter_let_binding.rs)
 
 > `let` binding has a single-letter name
 

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_let_binding`
 
-**Default state:** `active`\
-**Source:** [`src/rules/single_letter_let_binding.rs`](../src/rules/single_letter_let_binding.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_let_binding.rs`](../src/rules/single_letter_let_binding.rs)
 
 > `let` binding has a single-letter name
 

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_let_binding`
 
-**Default state:** `active`
-**Source:** [`src/rules/single_letter_let_binding.rs`](../src/rules/single_letter_let_binding.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_let_binding.rs`](../src/rules/single_letter_let_binding.rs)
 
 > `let` binding has a single-letter name
 

--- a/rules/single_letter_let_binding.md
+++ b/rules/single_letter_let_binding.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::single_letter_let_binding`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/single_letter_let_binding.rs`](../src/rules/single_letter_let_binding.rs)
 
 > `let` binding has a single-letter name

--- a/rules/single_letter_static_item.md
+++ b/rules/single_letter_static_item.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_static_item`
 
-**Default state:** `active`\
-**Source:** [`src/rules/single_letter_static_item.rs`](../src/rules/single_letter_static_item.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_static_item.rs`](../src/rules/single_letter_static_item.rs)
 
 > static item has a single-letter name
 

--- a/rules/single_letter_static_item.md
+++ b/rules/single_letter_static_item.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_static_item`
 
-**Default state:** `active`
-**Source:** [`src/rules/single_letter_static_item.rs`](../src/rules/single_letter_static_item.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/single_letter_static_item.rs`](../src/rules/single_letter_static_item.rs)
 
 > static item has a single-letter name
 

--- a/rules/single_letter_static_item.md
+++ b/rules/single_letter_static_item.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::single_letter_static_item`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/single_letter_static_item.rs`](../src/rules/single_letter_static_item.rs)
+**Default state:** `active`
+**Source:** [`src/rules/single_letter_static_item.rs`](../src/rules/single_letter_static_item.rs)
 
 > static item has a single-letter name
 

--- a/rules/single_letter_static_item.md
+++ b/rules/single_letter_static_item.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::single_letter_static_item`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/single_letter_static_item.rs`](../src/rules/single_letter_static_item.rs)
 
 > static item has a single-letter name

--- a/rules/thiserror_usage.md
+++ b/rules/thiserror_usage.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::thiserror_usage`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/thiserror_usage.rs`](../src/rules/thiserror_usage.rs)
 
 > `thiserror` import, derive, or attribute; this catalogue prefers `derive_more::{Display, Error}`

--- a/rules/thiserror_usage.md
+++ b/rules/thiserror_usage.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::thiserror_usage`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/thiserror_usage.rs`](../src/rules/thiserror_usage.rs)
+**Default state:** `active`
+**Source:** [`src/rules/thiserror_usage.rs`](../src/rules/thiserror_usage.rs)
 
 > `thiserror` import, derive, or attribute; this catalogue prefers `derive_more::{Display, Error}`
 

--- a/rules/thiserror_usage.md
+++ b/rules/thiserror_usage.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::thiserror_usage`
 
-**Default state:** `active`
-**Source:** [`src/rules/thiserror_usage.rs`](../src/rules/thiserror_usage.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/thiserror_usage.rs`](../src/rules/thiserror_usage.rs)
 
 > `thiserror` import, derive, or attribute; this catalogue prefers `derive_more::{Display, Error}`
 

--- a/rules/thiserror_usage.md
+++ b/rules/thiserror_usage.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::thiserror_usage`
 
-**Default state:** `active`\
-**Source:** [`src/rules/thiserror_usage.rs`](../src/rules/thiserror_usage.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/thiserror_usage.rs`](../src/rules/thiserror_usage.rs)
 
 > `thiserror` import, derive, or attribute; this catalogue prefers `derive_more::{Display, Error}`
 

--- a/rules/uncombined_self_import.md
+++ b/rules/uncombined_self_import.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::uncombined_self_import`
 
-**Default state:** `inactive`
-**Source:** [`src/rules/uncombined_self_import.rs`](../src/rules/uncombined_self_import.rs)
+- _Default state:_ `inactive`
+- _Source:_ [`src/rules/uncombined_self_import.rs`](../src/rules/uncombined_self_import.rs)
 
 > a module import and an adjacent item import from it can be combined through `self`
 

--- a/rules/uncombined_self_import.md
+++ b/rules/uncombined_self_import.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::uncombined_self_import`
 
-**Default state:** `inactive`  
+**Default state:** `inactive`\
 **Source:** [`src/rules/uncombined_self_import.rs`](../src/rules/uncombined_self_import.rs)
 
 > a module import and an adjacent item import from it can be combined through `self`

--- a/rules/uncombined_self_import.md
+++ b/rules/uncombined_self_import.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::uncombined_self_import`
 
-- _Default state:_ `inactive`
-- _Source:_ [`src/rules/uncombined_self_import.rs`](../src/rules/uncombined_self_import.rs)
+**Default state:** `inactive`
+**Source:** [`src/rules/uncombined_self_import.rs`](../src/rules/uncombined_self_import.rs)
 
 > a module import and an adjacent item import from it can be combined through `self`
 

--- a/rules/uncombined_self_import.md
+++ b/rules/uncombined_self_import.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::uncombined_self_import`
 
-**Default state:** `inactive`\
-**Source:** [`src/rules/uncombined_self_import.rs`](../src/rules/uncombined_self_import.rs)
+- _Default state:_ `inactive`
+- _Source:_ [`src/rules/uncombined_self_import.rs`](../src/rules/uncombined_self_import.rs)
 
 > a module import and an adjacent item import from it can be combined through `self`
 

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unicode_ellipsis_in_comments`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/unicode_ellipsis_in_comments.rs`](../src/rules/unicode_ellipsis_in_comments.rs)
+**Default state:** `active`
+**Source:** [`src/rules/unicode_ellipsis_in_comments.rs`](../src/rules/unicode_ellipsis_in_comments.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in non-doc comments; prefer `...`
 

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unicode_ellipsis_in_comments`
 
-**Default state:** `active`\
-**Source:** [`src/rules/unicode_ellipsis_in_comments.rs`](../src/rules/unicode_ellipsis_in_comments.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/unicode_ellipsis_in_comments.rs`](../src/rules/unicode_ellipsis_in_comments.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in non-doc comments; prefer `...`
 

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unicode_ellipsis_in_comments`
 
-**Default state:** `active`
-**Source:** [`src/rules/unicode_ellipsis_in_comments.rs`](../src/rules/unicode_ellipsis_in_comments.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/unicode_ellipsis_in_comments.rs`](../src/rules/unicode_ellipsis_in_comments.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in non-doc comments; prefer `...`
 

--- a/rules/unicode_ellipsis_in_comments.md
+++ b/rules/unicode_ellipsis_in_comments.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::unicode_ellipsis_in_comments`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/unicode_ellipsis_in_comments.rs`](../src/rules/unicode_ellipsis_in_comments.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in non-doc comments; prefer `...`

--- a/rules/unicode_ellipsis_in_docs.md
+++ b/rules/unicode_ellipsis_in_docs.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::unicode_ellipsis_in_docs`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/unicode_ellipsis_in_docs.rs`](../src/rules/unicode_ellipsis_in_docs.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in doc comments; prefer `...`

--- a/rules/unicode_ellipsis_in_docs.md
+++ b/rules/unicode_ellipsis_in_docs.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unicode_ellipsis_in_docs`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/unicode_ellipsis_in_docs.rs`](../src/rules/unicode_ellipsis_in_docs.rs)
+**Default state:** `active`
+**Source:** [`src/rules/unicode_ellipsis_in_docs.rs`](../src/rules/unicode_ellipsis_in_docs.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in doc comments; prefer `...`
 

--- a/rules/unicode_ellipsis_in_docs.md
+++ b/rules/unicode_ellipsis_in_docs.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unicode_ellipsis_in_docs`
 
-**Default state:** `active`\
-**Source:** [`src/rules/unicode_ellipsis_in_docs.rs`](../src/rules/unicode_ellipsis_in_docs.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/unicode_ellipsis_in_docs.rs`](../src/rules/unicode_ellipsis_in_docs.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in doc comments; prefer `...`
 

--- a/rules/unicode_ellipsis_in_docs.md
+++ b/rules/unicode_ellipsis_in_docs.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unicode_ellipsis_in_docs`
 
-**Default state:** `active`
-**Source:** [`src/rules/unicode_ellipsis_in_docs.rs`](../src/rules/unicode_ellipsis_in_docs.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/unicode_ellipsis_in_docs.rs`](../src/rules/unicode_ellipsis_in_docs.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in doc comments; prefer `...`
 

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unicode_ellipsis_in_panic_messages`
 
-**Default state:** `active`
-**Source:** [`src/rules/unicode_ellipsis_in_panic_messages.rs`](../src/rules/unicode_ellipsis_in_panic_messages.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/unicode_ellipsis_in_panic_messages.rs`](../src/rules/unicode_ellipsis_in_panic_messages.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in panic / assertion / expect messages; prefer `...`
 

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::unicode_ellipsis_in_panic_messages`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/unicode_ellipsis_in_panic_messages.rs`](../src/rules/unicode_ellipsis_in_panic_messages.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in panic / assertion / expect messages; prefer `...`

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unicode_ellipsis_in_panic_messages`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/unicode_ellipsis_in_panic_messages.rs`](../src/rules/unicode_ellipsis_in_panic_messages.rs)
+**Default state:** `active`
+**Source:** [`src/rules/unicode_ellipsis_in_panic_messages.rs`](../src/rules/unicode_ellipsis_in_panic_messages.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in panic / assertion / expect messages; prefer `...`
 

--- a/rules/unicode_ellipsis_in_panic_messages.md
+++ b/rules/unicode_ellipsis_in_panic_messages.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unicode_ellipsis_in_panic_messages`
 
-**Default state:** `active`\
-**Source:** [`src/rules/unicode_ellipsis_in_panic_messages.rs`](../src/rules/unicode_ellipsis_in_panic_messages.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/unicode_ellipsis_in_panic_messages.rs`](../src/rules/unicode_ellipsis_in_panic_messages.rs)
 
 > U+2026 HORIZONTAL ELLIPSIS in panic / assertion / expect messages; prefer `...`
 

--- a/rules/unknown_perfectionist_lints.md
+++ b/rules/unknown_perfectionist_lints.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::unknown_perfectionist_lints`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/unknown_perfectionist_lints.rs`](../src/rules/unknown_perfectionist_lints.rs)
 
 > lint-control attribute references a `perfectionist::*` lint that this plugin does not register

--- a/rules/unknown_perfectionist_lints.md
+++ b/rules/unknown_perfectionist_lints.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unknown_perfectionist_lints`
 
-**Default state:** `active`\
-**Source:** [`src/rules/unknown_perfectionist_lints.rs`](../src/rules/unknown_perfectionist_lints.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/unknown_perfectionist_lints.rs`](../src/rules/unknown_perfectionist_lints.rs)
 
 > lint-control attribute references a `perfectionist::*` lint that this plugin does not register
 

--- a/rules/unknown_perfectionist_lints.md
+++ b/rules/unknown_perfectionist_lints.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unknown_perfectionist_lints`
 
-**Default state:** `active`
-**Source:** [`src/rules/unknown_perfectionist_lints.rs`](../src/rules/unknown_perfectionist_lints.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/unknown_perfectionist_lints.rs`](../src/rules/unknown_perfectionist_lints.rs)
 
 > lint-control attribute references a `perfectionist::*` lint that this plugin does not register
 

--- a/rules/unknown_perfectionist_lints.md
+++ b/rules/unknown_perfectionist_lints.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unknown_perfectionist_lints`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/unknown_perfectionist_lints.rs`](../src/rules/unknown_perfectionist_lints.rs)
+**Default state:** `active`
+**Source:** [`src/rules/unknown_perfectionist_lints.rs`](../src/rules/unknown_perfectionist_lints.rs)
 
 > lint-control attribute references a `perfectionist::*` lint that this plugin does not register
 

--- a/rules/unordered_derives.md
+++ b/rules/unordered_derives.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unordered_derives`
 
-**Default state:** `inactive`\
-**Source:** [`src/rules/unordered_derives.rs`](../src/rules/unordered_derives.rs)
+- _Default state:_ `inactive`
+- _Source:_ [`src/rules/unordered_derives.rs`](../src/rules/unordered_derives.rs)
 
 > trait names in a `#[derive(...)]` list are not in the configured order
 

--- a/rules/unordered_derives.md
+++ b/rules/unordered_derives.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unordered_derives`
 
-- _Default state:_ `inactive`
-- _Source:_ [`src/rules/unordered_derives.rs`](../src/rules/unordered_derives.rs)
+**Default state:** `inactive`
+**Source:** [`src/rules/unordered_derives.rs`](../src/rules/unordered_derives.rs)
 
 > trait names in a `#[derive(...)]` list are not in the configured order
 

--- a/rules/unordered_derives.md
+++ b/rules/unordered_derives.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unordered_derives`
 
-**Default state:** `inactive`
-**Source:** [`src/rules/unordered_derives.rs`](../src/rules/unordered_derives.rs)
+- _Default state:_ `inactive`
+- _Source:_ [`src/rules/unordered_derives.rs`](../src/rules/unordered_derives.rs)
 
 > trait names in a `#[derive(...)]` list are not in the configured order
 

--- a/rules/unordered_derives.md
+++ b/rules/unordered_derives.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::unordered_derives`
 
-**Default state:** `inactive`  
+**Default state:** `inactive`\
 **Source:** [`src/rules/unordered_derives.rs`](../src/rules/unordered_derives.rs)
 
 > trait names in a `#[derive(...)]` list are not in the configured order

--- a/rules/unpinned_repo_ref.md
+++ b/rules/unpinned_repo_ref.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unpinned_repo_ref`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/unpinned_repo_ref.rs`](../src/rules/unpinned_repo_ref.rs)
+**Default state:** `active`
+**Source:** [`src/rules/unpinned_repo_ref.rs`](../src/rules/unpinned_repo_ref.rs)
 
 > repository URL references a branch or tag instead of a commit SHA
 

--- a/rules/unpinned_repo_ref.md
+++ b/rules/unpinned_repo_ref.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::unpinned_repo_ref`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/unpinned_repo_ref.rs`](../src/rules/unpinned_repo_ref.rs)
 
 > repository URL references a branch or tag instead of a commit SHA

--- a/rules/unpinned_repo_ref.md
+++ b/rules/unpinned_repo_ref.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unpinned_repo_ref`
 
-**Default state:** `active`\
-**Source:** [`src/rules/unpinned_repo_ref.rs`](../src/rules/unpinned_repo_ref.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/unpinned_repo_ref.rs`](../src/rules/unpinned_repo_ref.rs)
 
 > repository URL references a branch or tag instead of a commit SHA
 

--- a/rules/unpinned_repo_ref.md
+++ b/rules/unpinned_repo_ref.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::unpinned_repo_ref`
 
-**Default state:** `active`
-**Source:** [`src/rules/unpinned_repo_ref.rs`](../src/rules/unpinned_repo_ref.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/unpinned_repo_ref.rs`](../src/rules/unpinned_repo_ref.rs)
 
 > repository URL references a branch or tag instead of a commit SHA
 

--- a/rules/wildcard_imports.md
+++ b/rules/wildcard_imports.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::wildcard_imports`
 
-**Default state:** `active`
-**Source:** [`src/rules/wildcard_imports.rs`](../src/rules/wildcard_imports.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/wildcard_imports.rs`](../src/rules/wildcard_imports.rs)
 
 > glob (`*`) import in a module body, outside the prelude and root-re-export exceptions
 

--- a/rules/wildcard_imports.md
+++ b/rules/wildcard_imports.md
@@ -2,7 +2,7 @@
 
 # `perfectionist::wildcard_imports`
 
-**Default state:** `active`  
+**Default state:** `active`\
 **Source:** [`src/rules/wildcard_imports.rs`](../src/rules/wildcard_imports.rs)
 
 > glob (`*`) import in a module body, outside the prelude and root-re-export exceptions

--- a/rules/wildcard_imports.md
+++ b/rules/wildcard_imports.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::wildcard_imports`
 
-- _Default state:_ `active`
-- _Source:_ [`src/rules/wildcard_imports.rs`](../src/rules/wildcard_imports.rs)
+**Default state:** `active`
+**Source:** [`src/rules/wildcard_imports.rs`](../src/rules/wildcard_imports.rs)
 
 > glob (`*`) import in a module body, outside the prelude and root-re-export exceptions
 

--- a/rules/wildcard_imports.md
+++ b/rules/wildcard_imports.md
@@ -2,8 +2,8 @@
 
 # `perfectionist::wildcard_imports`
 
-**Default state:** `active`\
-**Source:** [`src/rules/wildcard_imports.rs`](../src/rules/wildcard_imports.rs)
+- _Default state:_ `active`
+- _Source:_ [`src/rules/wildcard_imports.rs`](../src/rules/wildcard_imports.rs)
 
 > glob (`*`) import in a module body, outside the prelude and root-re-export exceptions
 

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -23,12 +23,14 @@
 //! no rendered line ends in whitespace, so the `check-md`
 //! byte-comparison stays stable across editors that strip or add a
 //! final newline and that trim trailing whitespace on save. The
-//! second half of that rules out the two-space spelling of a
-//! CommonMark hard line break, so the backslash spelling is the one
-//! used here. Inline doc-comment prose is taken verbatim — the
-//! extractor has already normalised the leading convention space —
-//! and is wrapped in blank lines on either side so it never glues
-//! itself to the headings around it.
+//! second half of that rules out CommonMark hard line breaks, whose
+//! two-space spelling is the whitespace an editor trims and whose
+//! backslash spelling is line noise; the layout uses lists and
+//! blank lines to separate what would otherwise need one. Inline
+//! doc-comment prose is taken verbatim — the extractor has already
+//! normalised the leading convention space — and is wrapped in
+//! blank lines on either side so it never glues itself to the
+//! headings around it.
 
 use crate::model::{
     ConfigDoc, ConfigField, EnumVariant, NAMESPACE, Optionality, Rule, StructField, TypeDoc,
@@ -74,19 +76,24 @@ pub(crate) fn render_rule_md(rule: &Rule, source_link_prefix: &str) -> String {
     out.push('\n');
     let _ = writeln!(out, "# `{}`", rule.namespaced);
     out.push('\n');
-    // The state and source lines form one paragraph, so the first
-    // needs a hard line break. CommonMark spells that two ways —
-    // two trailing spaces, or a trailing backslash — and only the
-    // backslash survives a round trip through an editor that trims
-    // trailing whitespace on save. The invisible form put every
-    // generated file one save away from silent drift: the break
-    // disappeared, `check-md` reported a mismatch, and the diff
-    // showed two identical-looking lines. Keep the backslash.
-    let _ = writeln!(out, r"**Default state:** `{}`\", rule.default_state.word());
+    // The rule's own metadata list, the same shape as the one under
+    // every field, type and variant heading below. A list rather
+    // than two lines of one paragraph, because that paragraph needs
+    // a hard line break between them and neither CommonMark
+    // spelling of one is fit to commit: two trailing spaces
+    // disappear the moment an editor that trims trailing whitespace
+    // saves the file, leaving `check-md` to report drift over a
+    // diff whose two sides look identical, and a trailing backslash
+    // is line noise in a file meant to be read as source. A list
+    // puts each entry on its own line and needs no break at all.
+    write_metadata(&mut out, "Default state", Some(rule.default_state.word()));
     let source_path = source_path_str(rule);
+    // Not `write_metadata`: the value is a link, and the backticks
+    // that helper adds belong around the path inside it, not around
+    // the whole `[text](url)` span.
     let _ = writeln!(
         out,
-        "**Source:** [`{source_path}`]({source_link_prefix}{source_path})",
+        "- _Source:_ [`{source_path}`]({source_link_prefix}{source_path})",
     );
     out.push('\n');
     let _ = writeln!(out, "> {}", rule.short_desc);

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -23,14 +23,11 @@
 //! no rendered line ends in whitespace, so the `check-md`
 //! byte-comparison stays stable across editors that strip or add a
 //! final newline and that trim trailing whitespace on save. The
-//! second half of that rules out CommonMark hard line breaks, whose
-//! two-space spelling is the whitespace an editor trims and whose
-//! backslash spelling is line noise; the layout uses lists and
-//! blank lines to separate what would otherwise need one. Inline
-//! doc-comment prose is taken verbatim — the extractor has already
-//! normalised the leading convention space — and is wrapped in
-//! blank lines on either side so it never glues itself to the
-//! headings around it.
+//! second half of that rules out the two-space spelling of a
+//! CommonMark hard line break. Inline doc-comment prose is taken
+//! verbatim — the extractor has already normalised the leading
+//! convention space — and is wrapped in blank lines on either side
+//! so it never glues itself to the headings around it.
 
 use crate::model::{
     ConfigDoc, ConfigField, EnumVariant, NAMESPACE, Optionality, Rule, StructField, TypeDoc,
@@ -76,24 +73,18 @@ pub(crate) fn render_rule_md(rule: &Rule, source_link_prefix: &str) -> String {
     out.push('\n');
     let _ = writeln!(out, "# `{}`", rule.namespaced);
     out.push('\n');
-    // The rule's own metadata list, the same shape as the one under
-    // every field, type and variant heading below. A list rather
-    // than two lines of one paragraph, because that paragraph needs
-    // a hard line break between them and neither CommonMark
-    // spelling of one is fit to commit: two trailing spaces
-    // disappear the moment an editor that trims trailing whitespace
-    // saves the file, leaving `check-md` to report drift over a
-    // diff whose two sides look identical, and a trailing backslash
-    // is line noise in a file meant to be read as source. A list
-    // puts each entry on its own line and needs no break at all.
-    write_metadata(&mut out, "Default state", Some(rule.default_state.word()));
+    // No hard line break between these two lines. CommonMark
+    // spells one as two trailing spaces, and that is whitespace an
+    // editor deletes on save, which left every generated file one
+    // save away from `check-md` drift over a diff whose two sides
+    // look identical. Rendered, the two facts now run together on
+    // one line; in the file — which is where this copy is meant to
+    // be read — they stay on their own lines.
+    let _ = writeln!(out, "**Default state:** `{}`", rule.default_state.word());
     let source_path = source_path_str(rule);
-    // Not `write_metadata`: the value is a link, and the backticks
-    // that helper adds belong around the path inside it, not around
-    // the whole `[text](url)` span.
     let _ = writeln!(
         out,
-        "- _Source:_ [`{source_path}`]({source_link_prefix}{source_path})",
+        "**Source:** [`{source_path}`]({source_link_prefix}{source_path})",
     );
     out.push('\n');
     let _ = writeln!(out, "> {}", rule.short_desc);

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -82,7 +82,7 @@ pub(crate) fn render_rule_md(rule: &Rule, source_link_prefix: &str) -> String {
     // generated file one save away from silent drift: the break
     // disappeared, `check-md` reported a mismatch, and the diff
     // showed two identical-looking lines. Keep the backslash.
-    let _ = writeln!(out, "**Default state:** `{}`\\", rule.default_state.word());
+    let _ = writeln!(out, r"**Default state:** `{}`\", rule.default_state.word());
     let source_path = source_path_str(rule);
     let _ = writeln!(
         out,

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -74,9 +74,6 @@ pub(crate) fn render_rule_md(rule: &Rule, source_link_prefix: &str) -> String {
     out.push('\n');
     write_metadata(&mut out, "Default state", Some(rule.default_state.word()));
     let source_path = source_path_str(rule);
-    // Written out rather than passed to `write_metadata`: the
-    // backticks that helper adds belong around the path inside the
-    // link, not around the whole `[text](url)` span.
     let _ = writeln!(
         out,
         "- _Source:_ [`{source_path}`]({source_link_prefix}{source_path})",

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -23,11 +23,14 @@
 //! no rendered line ends in whitespace, so the `check-md`
 //! byte-comparison stays stable across editors that strip or add a
 //! final newline and that trim trailing whitespace on save. The
-//! second half of that rules out the two-space spelling of a
-//! CommonMark hard line break. Inline doc-comment prose is taken
-//! verbatim — the extractor has already normalised the leading
-//! convention space — and is wrapped in blank lines on either side
-//! so it never glues itself to the headings around it.
+//! second half of that rules out CommonMark hard line breaks, whose
+//! two-space spelling is the whitespace an editor trims and whose
+//! backslash spelling is line noise; the layout uses lists and
+//! blank lines to separate what would otherwise need one. Inline
+//! doc-comment prose is taken verbatim — the extractor has already
+//! normalised the leading convention space — and is wrapped in
+//! blank lines on either side so it never glues itself to the
+//! headings around it.
 
 use crate::model::{
     ConfigDoc, ConfigField, EnumVariant, NAMESPACE, Optionality, Rule, StructField, TypeDoc,
@@ -73,18 +76,24 @@ pub(crate) fn render_rule_md(rule: &Rule, source_link_prefix: &str) -> String {
     out.push('\n');
     let _ = writeln!(out, "# `{}`", rule.namespaced);
     out.push('\n');
-    // No hard line break between these two lines. CommonMark
-    // spells one as two trailing spaces, and that is whitespace an
-    // editor deletes on save, which left every generated file one
-    // save away from `check-md` drift over a diff whose two sides
-    // look identical. Rendered, the two facts now run together on
-    // one line; in the file — which is where this copy is meant to
-    // be read — they stay on their own lines.
-    let _ = writeln!(out, "**Default state:** `{}`", rule.default_state.word());
+    // The rule's own metadata list, the same shape as the one under
+    // every field, type and variant heading below. A list rather
+    // than two lines of one paragraph, because that paragraph needs
+    // a hard line break between them and neither CommonMark
+    // spelling of one is fit to commit: two trailing spaces
+    // disappear the moment an editor that trims trailing whitespace
+    // saves the file, leaving `check-md` to report drift over a
+    // diff whose two sides look identical, and a trailing backslash
+    // is line noise in a file meant to be read as source. A list
+    // puts each entry on its own line and needs no break at all.
+    write_metadata(&mut out, "Default state", Some(rule.default_state.word()));
     let source_path = source_path_str(rule);
+    // Not `write_metadata`: the value is a link, and the backticks
+    // that helper adds belong around the path inside it, not around
+    // the whole `[text](url)` span.
     let _ = writeln!(
         out,
-        "**Source:** [`{source_path}`]({source_link_prefix}{source_path})",
+        "- _Source:_ [`{source_path}`]({source_link_prefix}{source_path})",
     );
     out.push('\n');
     let _ = writeln!(out, "> {}", rule.short_desc);

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -19,12 +19,16 @@
 //! inbound link. The kind word doubles as a namespace, keeping a
 //! field and a same-named type from slugifying to one anchor.
 //!
-//! Every rendered string ends with exactly one trailing newline so
-//! the `check-md` byte-comparison stays stable across editors that
-//! strip or add a final newline. Inline doc-comment prose is taken
-//! verbatim — the extractor has already normalised the leading
-//! convention space — and is wrapped in blank lines on either side
-//! so it never glues itself to the headings around it.
+//! Every rendered string ends with exactly one trailing newline and
+//! no rendered line ends in whitespace, so the `check-md`
+//! byte-comparison stays stable across editors that strip or add a
+//! final newline and that trim trailing whitespace on save. The
+//! second half of that rules out the two-space spelling of a
+//! CommonMark hard line break, so the backslash spelling is the one
+//! used here. Inline doc-comment prose is taken verbatim — the
+//! extractor has already normalised the leading convention space —
+//! and is wrapped in blank lines on either side so it never glues
+//! itself to the headings around it.
 
 use crate::model::{
     ConfigDoc, ConfigField, EnumVariant, NAMESPACE, Optionality, Rule, StructField, TypeDoc,
@@ -70,7 +74,15 @@ pub(crate) fn render_rule_md(rule: &Rule, source_link_prefix: &str) -> String {
     out.push('\n');
     let _ = writeln!(out, "# `{}`", rule.namespaced);
     out.push('\n');
-    let _ = writeln!(out, "**Default state:** `{}`  ", rule.default_state.word());
+    // The state and source lines form one paragraph, so the first
+    // needs a hard line break. CommonMark spells that two ways —
+    // two trailing spaces, or a trailing backslash — and only the
+    // backslash survives a round trip through an editor that trims
+    // trailing whitespace on save. The invisible form put every
+    // generated file one save away from silent drift: the break
+    // disappeared, `check-md` reported a mismatch, and the diff
+    // showed two identical-looking lines. Keep the backslash.
+    let _ = writeln!(out, "**Default state:** `{}`\\", rule.default_state.word());
     let source_path = source_path_str(rule);
     let _ = writeln!(
         out,

--- a/tools/gen-docs/src/render_md.rs
+++ b/tools/gen-docs/src/render_md.rs
@@ -22,11 +22,7 @@
 //! Every rendered string ends with exactly one trailing newline and
 //! no rendered line ends in whitespace, so the `check-md`
 //! byte-comparison stays stable across editors that strip or add a
-//! final newline and that trim trailing whitespace on save. The
-//! second half of that rules out CommonMark hard line breaks, whose
-//! two-space spelling is the whitespace an editor trims and whose
-//! backslash spelling is line noise; the layout uses lists and
-//! blank lines to separate what would otherwise need one. Inline
+//! final newline and that trim trailing whitespace on save. Inline
 //! doc-comment prose is taken verbatim — the extractor has already
 //! normalised the leading convention space — and is wrapped in
 //! blank lines on either side so it never glues itself to the
@@ -76,21 +72,11 @@ pub(crate) fn render_rule_md(rule: &Rule, source_link_prefix: &str) -> String {
     out.push('\n');
     let _ = writeln!(out, "# `{}`", rule.namespaced);
     out.push('\n');
-    // The rule's own metadata list, the same shape as the one under
-    // every field, type and variant heading below. A list rather
-    // than two lines of one paragraph, because that paragraph needs
-    // a hard line break between them and neither CommonMark
-    // spelling of one is fit to commit: two trailing spaces
-    // disappear the moment an editor that trims trailing whitespace
-    // saves the file, leaving `check-md` to report drift over a
-    // diff whose two sides look identical, and a trailing backslash
-    // is line noise in a file meant to be read as source. A list
-    // puts each entry on its own line and needs no break at all.
     write_metadata(&mut out, "Default state", Some(rule.default_state.word()));
     let source_path = source_path_str(rule);
-    // Not `write_metadata`: the value is a link, and the backticks
-    // that helper adds belong around the path inside it, not around
-    // the whole `[text](url)` span.
+    // Written out rather than passed to `write_metadata`: the
+    // backticks that helper adds belong around the path inside the
+    // link, not around the whole `[text](url)` span.
     let _ = writeln!(
         out,
         "- _Source:_ [`{source_path}`]({source_link_prefix}{source_path})",

--- a/tools/gen-docs/src/render_md/tests.rs
+++ b/tools/gen-docs/src/render_md/tests.rs
@@ -30,7 +30,7 @@ fn rule_file_name_strips_namespace() {
 fn rule_md_includes_header_state_and_short_desc() {
     let md = render_rule_md(&fake_rule(), "../");
     assert!(md.contains("# `perfectionist::demo_rule`\n"));
-    assert!(md.contains("- _Default state:_ `active`"), "got:\n{md}");
+    assert!(md.contains("**Default state:** `active`"), "got:\n{md}");
     assert!(md.contains("> demo rule used in tests"));
     assert!(md.ends_with('\n'));
     assert!(!md.ends_with("\n\n"));
@@ -41,27 +41,25 @@ fn rule_md_renders_inactive_state_for_opt_in_rules() {
     let mut rule = fake_rule();
     rule.default_state = DefaultState::Inactive;
     let md = render_rule_md(&rule, "../");
-    assert!(md.contains("- _Default state:_ `inactive`"), "got:\n{md}");
+    assert!(md.contains("**Default state:** `inactive`"), "got:\n{md}");
 }
 
 #[test]
-fn rule_md_header_metadata_is_a_list_with_no_hard_break() {
-    // The state and the source are two entries of one metadata
-    // list. Writing them as two lines of a paragraph instead
-    // would need a hard line break between them, and both
-    // CommonMark spellings of one are unwelcome in a committed
-    // file: two trailing spaces are whitespace an editor trims on
-    // save, and a trailing backslash is line noise. Pin the list
-    // so neither comes back.
+fn rule_md_header_lines_carry_no_hard_line_break() {
+    // The state line ends at its last backtick. It used to end
+    // with the two trailing spaces that spell a CommonMark hard
+    // line break, which is whitespace an editor deletes on save —
+    // leaving `check-md` to report drift over a diff whose two
+    // sides look identical. Pin the exact bytes so it can't
+    // come back.
     let md = render_rule_md(&fake_rule(), "../");
     assert!(
         md.contains(
-            "- _Default state:_ `active`\n\
-             - _Source:_ [`src/rules/demo_rule.rs`](../src/rules/demo_rule.rs)\n",
+            "**Default state:** `active`\n\
+             **Source:** [`src/rules/demo_rule.rs`](../src/rules/demo_rule.rs)\n",
         ),
         "got:\n{md}",
     );
-    assert!(!md.contains("\\\n"), "no backslash line break: {md}");
 }
 
 #[test]

--- a/tools/gen-docs/src/render_md/tests.rs
+++ b/tools/gen-docs/src/render_md/tests.rs
@@ -45,6 +45,94 @@ fn rule_md_renders_inactive_state_for_opt_in_rules() {
 }
 
 #[test]
+fn rule_md_hard_break_between_header_lines_is_a_backslash() {
+    // The state and source lines are one paragraph split by a
+    // hard line break. Spelling that break CommonMark's other
+    // way — two trailing spaces — put every generated file one
+    // save away from drift, since editors trim trailing
+    // whitespace and `check-md` compares bytes. Assert the
+    // backslash so nobody swaps it back, and assert the two
+    // lines still sit together so nobody drops the break.
+    let md = render_rule_md(&fake_rule(), "../");
+    assert!(
+        md.contains(
+            "**Default state:** `active`\\\n\
+             **Source:** [`src/rules/demo_rule.rs`](../src/rules/demo_rule.rs)\n",
+        ),
+        "got:\n{md}",
+    );
+}
+
+#[test]
+fn rendered_markdown_never_ends_a_line_with_whitespace() {
+    // Whichever branches a rule takes, the bytes on disk have to
+    // be bytes a whitespace-trimming editor would leave alone;
+    // anything else turns an innocent save into `check-md`
+    // drift with an invisible diff. Render a rule that reaches
+    // every section — prose with a fenced block, fields, an
+    // enum type and a struct type — plus the index, and hold
+    // both to that.
+    let mut rule = fake_rule();
+    rule.doc_markdown =
+        "### What it does\nDoes a demo.\n\n### Example\n```text\ndemo\n```".to_owned();
+    rule.config = ConfigDoc {
+        key: "perfectionist::demo_rule".to_owned(),
+        fields: vec![
+            ConfigField {
+                name: "style".to_owned(),
+                type_label: "Style".to_owned(),
+                doc_markdown: "Pick a style.".to_owned(),
+                optionality: Optionality::Mandatory,
+            },
+            ConfigField {
+                name: "hosts".to_owned(),
+                type_label: "[HostEntry]".to_owned(),
+                doc_markdown: String::new(),
+                optionality: Optionality::Optional,
+            },
+        ],
+        custom_types: vec![
+            TypeDoc {
+                name: "Style".to_owned(),
+                doc_markdown: "Style enum.".to_owned(),
+                kind: TypeKind::Enum {
+                    variants: vec![EnumVariant {
+                        rust_name: "Preserve".to_owned(),
+                        serialized: "preserve".to_owned(),
+                        doc_markdown: "Leave it alone.".to_owned(),
+                    }],
+                },
+            },
+            TypeDoc {
+                name: "HostEntry".to_owned(),
+                doc_markdown: "One host.".to_owned(),
+                kind: TypeKind::Struct {
+                    fields: vec![StructField {
+                        name: "host".to_owned(),
+                        type_label: "string".to_owned(),
+                        doc_markdown: "The hostname.".to_owned(),
+                    }],
+                },
+            },
+        ],
+    };
+    let rendered = [
+        ("rule", render_rule_md(&rule, "../")),
+        ("index", render_index_md(std::slice::from_ref(&rule))),
+    ];
+    for (label, markdown) in &rendered {
+        for (index, line) in markdown.lines().enumerate() {
+            assert_eq!(
+                line.trim_end(),
+                line,
+                "{label} markdown line {number} ends with whitespace",
+                number = index + 1,
+            );
+        }
+    }
+}
+
+#[test]
 fn rule_md_with_no_config_prints_none_section() {
     let md = render_rule_md(&fake_rule(), "../");
     assert!(md.contains("## Configuration"));

--- a/tools/gen-docs/src/render_md/tests.rs
+++ b/tools/gen-docs/src/render_md/tests.rs
@@ -20,6 +20,20 @@ fn fake_rule() -> Rule {
     }
 }
 
+/// Hold rendered markdown to the no-trailing-whitespace invariant: a
+/// generated file that an editor changes on save shows up as
+/// `check-md` drift over a diff whose two sides look identical.
+fn assert_no_trailing_whitespace(label: &str, markdown: &str) {
+    for (index, line) in markdown.lines().enumerate() {
+        assert_eq!(
+            line.trim_end(),
+            line,
+            "{label} markdown line {number} ends with whitespace",
+            number = index + 1,
+        );
+    }
+}
+
 #[test]
 fn rule_file_name_strips_namespace() {
     let rule = fake_rule();
@@ -32,6 +46,7 @@ fn rule_md_includes_header_state_and_short_desc() {
     assert!(md.contains("# `perfectionist::demo_rule`\n"));
     assert!(md.contains("- _Default state:_ `active`"), "got:\n{md}");
     assert!(md.contains("> demo rule used in tests"));
+    assert_no_trailing_whitespace("rule", &md);
     assert!(md.ends_with('\n'));
     assert!(!md.ends_with("\n\n"));
 }
@@ -45,14 +60,9 @@ fn rule_md_renders_inactive_state_for_opt_in_rules() {
 }
 
 #[test]
-fn rule_md_header_metadata_is_a_list_with_no_hard_break() {
-    // The state and the source are two entries of one metadata
-    // list. Writing them as two lines of a paragraph instead
-    // would need a hard line break between them, and both
-    // CommonMark spellings of one are unwelcome in a committed
-    // file: two trailing spaces are whitespace an editor trims on
-    // save, and a trailing backslash is line noise. Pin the list
-    // so neither comes back.
+fn rule_md_header_metadata_is_a_list() {
+    // The state and the source are the two entries of the rule's
+    // own metadata list, in that order, directly under the title.
     let md = render_rule_md(&fake_rule(), "../");
     assert!(
         md.contains(
@@ -61,76 +71,6 @@ fn rule_md_header_metadata_is_a_list_with_no_hard_break() {
         ),
         "got:\n{md}",
     );
-    assert!(!md.contains("\\\n"), "no backslash line break: {md}");
-}
-
-#[test]
-fn rendered_markdown_never_ends_a_line_with_whitespace() {
-    // Whichever branches a rule takes, the bytes on disk have to
-    // be bytes a whitespace-trimming editor would leave alone;
-    // anything else turns an innocent save into `check-md`
-    // drift with an invisible diff. Render a rule that reaches
-    // every section — prose with a fenced block, fields, an
-    // enum type and a struct type — plus the index, and hold
-    // both to that.
-    let mut rule = fake_rule();
-    rule.doc_markdown =
-        "### What it does\nDoes a demo.\n\n### Example\n```text\ndemo\n```".to_owned();
-    rule.config = ConfigDoc {
-        key: "perfectionist::demo_rule".to_owned(),
-        fields: vec![
-            ConfigField {
-                name: "style".to_owned(),
-                type_label: "Style".to_owned(),
-                doc_markdown: "Pick a style.".to_owned(),
-                optionality: Optionality::Mandatory,
-            },
-            ConfigField {
-                name: "hosts".to_owned(),
-                type_label: "[HostEntry]".to_owned(),
-                doc_markdown: String::new(),
-                optionality: Optionality::Optional,
-            },
-        ],
-        custom_types: vec![
-            TypeDoc {
-                name: "Style".to_owned(),
-                doc_markdown: "Style enum.".to_owned(),
-                kind: TypeKind::Enum {
-                    variants: vec![EnumVariant {
-                        rust_name: "Preserve".to_owned(),
-                        serialized: "preserve".to_owned(),
-                        doc_markdown: "Leave it alone.".to_owned(),
-                    }],
-                },
-            },
-            TypeDoc {
-                name: "HostEntry".to_owned(),
-                doc_markdown: "One host.".to_owned(),
-                kind: TypeKind::Struct {
-                    fields: vec![StructField {
-                        name: "host".to_owned(),
-                        type_label: "string".to_owned(),
-                        doc_markdown: "The hostname.".to_owned(),
-                    }],
-                },
-            },
-        ],
-    };
-    let rendered = [
-        ("rule", render_rule_md(&rule, "../")),
-        ("index", render_index_md(std::slice::from_ref(&rule))),
-    ];
-    for (label, markdown) in &rendered {
-        for (index, line) in markdown.lines().enumerate() {
-            assert_eq!(
-                line.trim_end(),
-                line,
-                "{label} markdown line {number} ends with whitespace",
-                number = index + 1,
-            );
-        }
-    }
 }
 
 #[test]
@@ -217,6 +157,7 @@ fn rule_md_with_config_lists_fields_and_types() {
     assert!(!md.contains("_Rust:_ `Same`"));
     // Empty doc fall-back.
     assert!(md.contains("*Undocumented.*"));
+    assert_no_trailing_whitespace("rule", &md);
 }
 
 #[test]
@@ -252,6 +193,7 @@ fn rule_md_struct_type_fields_carry_a_type_bullet() {
         md.contains("##### Field: `host`\n\n- _Type:_ `string`\n\nThe hostname.\n"),
         "got:\n{md}",
     );
+    assert_no_trailing_whitespace("rule", &md);
 }
 
 #[test]
@@ -267,6 +209,7 @@ fn index_md_renders_bullet_list() {
     // The bullet-list form needs no `|` escaping (unlike a
     // table) — the pipe in the description appears raw.
     assert!(!index.contains(r"\|"));
+    assert_no_trailing_whitespace("index", &index);
 }
 
 #[test]
@@ -298,6 +241,7 @@ fn doc_markdown_headings_are_promoted_one_level() {
     assert!(md.contains("### not a heading"), "got:\n{md}");
     // And the original h3 must not survive at top level.
     assert!(!md.contains("\n### What it does\n"), "got:\n{md}");
+    assert_no_trailing_whitespace("rule", &md);
 }
 
 #[test]

--- a/tools/gen-docs/src/render_md/tests.rs
+++ b/tools/gen-docs/src/render_md/tests.rs
@@ -30,7 +30,7 @@ fn rule_file_name_strips_namespace() {
 fn rule_md_includes_header_state_and_short_desc() {
     let md = render_rule_md(&fake_rule(), "../");
     assert!(md.contains("# `perfectionist::demo_rule`\n"));
-    assert!(md.contains("**Default state:** `active`"), "got:\n{md}");
+    assert!(md.contains("- _Default state:_ `active`"), "got:\n{md}");
     assert!(md.contains("> demo rule used in tests"));
     assert!(md.ends_with('\n'));
     assert!(!md.ends_with("\n\n"));
@@ -41,25 +41,27 @@ fn rule_md_renders_inactive_state_for_opt_in_rules() {
     let mut rule = fake_rule();
     rule.default_state = DefaultState::Inactive;
     let md = render_rule_md(&rule, "../");
-    assert!(md.contains("**Default state:** `inactive`"), "got:\n{md}");
+    assert!(md.contains("- _Default state:_ `inactive`"), "got:\n{md}");
 }
 
 #[test]
-fn rule_md_header_lines_carry_no_hard_line_break() {
-    // The state line ends at its last backtick. It used to end
-    // with the two trailing spaces that spell a CommonMark hard
-    // line break, which is whitespace an editor deletes on save —
-    // leaving `check-md` to report drift over a diff whose two
-    // sides look identical. Pin the exact bytes so it can't
-    // come back.
+fn rule_md_header_metadata_is_a_list_with_no_hard_break() {
+    // The state and the source are two entries of one metadata
+    // list. Writing them as two lines of a paragraph instead
+    // would need a hard line break between them, and both
+    // CommonMark spellings of one are unwelcome in a committed
+    // file: two trailing spaces are whitespace an editor trims on
+    // save, and a trailing backslash is line noise. Pin the list
+    // so neither comes back.
     let md = render_rule_md(&fake_rule(), "../");
     assert!(
         md.contains(
-            "**Default state:** `active`\n\
-             **Source:** [`src/rules/demo_rule.rs`](../src/rules/demo_rule.rs)\n",
+            "- _Default state:_ `active`\n\
+             - _Source:_ [`src/rules/demo_rule.rs`](../src/rules/demo_rule.rs)\n",
         ),
         "got:\n{md}",
     );
+    assert!(!md.contains("\\\n"), "no backslash line break: {md}");
 }
 
 #[test]

--- a/tools/gen-docs/src/render_md/tests.rs
+++ b/tools/gen-docs/src/render_md/tests.rs
@@ -30,7 +30,7 @@ fn rule_file_name_strips_namespace() {
 fn rule_md_includes_header_state_and_short_desc() {
     let md = render_rule_md(&fake_rule(), "../");
     assert!(md.contains("# `perfectionist::demo_rule`\n"));
-    assert!(md.contains("**Default state:** `active`"));
+    assert!(md.contains("- _Default state:_ `active`"), "got:\n{md}");
     assert!(md.contains("> demo rule used in tests"));
     assert!(md.ends_with('\n'));
     assert!(!md.ends_with("\n\n"));
@@ -41,26 +41,27 @@ fn rule_md_renders_inactive_state_for_opt_in_rules() {
     let mut rule = fake_rule();
     rule.default_state = DefaultState::Inactive;
     let md = render_rule_md(&rule, "../");
-    assert!(md.contains("**Default state:** `inactive`"));
+    assert!(md.contains("- _Default state:_ `inactive`"), "got:\n{md}");
 }
 
 #[test]
-fn rule_md_hard_break_between_header_lines_is_a_backslash() {
-    // The state and source lines are one paragraph split by a
-    // hard line break. Spelling that break CommonMark's other
-    // way — two trailing spaces — put every generated file one
-    // save away from drift, since editors trim trailing
-    // whitespace and `check-md` compares bytes. Assert the
-    // backslash so nobody swaps it back, and assert the two
-    // lines still sit together so nobody drops the break.
+fn rule_md_header_metadata_is_a_list_with_no_hard_break() {
+    // The state and the source are two entries of one metadata
+    // list. Writing them as two lines of a paragraph instead
+    // would need a hard line break between them, and both
+    // CommonMark spellings of one are unwelcome in a committed
+    // file: two trailing spaces are whitespace an editor trims on
+    // save, and a trailing backslash is line noise. Pin the list
+    // so neither comes back.
     let md = render_rule_md(&fake_rule(), "../");
     assert!(
         md.contains(
-            "**Default state:** `active`\\\n\
-             **Source:** [`src/rules/demo_rule.rs`](../src/rules/demo_rule.rs)\n",
+            "- _Default state:_ `active`\n\
+             - _Source:_ [`src/rules/demo_rule.rs`](../src/rules/demo_rule.rs)\n",
         ),
         "got:\n{md}",
     );
+    assert!(!md.contains("\\\n"), "no backslash line break: {md}");
 }
 
 #[test]


### PR DESCRIPTION
## Reason

Editors hate trailing whitespaces.

And why the fuck even was this a part of CommonMark specs?