### PR TITLE
refactor: share the per-function measurement preamble

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ mod literal_scan;
 mod macro_path;
 mod macro_template;
 mod markdown;
+mod measured_fn;
 mod module_reparse;
 mod rule_index;
 mod rules;

--- a/src/measured_fn.rs
+++ b/src/measured_fn.rs
@@ -1,0 +1,52 @@
+//! Which functions the per-function size and complexity rules
+//! measure, decided once for all of them.
+//!
+//! Each of those rules is handed every body a crate has — closures,
+//! macro-generated functions, test helpers — and measures the same
+//! subset: a function or method the author wrote, and only test code
+//! when the rule's `exempt_tests` is off. A closure is part of
+//! the function that contains it; a function produced by a macro is
+//! nothing the author can split; and test code is exempt on request
+//! through [`crate::test_code::fn_in_test_code`].
+
+use crate::test_code::fn_in_test_code;
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::intravisit::FnKind;
+use rustc_lint::LateContext;
+use rustc_span::{Span, Symbol};
+
+/// A function the rule measures: what to call it in the diagnostic and
+/// where to anchor the diagnostic — its signature.
+pub(crate) struct MeasuredFn {
+    pub(crate) name: Symbol,
+    pub(crate) kind_label: &'static str,
+    pub(crate) span: Span,
+}
+
+/// The function `check_fn` was handed, or `None` when it is a closure,
+/// produced by a macro, or test code that `exempt_tests` leaves
+/// alone.
+pub(crate) fn measured_fn(
+    cx: &LateContext<'_>,
+    kind: FnKind<'_>,
+    def_id: LocalDefId,
+    exempt_tests: bool,
+) -> Option<MeasuredFn> {
+    let (ident, kind_label) = match kind {
+        FnKind::ItemFn(ident, ..) => (ident, "function"),
+        FnKind::Method(ident, ..) => (ident, "method"),
+        FnKind::Closure => return None,
+    };
+    let span = cx.tcx.def_span(def_id);
+    if span.from_expansion() {
+        return None;
+    }
+    if exempt_tests && fn_in_test_code(cx, def_id) {
+        return None;
+    }
+    Some(MeasuredFn {
+        name: ident.name,
+        kind_label,
+        span,
+    })
+}

--- a/src/rules/excessive_cognitive_complexity.rs
+++ b/src/rules/excessive_cognitive_complexity.rs
@@ -1,6 +1,6 @@
 use crate::common::DefaultState;
+use crate::measured_fn::measured_fn;
 use crate::rule_index::{Register, rule};
-use crate::test_code::fn_in_test_code;
 use clippy_utils::diagnostics::span_lint_and_then;
 use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
@@ -191,28 +191,18 @@ impl<'tcx> LateLintPass<'tcx> for ExcessiveCognitiveComplexity {
         _span: Span,
         def_id: LocalDefId,
     ) {
-        // A closure is scored as part of the function that contains it.
-        let (ident, kind_label) = match kind {
-            FnKind::ItemFn(ident, ..) => (ident, "function"),
-            FnKind::Method(ident, ..) => (ident, "method"),
-            FnKind::Closure => return,
+        let Some(function) = measured_fn(cx, kind, def_id, self.config.exempt_tests) else {
+            return;
         };
-        let def_span = cx.tcx.def_span(def_id);
-        if def_span.from_expansion() {
-            return;
-        }
-        if self.config.exempt_tests && fn_in_test_code(cx, def_id) {
-            return;
-        }
         let score = score_body(cx, def_id, body);
         if score.total <= self.config.max_complexity {
             return;
         }
         emit(
             cx,
-            def_span,
-            kind_label,
-            ident.name,
+            function.span,
+            function.kind_label,
+            function.name,
             score,
             self.config.max_complexity,
         );

--- a/src/rules/too_many_local_bindings.rs
+++ b/src/rules/too_many_local_bindings.rs
@@ -1,6 +1,6 @@
 use crate::common::DefaultState;
+use crate::measured_fn::measured_fn;
 use crate::rule_index::{Register, rule};
-use crate::test_code::fn_in_test_code;
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
@@ -150,25 +150,16 @@ impl<'tcx> LateLintPass<'tcx> for TooManyLocalBindings {
         _span: Span,
         def_id: LocalDefId,
     ) {
-        let (item, ident) = match kind {
-            FnKind::ItemFn(ident, ..) => ("function", ident),
-            FnKind::Method(ident, ..) => ("method", ident),
-            // A closure's bindings belong to the function that contains it.
-            FnKind::Closure => return,
+        let Some(function) = measured_fn(cx, kind, def_id, self.config.exempt_tests) else {
+            return;
         };
-        let def_span = cx.tcx.def_span(def_id);
-        if def_span.from_expansion() {
-            return;
-        }
-        if self.config.exempt_tests && fn_in_test_code(cx, def_id) {
-            return;
-        }
         let count = count_local_bindings(cx.tcx, body);
         if count <= self.config.max_bindings {
             return;
         }
         let max = self.config.max_bindings;
-        let name = ident.name;
+        let name = function.name;
+        let item = function.kind_label;
         let noun = if count == 1 { "name" } else { "names" };
         let message = format!(
             "{item} `{name}` binds {count} distinct local {noun}, above the limit of {max}",
@@ -176,7 +167,7 @@ impl<'tcx> LateLintPass<'tcx> for TooManyLocalBindings {
         span_lint_and_help(
             cx,
             TOO_MANY_LOCAL_BINDINGS,
-            def_span,
+            function.span,
             message,
             None,
             "split the body into one function per step, or gather related values into a struct",


### PR DESCRIPTION
## Summary

`excessive_cognitive_complexity` and `too_many_local_bindings` open their `check_fn` with the same twelve lines: skip closures, take the `def_span`, skip anything from a macro expansion, and honour `exempt_tests`. The two copies differ only in the order of the destructured tuple and in where the closure comment sits.

This adds `src/measured_fn.rs`, which makes that decision once and returns the name, kind label, and span the diagnostic needs, and points both rules at it.

## Behaviour is unchanged

`measured_fn` is a mechanical extraction of the existing preamble — same `FnKind` match (`Closure` returns early), same `"function"` / `"method"` labels, same `cx.tcx.def_span(def_id)`, same `from_expansion()` guard, and the same `exempt_tests && fn_in_test_code(cx, def_id)` check, in the same order. Diagnostic text and spans are identical; `too_many_local_bindings` swapping its anchor from `def_span` to `function.span` is the same value.

## Why split out

Extracted from https://github.com/KSXGitHub/perfectionist/pull/404, which adds `overly_long_function` — a third rule needing the identical preamble. Landing the extraction on its own keeps that PR's diff to the new rule alone, and keeps this behaviour-preserving refactor reviewable as the mechanical change it is.

`measured_fn` earns its own module rather than a `common.rs` entry: it carries an invariant worth documenting (which bodies the per-function rules measure, and why closures and macro-generated functions are excluded), and it has more than one consumer.

## Validation

`cargo check --all-targets` under `-D warnings` and `cargo fmt --check` are clean. The dylint self-lint and UI compiletests were not run in the authoring environment (no `cargo-dylint` available there), so CI is the first full `just all` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UarqNtAZmLaHcCxUkwdcu


---
_Generated by [Claude Code](https://claude.ai/code/session_011UarqNtAZmLaHcCxUkwdcu)_