### PR TITLE
docs(ai): cut prose that restates the code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,26 +362,13 @@ automated self-lint did not run.
 
 ## Normalised `.stderr` fixtures
 
-The `ui/` and `ui-toml/` compiletest fixtures keep each diagnostic's
-`line:column` pinned to `LL:CC` in the committed `.stderr`, so
-inserting a line above a diagnostic no longer churns every header
-below it — and the `.rs` fixtures themselves stay untouched.
-
-The gutter `LL` comes for free: `dylint_testing` runs rustc under
-`-Zui-testing`, whose `ANONYMIZED_LINE_PREFIX` is a fixed `LL`
-regardless of the real line's digit count, so a three-digit line is
-`LL |`, not `LLL |`. That mode leaves the `--> …:line:col` header
-alone, so the header is normalised separately: every UI test runs from
-a throwaway copy of its fixtures made by
-[`copy_fixtures_with_directive`](utils/src/ui_fixtures.rs), which
-injects a compiletest `// normalize-stderr-test` directive into the
-copy — never the committed `.rs`. See that module for the mechanism,
-and for why the copy reproduces each fixture's repository-relative
-path.
-
-When a fixture's expected output changes, spell the `line:column` in
-the new `.stderr` as `LL:CC`; the injected directive collapses the
-driver's real numbers to match.
+A `.stderr` under `ui/` or `ui-toml/` is a normalised copy of the
+driver's output rather than the output itself: a span header's
+`line:column` reads `LL:CC`, so inserting a line above a diagnostic
+does not renumber every header below it. Spell it that way when
+writing one — pasting the driver's real numbers in will not match.
+[`utils/src/ui_fixtures.rs`](utils/src/ui_fixtures.rs) performs the
+normalisation and explains how.
 
 ## Generated documentation site (`tools/gen-docs/`)
 


### PR DESCRIPTION
The "Normalised `.stderr` fixtures" section spends most of its length on things the repository already states elsewhere.

It describes the fixture-copy mechanism that `copy_fixtures_with_directive` and `inject_directive` carry doc comments for, down to the same clause about the directive going into the copy and never the committed `.rs`. Stating it in both places means nothing fails when one of them changes. It then explains why the source-line gutter reads `LL`, which is rustc's behaviour under `-Zui-testing` rather than anything this repository decides, and which every fixture shows on every line.

What a reader genuinely cannot observe is that the file is a normalised copy at all — so the natural move, pasting a failure message straight in, produces something that will not match. That fact, the `LL:CC` spelling it implies, and the pointer to the module are what stay. 20 lines out, 7 in.

Draft because it is a judgement call about a file you curate closely, and the line between "explains the reasoning" and "restates the code" is yours to draw. Happy to keep more of it — the `-Zui-testing` paragraph is the most defensible thing I cut, since it explains upstream behaviour rather than ours.

Note for sequencing: KSXGitHub/perfectionist#426 also rewrites this section, so whichever lands second needs a rebase. If this one lands first, that PR stops touching `CLAUDE.md` altogether, which is the cleaner split — the docs cleanup is orthogonal to the fixture normalisation it was tangled up with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HH8hGTKGVvUniHpZ4sTgqD

---
_Generated by [Claude Code](https://claude.ai/code/session_01HH8hGTKGVvUniHpZ4sTgqD)_