### PR TITLE
docs(ai): say that the same thing gets the same word

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,23 @@ and this guide, the deliberate typos around
 `unknown_perfectionist_lints`, and `gen-docs`' unit tests, which
 invent lint names — so read the hits, not the count.
 
+## Repeat the word; do not vary it
+
+A synonym signals a distinction. Where there is none, it sends the
+reader looking for one. Use the same word for the same thing, however
+often it recurs.
+
+- The same word in rustdoc, in comments, and in fixtures. "measured
+  on its own" in one place and "measured independently" in the next
+  describe one behaviour and read as two.
+- Spell a value the way the code spells it. The diagnostic says
+  `nests 1 level deep`, so the comment says `1 level`, not
+  `one level`.
+
+The
+[fact-duplication rule](#do-not-write-documentation-that-restates-the-code)
+is this one's complement: repeat words freely, never facts.
+
 ## Shipped docs address the consumer, not the contributor
 
 A doc is *shipped* if a consumer reads it without cloning: `README.md`,


### PR DESCRIPTION
Resolves <https://github.com/KSXGitHub/perfectionist/issues/432>.

Adds one section to `CLAUDE.md`, placed immediately after the restates-the-code section because the two only make sense together. A synonym signals a distinction, so where there is none, the same thing gets the same word. Two bullets carry the concrete cases — the same word across rustdoc, comments and fixtures, and a value spelled the way the code spells it — and a closing line names the pairing, since the new rule is easy to mistake for the opposite of the one it sits beside: repeat words freely, never facts.

Three decisions on the issue's draft. The third bullet (no metaphor, no imagery, no varied sentence shapes) is dropped: decoration is a separate preference the heading does not cover, and neither instance the issue cites was one. Both examples are kept, because they are different failures — a synonym for a phrase spread across three places, and a value spelled differently from the diagnostic the fixture exists to pin. The draft's "the section above" became an anchor link, which is the form that survives a section moving; every in-file anchor in `CLAUDE.md` still resolves.

Documentation only: 17 added lines in one file, no Rust touched, so `just all` was not run. `AGENTS.md` and `.github/copilot-instructions.md` are symlinks to `CLAUDE.md` and pick the section up unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qttqoEjH1CsESoxAodpyL