### PR TITLE
fix(githooks): reject a subject that spans more than one line

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -6,5 +6,6 @@ hooks_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/commit-msg-hooks"
 
 "$hooks_dir/bare-issue-refs" "$msg_file"
 "$hooks_dir/bare-mentions" "$msg_file"
+"$hooks_dir/multiline-subject" "$msg_file"
 "$hooks_dir/subject-length" "$msg_file"
 "$hooks_dir/release-contract" "$msg_file"

--- a/.githooks/commit-msg-hooks/multiline-subject
+++ b/.githooks/commit-msg-hooks/multiline-subject
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# commit-msg check: reject any commit message whose first paragraph
+# spans more than one line. Git reads the subject as every line up to
+# the first blank one, joined with spaces — not as the first line — so
+# a second line in that paragraph is folded into the title instead of
+# starting the body. Pure text, runs for every commit. This is what
+# lets `subject-length` measure the first line and still be measuring
+# the subject.
+set -euo pipefail
+
+msg_file="$1"
+lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/lib"
+source "$lib_dir/comment-char.sh"
+source "$lib_dir/message-body.sh"
+comment_char=$(git_comment_char)
+
+# The human-authored text, then the run of lines from the first
+# non-blank one to the next blank one — exactly the span git joins into
+# the subject. Reading it out of `message_body` rather than the raw
+# file is what makes the check survive `git commit`'s default template,
+# whose line 2 is a comment rather than a blank.
+paragraph=$(
+  message_body "$msg_file" "$comment_char" \
+    | awk 'NF == 0 { if (seen) exit; next } { seen = 1; print }'
+)
+
+# Comments and blanks only: git aborts an empty message on its own, and
+# there is no subject to judge.
+if [ -z "$paragraph" ]; then
+  exit 0
+fi
+
+if [ "$(printf '%s\n' "$paragraph" | wc -l)" -le 1 ]; then
+  exit 0
+fi
+
+# Join the paragraph the way git does, so the report shows the subject
+# the commit would carry: trailing whitespace trimmed off each line,
+# lines separated by a single space. Git drops comment lines first only
+# under the `strip` cleanup an editor commit gets, so a comment line
+# sitting inside the paragraph would survive into `git commit -F`'s
+# subject and this join would omit it — the same approximation the
+# sibling checks make by scanning `message_body`, and one that changes
+# only the report, never the verdict.
+joined=$(
+  printf '%s\n' "$paragraph" |
+    awk '
+      { sub(/[[:space:]]+$/, ""); printf "%s%s", (NR > 1 ? " " : ""), $0 }
+      END { print "" }
+    '
+)
+
+cat >&2 <<EOF
+✖ Commit message rejected: the subject spans more than one line.
+
+$(printf '%s\n' "$paragraph" | sed 's/^/    /')
+
+Git does not read the subject as the first line: it takes every line
+up to the first blank one and joins them with spaces. So every line
+above lands in the title rather than the body, and the subject reads:
+
+    $joined
+
+Put a blank line after the subject so the rest becomes the body, or
+fold the extra words into the subject itself. Conventional Commits
+specifies a single-line header, and git's own convention is subject,
+blank line, body — a first paragraph of more than one line has no
+legitimate form, so this check has no opt-out.
+EOF
+exit 1

--- a/.githooks/commit-msg-hooks/multiline-subject
+++ b/.githooks/commit-msg-hooks/multiline-subject
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 # commit-msg check: reject any commit message whose first paragraph
-# spans more than one line. Git reads the subject as every line up to
-# the first blank one, joined with spaces — not as the first line — so
-# a second line in that paragraph is folded into the title instead of
-# starting the body. Pure text, runs for every commit. This is what
-# lets `subject-length` measure the first line and still be measuring
-# the subject.
+# spans more than one line. Pure text, runs for every commit. Ordered
+# before `subject-length`, whose first line is then the whole subject.
 set -euo pipefail
 
 msg_file="$1"
@@ -14,18 +10,14 @@ source "$lib_dir/comment-char.sh"
 source "$lib_dir/message-body.sh"
 comment_char=$(git_comment_char)
 
-# The human-authored text, then the run of lines from the first
-# non-blank one to the next blank one — exactly the span git joins into
-# the subject. Reading it out of `message_body` rather than the raw
-# file is what makes the check survive `git commit`'s default template,
-# whose line 2 is a comment rather than a blank.
+# Read from `message_body`, not the raw file: under `git commit`'s
+# default template, line 2 is a comment rather than a blank.
 paragraph=$(
   message_body "$msg_file" "$comment_char" \
     | awk 'NF == 0 { if (seen) exit; next } { seen = 1; print }'
 )
 
-# Comments and blanks only: git aborts an empty message on its own, and
-# there is no subject to judge.
+# Git aborts an empty message on its own.
 if [ -z "$paragraph" ]; then
   exit 0
 fi
@@ -34,14 +26,10 @@ if [ "$(printf '%s\n' "$paragraph" | wc -l)" -le 1 ]; then
   exit 0
 fi
 
-# Join the paragraph the way git does, so the report shows the subject
-# the commit would carry: trailing whitespace trimmed off each line,
-# lines separated by a single space. Git drops comment lines first only
-# under the `strip` cleanup an editor commit gets, so a comment line
-# sitting inside the paragraph would survive into `git commit -F`'s
-# subject and this join would omit it — the same approximation the
-# sibling checks make by scanning `message_body`, and one that changes
-# only the report, never the verdict.
+# Join as git does. Exact only under the `strip` cleanup an editor
+# commit gets: `git commit -F` keeps a comment line sitting inside the
+# paragraph, which this join omits. That changes the report, never the
+# verdict.
 joined=$(
   printf '%s\n' "$paragraph" |
     awk '
@@ -62,9 +50,8 @@ above lands in the title rather than the body, and the subject reads:
     $joined
 
 Put a blank line after the subject so the rest becomes the body, or
-fold the extra words into the subject itself. Conventional Commits
-specifies a single-line header, and git's own convention is subject,
-blank line, body — a first paragraph of more than one line has no
-legitimate form, so this check has no opt-out.
+fold the extra words into the subject itself. A first paragraph of
+more than one line has no legitimate form, so this check has no
+opt-out.
 EOF
 exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,14 +549,9 @@ The single exception is version-bump commits, whose subject is
 just the version itself (e.g. `0.0.0-rc.6`). Use this form only
 for commits that do nothing other than bump the version.
 
-The subject is **one line**. Git does not stop at the first line: it
-takes every line up to the first blank one and joins them with
-spaces, so a subject wrapped onto a second line swallows that line
-instead of starting the body. The [`commit-msg`
+The subject is **one line**. The [`commit-msg`
 hook](.githooks/commit-msg) rejects any commit whose first paragraph
-spans more than one line. That check has no opt-out — Conventional
-Commits specifies a single-line header, and git's own convention is
-subject, blank line, body.
+spans more than one line, with no opt-out.
 
 Keep the subject at **72 characters or fewer** — the conventional
 hard cap; 50 is the ideal. GitHub's web UI truncates a longer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,17 +549,25 @@ The single exception is version-bump commits, whose subject is
 just the version itself (e.g. `0.0.0-rc.6`). Use this form only
 for commits that do nothing other than bump the version.
 
-Keep the subject line (the first line) at **72 characters or
-fewer** — the conventional hard cap; 50 is the ideal. GitHub's web
-UI truncates a longer subject, appends a `…`, and folds the
-overflow into the body behind another `…`, so the commit reads as a
-mangled title/body split. The [`commit-msg`
-hook](.githooks/commit-msg) rejects any commit whose subject
-exceeds the cap (version-bump commits are exempt, but are short
-anyway); it measures characters, not bytes, so an accented or
-non-Latin subject is judged by what GitHub displays. Move any
-detail that does not fit into the commit body — a blank line after
-the subject, then the rest.
+The subject is **one line**. Git does not stop at the first line: it
+takes every line up to the first blank one and joins them with
+spaces, so a subject wrapped onto a second line swallows that line
+instead of starting the body. The [`commit-msg`
+hook](.githooks/commit-msg) rejects any commit whose first paragraph
+spans more than one line. That check has no opt-out — Conventional
+Commits specifies a single-line header, and git's own convention is
+subject, blank line, body.
+
+Keep the subject at **72 characters or fewer** — the conventional
+hard cap; 50 is the ideal. GitHub's web UI truncates a longer
+subject, appends a `…`, and folds the overflow into the body behind
+another `…`, so the commit reads as a mangled title/body split. The
+[`commit-msg` hook](.githooks/commit-msg) rejects any commit whose
+subject exceeds the cap (version-bump commits are exempt, but are
+short anyway); it measures characters, not bytes, so an accented or
+non-Latin subject is judged by what GitHub displays. Move any detail
+that does not fit into the commit body — a blank line after the
+subject, then the rest.
 
 When a longer subject is genuinely warranted, set
 `PERFECTIONIST_GIT_HOOK_ALLOW_LONG_SUBJECT=true` for that `git


### PR DESCRIPTION
Resolves <https://github.com/KSXGitHub/perfectionist/issues/433>.

A commit message whose first paragraph spans two lines passed every `commit-msg` check: `subject-length` measures the first line, while git joins every line up to the first blank one into the subject. Length alone cannot catch this — `fix: thing` / `more words` joins to 21 characters and is still malformed, because the missing blank line has absorbed the body into the title.

`.githooks/commit-msg-hooks/multiline-subject` is a new check that makes the assumption true instead of changing what is measured. It takes `message_body`'s stripped text — comment lines honouring `core.commentChar`, nothing past the `>8` scissors marker — reads the lines from the first non-blank one to the next blank one, and rejects unless there is exactly one. It runs before `subject-length`, which is unchanged: with the guard in place, "first line" and "subject" coincide. The check has no opt-out and exempts nothing, version-bump commits included; `PERFECTIONIST_GIT_HOOK_ALLOW_LONG_SUBJECT` still waives only the length cap.

The diagnostic shows the offending paragraph and the subject it would join to. That join is exact under the `strip` cleanup an editor commit gets; a comment line sitting inside the paragraph survives into `git commit -F`'s subject and would be omitted from the join. This is the same approximation the sibling checks make by scanning `message_body`, it changes only the report and never the verdict, and it is noted in the script.

`CLAUDE.md` gains the rule and where it is enforced. How git derives a subject is public knowledge and stays out of it; the mechanics live in the hook's diagnostic, read by whoever trips over the check rather than loaded into every session. The script's comments say only what its code cannot: why the text comes from `message_body`, why an empty paragraph is git's problem, and where the join is an approximation.

Verified with a scratch harness of 40 cases (kept out of the repository, per review): well-formed shapes, `git commit`'s default template, leading blanks and comments, `-v` scissors blocks in two positions, whitespace-only separators, empty and comment-only messages, both cases from the issue, three-line paragraphs, a comment line inside the paragraph, unicode, `core.commentChar=;` and `=auto`, driver ordering, non-regression of the sibling checks, and end-to-end through a real `git commit`. The join was separately cross-checked against git's own `%s`, and hostile message content is not evaluated by the shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVMqiGHWxwRebm6CRmqUoA