### PR TITLE
refactor: share the line counter between the size rules

### DIFF
--- a/rules/overly_long_function.md
+++ b/rules/overly_long_function.md
@@ -13,8 +13,8 @@ Counts the lines of code in a function or method body and flags
 the body when the count is above `max_lines`.
 
 A line counts when it holds anything other than whitespace and
-comments, so blank lines, comment-only lines, and the lines a
-block comment spans are free. The braces that open and close
+comments, so blank lines, comment-only lines, doc comments, and
+the lines a block comment spans are free. The braces that open and close
 the body are not counted. A function produced by a macro is not
 measured. A nested function's lines count towards the function
 that contains it, since they sit in its body.

--- a/src/code_lines.rs
+++ b/src/code_lines.rs
@@ -1,0 +1,41 @@
+//! Counting lines of code in a stretch of Rust source, for the rules
+//! that cap the length of a function body or a file.
+
+use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
+
+/// How many lines of `source` hold a token that is neither whitespace
+/// nor a comment.
+pub(crate) fn count_code_lines(source: &str) -> usize {
+    let mut code_lines = 0;
+    let mut line_has_code = false;
+    let mut offset = 0;
+    for token in tokenize(source, FrontmatterAllowed::No) {
+        let text = &source[offset..offset + token.len as usize];
+        offset += token.len as usize;
+        let is_code = !matches!(
+            token.kind,
+            TokenKind::Whitespace | TokenKind::LineComment { .. } | TokenKind::BlockComment { .. },
+        );
+        // Each newline inside the token ends a line. The first ends the
+        // line the token started on, which counts if anything before it
+        // was code; the rest end lines lying wholly inside the token,
+        // which count only for a code token such as a multi-line string.
+        for (newline_index, _) in text.match_indices('\n').enumerate() {
+            if is_code || (newline_index == 0 && line_has_code) {
+                code_lines += 1;
+            }
+        }
+        line_has_code = if text.contains('\n') {
+            is_code
+        } else {
+            line_has_code || is_code
+        };
+    }
+    if line_has_code {
+        code_lines += 1;
+    }
+    code_lines
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/code_lines/tests.rs
+++ b/src/code_lines/tests.rs
@@ -1,0 +1,97 @@
+use super::count_code_lines;
+use text_block_macros::{text_block, text_block_fnl};
+
+#[test]
+fn blank_and_comment_only_lines_are_free() {
+    let source = text_block_fnl! {
+        ""
+        "    // setup"
+        "    let first = 1;"
+        ""
+        "    /* a"
+        "       block */"
+        "    let second = 2; // trailing"
+    };
+    assert_eq!(count_code_lines(source), 2);
+}
+
+#[test]
+fn a_doc_comment_is_free() {
+    let source = text_block_fnl! {
+        "/// Documented."
+        "fn work() {}"
+        "/** Block form."
+        "    still a comment. */"
+        "fn other() {}"
+    };
+    assert_eq!(count_code_lines(source), 2);
+}
+
+#[test]
+fn a_multi_line_string_counts_every_line_it_spans() {
+    let source = text_block_fnl! {
+        ""
+        r#"    let text = "one"#
+        "two"
+        r#"three";"#
+    };
+    assert_eq!(count_code_lines(source), 3);
+}
+
+#[test]
+fn a_comment_inside_a_string_is_still_code() {
+    let source = text_block_fnl! {
+        ""
+        r#"    let url = "http://x";"#
+    };
+    assert_eq!(count_code_lines(source), 1);
+}
+
+#[test]
+fn an_empty_body_has_no_lines() {
+    assert_eq!(count_code_lines(""), 0);
+    assert_eq!(
+        count_code_lines(text_block_fnl! {
+            ""
+            "    "
+        }),
+        0,
+    );
+}
+
+#[test]
+fn a_last_line_without_a_trailing_newline_still_counts() {
+    // A one-line body: `body_interior` leaves no newline at all, so the
+    // count comes entirely from the tail of `count_code_lines`.
+    assert_eq!(count_code_lines(" work() "), 1);
+    assert_eq!(
+        count_code_lines(text_block! {
+            ""
+            "    first();"
+            "    last()"
+        }),
+        2,
+    );
+}
+
+#[test]
+fn a_local_macro_definition_counts_its_own_lines() {
+    // A `macro_rules!` written inside a body is ordinary body source:
+    // its definition lines count, and the invocation costs only the
+    // line it is written on -- never the lines it expands to.
+    let source = text_block_fnl! {
+        ""
+        "    macro_rules! double {"
+        "        ($x:expr) => { $x * 2 };"
+        "    }"
+        "    double!(2)"
+    };
+    assert_eq!(count_code_lines(source), 4);
+    assert_eq!(
+        count_code_lines(text_block_fnl! {
+            ""
+            "    double!(2);"
+        }),
+        1,
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod abs_path;
 mod ascii_letter;
 mod attr_tokens;
 mod cargo_target;
+mod code_lines;
 mod comment_walk;
 mod common;
 mod derive_list;

--- a/src/rules/overly_long_function.rs
+++ b/src/rules/overly_long_function.rs
@@ -1,3 +1,4 @@
+use crate::code_lines::count_code_lines;
 use crate::common::DefaultState;
 use crate::measured_fn::measured_fn;
 use crate::rule_index::{Register, rule};
@@ -6,7 +7,6 @@ use clippy_utils::source::snippet_opt;
 use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::FnKind;
-use rustc_lexer::{FrontmatterAllowed, TokenKind, tokenize};
 use rustc_lint::{LateContext, LateLintPass, LintStore};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::Span;
@@ -18,8 +18,8 @@ declare_tool_lint! {
     /// the body when the count is above `max_lines`.
     ///
     /// A line counts when it holds anything other than whitespace and
-    /// comments, so blank lines, comment-only lines, and the lines a
-    /// block comment spans are free. The braces that open and close
+    /// comments, so blank lines, comment-only lines, doc comments, and
+    /// the lines a block comment spans are free. The braces that open and close
     /// the body are not counted. A function produced by a macro is not
     /// measured. A nested function's lines count towards the function
     /// that contains it, since they sit in its body.
@@ -156,40 +156,6 @@ fn body_interior(source: &str) -> &str {
         .strip_prefix('{')
         .and_then(|rest| rest.strip_suffix('}'))
         .unwrap_or(source)
-}
-
-/// How many lines of `source` hold a token that is neither whitespace
-/// nor a comment.
-fn count_code_lines(source: &str) -> usize {
-    let mut code_lines = 0;
-    let mut line_has_code = false;
-    let mut offset = 0;
-    for token in tokenize(source, FrontmatterAllowed::No) {
-        let text = &source[offset..offset + token.len as usize];
-        offset += token.len as usize;
-        let is_code = !matches!(
-            token.kind,
-            TokenKind::Whitespace | TokenKind::LineComment { .. } | TokenKind::BlockComment { .. },
-        );
-        // Each newline inside the token ends a line. The first ends the
-        // line the token started on, which counts if anything before it
-        // was code; the rest end lines lying wholly inside the token,
-        // which count only for a code token such as a multi-line string.
-        for (newline_index, _) in text.match_indices('\n').enumerate() {
-            if is_code || (newline_index == 0 && line_has_code) {
-                code_lines += 1;
-            }
-        }
-        line_has_code = if text.contains('\n') {
-            is_code
-        } else {
-            line_has_code || is_code
-        };
-    }
-    if line_has_code {
-        code_lines += 1;
-    }
-    code_lines
 }
 
 #[cfg(test)]

--- a/src/rules/overly_long_function/tests.rs
+++ b/src/rules/overly_long_function/tests.rs
@@ -1,4 +1,4 @@
-use super::{body_interior, count_code_lines};
+use super::body_interior;
 use text_block_macros::{text_block, text_block_fnl};
 
 #[test]
@@ -15,87 +15,4 @@ fn braces_are_stripped() {
         },
     );
     assert_eq!(body_interior("work()"), "work()");
-}
-
-#[test]
-fn blank_and_comment_only_lines_are_free() {
-    let source = text_block_fnl! {
-        ""
-        "    // setup"
-        "    let first = 1;"
-        ""
-        "    /* a"
-        "       block */"
-        "    let second = 2; // trailing"
-    };
-    assert_eq!(count_code_lines(source), 2);
-}
-
-#[test]
-fn a_multi_line_string_counts_every_line_it_spans() {
-    let source = text_block_fnl! {
-        ""
-        r#"    let text = "one"#
-        "two"
-        r#"three";"#
-    };
-    assert_eq!(count_code_lines(source), 3);
-}
-
-#[test]
-fn a_comment_inside_a_string_is_still_code() {
-    let source = text_block_fnl! {
-        ""
-        r#"    let url = "http://x";"#
-    };
-    assert_eq!(count_code_lines(source), 1);
-}
-
-#[test]
-fn an_empty_body_has_no_lines() {
-    assert_eq!(count_code_lines(""), 0);
-    assert_eq!(
-        count_code_lines(text_block_fnl! {
-            ""
-            "    "
-        }),
-        0,
-    );
-}
-
-#[test]
-fn a_last_line_without_a_trailing_newline_still_counts() {
-    // A one-line body: `body_interior` leaves no newline at all, so the
-    // count comes entirely from the tail of `count_code_lines`.
-    assert_eq!(count_code_lines(" work() "), 1);
-    assert_eq!(
-        count_code_lines(text_block! {
-            ""
-            "    first();"
-            "    last()"
-        }),
-        2,
-    );
-}
-
-#[test]
-fn a_local_macro_definition_counts_its_own_lines() {
-    // A `macro_rules!` written inside a body is ordinary body source:
-    // its definition lines count, and the invocation costs only the
-    // line it is written on -- never the lines it expands to.
-    let source = text_block_fnl! {
-        ""
-        "    macro_rules! double {"
-        "        ($x:expr) => { $x * 2 };"
-        "    }"
-        "    double!(2)"
-    };
-    assert_eq!(count_code_lines(source), 4);
-    assert_eq!(
-        count_code_lines(text_block_fnl! {
-            ""
-            "    double!(2);"
-        }),
-        1,
-    );
 }


### PR DESCRIPTION
Split out of KSXGitHub/perfectionist#406, which needs this and is otherwise a rule of its own. Nothing here depends on that PR, and this can land on its own.

## What moves

`count_code_lines` was private to `overly_long_function`. Counting the lines of code in a stretch of source is not particular to a function body, and a rule that caps the length of a *file* wants the same count — and wants it to agree rather than merely resemble. The function and its tests move to `src/code_lines.rs`.

It earns a file rather than a place in `common` because it has an invariant worth a module docstring: a newline *inside* a token ends the line, which is what makes a multi-line string count its own lines rather than one.

## A disagreement the move exposed

`overly_long_function`'s shipped rustdoc listed what a line does not count — "blank lines, comment-only lines, and the lines a block comment spans" — and omitted doc comments, though the counter has always treated them as free. `overly_long_file`'s doc named them. One counter, two descriptions.

The rustdoc names them now. The behaviour is unchanged; only the description was wrong.

No unit test pinned it either: doc comments were reached only through an integration fixture, and only for one rule. The counter's own tests cover them now, in both the `///` and `/** */` forms.

## Verification

`just all` green: fmt, build, doc (including `check-rules-md`), lint, test, self-lint.

The moved counter was mutation-tested as part of KSXGitHub/perfectionist#406 — comments counted as code, blank lines counted, the final line dropped when a file ends without a newline, and a newline inside a multi-line token mishandled. Each is caught by a test that fails without it.

---
Written by an agent (Claude Code).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NZr1nch5Gd47YQkR7Bu7Lx)_