### PR TITLE
refactor: name the test-code check for items, not functions

### DIFF
--- a/src/measured_fn.rs
+++ b/src/measured_fn.rs
@@ -7,9 +7,9 @@
 //! when the rule's `exempt_tests` is off. A closure is part of
 //! the function that contains it; a function produced by a macro is
 //! nothing the author can split; and test code is exempt on request
-//! through [`crate::test_code::fn_in_test_code`].
+//! through [`crate::test_code::item_in_test_code`].
 
-use crate::test_code::fn_in_test_code;
+use crate::test_code::item_in_test_code;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::FnKind;
 use rustc_lint::LateContext;
@@ -41,7 +41,7 @@ pub(crate) fn measured_fn(
     if span.from_expansion() {
         return None;
     }
-    if exempt_tests && fn_in_test_code(cx, def_id) {
+    if exempt_tests && item_in_test_code(cx, def_id) {
         return None;
     }
     Some(MeasuredFn {

--- a/src/test_code.rs
+++ b/src/test_code.rs
@@ -120,10 +120,9 @@ fn entry_implies_test(cfg: &CfgEntry, negated: bool) -> bool {
     }
 }
 
-/// Whether the function `fn_def_id` is test code under either reading:
+/// Whether the item `def_id` is test code under either reading:
 /// the whole crate is an integration-test or benchmark target, or the
-/// function sits in test-exclusive code per [`in_test_code`].
-pub(crate) fn fn_in_test_code(cx: &LateContext<'_>, fn_def_id: LocalDefId) -> bool {
-    crate_target(cx).is_test_target()
-        || in_test_code(cx.tcx, cx.tcx.local_def_id_to_hir_id(fn_def_id))
+/// item sits in test-exclusive code per [`in_test_code`].
+pub(crate) fn item_in_test_code(cx: &LateContext<'_>, def_id: LocalDefId) -> bool {
+    crate_target(cx).is_test_target() || in_test_code(cx.tcx, cx.tcx.local_def_id_to_hir_id(def_id))
 }


### PR DESCRIPTION
Split out of KSXGitHub/perfectionist#406, which needs this and is otherwise a rule of its own. Independent of KSXGitHub/perfectionist#438, the other piece split out of it — the two share no files and either can land first.

## The rename

`fn_in_test_code` → `item_in_test_code`, and its parameter `fn_def_id` → `def_id`.

Nothing in the function is particular to a function. The crate-target half does not look at the item at all, and `in_test_code` walks the parents of whatever `HirId` it is handed. Ask it about a module — a file, say — and it already returns the right answer; the caller just has to write `fn_` to get it.

`item_` is the word rustc uses for the general case, so the name now claims exactly what the trigger checks, and no more.

## Scope

Seven lines across two files. `src/measured_fn.rs` is the only caller on `master`; its module docstring carries an intra-doc link to the old name, which moves with it.

The four per-function rules reach this through `measured_fn` and are untouched.

## Verification

`just all` green: fmt, build, doc (including `check-rules-md`), lint, test, self-lint. No reference to the old name survives anywhere in the tree.

Both halves of this function were mutation-tested as part of KSXGitHub/perfectionist#406 — disabling either the crate-target reading or the `#[cfg(test)]` reading is caught by a test that fails without it. Before that PR, the crate-target half was exercised by only one rule's tests.

---
Written by an agent (Claude Code).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NZr1nch5Gd47YQkR7Bu7Lx)_